### PR TITLE
Added documentation to support using E2E testing with less gotchas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,11 @@ Requirements: Docker & docker-compose installed locally.
 
 Though these tests are useful when developing new features on your own feature branch,
 it's first helpful to ensure you can run them against a known-good version of the application.
-The project builds working docker container images nightly,
+The project builds [working docker container images nightly][nightlies],
 using the codebase on the mainline `dev` branch,
 so we'll pull and run those first.
+
+   [nightlies]: https://hub.docker.com/u/polisdemo
 
 ```
 git clone https://github.com/compdemocracy/polis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,71 @@
 # Contributing to Polis
 
+## Running E2E Tests
+
+End-to-end (E2E) tests are tests that puppet a real browser to drive simulated user interactions on a functional copy of the website.
+
+Requirements: Docker & docker-compose installed locally.
+
+Though these tests are useful when developing new features on your own feature branch,
+it's first helpful to ensure you can run them against a known-good version of the application.
+The project builds working docker container images nightly,
+using the codebase on the mainline `dev` branch,
+so we'll pull and run those first.
+
+```
+git clone https://github.com/compdemocracy/polis
+cd polis
+make pull
+make start
+```
+
+You can confirm that this is running here: `http://127.0.0.1`
+
+Your local application is running inside Docker! Now, to prepare your Cypress testing environment:
+
+```
+make e2e-install
+```
+
+You can then run a minimal test suite with:
+
+```
+make e2e-run-minimal
+```
+
+If for whatever reason, Docker is serving your application from a remote IP or URL instead of `http://127.0.0.1`, then there are work-arounds:
+
+```
+make e2e-run-minimal BASEURL=https://123.45.67.89.xip.io
+make e2e-run-minimal BASEURL=https://mydomain.dev # Won't work right now
+```
+
+(Specifically, [xip.io](https://xip.io) is a free third-party support service that allows any IP to "pretend" it's a domain.
+There is currently a hardcoded "allow list" in the codebase,
+that lets this service work in the "development mode" that our Docker environment currently uses.)
+
+Once you've confirmed that these work, you're good to make some changes and try testing your own version of the codebase.
+You'll need to rebuild the Docker containers locally, which can take more time than pulling pre-built ones like before.
+
+After ensuring you're back in the project root directory, run:
+
+```
+make prepare-e2e
+make start-rebuild
+make e2e-run-standalone
+```
+
+### Tests requiring third-party credentials
+
+Some of our E2E tests require third-party credentials, which are acquired as described here:
+- [Google Translate credentials](/docs/deployment.md#enabling-comment-translation)
+
+Once you have those credentials in place, you can run these specific tests via:
+
+```
+make e2e-run-secret
+```
+
 ## :telephone_receiver: Open Calls
 
 :clock10: **When?** Every Saturday at 19:00 UTC (noon PT / 3pm ET / [your timezone][]) \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+BASEURL ?= https://127.0.0.1.xip.io
+E2E_RUN = cd e2e; CYPRESS_BASE_URL=$(BASEURL)
+
+pull: ## Pull most recent Docker container builds (nightlies)
+	docker-compose pull
+
+start: ## Start all Docker containers
+	docker-compose up --detach
+
+start-rebuild: ## Start all Docker containers, [re]building as needed
+	docker-compose up --detach --build
+
+e2e-install: e2e/node_modules ## Install Cypress E2E testing tools
+	$(E2E_RUN) npm install
+
+e2e-prepare: ## Prepare to run Cypress E2E tests
+	@# Testing embeds requires a override of a file prior to build.
+	cp e2e/cypress/fixtures/html/embed.html client-admin/embed.html
+
+e2e-run-minimal: ## Run E2E tests: minimal (for nightly builds)
+	$(E2E_RUN) npm run e2e:minimal
+
+e2e-run-standalone: ## Run E2E tests: standalone (no credentials required)
+	$(E2E_RUN) npm run e2e:standalone
+
+e2e-run-secret: ## Run E2E tests: secret (credentials required)
+	$(E2E_RUN) npm run e2e:secret
+
+e2e-run-all: ## Run E2E tests: all
+	$(E2E_RUN) npm run e2e:all
+
+
+# Helpful CLI shortcuts
+rbs: start-rebuild
+
+
+%:
+	@true
+
+.PHONY: help
+
+help:
+	@echo 'Usage: make <command>'
+	@echo
+	@echo 'where <command> is one of the following:'
+	@echo
+	@grep -E '^[a-z0-9A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ git config --local include.path ../.gitconfig
 
 We use Cypress for automated, end-to-end browser testing! (See badge above.)
 
-Please see [`e2e/README.md`](/e2e/README.md).
+Please see [`e2e/README.md`](/e2e/README.md) and [`CONTRIBUTING.md`](/CONTRIBUTING.md#running-e2e-tests).
 
 ## 🚀 Deployment
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,8 +9,9 @@
     "lint:fix": "eslint --fix .",
     "test": "npm run e2e:all",
     "e2e:all": "cypress run --spec 'cypress/integration/polis/**' --browser=chrome",
+    "e2e:minimal": "cypress run --spec '**/polis/**/!(*.secrets).spec.js,!**/embeds.spec.js' --browser=chrome",
     "e2e:standalone": "cypress run --spec '**/polis/**/!(*.secrets).spec.js' --browser=chrome",
-    "e2e:secret": "cypress run --spec '**/*.secrets.spec.js' --browser=chrome"
+    "e2e:secret": "cypress run --spec '**/(*.secrets).spec.js' --browser=chrome"
   },
   "author": "Benjamin Rosas <ben@aliencyb.org>",
   "devDependencies": {


### PR DESCRIPTION
Addresses https://github.com/compdemocracy/polis/issues/840 & https://github.com/compdemocracy/polis/issues/839#issuecomment-784534697

Could use a pair of eyes for review, as I'm sure I've missed some stuff. Also fine to not lean to hard on `make`, but it feels nice that we can modify command/scripty parts of this, without needing to go back through docs to find places that need updating -- the commands will just change transparently underneath the make target :)

I find this allows docs to be more comprehensive, but open to push-back on that!

cc: @micahstubbs @ballPointPenguin 