### PR TITLE
Fixed bug where gulpfile builds into multiple directories sometimes

### DIFF
--- a/client-participation/gulpfile.js
+++ b/client-participation/gulpfile.js
@@ -1023,7 +1023,3 @@ gulp.task('default', [
   "watchForDev",
   ], function() {
 });
-
-var tasks = process.argv.slice(2);
-gulp.start.apply(gulp, tasks);
-


### PR DESCRIPTION
Not sure how we didn't notice this sooner, but it seems that a bit of code at the bottom of the gulpfile means that some parts of run twice, which leads to some files going in one cache folder, and others going into another. Essentially, it means that sometimes vis_bundle.js builds into a folder on its own.

This would seem to explain some odd behavior I'd see every so often, where a rebuild would be necessary.

You can see in the output below that the folder `destRoot` is printed twice, with different paths based on the "second" part of the datetime advancing. When fixed, it only shows once in the output.

### Screenshot

<img width="806" alt="Screen Shot 2021-01-05 at 12 52 18 PM" src="https://user-images.githubusercontent.com/305339/103680951-e0a9be80-4f54-11eb-913d-9b43e421aed5.png">
