### PR TITLE
fix: trailing whitespace

### DIFF
--- a/client-participation/js/strings.js
+++ b/client-participation/js/strings.js
@@ -36,10 +36,10 @@ var translations = {
 
   // Japanese
   ja: require("./strings/ja.js"),
-  
+
   // Croatian
   hr: require("./strings/hr.js"),
-  
+
   // Slovak
   sk: require("./strings/sk.js")
 };
@@ -95,8 +95,8 @@ preloadHelper.acceptLanguagePromise.then(function() {
     else if (languageCode.match(/^nl/)) {
       _.extend(strings, translations.nl);
     }
-    else if (languageCode.match(/^sk/)) { 
-      _.extend(strings, translations.sk); 
+    else if (languageCode.match(/^sk/)) {
+      _.extend(strings, translations.sk);
     }
     else if (
       languageCode.match(/^pt/) ||  // To help other Portuguese speaker participants until its specific translation is not here


### PR DESCRIPTION
Doing a production build gives:
```
/app/js/strings.js: line 98, col 42, Trailing whitespace.
/app/js/strings.js: line 99, col 42, Trailing whitespace.
```
This removes that white space.