### PR TITLE
Add browserslist to clearly communicate browser support

### DIFF
--- a/client-participation/package.json
+++ b/client-participation/package.json
@@ -77,5 +77,12 @@
     "webpack": "^1.12.2",
     "webpack-dev-middleware": "^1.2.0",
     "webpack-hot-middleware": "^2.4.1"
-  }
+  },
+  "browserslist": [
+    "> 0.5%",
+    "last 2 versions",
+    "Firefox ESR",
+    "not dead",
+    "ie >= 10"
+  ]
 }


### PR DESCRIPTION
Re-ticketed https://github.com/pol-is/polis/issues/166#issuecomment-668343520

Note that a `defaults` helper exists, but I expanded it into its component parts in order to make it more clear, then added `ie >= 10` to clarify what works right now. (If we add ie9 support back in, we should update this)

Would love to get this in as a first pass, and then perhaps expand to a more nuanced set with more thought.

this expands to:

```
and_chr 87
and_ff 83
and_qq 10.4
and_uc 12.12
android 81
baidu 7.12
chrome 87
chrome 86
chrome 85
edge 87
edge 86
firefox 84
firefox 83
firefox 82
firefox 78
ie 11
ie 10
ios_saf 14.0-14.2
ios_saf 13.4-13.7
ios_saf 12.2-12.4
kaios 2.5
op_mini all
op_mob 59
opera 72
opera 71
safari 14
safari 13.1
samsung 13.0
samsung 12.0
```

Would this be a good start? Also, are there older versions of other browsers we'd like to support? (there are some other ways to specify support, including:
- `opera 60` specify specific version
- `chrome > 0 and since 2015` all chrome versions released since 2012 (incl ones with low stats now)
- `cover 95%` to select the minimum set of browsers to cover 95% of visitors
- `cover 95% in alt-eu` to cover 95% visitors from europe
- `cover 95% in alt-af` from africa
- `cover 95% in my data` to cover 95% of visitors extracted [from Polis' google analytics data](https://github.com/browserslist/browserslist-ga)