### PR TITLE
Migrate from xip.io to alternatives for local dev whitelist

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         npm install
         cp polis.config.template.js polis.config.js
-        npm run build:preprod
+        npm run deploy:prod
         # So directory stays consistent between builds for comparison.
         mv dist/cached/* dist/cached/xxxxxxxxx
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ docker-machine ip
 >>> 123.45.67.89
 ```
 
-Visit your instance at: `http://123.45.67.89.xip.io/`
+Visit your instance at: `http://123.45.67.89.sslip.io/`
 
 Or visit a native docker instance at `http://localhost:80/`
 

--- a/client-admin/polis.config.template.js
+++ b/client-admin/polis.config.template.js
@@ -7,8 +7,8 @@ module.exports = {
     "^192\\.168\\.1\\.140$",
     "^pol\\.is",
     ".+\\.pol\\.is$",
-    "^xip\\.io$",
-    ".+\\.xip\\.io$",
+    "^(n|x|ssl)ip\\.io$",
+    ".+\\.(n|x|ssl)ip\\.io$",
   ],
 
   DISABLE_INTERCOM: true,

--- a/client-admin/polis.config.template.js
+++ b/client-admin/polis.config.template.js
@@ -2,13 +2,16 @@
 module.exports = {
 
   domainWhitelist: [
+    // local ports
     "^localhost$",
     "^127\\.0\\.0\\.1$",
     "^192\\.168\\.1\\.140$",
+    // sample configuration for main pol.is deployment
     "^pol\\.is",
     ".+\\.pol\\.is$",
-    "^(n|x|ssl)ip\\.io$",
-    ".+\\.(n|x|ssl)ip\\.io$",
+    // These allow for local ip routing for remote dev deployment
+    "^(n|ssl)ip\\.io$",
+    ".+\\.(n|ssl)ip\\.io$",
   ],
 
   DISABLE_INTERCOM: true,

--- a/client-participation/polis.config.template.js
+++ b/client-participation/polis.config.template.js
@@ -1,12 +1,15 @@
 module.exports = {
   domainWhitelist: [
+    // local ports
     "^localhost$",
     "^127\\.0\\.0\\.1$",
     "^192\\.168\\.1\\.140$",
+    // sample configuration for main pol.is deployment
     "^pol\\.is",
     ".+\\.pol\\.is$",
-    "^(n|x|ssl)ip\\.io$",
-    ".+\\.(n|x|ssl)ip\\.io$",
+    // These allow for local ip routing for remote dev deployment
+    "^(n|ssl)ip\\.io$",
+    ".+\\.(n|ssl)ip\\.io$",
   ],
 
   // Point to a polisServer instance (local recommended for dev)

--- a/client-participation/polis.config.template.js
+++ b/client-participation/polis.config.template.js
@@ -5,8 +5,8 @@ module.exports = {
     "^192\\.168\\.1\\.140$",
     "^pol\\.is",
     ".+\\.pol\\.is$",
-    "^xip\\.io$",
-    ".+\\.xip\\.io$",
+    "^(n|x|ssl)ip\\.io$",
+    ".+\\.(n|x|ssl)ip\\.io$",
   ],
 
   // Point to a polisServer instance (local recommended for dev)
@@ -14,8 +14,8 @@ module.exports = {
   SERVICE_URL: "http:localhost:5000",
 
   // Used for setting appropriate hostname for embedding.
-  //SERVICE_HOSTNAME: "123.45.67.89.xip.io",
-  SERVICE_HOSTNAME: "localhost", 
+  //SERVICE_HOSTNAME: "123.45.67.89.sslip.io",
+  SERVICE_HOSTNAME: "localhost",
 
   // Note that this must match the participation client port specified in polisServer instance
   PORT: 5001,

--- a/client-report/src/util/url.js
+++ b/client-report/src/util/url.js
@@ -34,7 +34,7 @@ if (document.domain === "localhost" && document.location.port === "5010") {
   urlPrefix = localhost5010;
 }
 
-if (0 === document.domain.indexOf("192.168") || (new RegExp(/\.(ssl|n|x)ip\.io/)).test(document.domain) ) {
+if (0 === document.domain.indexOf("192.168") || (new RegExp(/\.(ssl|n)ip\.io/)).test(document.domain) ) {
   urlPrefix = "http://" + document.location.hostname + ":" + document.location.port + "/";
 }
 

--- a/client-report/src/util/url.js
+++ b/client-report/src/util/url.js
@@ -34,7 +34,7 @@ if (document.domain === "localhost" && document.location.port === "5010") {
   urlPrefix = localhost5010;
 }
 
-if (0 === document.domain.indexOf("192.168") || document.domain.includes(".xip.io")) {
+if (0 === document.domain.indexOf("192.168") || (new RegExp(/\.(ssl|n|x)ip\.io/)).test(document.domain) ) {
   urlPrefix = "http://" + document.location.hostname + ":" + document.location.port + "/";
 }
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -31,7 +31,7 @@ To run these tests:
 
 - We keep some helper scripts in `package.json`.
 - The default base url for running tests against, is https://localhost
-  - You may override any cypress-related command this like so: `CYPRESS_BASE_URL=http://123.45.67.89.xip.io npm test`
+  - You may override any cypress-related command this like so: `CYPRESS_BASE_URL=http://123.45.67.89.sslip.io npm test`
 - `cypress/integration/polis/`: where we store our tests
 - `cypress/integration/examples`: where we store boilerplate examples (ignored by test runner)
 - `cypress/support/commands.js`: where we keep oft-used commands, e.g., for logging in, creating conversations, etc.

--- a/e2e/cypress/integration/polis/client-participation/integration.spec.js
+++ b/e2e/cypress/integration/polis/client-participation/integration.spec.js
@@ -31,7 +31,7 @@ describe('Integrated Conversations', () => {
   })
 
   beforeEach(function () {
-    // xip.io is maybe throttling these fast tests.
+    // sslip.io is maybe throttling these fast tests.
     cy.wait(500)
   })
 


### PR DESCRIPTION
After Basecamp controversy, xip.io is down, and maybe no more:
https://twitter.com/sstephenson/status/1388146130261790721

Alternatives are https://sslip.io/ or https://nip.io/