### PR TITLE
REDO: Modify UNIQUE constraint on xids table

### DIFF
--- a/server/postgres/migrations/000000_initial.sql
+++ b/server/postgres/migrations/000000_initial.sql
@@ -414,7 +414,7 @@ CREATE TABLE xids (
     x_email VARCHAR(256), -- http://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address
     created BIGINT DEFAULT now_as_millis(),
     modified BIGINT NOT NULL DEFAULT now_as_millis(),
-    UNIQUE (owner, uid)
+    UNIQUE (owner, xid)
 );
 CREATE INDEX xids_owner_idx ON xids USING btree (owner);
 

--- a/server/postgres/migrations/000000_initial.sql
+++ b/server/postgres/migrations/000000_initial.sql
@@ -414,7 +414,7 @@ CREATE TABLE xids (
     x_email VARCHAR(256), -- http://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address
     created BIGINT DEFAULT now_as_millis(),
     modified BIGINT NOT NULL DEFAULT now_as_millis(),
-    UNIQUE (owner, xid)
+    UNIQUE (owner, uid)
 );
 CREATE INDEX xids_owner_idx ON xids USING btree (owner);
 

--- a/server/postgres/migrations/000002_add_xid_constraint.sql
+++ b/server/postgres/migrations/000002_add_xid_constraint.sql
@@ -1,0 +1,3 @@
+ALTER TABLE xids
+  DROP CONSTRAINT xids_owner_uid_key,
+  ADD CONSTRAINT xids_owner_xid_key UNIQUE (owner, xid);

--- a/server/postgres/migrations/000002_add_xid_constraint.sql
+++ b/server/postgres/migrations/000002_add_xid_constraint.sql
@@ -1,3 +1,3 @@
 ALTER TABLE xids
-  DROP CONSTRAINT xids_owner_uid_key,
+  DROP CONSTRAINT IF EXISTS xids_owner_uid_key,
   ADD CONSTRAINT xids_owner_xid_key UNIQUE (owner, xid);


### PR DESCRIPTION
Supercedes https://github.com/compdemocracy/polis/pull/758

To not force a block based on @joshsmith2's capacity, redid PR as per @metasoarous comment in https://github.com/compdemocracy/polis/pull/758#issuecomment-822894861

cherry-picked @joshsmith2's initial commit so that he gets credit in commit history and enjoys great glory in the afterlife 🙂 (assuming one subscribes to a belief system in which this is what's tallied)