### PR TITLE
Add ability for moderator to close conversations

### DIFF
--- a/client-admin/package.json
+++ b/client-admin/package.json
@@ -17,6 +17,7 @@
     "deploy:preprod": "./deployPreprod",
     "start": "./x",
     "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
     "test": "jest"
   },
   "author": "Colin Megill",

--- a/client-admin/src/components/conversation-admin/CheckboxField.js
+++ b/client-admin/src/components/conversation-admin/CheckboxField.js
@@ -1,27 +1,32 @@
 import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { Box, Flex, Text, jsx } from 'theme-ui'
+import { Box, Flex, Text } from 'theme-ui'
 import PropTypes from 'prop-types'
 
 import { handleZidMetadataUpdate } from '../../actions'
 
-export const CheckboxField = ({ field, label = '', children, isIntegerBool = false }) => {
+export const CheckboxField = ({
+  field,
+  label = '',
+  children,
+  isIntegerBool = false
+}) => {
   const { zid_metadata } = useSelector(state => state.zid_metadata)
-  const [ state, setState ] = useState(zid_metadata[field])
+  const [state, setState] = useState(zid_metadata[field])
   const dispatch = useDispatch()
 
-  const handleBoolValueChange = (field) => {
-    let val = !state
+  const handleBoolValueChange = field => {
+    const val = !state
     setState(val)
     dispatch(handleZidMetadataUpdate(zid_metadata, field, val))
   }
 
-  const transformBoolToInt = (value) => {
+  const transformBoolToInt = value => {
     return value ? 1 : 0
   }
 
-  const handleIntegerBoolValueChange = (field) => {
-    let val = transformBoolToInt(!state)
+  const handleIntegerBoolValueChange = field => {
+    const val = transformBoolToInt(!state)
     setState(val)
     dispatch(handleZidMetadataUpdate(zid_metadata, field, val))
   }
@@ -33,13 +38,13 @@ export const CheckboxField = ({ field, label = '', children, isIntegerBool = fal
           type="checkbox"
           label={label}
           data-test-id={field}
-          checked={isIntegerBool
-            ? zid_metadata[field] === 1
-            : zid_metadata[field]
+          checked={
+            isIntegerBool ? zid_metadata[field] === 1 : zid_metadata[field]
           }
-          onChange={isIntegerBool
-            ? () => handleIntegerBoolValueChange(field)
-            : () => handleBoolValueChange(field)
+          onChange={
+            isIntegerBool
+              ? () => handleIntegerBoolValueChange(field)
+              : () => handleBoolValueChange(field)
           }
         />
       </Box>
@@ -53,5 +58,5 @@ CheckboxField.propTypes = {
   field: PropTypes.string.isRequired,
   label: PropTypes.string,
   children: PropTypes.string.isRequired,
-  isIntegerBool: PropTypes.bool,
+  isIntegerBool: PropTypes.bool
 }

--- a/client-admin/src/components/conversation-admin/CheckboxField.js
+++ b/client-admin/src/components/conversation-admin/CheckboxField.js
@@ -1,0 +1,57 @@
+import React, { useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { Box, Flex, Text, jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
+
+import { handleZidMetadataUpdate } from '../../actions'
+
+export const CheckboxField = ({ field, label = '', children, isIntegerBool = false }) => {
+  const { zid_metadata } = useSelector(state => state.zid_metadata)
+  const [ state, setState ] = useState(zid_metadata[field])
+  const dispatch = useDispatch()
+
+  const handleBoolValueChange = (field) => {
+    let val = !state
+    setState(val)
+    dispatch(handleZidMetadataUpdate(zid_metadata, field, val))
+  }
+
+  const transformBoolToInt = (value) => {
+    return value ? 1 : 0
+  }
+
+  const handleIntegerBoolValueChange = (field) => {
+    let val = transformBoolToInt(!state)
+    setState(val)
+    dispatch(handleZidMetadataUpdate(zid_metadata, field, val))
+  }
+
+  return (
+    <Flex sx={{ alignItems: 'flex-start', mb: [3] }}>
+      <Box sx={{ flexShrink: 0, position: 'relative', top: -0.5 }}>
+        <input
+          type="checkbox"
+          label={label}
+          data-test-id={field}
+          checked={isIntegerBool
+            ? zid_metadata[field] === 1
+            : zid_metadata[field]
+          }
+          onChange={isIntegerBool
+            ? () => handleIntegerBoolValueChange(field)
+            : () => handleBoolValueChange(field)
+          }
+        />
+      </Box>
+      <Box sx={{ ml: [2], flexShrink: 0, maxWidth: '35em' }}>
+        <Text>{children}</Text>
+      </Box>
+    </Flex>
+  )
+}
+CheckboxField.propTypes = {
+  field: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  children: PropTypes.string.isRequired,
+  isIntegerBool: PropTypes.bool,
+}

--- a/client-admin/src/components/conversation-admin/conversation-config.js
+++ b/client-admin/src/components/conversation-admin/conversation-config.js
@@ -174,6 +174,10 @@ class ConversationConfig extends React.Component {
           Schemes
         </Heading>
 
+        <CheckboxField field="is_active" label="Conversation Is Open">
+          Conversation is open to participation
+        </CheckboxField>
+
         <CheckboxField field="strict_moderation">
           No comments shown without moderator approval
         </CheckboxField>

--- a/client-admin/src/components/conversation-admin/conversation-config.js
+++ b/client-admin/src/components/conversation-admin/conversation-config.js
@@ -71,10 +71,8 @@ class ConversationConfig extends React.Component {
           {this.props.error ? <Text>Error Saving</Text> : null}
         </Box>
 
-        <CheckboxField field="is_active" label="Participants Can Vote">
-          {
-            "Participants can vote. If unchecked, the conversation is considered 'closed' to participation."
-          }
+        <CheckboxField field="is_active" label="Conversation Is Open">
+          Conversation is open. Unchecking disables both voting and commenting.
         </CheckboxField>
 
         <Box sx={{ mb: [3] }}>

--- a/client-admin/src/components/conversation-admin/conversation-config.js
+++ b/client-admin/src/components/conversation-admin/conversation-config.js
@@ -149,11 +149,14 @@ class ConversationConfig extends React.Component {
           Show explanation text above voting and visualization
         </CheckboxField>
 
-        <CheckboxField field="subscribe_type" label="Prompt participants to subscribe to updates" isIntegerBool>
+        <CheckboxField
+          field="subscribe_type"
+          label="Prompt participants to subscribe to updates"
+          isIntegerBool>
           Prompt participants to subscribe to updates. A prompt is shown to
-          users once they finish voting on all available comments. If
-          enabled, participants may optionally provide their email address
-          to receive notifications when there are new comments to vote on.
+          users once they finish voting on all available comments. If enabled,
+          participants may optionally provide their email address to receive
+          notifications when there are new comments to vote on.
         </CheckboxField>
 
         <CheckboxField field="auth_opt_fb" label="Facebook login prompt">
@@ -182,14 +185,16 @@ class ConversationConfig extends React.Component {
           No comments shown without moderator approval
         </CheckboxField>
 
-        <CheckboxField field="auth_needed_to_write" label="Require Auth to Comment">
-          Participants cannot submit comments without first connecting
-          either Facebook or Twitter
+        <CheckboxField
+          field="auth_needed_to_write"
+          label="Require Auth to Comment">
+          Participants cannot submit comments without first connecting either
+          Facebook or Twitter
         </CheckboxField>
 
         <CheckboxField field="auth_needed_to_vote" label="Require Auth to Vote">
-          Participants cannot vote without first connecting either Facebook
-          or Twitter
+          Participants cannot vote without first connecting either Facebook or
+          Twitter
         </CheckboxField>
       </Box>
     )

--- a/client-admin/src/components/conversation-admin/conversation-config.js
+++ b/client-admin/src/components/conversation-admin/conversation-config.js
@@ -10,44 +10,16 @@ import {
 } from '../../actions'
 import ComponentHelpers from '../../util/component-helpers'
 import NoPermission from './no-permission'
-import { Heading, Box, Flex, Text, jsx } from 'theme-ui'
+import { Heading, Box, Text, jsx } from 'theme-ui'
 import emoji from 'react-easy-emoji'
 
+import { CheckboxField } from './CheckboxField'
 import ModerateCommentsSeed from './seed-comment'
 // import ModerateCommentsSeedTweet from "./seed-tweet";
 
 @connect(state => state.user)
 @connect(state => state.zid_metadata)
 class ConversationConfig extends React.Component {
-  handleBoolValueChange(field) {
-    return () => {
-      let val = this[field].checked
-      if (field === 'bgcolor') {
-        // gray checked=default, unchecked white
-        val = val ? 'default' : '#fff'
-      }
-      this.props.dispatch(
-        handleZidMetadataUpdate(this.props.zid_metadata, field, val)
-      )
-    }
-  }
-
-  transformBoolToInt(value) {
-    return value ? 1 : 0
-  }
-
-  handleIntegerBoolValueChange(field) {
-    return () => {
-      this.props.dispatch(
-        handleZidMetadataUpdate(
-          this.props.zid_metadata,
-          field,
-          this.transformBoolToInt(this[field].checked)
-        )
-      )
-    }
-  }
-
   handleStringValueChange(field) {
     return () => {
       let val = this[field].value
@@ -165,114 +137,32 @@ class ConversationConfig extends React.Component {
           Customize the user interface
         </Heading>
 
-        <Flex sx={{ alignItems: 'flex-start', mb: [3] }}>
-          <Box sx={{ flexShrink: 0, position: 'relative', top: -0.5 }}>
-            <input
-              type="checkbox"
-              label="Visualization"
-              data-test-id="vis_type"
-              ref={c => (this.vis_type = c)}
-              checked={this.props.zid_metadata.vis_type === 1}
-              onChange={this.handleIntegerBoolValueChange('vis_type').bind(
-                this
-              )}
-            />
-          </Box>
-          <Box sx={{ ml: [2], flexShrink: 0, maxWidth: '35em' }}>
-            <Text>Participants can see the visualization</Text>
-          </Box>
-        </Flex>
+        <CheckboxField field="vis_type" label="Visualization" isIntegerBool>
+          Participants can see the visualization
+        </CheckboxField>
 
-        <Flex sx={{ alignItems: 'flex-start', mb: [3] }}>
-          <Box sx={{ flexShrink: 0, position: 'relative', top: -0.5 }}>
-            <input
-              type="checkbox"
-              label="Comment form"
-              data-test-id="write_type"
-              ref={c => (this.write_type = c)}
-              checked={this.props.zid_metadata.write_type === 1}
-              onChange={this.handleIntegerBoolValueChange('write_type').bind(
-                this
-              )}
-            />
-          </Box>
-          <Box sx={{ ml: [2], flexShrink: 0, maxWidth: '35em' }}>
-            <Text>Participants can submit comments</Text>
-          </Box>
-        </Flex>
+        <CheckboxField field="write_type" label="Comment form" isIntegerBool>
+          Participants can submit comments
+        </CheckboxField>
 
-        <Flex sx={{ alignItems: 'flex-start', mb: [3] }}>
-          <Box sx={{ flexShrink: 0, position: 'relative', top: -0.5 }}>
-            <input
-              type="checkbox"
-              label="Help text"
-              data-test-id="help_type"
-              ref={c => (this.help_type = c)}
-              checked={this.props.zid_metadata.help_type === 1}
-              onChange={this.handleIntegerBoolValueChange('help_type').bind(
-                this
-              )}
-            />
-          </Box>
-          <Box sx={{ ml: [2], flexShrink: 0, maxWidth: '35em' }}>
-            <Text>Show explanation text above voting and visualization</Text>
-          </Box>
-        </Flex>
+        <CheckboxField field="help_type" label="Help text" isIntegerBool>
+          Show explanation text above voting and visualization
+        </CheckboxField>
 
-        <Flex sx={{ alignItems: 'flex-start', mb: [3] }}>
-          <Box sx={{ flexShrink: 0, position: 'relative', top: -0.5 }}>
-            <input
-              type="checkbox"
-              label="Prompt participants to subscribe to updates"
-              data-test-id="subscribe_type"
-              ref={c => (this.subscribe_type = c)}
-              checked={this.props.zid_metadata.subscribe_type === 1}
-              onChange={this.handleIntegerBoolValueChange(
-                'subscribe_type'
-              ).bind(this)}
-            />
-          </Box>
-          <Box sx={{ ml: [2], flexShrink: 0, maxWidth: '35em' }}>
-            <Text>
-              Prompt participants to subscribe to updates. A prompt is shown to
-              users once they finish voting on all available comments. If
-              enabled, participants may optionally provide their email address
-              to receive notifications when there are new comments to vote on.
-            </Text>
-          </Box>
-        </Flex>
+        <CheckboxField field="subscribe_type" label="Prompt participants to subscribe to updates" isIntegerBool>
+          Prompt participants to subscribe to updates. A prompt is shown to
+          users once they finish voting on all available comments. If
+          enabled, participants may optionally provide their email address
+          to receive notifications when there are new comments to vote on.
+        </CheckboxField>
 
-        <Flex sx={{ alignItems: 'flex-start', mb: [3] }}>
-          <Box sx={{ flexShrink: 0, position: 'relative', top: -0.5 }}>
-            <input
-              type="checkbox"
-              label="Facebook login prompt"
-              data-test-id="auth_opt_fb"
-              ref={c => (this.auth_opt_fb = c)}
-              checked={this.props.zid_metadata.auth_opt_fb}
-              onChange={this.handleBoolValueChange('auth_opt_fb').bind(this)}
-            />
-          </Box>
-          <Box sx={{ ml: [2], flexShrink: 0, maxWidth: '35em' }}>
-            <Text>Show Facebook login prompt</Text>
-          </Box>
-        </Flex>
+        <CheckboxField field="auth_opt_fb" label="Facebook login prompt">
+          Show Facebook login prompt
+        </CheckboxField>
 
-        <Flex sx={{ alignItems: 'flex-start', mb: [3] }}>
-          <Box sx={{ flexShrink: 0, position: 'relative', top: -0.5 }}>
-            <input
-              type="checkbox"
-              label="Twitter login prompt"
-              data-test-id="auth_opt_tw"
-              ref={c => (this.auth_opt_tw = c)}
-              checked={this.props.zid_metadata.auth_opt_tw}
-              onChange={this.handleBoolValueChange('auth_opt_tw').bind(this)}
-            />
-          </Box>
-          <Box sx={{ ml: [2], flexShrink: 0, maxWidth: '35em' }}>
-            <Text>Show Twitter login prompt</Text>
-          </Box>
-        </Flex>
+        <CheckboxField field="auth_opt_tw" label="Twitter login prompt">
+          Show Twitter login prompt
+        </CheckboxField>
 
         <Heading
           as="h6"
@@ -284,64 +174,19 @@ class ConversationConfig extends React.Component {
           Schemes
         </Heading>
 
-        <Flex sx={{ alignItems: 'flex-start', mb: [3] }}>
-          <Box sx={{ flexShrink: 0, position: 'relative', top: -0.5 }}>
-            <input
-              type="checkbox"
-              data-test-id="strict_moderation"
-              ref={c => (this.strict_moderation = c)}
-              checked={this.props.zid_metadata.strict_moderation}
-              onChange={this.handleBoolValueChange('strict_moderation').bind(
-                this
-              )}
-            />
-          </Box>
-          <Box sx={{ ml: [2], flexShrink: 0, maxWidth: '35em' }}>
-            <Text>No comments shown without moderator approval</Text>
-          </Box>
-        </Flex>
+        <CheckboxField field="strict_moderation">
+          No comments shown without moderator approval
+        </CheckboxField>
 
-        <Flex sx={{ alignItems: 'flex-start', mb: [3] }}>
-          <Box sx={{ flexShrink: 0, position: 'relative', top: -0.5 }}>
-            <input
-              type="checkbox"
-              label="Require Auth to Comment"
-              data-test-id="auth_needed_to_write"
-              ref={c => (this.auth_needed_to_write = c)}
-              checked={this.props.zid_metadata.auth_needed_to_write}
-              onChange={this.handleBoolValueChange('auth_needed_to_write').bind(
-                this
-              )}
-            />
-          </Box>
-          <Box sx={{ ml: [2], flexShrink: 0, maxWidth: '35em' }}>
-            <Text>
-              Participants cannot submit comments without first connecting
-              either Facebook or Twitter
-            </Text>
-          </Box>
-        </Flex>
+        <CheckboxField field="auth_needed_to_write" label="Require Auth to Comment">
+          Participants cannot submit comments without first connecting
+          either Facebook or Twitter
+        </CheckboxField>
 
-        <Flex sx={{ alignItems: 'flex-start', mb: [3] }}>
-          <Box sx={{ flexShrink: 0, position: 'relative', top: -0.5 }}>
-            <input
-              type="checkbox"
-              label="Require Auth to Vote"
-              data-test-id="auth_needed_to_vote"
-              ref={c => (this.auth_needed_to_vote = c)}
-              checked={this.props.zid_metadata.auth_needed_to_vote}
-              onChange={this.handleBoolValueChange('auth_needed_to_vote').bind(
-                this
-              )}
-            />
-          </Box>
-          <Box sx={{ ml: [2], flexShrink: 0, maxWidth: '35em' }}>
-            <Text>
-              Participants cannot vote without first connecting either Facebook
-              or Twitter
-            </Text>
-          </Box>
-        </Flex>
+        <CheckboxField field="auth_needed_to_vote" label="Require Auth to Vote">
+          Participants cannot vote without first connecting either Facebook
+          or Twitter
+        </CheckboxField>
       </Box>
     )
   }

--- a/client-admin/src/components/conversation-admin/conversation-config.js
+++ b/client-admin/src/components/conversation-admin/conversation-config.js
@@ -71,8 +71,8 @@ class ConversationConfig extends React.Component {
           {this.props.error ? <Text>Error Saving</Text> : null}
         </Box>
 
-        <CheckboxField field="is_active" label="Conversation Is Active">
-          Conversation is ACTIVE. Participants can vote and comment.
+        <CheckboxField field="is_active" label="Participants Can Vote">
+          {"Participants can vote. If unchecked, the conversation is considered 'closed' to participation."}
         </CheckboxField>
 
         <Box sx={{ mb: [3] }}>

--- a/client-admin/src/components/conversation-admin/conversation-config.js
+++ b/client-admin/src/components/conversation-admin/conversation-config.js
@@ -70,6 +70,11 @@ class ConversationConfig extends React.Component {
           )}
           {this.props.error ? <Text>Error Saving</Text> : null}
         </Box>
+
+        <CheckboxField field="is_active" label="Conversation Is Active">
+          Conversation is ACTIVE. Participants can vote and comment.
+        </CheckboxField>
+
         <Box sx={{ mb: [3] }}>
           <Text sx={{ mb: [2] }}>Topic</Text>
           <input
@@ -177,10 +182,6 @@ class ConversationConfig extends React.Component {
           }}>
           Schemes
         </Heading>
-
-        <CheckboxField field="is_active" label="Conversation Is Open">
-          Conversation is open to participation
-        </CheckboxField>
 
         <CheckboxField field="strict_moderation">
           No comments shown without moderator approval

--- a/client-admin/src/components/conversation-admin/conversation-config.js
+++ b/client-admin/src/components/conversation-admin/conversation-config.js
@@ -72,7 +72,9 @@ class ConversationConfig extends React.Component {
         </Box>
 
         <CheckboxField field="is_active" label="Participants Can Vote">
-          {"Participants can vote. If unchecked, the conversation is considered 'closed' to participation."}
+          {
+            "Participants can vote. If unchecked, the conversation is considered 'closed' to participation."
+          }
         </CheckboxField>
 
         <Box sx={{ mb: [3] }}>

--- a/client-admin/src/components/conversation-admin/conversation-config.js
+++ b/client-admin/src/components/conversation-admin/conversation-config.js
@@ -83,6 +83,7 @@ class ConversationConfig extends React.Component {
               border: '1px solid',
               borderColor: 'mediumGray'
             }}
+            data-test-id="topic"
             onBlur={this.handleStringValueChange('topic').bind(this)}
             onChange={this.handleConfigInputTyping('topic').bind(this)}
             defaultValue={this.props.zid_metadata.topic}

--- a/e2e/cypress/integration/polis/client-admin/configure.spec.js
+++ b/e2e/cypress/integration/polis/client-admin/configure.spec.js
@@ -1,0 +1,20 @@
+describe('Conversation: Closing', () => {
+  before(function () {
+    cy.createConvo('moderator').then(() => {
+      cy.visit(`/m/${this.convoId}`)
+      // We must set the topic in order for "Closed" badge to display.
+      // TODO: Allow badge to display without topic set.
+      cy.get('input[data-test-id="topic"]').type('Dummy topic')
+      cy.seedComment('Some seed statement', this.convoId)
+      cy.get('input[data-test-id="is_active"]').uncheck().should('not.be.checked')
+    })
+  })
+
+  it('responds properly to being closed', function () {
+    cy.login('participant')
+    cy.visit(`/${this.convoId}`)
+    cy.get('.no_you_vote').should('be.visible')
+    cy.get('#readReactView').should('not.be.visible')
+    cy.get('#commentFormParent').should('not.be.visible')
+  })
+})


### PR DESCRIPTION
Resolves #126

The scope of this PR is:
- [x] it refactors the checkbox elements into their own component
- [x] it adds a new checkbox in admin interface, to toggle `is_active` metadata
- [x] add e2e test to confirm closing works properly
- ~~add e2e test to confirm default convo settings are correct~~ `wontfix` see https://github.com/pol-is/polis/pull/770#issuecomment-763127105

## Screenshots

<img width="789" alt="Screen Shot 2021-01-19 at 1 13 36 PM" src="https://user-images.githubusercontent.com/305339/105075928-669b2e80-5a58-11eb-85d8-f8e9711b8b69.png">
<img width="853" alt="Screen Shot 2021-01-19 at 1 14 58 PM" src="https://user-images.githubusercontent.com/305339/105075931-6733c500-5a58-11eb-9f81-f56079ffcdcd.png">
