### PR TITLE
Fix regression of default settings on convo creation

### DIFF
--- a/e2e/cypress/integration/polis/client-admin/configure.spec.js
+++ b/e2e/cypress/integration/polis/client-admin/configure.spec.js
@@ -22,14 +22,7 @@ describe('Conversation: Configure', () => {
 
   describe('Defaults', () => {
     before(function () {
-      cy.createConvo('moderator').then(() => {
-        cy.visit(`/m/${this.convoId}`)
-        // We must set the topic in order for "Closed" badge to display.
-        // TODO: Allow badge to display without topic set.
-        cy.get('input[data-test-id="topic"]').type('Dummy topic')
-        cy.seedComment('Some seed statement', this.convoId)
-        cy.get('input[data-test-id="is_active"]').uncheck().should('not.be.checked')
-      })
+      cy.createConvo('moderator')
     })
 
     it('creates with proper defaults', function () {

--- a/e2e/cypress/integration/polis/client-admin/configure.spec.js
+++ b/e2e/cypress/integration/polis/client-admin/configure.spec.js
@@ -1,20 +1,52 @@
-describe('Conversation: Closing', () => {
-  before(function () {
-    cy.createConvo('moderator').then(() => {
-      cy.visit(`/m/${this.convoId}`)
-      // We must set the topic in order for "Closed" badge to display.
-      // TODO: Allow badge to display without topic set.
-      cy.get('input[data-test-id="topic"]').type('Dummy topic')
-      cy.seedComment('Some seed statement', this.convoId)
-      cy.get('input[data-test-id="is_active"]').uncheck().should('not.be.checked')
+describe('Conversation: Configure', () => {
+  describe('Closing', () => {
+    before(function () {
+      cy.createConvo('moderator').then(() => {
+        cy.visit(`/m/${this.convoId}`)
+        // We must set the topic in order for "Closed" badge to display.
+        // TODO: Allow badge to display without topic set.
+        cy.get('input[data-test-id="topic"]').type('Dummy topic')
+        cy.seedComment('Some seed statement', this.convoId)
+        cy.get('input[data-test-id="is_active"]').uncheck().should('not.be.checked')
+      })
+    })
+
+    it('responds properly to being closed', function () {
+      cy.login('participant')
+      cy.visit(`/${this.convoId}`)
+      cy.get('.no_you_vote').should('be.visible')
+      cy.get('#readReactView').should('not.be.visible')
+      cy.get('#commentFormParent').should('not.be.visible')
     })
   })
 
-  it('responds properly to being closed', function () {
-    cy.login('participant')
-    cy.visit(`/${this.convoId}`)
-    cy.get('.no_you_vote').should('be.visible')
-    cy.get('#readReactView').should('not.be.visible')
-    cy.get('#commentFormParent').should('not.be.visible')
+  describe('Defaults', () => {
+    before(function () {
+      cy.createConvo('moderator').then(() => {
+        cy.visit(`/m/${this.convoId}`)
+        // We must set the topic in order for "Closed" badge to display.
+        // TODO: Allow badge to display without topic set.
+        cy.get('input[data-test-id="topic"]').type('Dummy topic')
+        cy.seedComment('Some seed statement', this.convoId)
+        cy.get('input[data-test-id="is_active"]').uncheck().should('not.be.checked')
+      })
+    })
+
+    it('creates with proper defaults', function () {
+      cy.visit(`/m/${this.convoId}`)
+      // Customize section
+      cy.get('input[data-test-id="vis_type"]').should('not.be.checked')
+      cy.get('input[data-test-id="write_type"]').should('be.checked')
+      cy.get('input[data-test-id="help_type"]').should('be.checked')
+      cy.get('input[data-test-id="subscribe_type"]').should('be.checked')
+      cy.get('input[data-test-id="auth_opt_fb"]').should('be.checked')
+      cy.get('input[data-test-id="auth_opt_tw"]').should('be.checked')
+
+      // Schemes section
+      cy.get('input[data-test-id="is_active"]').should('be.checked')
+      cy.get('input[data-test-id="strict_moderation"]').should('not.be.checked')
+      cy.get('input[data-test-id="auth_needed_to_write"]').should('be.checked')
+      cy.get('input[data-test-id="auth_needed_to_vote"]').should('not.be.checked')
+    })
   })
 })

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -73,6 +73,9 @@ const cookies = require('./utils/cookies');
 const COOKIES = cookies.COOKIES;
 const COOKIES_TO_CLEAR = cookies.COOKIES_TO_CLEAR;
 
+const constants = require('./utils/constants');
+const DEFAULTS = constants.DEFAULTS;
+
 const User = require('./user');
 const Conversation = require('./conversation');
 const Session = require('./session');
@@ -8178,11 +8181,11 @@ Email verified! You can close this tab or hit the back button.
           context: req.p.context || null,
           owner_sees_participation_stats: !!req.p.owner_sees_participation_stats,
           // Set defaults for fields that aren't set at postgres level.
-          auth_needed_to_vote: req.p.auth_needed_to_vote || false,
-          auth_needed_to_write: req.p.auth_needed_to_write || true,
-          auth_opt_allow_3rdparty: req.p.auth_opt_allow_3rdparty || true,
-          auth_opt_fb: req.p.auth_opt_fb || true,
-          auth_opt_tw: req.p.auth_opt_tw || true,
+          auth_needed_to_vote: req.p.auth_needed_to_vote || DEFAULTS.auth_needed_to_vote,
+          auth_needed_to_write: req.p.auth_needed_to_write || DEFAULTS.auth_needed_to_write,
+          auth_opt_allow_3rdparty: req.p.auth_opt_allow_3rdparty || DEFAULTS.auth_opt_allow_3rdparty,
+          auth_opt_fb: req.p.auth_opt_fb || DEFAULTS.auth_opt_fb,
+          auth_opt_tw: req.p.auth_opt_tw || DEFAULTS.auth_opt_tw,
         }).returning('*').toString();
 
         pgQuery(q, [], function(err, result) {
@@ -11227,9 +11230,9 @@ CREATE TABLE slack_user_invites (
     }).then(function(a) {
       let conv = a[0];
 
-      let auth_opt_allow_3rdparty = ifDefinedFirstElseSecond(conv.auth_opt_allow_3rdparty, true);
-      let auth_opt_fb_computed = auth_opt_allow_3rdparty && ifDefinedFirstElseSecond(conv.auth_opt_fb, true);
-      let auth_opt_tw_computed = auth_opt_allow_3rdparty && ifDefinedFirstElseSecond(conv.auth_opt_tw, true);
+      let auth_opt_allow_3rdparty = ifDefinedFirstElseSecond(conv.auth_opt_allow_3rdparty, DEFAULTS.auth_opt_allow_3rdparty);
+      let auth_opt_fb_computed = auth_opt_allow_3rdparty && ifDefinedFirstElseSecond(conv.auth_opt_fb, DEFAULTS.auth_opt_fb);
+      let auth_opt_tw_computed = auth_opt_allow_3rdparty && ifDefinedFirstElseSecond(conv.auth_opt_tw, DEFAULTS.auth_opt_tw);
 
       conv = {
         topic: conv.topic,
@@ -11245,8 +11248,8 @@ CREATE TABLE slack_user_invites (
         help_color: conv.help_color,
         help_bgcolor: conv.help_bgcolor,
         style_btn: conv.style_btn,
-        auth_needed_to_vote: ifDefinedFirstElseSecond(conv.auth_needed_to_vote, false),
-        auth_needed_to_write: ifDefinedFirstElseSecond(conv.auth_needed_to_write, true),
+        auth_needed_to_vote: ifDefinedFirstElseSecond(conv.auth_needed_to_vote, DEFAULTS.auth_needed_to_vote),
+        auth_needed_to_write: ifDefinedFirstElseSecond(conv.auth_needed_to_write, DEFAULTS.auth_needed_to_write),
         auth_opt_allow_3rdparty: auth_opt_allow_3rdparty,
         auth_opt_fb_computed: auth_opt_fb_computed,
         auth_opt_tw_computed: auth_opt_tw_computed,

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -8177,6 +8177,12 @@ Email verified! You can close this tab or hit the back button.
           strict_moderation: req.p.strict_moderation,
           context: req.p.context || null,
           owner_sees_participation_stats: !!req.p.owner_sees_participation_stats,
+          // Set defaults for fields that aren't set at postgres level.
+          auth_needed_to_vote: req.p.auth_needed_to_vote || false,
+          auth_needed_to_write: req.p.auth_needed_to_write || true,
+          auth_opt_allow_3rdparty: req.p.auth_opt_allow_3rdparty || true,
+          auth_opt_fb: req.p.auth_opt_fb || true,
+          auth_opt_tw: req.p.auth_opt_tw || true,
         }).returning('*').toString();
 
         pgQuery(q, [], function(err, result) {

--- a/server/src/utils/constants.js
+++ b/server/src/utils/constants.js
@@ -1,0 +1,11 @@
+const DEFAULTS = {
+  auth_needed_to_vote: false,
+  auth_needed_to_write: true,
+  auth_opt_allow_3rdparty: true,
+  auth_opt_fb: true,
+  auth_opt_tw: true,
+};
+
+module.exports = {
+  DEFAULTS,
+};


### PR DESCRIPTION
Re-ticketed from https://github.com/pol-is/polis/pull/770#issuecomment-763127105

> I discovered that, some checkboxes started defaulting to unchecked much longer ago. (It affects any convo setting checkboxes with data stored as bools instead of ints.)
>
> I'm currently running git-bisect builds to determine when this issue was introduced, and then I'll fix it and we'll have the e2e test I wrote. (It's a little out-of-scope for this PR, I'll create another PR for this bug, and let this one stand on its own.)

- these fields are returned from zid_metadata with `null` as their initial state.
- this likely was introduced during refactor of server with PDIS fork improvements

## Reviewed Commits

- 4f01fb8f BAD -- regression existed (5 months ago)
- 2c383150 WONT RUN
- ade5a07f BAD
- 4fe726e8 BAD commit that merged me admin ui..?
- 7f772432 WONT BUILD
- 915431a90 WONT BUILD
- 9d74bbb7 BAD
- 5ac29b72 BAD docker support merged

## To Do

- [x] write e2e test
- [x] ~~find regression commit~~ never found it. very old.
- [x] fix it

## Screenshots

### Hosted Pol.is (desired)

<img width="1388" alt="Screen Shot 2021-01-19 at 3 48 07 PM" src="https://user-images.githubusercontent.com/305339/105091471-dd8ef200-5a6d-11eb-82e3-3de7b2b3895d.png">

### Built polis (regression)

<img width="1388" alt="Screen Shot 2021-01-19 at 3 47 53 PM" src="https://user-images.githubusercontent.com/305339/105091458-d9fb6b00-5a6d-11eb-91ff-6c31b9e7b63b.png">