### PR TITLE
Limit unmoderated comments displayed to 100

### DIFF
--- a/client-admin/src/components/conversation-admin/comment-moderation/moderate-comments-todo.js
+++ b/client-admin/src/components/conversation-admin/comment-moderation/moderate-comments-todo.js
@@ -50,7 +50,7 @@ class ModerateCommentsTodo extends React.Component {
     return (
       <div>
         <div>
-          <p> Displays maximum {max} comments <p> 
+          <p> Displays maximum {max} comments </p> 
           {this.props.unmoderated_comments !== null
             ? this.createCommentMarkup(max)
             : 'Loading unmoderated comments...'}

--- a/client-admin/src/components/conversation-admin/comment-moderation/moderate-comments-todo.js
+++ b/client-admin/src/components/conversation-admin/comment-moderation/moderate-comments-todo.js
@@ -24,8 +24,8 @@ class ModerateCommentsTodo extends React.Component {
     this.props.dispatch(changeCommentCommentIsMeta(comment, is_meta))
   }
 
-  createCommentMarkup() {
-    const max = 100;
+  createCommentMarkup(max) {
+
     const _perhaps_fewer_unmoderated_comments = this.props.unmoderated_comments.slice(0,max);
     
     const comments = _perhaps_fewer_unmoderated_comments.map((comment, i) => {
@@ -48,11 +48,13 @@ class ModerateCommentsTodo extends React.Component {
   }
 
   render() {
+    const max = 100;
     return (
       <div>
         <div>
+          <p> Displays maximum {max} comments <p> 
           {this.props.unmoderated_comments !== null
-            ? this.createCommentMarkup()
+            ? this.createCommentMarkup(max)
             : 'Loading unmoderated comments...'}
         </div>
       </div>

--- a/client-admin/src/components/conversation-admin/comment-moderation/moderate-comments-todo.js
+++ b/client-admin/src/components/conversation-admin/comment-moderation/moderate-comments-todo.js
@@ -25,7 +25,10 @@ class ModerateCommentsTodo extends React.Component {
   }
 
   createCommentMarkup() {
-    const comments = this.props.unmoderated_comments.map((comment, i) => {
+    const max = 100;
+    const _perhaps_fewer_unmoderated_comments = this.props.unmoderated_comments.slice(0,max);
+    
+    const comments = _perhaps_fewer_unmoderated_comments.map((comment, i) => {
       return (
         <Comment
           key={i}

--- a/client-admin/src/components/conversation-admin/comment-moderation/moderate-comments-todo.js
+++ b/client-admin/src/components/conversation-admin/comment-moderation/moderate-comments-todo.js
@@ -26,9 +26,7 @@ class ModerateCommentsTodo extends React.Component {
 
   createCommentMarkup(max) {
 
-    const _perhaps_fewer_unmoderated_comments = this.props.unmoderated_comments.slice(0,max);
-    
-    const comments = _perhaps_fewer_unmoderated_comments.map((comment, i) => {
+    return this.props.unmoderated_comments.slice(0,max).map((comment, i) => {
       return (
         <Comment
           key={i}
@@ -44,7 +42,7 @@ class ModerateCommentsTodo extends React.Component {
         />
       )
     })
-    return comments
+    
   }
 
   render() {


### PR DESCRIPTION
In lieu of pagination, clip unmoderated comments to the first 100. Moderating naturally moves through the queue