### PR TITLE
Modify UNIQUE constraint on xids table

### DIFF
--- a/server/postgres/migrations/000000_initial.sql
+++ b/server/postgres/migrations/000000_initial.sql
@@ -414,7 +414,7 @@ CREATE TABLE xids (
     x_email VARCHAR(256), -- http://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address
     created BIGINT DEFAULT now_as_millis(),
     modified BIGINT NOT NULL DEFAULT now_as_millis(),
-    UNIQUE (owner, uid)
+    UNIQUE (owner, xid)
 );
 CREATE INDEX xids_owner_idx ON xids USING btree (owner);
 

--- a/server/postgres/migrations/000000_initial.sql
+++ b/server/postgres/migrations/000000_initial.sql
@@ -414,7 +414,7 @@ CREATE TABLE xids (
     x_email VARCHAR(256), -- http://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address
     created BIGINT DEFAULT now_as_millis(),
     modified BIGINT NOT NULL DEFAULT now_as_millis(),
-    UNIQUE (owner, xid)
+    UNIQUE (owner, uid)
 );
 CREATE INDEX xids_owner_idx ON xids USING btree (owner);
 

--- a/server/src/conversation.js
+++ b/server/src/conversation.js
@@ -5,7 +5,7 @@ const LruCache = require("lru-cache");
 
 function createXidRecord(ownerUid, uid, xid, x_profile_image_url, x_name, x_email) {
   return pg.queryP("insert into xids (owner, uid, xid, x_profile_image_url, x_name, x_email) values ($1, $2, $3, $4, $5, $6) " +
-    "on conflict (owner, xid) do nothing;", [
+    "on conflict (owner, uid) do nothing;", [
       ownerUid,
       uid,
       xid,
@@ -23,7 +23,7 @@ function createXidRecordByZid(zid, uid, xid, x_profile_image_url, x_name, x_emai
         throw new Error("polis_err_xid_not_whitelisted_2");
       }
       return pg.queryP("insert into xids (owner, uid, xid, x_profile_image_url, x_name, x_email) values ((select org_id from conversations where zid = ($1)), $2, $3, $4, $5, $6) " +
-        "on conflict (owner, xid) do nothing;", [
+        "on conflict (owner, uid) do nothing;", [
           zid,
           uid,
           xid,


### PR DESCRIPTION
Resolves a breaking issue running conversations with xids, for which having an `?xid=` attribute set in a conversation would allow the conversation to load, but error when a user attempted to vote or comment. Closes #287.

The issue was caused by an ON CONFLICT clause referencing `xid` and `uid`, without the `xids` table setting those fields as unique.