### PR TITLE
Remove circular dependency between conversation and user

### DIFF
--- a/server/src/conversation.js
+++ b/server/src/conversation.js
@@ -1,5 +1,4 @@
 const pg = require('./db/pg-query');
-const User = require('./user');
 const MPromise = require('./utils/metered').MPromise;
 const LruCache = require("lru-cache");
 
@@ -37,58 +36,6 @@ function createXidRecordByZid(zid, uid, xid, x_profile_image_url, x_name, x_emai
 
 function getXidRecord(xid, zid) {
   return pg.queryP("select * from xids where xid = ($1) and owner = (select org_id from conversations where zid = ($2));", [xid, zid]);
-}
-
-function getXidRecordByXidOwnerId(xid, owner, zid_optional, x_profile_image_url, x_name, x_email, createIfMissing) {
-  return pg.queryP("select * from xids where xid = ($1) and owner = ($2);", [xid, owner]).then(function(rows) {
-    if (!rows || !rows.length) {
-      console.log('no xInfo yet');
-      if (!createIfMissing) {
-        return null;
-      }
-
-      var shouldCreateXidEntryPromise = !zid_optional ? Promise.resolve(true) : getConversationInfo(zid_optional).then((conv) => {
-        return conv.use_xid_whitelist ? isXidWhitelisted(owner, xid) : Promise.resolve(true);
-      });
-
-      return shouldCreateXidEntryPromise.then((should) => {
-        if (!should) {
-          return null;
-        }
-        return User.createDummyUser().then((newUid) => {
-          console.log('created dummy');
-          return createXidRecord(owner, newUid, xid, x_profile_image_url||null, x_name||null, x_email||null).then(() => {
-            console.log('created xInfo');
-            return [{
-              uid: newUid,
-              owner: owner,
-              xid: xid,
-              x_profile_image_url: x_profile_image_url,
-              x_name: x_name,
-              x_email: x_email,
-            }];
-          });
-        });
-      });
-    }
-    return rows;
-  });
-}
-
-function getXidStuff(xid, zid) {
-  return getXidRecord(xid, zid).then((rows) => {
-    if (!rows || !rows.length) {
-      return "noXidRecord";
-    }
-    let xidRecordForPtpt = rows[0];
-    if (xidRecordForPtpt) {
-      return User.getPidPromise(zid, xidRecordForPtpt.uid, true).then((pidForXid) => {
-        xidRecordForPtpt.pid = pidForXid;
-        return xidRecordForPtpt;
-      });
-    }
-    return xidRecordForPtpt;
-  });
 }
 
 function isXidWhitelisted(owner, xid) {
@@ -150,9 +97,8 @@ function getZidFromConversationId(conversation_id) {
 
 module.exports = {
   createXidRecordByZid,
+  createXidRecord,
   getXidRecord,
-  getXidRecordByXidOwnerId,
-  getXidStuff,
   isXidWhitelisted,
   getConversationInfo,
   getConversationInfoByConversationId,

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -373,7 +373,7 @@ const createDummyUser = User.createDummyUser;
 const getConversationInfo = Conversation.getConversationInfo;
 const getConversationInfoByConversationId = Conversation.getConversationInfoByConversationId;
 const isXidWhitelisted = Conversation.isXidWhitelisted;
-const getXidRecordByXidOwnerId = Conversation.getXidRecordByXidOwnerId;
+const getXidRecordByXidOwnerId = User.getXidRecordByXidOwnerId;
 
 // function doXidOwnerConversationIdAuth(assigner, xid, conversation_id, req, res, next) {
 //   getXidRecordByXidConversationId(xid, conversation_id).then(function(rows) {
@@ -6415,7 +6415,7 @@ Email verified! You can close this tab or hit the back button.
   }
 
   const createXidRecordByZid = Conversation.createXidRecordByZid;
-  const getXidStuff = Conversation.getXidStuff;
+  const getXidStuff = User.getXidStuff;
 
   function handle_PUT_participants_extended(req, res) {
     let zid = req.p.zid;


### PR DESCRIPTION
This is a refactor to resolve a circular dependency issue which was causing an error on calling two XID functions from working properly. You should be able to recreate this by creating a conversation and navigating to https://yourserverid/conversationid?xid=ohdear

It is the first of two commits needed to fix XID functionality in the current `dev` branch.

The commit resolves a `require` loop noticed between `user.js` and `conversation.js,` by refactoring two functions requiring access to the `User` object out of `conversation.js` and into `user.js`: `getXidRecordByXidOwnerId` and the majestically named `getXidStuff`. It also updates references to those functions to call them from the conversation object rather than the user object. 