### PR TITLE
fix: show report errors in more cases

### DIFF
--- a/client-report/src/components/app.js
+++ b/client-report/src/components/app.js
@@ -364,10 +364,10 @@ class App extends React.Component {
         nothingToShow: !comments.length || !groupDemographics.length
       });
 
-    }, (err) => {
+    }).catch((err) => {
       this.setState({
         error: true,
-        errorText: err,
+        errorText: String(err),
       });
     });
   }


### PR DESCRIPTION
Two changes here:

1. `errorText` doesn't display unless it's a string (and displays a React error), but isn't necessarily a string. It could be a [jqXHR](https://api.jquery.com/Jquery.ajax/) object (if `$.ajax` fails) or a plain error (or maybe something else).
2. Currently, you're calling the promises as `promise.then(X, Y)`. If something in `X` crashes, you'll forever display "Loading...". This changes it to use `promise.then(X).catch(Y)`, which lets you catch errors in X and display them. One example of something that can happen is that `mathResult` can be blank (no data returned), and so accessing `mathResult.pca` crashes with a TypeError.