### PR TITLE
Attempt to fix broken env setting for DO_COMMENT_TRANSLATION

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -63,7 +63,7 @@ jobs:
         run: docker-compose up --detach
 
       - name: "Run Cypress tests: default"
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v2
         env:
           CYPRESS_BASE_URL: https://localhost
         with:
@@ -74,7 +74,7 @@ jobs:
 
       - name: "Run Cypress tests: comment translation"
         if: env.DO_COMMENT_TRANSLATION
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v2
         env:
           CYPRESS_BASE_URL: https://localhost
         with:

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -41,7 +41,7 @@ jobs:
           GOOGLE_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_CREDENTIALS_BASE64 }}
         run: |
           if [ -n "$GOOGLE_CREDENTIALS_BASE64" ]; then
-            echo "::set-env name=DO_COMMENT_TRANSLATION::true"
+            echo "DO_COMMENT_TRANSLATION=true" >> $GITHUB_ENV
           fi
 
       - name: Enable comment translation

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           unset HAS_SECRET
           if [ -n "$GITHUB_TOKEN" ]; then HAS_SECRET=true; fi
-          echo ::set-env name=HAS_SECRET::${HAS_SECRET}
+          echo "name=HAS_SECRET" >> $GITHUB_ENV
 
       - name: Use Node.js
         uses: actions/setup-node@v2.1.2


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/, which is leaving errors in our automated testing (e.g. https://github.com/pol-is/polis/pull/654/checks?check_run_id=1440369766).

See also https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions\#setting-an-environment-variable for specific resolution.

This PR will serve as a test case to see if the automated tests are working again.