### PR TITLE
use just 127.0.0.0.1 without xip.io as default BASEURL for tests in M…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASEURL ?= https://127.0.0.1.xip.io
+BASEURL ?= https://127.0.0.1
 E2E_RUN = cd e2e; CYPRESS_BASE_URL=$(BASEURL)
 
 pull: ## Pull most recent Docker container builds (nightlies)


### PR DESCRIPTION
…akefile

@patcon I had to do this to run the tests against Polis deployed in a locally hosted docker container. 

Is this makefile used anywhere else now? Is it okay to make the default `BASEURL ?= https://127.0.0.1` without the `xip.io`?