### PR TITLE
add project license to client-participation sub-project

### DIFF
--- a/client-participation/package.json
+++ b/client-participation/package.json
@@ -2,6 +2,7 @@
   "name": "dashboard-require",
   "appName": "DashboardRequire",
   "version": "0.0.0",
+  "license": "AGPL-3.0",
   "scripts": {
     "build:preprod": "gulp deployPreprod",
     "start": "node ./node_modules/.bin/grunt",


### PR DESCRIPTION
fix #792 

existing license for the project is AGPL-3.0 https://github.com/pol-is/polis/blob/dev/LICENSE

the SPDX code is `AGPL-3.0` https://spdx.org/licenses/AGPL-3.0.html