### PR TITLE
Add e2e tests for embed features

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -60,7 +60,7 @@ jobs:
           echo EMAIL_TRANSPORT_TYPES=mailgun,aws-ses,nonexistent,maildev >> server/docker-dev.env
 
       - name: Ensure embed test html is served
-      - run: cp e2e/cypress/fixtures/html/embed.html client-admin/embed.html
+        run: cp e2e/cypress/fixtures/html/embed.html client-admin/embed.html
 
       - name: Serve app via docker-compose
         run: docker-compose up --detach

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -59,6 +59,11 @@ jobs:
           # maildev: catch-all dev email server running in container (will work)
           echo EMAIL_TRANSPORT_TYPES=mailgun,aws-ses,nonexistent,maildev >> server/docker-dev.env
 
+      - name: Serve embed test assets
+        run: |
+          npm install --global serve forever
+          forever start -c serve e2e/cypress/fixtures/html
+
       - name: Serve app via docker-compose
         run: docker-compose up --detach
 

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -59,10 +59,8 @@ jobs:
           # maildev: catch-all dev email server running in container (will work)
           echo EMAIL_TRANSPORT_TYPES=mailgun,aws-ses,nonexistent,maildev >> server/docker-dev.env
 
-      - name: Serve embed test assets
-        run: |
-          npm install --global serve forever
-          forever start -c serve e2e/cypress/fixtures/html
+      - name: Ensure embed test html is served
+      - run: cp e2e/cypress/fixtures/html/embed.html client-admin/embed.html
 
       - name: Serve app via docker-compose
         run: docker-compose up --detach

--- a/client-admin/src/components/conversation-admin/conversation-config.js
+++ b/client-admin/src/components/conversation-admin/conversation-config.js
@@ -110,6 +110,7 @@ class ConversationConfig extends React.Component {
               border: '1px solid',
               borderColor: 'mediumGray'
             }}
+            data-test-id="description"
             onBlur={this.handleStringValueChange('description').bind(this)}
             onChange={this.handleConfigInputTyping('description').bind(this)}
             defaultValue={this.props.zid_metadata.description}

