### PR TITLE
Remove node engine version from package.json, in favour of dockerfile

### DIFF
--- a/client-admin/package.json
+++ b/client-admin/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.1",
   "repository": "github:pol-is/polisClientAdmin",
   "description": "Polis Admin Console",
-  "engines": {
-    "node": "8.17.0"
-  },
   "scripts": {
     "clean": "rimraf dist",
     "build:webpack": "npm run clean && NODE_ENV=production webpack --config webpack.config.js",

--- a/client-participation/package.json
+++ b/client-participation/package.json
@@ -7,9 +7,6 @@
     "start": "node ./node_modules/.bin/grunt",
     "test": "node ./node_modules/.bin/grunt test"
   },
-  "engines": {
-    "node": "11.15.0"
-  },
   "dependencies": {
     "autosize": "^3.0.3",
     "boolean": "^0.1.3",

--- a/client-report/package.json
+++ b/client-report/package.json
@@ -11,9 +11,6 @@
     "lint": "eslint src",
     "postinstall": "npm run build"
   },
-  "engines": {
-    "node": ">= 10.3"
-  },
   "author": "Colin Megill",
   "license": "",
   "devDependencies": {

--- a/file-server/package.json
+++ b/file-server/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "",
   "main": "app.js",
-  "engines": {
-    "node": "14.10.1"
-  },
   "scripts": {
     "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/server/package.json
+++ b/server/package.json
@@ -6,9 +6,6 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "engines": {
-    "node": "14.10.1"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/pol-is/polisServer.git"


### PR DESCRIPTION
Small thing. Annoyingly gets out of date easily when using dependabot to update dockerfiles. `npm ci` install throws error when they don't match. Seems best to just lean totally on dockerfile to specific supported versions?