### PR TITLE
Remove [skip ci] logic from GitHub Action workflow (now implemented on GitHub)

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -16,9 +16,6 @@ jobs:
   cypress-run:
     # Platform recommended in cypress-io/github-action docs.
     runs-on: ubuntu-16.04
-    # Manually skip this 10+ minute build based on commit message.
-    # Translation: If "skip ci" substring NOT found in push message or title of PR (hack).
-    if: "! (contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.pull_request.title, '[skip ci]'))"
     env:
       # Use native docker command within docker-compose
       COMPOSE_DOCKER_CLI_BUILD: 1


### PR DESCRIPTION
See: https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/