### PR TITLE
Disable CSS font ligatures from admin UI

### DIFF
--- a/client-admin/index.html
+++ b/client-admin/index.html
@@ -15,6 +15,11 @@
       href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400&display=swap"
       rel="stylesheet"
     />
+  <style>
+    * {
+    font-variant-ligatures: none;
+    }
+  </style>
   </head>
   <body class="viewport avenir">
     <div id="root"></div>


### PR DESCRIPTION
<img width="269" alt="Screen Shot 2020-12-15 at 9 42 49 PM" src="https://user-images.githubusercontent.com/305339/102298290-dfb9da00-3f1e-11eb-9bce-7ab3fe3edbbd.png">

"fi" seem to be automatically merging into a single character. I knew this happened in some coding/math fonts, but didn't realize it could happy in the browser.

https://stackoverflow.com/a/47063000/504018