--- a/client-admin/src/components/conversation-admin/share-and-embed.js
+++ b/client-admin/src/components/conversation-admin/share-and-embed.js
@@ -14,7 +14,7 @@ import NoPermission from './no-permission'
 class ShareAndEmbed extends React.Component {
   constructEmbeddedOnMarkup() {
     return (
-      <p>
+      <p data-test-id="embed-page">
         {'Embedded on: '}
         <a
           style={{ color: 'black' }}

--- a/client-admin/src/components/conversations-and-account/conversation.js
+++ b/client-admin/src/components/conversations-and-account/conversation.js
@@ -10,7 +10,9 @@ function Conversation({ c, i, goToConversation }) {
       key={i}>
       <Text sx={{ fontWeight: 700, mb: [2] }}>{c.topic}</Text>
       <Text>{c.description}</Text>
-      <Text data-test-id="embed-page">{c.parent_url ? `Embedded on ${c.parent_url}` : null}</Text>
+      <Text data-test-id="embed-page">
+        {c.parent_url ? `Embedded on ${c.parent_url}` : null}
+      </Text>
       <Text sx={{ mt: [2] }}>{c.participant_count} participants</Text>
     </Card>
   )

--- a/client-admin/src/components/conversations-and-account/conversation.js
+++ b/client-admin/src/components/conversations-and-account/conversation.js
@@ -10,7 +10,7 @@ function Conversation({ c, i, goToConversation }) {
       key={i}>
       <Text sx={{ fontWeight: 700, mb: [2] }}>{c.topic}</Text>
       <Text>{c.description}</Text>
-      <Text>{c.parent_url ? `Embedded on ${c.parent_url}` : null}</Text>
+      <Text data-test-id="embed-page">{c.parent_url ? `Embedded on ${c.parent_url}` : null}</Text>
       <Text sx={{ mt: [2] }}>{c.participant_count} participants</Text>
     </Card>
   )

--- a/client-participation/api/embed.js
+++ b/client-participation/api/embed.js
@@ -3,7 +3,7 @@
   var firstRun = !window.polis._hasRun;
   polis._hasRun = 1;
   var iframes = [];
-  var polisUrl = "https://pol.is";
+  var polisUrl = "https://<%= polisHostName %>";
   var maxHeightsSeen = {};
 
   polis.on = polis.on || {};
@@ -212,7 +212,7 @@
     window.addEventListener("message", function(event) {
       var data = event.data||{};
       var domain = event.origin.replace(/^https?:\/\//,'');
-      if (!domain.match(/(^|\.)pol.is$/)) {
+      if (!domain.match(/(^|\.)<%= polisHostName %>$/)) {
         return;
       }
 

--- a/client-participation/gulpfile.js
+++ b/client-participation/gulpfile.js
@@ -237,7 +237,7 @@ gulp.task('embedJs', function() {
     'api/twitterAuthReturn.html',
   ])
   .pipe(template({
-    polisHostName: polisConfig.HOSTNAME || 'pol.is',
+    polisHostName: polisConfig.SERVICE_HOSTNAME || 'pol.is',
   }))
   // .pipe(template({
   //   polisHostName: (preprodMode ? "preprod.pol.is" : "pol.is"),

--- a/client-participation/gulpfile.js
+++ b/client-participation/gulpfile.js
@@ -235,7 +235,10 @@ gulp.task('embedJs', function() {
     'api/embed.js',
     'api/embedPreprod.js',
     'api/twitterAuthReturn.html',
-    ])
+  ])
+  .pipe(template({
+    polisHostName: polisConfig.HOSTNAME || 'pol.is',
+  }))
   // .pipe(template({
   //   polisHostName: (preprodMode ? "preprod.pol.is" : "pol.is"),
   // }))

--- a/client-participation/polis.config.template.js
+++ b/client-participation/polis.config.template.js
@@ -14,6 +14,10 @@ module.exports = {
   //SERVICE_URL: "http://localhost:5000", // local server; recommended for dev
   SERVICE_URL: "http:localhost:5000",
 
+  // Used for setting appropriate hostname for embedding.
+  //SERVICE_HOSTNAME: "123.45.67.89.xip.io",
+  SERVICE_HOSTNAME: "localhost",
+
   // Note that this must match the participation client port specified in polisServer instance
   PORT: 5001,
 

--- a/e2e/cypress/fixtures/html/embed.html
+++ b/e2e/cypress/fixtures/html/embed.html
@@ -5,7 +5,7 @@
     if (event.target.readyState === 'complete') {
       const urlParams = new URLSearchParams(window.location.search);
       let params = paramsToObject(urlParams.entries());
-      params['data-conversation_id'] = params['data-conversation_id'] || '2demo';
+      //params['data-conversation_id'] = params['data-conversation_id'] || '2demo';
       let polisDomain = params.polisDomain || 'pol.is';
       const dataParams = Object.keys(params)
         .filter(key => key.startsWith('data-'))
@@ -29,7 +29,8 @@
   function setConvoAttrs (polisDomain, dataParams) {
     // Handles the initial handshake between server and iframe
     let messageElem = document.getElementById('message');
-    if (typeof dataParams.conversation_id === 'undefined') {
+    // Disabling errors for now
+    if (false && typeof dataParams.conversation_id === 'undefined') {
       messageElem.innerHTML = getMessage('error');
     } else {
       messageElem.innerHTML = getMessage('success');

--- a/e2e/cypress/fixtures/html/embed.html
+++ b/e2e/cypress/fixtures/html/embed.html
@@ -3,30 +3,37 @@
 
   document.addEventListener('readystatechange', event => {
     if (event.target.readyState === 'complete') {
-      let polisDomain = getQueryParam('polisDomain') || 'pol.is';
-      let convoId = getQueryParam('convoId') || '2demo';
-      let xid = getQueryParam('xid');
-      setConvoAttrs(polisDomain, convoId, xid);
+      const urlParams = new URLSearchParams(window.location.search);
+      let params = paramsToObject(urlParams.entries());
+      params['data-conversation_id'] = params['data-conversation_id'] || '2demo';
+      let polisDomain = params.polisDomain || 'pol.is';
+      const dataParams = Object.keys(params)
+        .filter(key => key.startsWith('data-'))
+        .reduce((obj, key) => {
+          // Remove data-* prefix from key when setting.
+          obj[key.replace('data-', '')] = params[key];
+          return obj;
+        }, {});
+      setConvoAttrs(polisDomain, dataParams);
     }
   });
 
-  function getQueryParam (name) {
-    const queryParamRe = '[?&]' + encodeURIComponent(name) + '=([^&]*)';
-    const queryString = location.search;
-    const match = new RegExp(queryParamRe).exec(queryString);
-    if (match) {
-      return decodeURIComponent(match[1]);
+  function paramsToObject(entries) {
+    const result = {}
+    for(const [key, value] of entries) { // each 'entry' is a [key, value] tupple
+      result[key] = value;
     }
+    return result;
   }
 
-  function setConvoAttrs (polisDomain, convoId, xid) {
+  function setConvoAttrs (polisDomain, dataParams) {
     // Handles the initial handshake between server and iframe
     let messageElem = document.getElementById('message');
-    if (typeof convoId === 'undefined') {
+    if (typeof dataParams.conversation_id === 'undefined') {
       messageElem.innerHTML = getMessage('error');
     } else {
       messageElem.innerHTML = getMessage('success');
-      attachPolis(polisDomain, convoId, xid);
+      attachPolis(polisDomain, dataParams);
     }
   }
 
@@ -34,7 +41,7 @@
     let message;
     switch (type) {
       case 'error':
-        message = "You have a missing or malformed value in polisUrl, convoId or xid in your URL."
+        message = "You have a missing or malformed value in polisUrl, or data- params in your URL."
         break;
       case 'success':
         message=null;
@@ -43,16 +50,19 @@
     return message;
   }
 
-  function attachPolis (polisDomain, convoId, xid) {
+  function attachPolis (polisDomain, dataParams) {
     let polisContainer = document.getElementById('polis-container');
-    let polisHtml = `<div class="polis" data-conversation_id="${convoId}" data-xid="${xid}"></div>`
+
+    let polisElem = document.createElement('div');
+    polisElem.className = 'polis';
+    Object.assign(polisElem.dataset, dataParams)
 
     let embedScript = document.createElement('script');
     embedScript.src = `//${polisDomain}/embed.js`;
     embedScript.type = 'text/javascript';
     embedScript.async = true;
 
-    polisContainer.innerHTML = polisHtml;
+    polisContainer.innerHTML = polisElem.outerHTML;
     polisContainer.appendChild(embedScript);
   }
 </script>

--- a/e2e/cypress/fixtures/html/embed.html
+++ b/e2e/cypress/fixtures/html/embed.html
@@ -1,0 +1,60 @@
+<script type="text/javascript">
+  // Inspiration: https://github.com/Demos-thinktank/dynata-id/blob/master/site-content/js/index.js
+
+  document.addEventListener('readystatechange', event => {
+    if (event.target.readyState === 'complete') {
+      let polisDomain = getQueryParam('polisDomain') || 'pol.is';
+      let convoId = getQueryParam('convoId') || '2demo';
+      let xid = getQueryParam('xid');
+      setConvoAttrs(polisDomain, convoId, xid);
+    }
+  });
+
+  function getQueryParam (name) {
+    const queryParamRe = '[?&]' + encodeURIComponent(name) + '=([^&]*)';
+    const queryString = location.search;
+    const match = new RegExp(queryParamRe).exec(queryString);
+    if (match) {
+      return decodeURIComponent(match[1]);
+    }
+  }
+
+  function setConvoAttrs (polisDomain, convoId, xid) {
+    // Handles the initial handshake between server and iframe
+    let messageElem = document.getElementById('message');
+    if (typeof convoId === 'undefined') {
+      messageElem.innerHTML = getMessage('error');
+    } else {
+      messageElem.innerHTML = getMessage('success');
+      attachPolis(polisDomain, convoId, xid);
+    }
+  }
+
+  function getMessage (type) {
+    let message;
+    switch (type) {
+      case 'error':
+        message = "You have a missing or malformed value in polisUrl, convoId or xid in your URL."
+        break;
+      case 'success':
+        message=null;
+        break;
+    }
+    return message;
+  }
+
+  function attachPolis (polisDomain, convoId, xid) {
+    let polisContainer = document.getElementById('polis-container');
+    let polisHtml = `<div class="polis" data-conversation_id="${convoId}" data-xid="${xid}"></div>`
+
+    let embedScript = document.createElement('script');
+    embedScript.src = `//${polisDomain}/embed.js`;
+    embedScript.type = 'text/javascript';
+    embedScript.async = true;
+
+    polisContainer.innerHTML = polisHtml;
+    polisContainer.appendChild(embedScript);
+  }
+</script>
+<p id="message">Loading...</p>
+<div id="polis-container"></div>

--- a/e2e/cypress/integration/polis/client-participation/embeds.spec.js
+++ b/e2e/cypress/integration/polis/client-participation/embeds.spec.js
@@ -127,7 +127,7 @@ describe('Embedded Conversations', () => {
   // See: https://roamresearch.com/#/app/polis-methods/page/hwRb6tXIA
 
   // This is currently broken and has a pending PR to fix.
-  // TODO fix
+  // TODO fix later
   it.skip('creates xid when provided', function () {
     cy.logout()
     cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-conversation_id=${this.convoId}`)
@@ -153,16 +153,4 @@ describe('Embedded Conversations', () => {
   })
 
   // TODO: test postMessage events
-
-  // TODO: test integration (that creates new convos), and related data-* params:
-  //   - data-subscribe_type
-  //   - data-show_share
-  //   - data-auth_needed_to_vote
-  //   - data-auth_needed_to_write
-  //   - data-auth_opt_fb
-  //   - data-auth_opt_tw
-  //   - data-auth_opt_allow_3rdparty
-  //   - data-dwok
-  //   - data-topic
-  //   - data-bg_white
 })

--- a/e2e/cypress/integration/polis/client-participation/embeds.spec.js
+++ b/e2e/cypress/integration/polis/client-participation/embeds.spec.js
@@ -1,0 +1,25 @@
+describe('Embedded Conversations', () => {
+  // This test requires overriding client-admin/embed.html with
+  // e2e/cypress/fixtures/html/embeds.html
+  const POLIS_DOMAIN = Cypress.config().baseUrl.replace('https://', '')
+
+  beforeEach(function () {
+    cy.createConvo('moderator').then(() => {
+      cy.seedComment('Seed statement 1', this.convoId)
+    })
+  })
+
+  it('renders a default embed', function () {
+    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&convoId=${this.convoId}`)
+    cy.frameLoaded(`#polis_${this.convoId}`)
+    cy.iframe(`#polis_${this.convoId}`).find('#agreeButton').should('be.visible')
+  })
+
+  // TODO: test each data-* attribute
+
+  // TODO: test xid usage
+
+  // TODO: test postMessage events
+
+  // TODO: test integration (that creates new convos)
+})

--- a/e2e/cypress/integration/polis/client-participation/embeds.spec.js
+++ b/e2e/cypress/integration/polis/client-participation/embeds.spec.js
@@ -2,24 +2,167 @@ describe('Embedded Conversations', () => {
   // This test requires overriding client-admin/embed.html with
   // e2e/cypress/fixtures/html/embeds.html
   const POLIS_DOMAIN = Cypress.config().baseUrl.replace('https://', '')
+  const CONVO_DESCRIPTION = 'This is dummy description for embed tests.'
+  const CONVO_TOPIC = 'Embed test topic'
 
   beforeEach(function () {
     cy.createConvo('moderator').then(() => {
       cy.seedComment('Seed statement 1', this.convoId)
+      cy.get('[data-test-id="description"]').type(CONVO_DESCRIPTION).blur()
+      cy.get('[data-test-id="topic"]').type(CONVO_TOPIC).blur()
     })
   })
 
   it('renders a default embed', function () {
-    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&convoId=${this.convoId}`)
-    cy.frameLoaded(`#polis_${this.convoId}`)
-    cy.iframe(`#polis_${this.convoId}`).find('#agreeButton').should('be.visible')
+    cy.logout()
+    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-conversation_id=${this.convoId}`)
+    cy.enter(`#polis_${this.convoId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cyframe().find('#readReactView').as('vote-widget')
+      cyframe().find('#comment_form_textarea').as('comment-widget')
+      cyframe().find('#helpTextWelcome').as('vote-help')
+      cyframe().find('.POLIS_HEADLINE').as('headline')
+      cyframe().find('svg.svgCenter').as('footer-logo')
+      cyframe().find('#vis_section').as('vis')
+    })
+
+    cy.get('@iframe').should('be.visible')
+    cy.get('@vote-widget').should('be.visible')
+    cy.get('@comment-widget').should('be.visible')
+    cy.get('@vote-help').should('be.visible')
+    cy.get('@headline').should('contain', CONVO_DESCRIPTION)
+    cy.get('@footer-logo').should('be.visible')
+    cy.get('@headline').should('contain', CONVO_TOPIC)
+    // TODO add full votes to check this
+    //cy.get('@vis').should('be.visible')
   })
 
-  // TODO: test each data-* attribute
+  it('hides voting when user-can-vote (ucv) is OFF', function () {
+    cy.logout()
+    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-conversation_id=${this.convoId}&data-ucv=false`)
+    cy.enter(`#polis_${this.convoId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cyframe().find('#readReactView').as('vote-widget')
+    })
 
-  // TODO: test xid usage
+    cy.get('@iframe').should('be.visible')
+    cy.get('@vote-widget').should('not.be.visible')
+  })
+
+  it('hides commenting when user-can-write (ucw) is OFF', function () {
+    cy.logout()
+    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-conversation_id=${this.convoId}&data-ucw=false`)
+    cy.enter(`#polis_${this.convoId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cyframe().find('#comment_form_textarea').as('comment-widget')
+    })
+
+    cy.get('@iframe').should('be.visible')
+    cy.get('@comment-widget').should('not.be.visible')
+  })
+
+  it('hides help text when user-can-see-help (ucsh) is OFF', function () {
+    cy.logout()
+    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-conversation_id=${this.convoId}&data-ucsh=false`)
+    cy.enter(`#polis_${this.convoId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cyframe().find('#helpTextWelcome').as('vote-help')
+    })
+
+    cy.get('@iframe').should('be.visible')
+    cy.get('@vote-help').should('not.be.visible')
+  })
+
+  it('hides description when user-can-see-description (ucsd) is OFF', function () {
+    cy.logout()
+    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-conversation_id=${this.convoId}&data-ucsd=false`)
+    cy.enter(`#polis_${this.convoId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cyframe().find('.POLIS_HEADLINE').as('headline')
+    })
+
+    cy.get('@iframe').should('be.visible')
+    cy.get('@headline').should('not.contain', CONVO_DESCRIPTION)
+  })
+
+  // Seems convo owner needs special permission to disable branding.
+  it.skip('hides footer when user-can-see-footer (ucsf) is OFF', function () {
+    cy.logout()
+    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-conversation_id=${this.convoId}&data-ucsf=false`)
+    cy.enter(`#polis_${this.convoId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cyframe().find('svg.svgCenter').as('footer-logo')
+    })
+
+    cy.get('@iframe').should('be.visible')
+    cy.get('@footer-logo').should('not.be.visible')
+  })
+
+  it('hides vis when user-can-see-vis (ucsv) is OFF', function () {
+    cy.logout()
+    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-conversation_id=${this.convoId}&data-ucsv=false`)
+    cy.enter(`#polis_${this.convoId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cyframe().find('#vis_section').as('vis')
+    })
+
+    cy.get('@iframe').should('be.visible')
+    cy.get('@vis').should('not.be.visible')
+  })
+
+  it('hides topic when user-can-see-topic (ucst) is OFF', function () {
+    cy.logout()
+    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-conversation_id=${this.convoId}&data-ucst=false`)
+    cy.enter(`#polis_${this.convoId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cyframe().find('.POLIS_HEADLINE').as('headline')
+    })
+
+    cy.get('@iframe').should('be.visible')
+    cy.get('@headline').should('not.contain', CONVO_TOPIC)
+  })
+  // TODO: test other data-* params
+  //   - data-x_name
+  //   - data-x_profile_image_url
+  // See: https://roamresearch.com/#/app/polis-methods/page/hwRb6tXIA
+
+  // This is currently broken and has a pending PR to fix.
+  // TODO fix
+  it.skip('creates xid when provided', function () {
+    cy.logout()
+    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-conversation_id=${this.convoId}`)
+    cy.enter(`#polis_${this.convoId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+    cy.task('dbQuery', {
+      sql: `
+      `,
+      values: [
+      ],
+    })
+  })
+
+  it.skip('does not create xid when not provided', function () {
+    cy.logout()
+    cy.visit(`${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-conversation_id=${this.convoId}&xid=foobar`)
+    cy.enter(`#polis_${this.convoId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+  })
 
   // TODO: test postMessage events
 
-  // TODO: test integration (that creates new convos)
+  // TODO: test integration (that creates new convos), and related data-* params:
+  //   - data-subscribe_type
+  //   - data-show_share
+  //   - data-auth_needed_to_vote
+  //   - data-auth_needed_to_write
+  //   - data-auth_opt_fb
+  //   - data-auth_opt_tw
+  //   - data-auth_opt_allow_3rdparty
+  //   - data-dwok
+  //   - data-topic
+  //   - data-bg_white
 })

--- a/e2e/cypress/integration/polis/client-participation/integration.spec.js
+++ b/e2e/cypress/integration/polis/client-participation/integration.spec.js
@@ -1,0 +1,273 @@
+describe('Integrated Conversations', () => {
+  // This test requires overriding client-admin/embed.html with
+  // e2e/cypress/fixtures/html/embeds.html
+  const POLIS_DOMAIN = Cypress.config().baseUrl.replace('https://', '')
+  const CONVO_DESCRIPTION = 'This is dummy description for embed tests.'
+  const CONVO_TOPIC = 'Integration test topic'
+  const CONVO_DEFAULTS = {
+    topic: null,
+    description: null,
+
+    vis_type: 0,
+    write_type: 1,
+    help_type: 1,
+    subscribe_type: 1,
+    auth_opt_fb: null,
+    auth_opt_tw: null,
+
+    strict_moderation: false,
+    auth_needed_to_write: null,
+    auth_needed_to_vote: null,
+  }
+
+  before(function () {
+    cy.login('moderator')
+    cy.visit('/integrate')
+    cy.get('pre').invoke('text').then((snippet) => {
+      const reSiteId = /'(polis_site_id_[a-zA-Z0-9]+)'/gm
+      const match = reSiteId.exec(snippet)
+      cy.wrap(match[1]).as('siteId')
+    })
+  })
+
+  beforeEach(function () {
+    // xip.io is maybe throttling these fast tests.
+    cy.wait(500)
+  })
+
+  it('creates a convo with defaults', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        for (const [field, val] of Object.entries(CONVO_DEFAULTS)) {
+          cy.wrap(mostRecentConvo).its(field).should('equal', val)
+        }
+        cy.wrap(mostRecentConvo).its('parent_url').should('equal', integrationUrl)
+
+        // Ensure integration url also showing in UI locations.
+        cy.visit(`/m/${mostRecentConvo.conversation_id}/share`)
+        cy.get('*[data-test-id="embed-page"]').should('contain', integrationUrl)
+        cy.visit('/')
+        cy.get('*[data-test-id="embed-page"]').first().should('contain', integrationUrl)
+      })
+  })
+
+  it('creates a convo with topic', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}&data-topic=${CONVO_TOPIC}`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        cy.wrap(mostRecentConvo).its('topic').should('equal', CONVO_TOPIC)
+      })
+  })
+
+  // Feature doesn't yet exist yet.
+  // See: https://github.com/pol-is/polis/issues/315
+  it.skip('creates a convo with description', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}&data-topic=${CONVO_DESCRIPTION}`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        cy.wrap(mostRecentConvo).its('description').should('equal', CONVO_DESCRIPTION)
+      })
+  })
+
+  it('creates a convo with vis enabled', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}&data-show_vis=true`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        cy.wrap(mostRecentConvo).its('vis_type').should('equal', 1)
+      })
+  })
+
+  // Not working
+  it.skip('creates a convo with top comments style vis', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}&data-vis_type=2`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        cy.wrap(mostRecentConvo).its('vis_type').should('equal', 2)
+      })
+  })
+
+  it.skip('creates a convo with commenting disabled', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}&data-write_type=0`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        cy.wrap(mostRecentConvo).its('write_type').should('equal', 0)
+      })
+  })
+
+  // Doesn't seem to work right now.
+  it.skip('creates a convo with help disabled', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}&data-help_type=0`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        cy.wrap(mostRecentConvo).its('help_type').should('equal', 0)
+      })
+  })
+
+  // Doesn't seem to work right now.
+  it.skip('creates a convo with new comment subscriptions disabled', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}&data-subscribe_type=0`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        cy.wrap(mostRecentConvo).its('subscribe_type').should('equal', 0)
+      })
+  })
+
+  it('creates a convo with login required to vote', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}&data-auth_needed_to_vote=true`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        cy.wrap(mostRecentConvo).its('auth_needed_to_vote').should('equal', true)
+      })
+  })
+
+  it('creates a convo with login required to comment', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}&data-auth_needed_to_write=true`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        cy.wrap(mostRecentConvo).its('auth_needed_to_write').should('equal', true)
+      })
+  })
+
+  it('creates a convo with facebook login button enabled', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}&data-auth_opt_fb=true`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        cy.wrap(mostRecentConvo).its('auth_opt_fb').should('equal', true)
+      })
+  })
+
+  it('creates a convo with twitter login button enabled', function () {
+    cy.logout()
+    const pageId = Math.floor(Date.now() / 1000)
+    const integrationUrl = `${Cypress.config().baseUrl}/embed.html?polisDomain=${POLIS_DOMAIN}&data-page_id=${pageId}&data-site_id=${this.siteId}&data-auth_opt_tw=true`
+    cy.visit(integrationUrl)
+    cy.enter(`#polis_${this.siteId}_${pageId}`).then(cyframe => {
+      cyframe().find('div[data-view-name="root"]').as('iframe')
+      cy.get('@iframe').should('be.visible')
+    })
+
+    cy.login('moderator')
+    cy.request('GET', Cypress.config().apiPath + '/conversations?include_all_conversations_i_am_in=true')
+      .then(resp => {
+        const mostRecentConvo = resp.body.shift()
+        cy.wrap(mostRecentConvo).its('auth_opt_tw').should('equal', true)
+      })
+  })
+
+  // deprecated data-* params:
+  //   - data-show_share - bool. sets socialbtn_type from 0 to 1. not in ui. no apparent effect.
+  //   - data-auth_opt_allow_3rdparty - bool. no apparent effect.
+  //   - data-dwok. (domain whitelist override key) unsure.
+  //   - data-bg_white - bool. toggles bgcolor db value, but no effect in ui.
+})

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -24,6 +24,10 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+// Adds commands for using iframes.
+// See: https://gitlab.com/kgroat/cypress-iframe
+require('cypress-iframe')
+
 Cypress.Commands.add("logout", () => {
   cy.request('POST', Cypress.config().apiPath + '/auth/deregister')
     .then(resp => {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -635,6 +635,12 @@
         }
       }
     },
+    "cypress-iframe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cypress-iframe/-/cypress-iframe-1.0.1.tgz",
+      "integrity": "sha512-Ne+xkZmWMhfq3x6wbfzK/SzsVTCrJru3R3cLXsoSAZyfUtJDamXyaIieHXeea3pQDXF4wE2w4iUuvCYHhoD31g==",
+      "dev": true
+    },
     "cypress-terminal-report": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-1.4.1.tgz",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,6 +15,7 @@
   "author": "Benjamin Rosas <ben@aliencyb.org>",
   "devDependencies": {
     "cypress": "^6.2.1",
+    "cypress-iframe": "^1.0.1",
     "cypress-terminal-report": "^1.4.1",
     "eslint": "^7.1.0",
     "eslint-config-prettier": "^6.11.0",


### PR DESCRIPTION
Related: #758 #287 and questions from Damien (a new open call participant) about which config work in embeds. (I realized I wasn't sure which ones still did.)

This PR:
- [x] adds a cypress helper for working with iframes
- [x] makes domain configurable for embeds (previously hardcoded for pol.is)
- [x] adds a simple html page for instantiating an embed with various settings (copied into app during e2e testing)
- [x] adds simple e2e test for embeds
- [x] add remaining embed tests
- [x] add remaining tests of advanced integration (creating new convos)
- [x] added data-test-id attributes as required