### PR TITLE
update ubuntu version used for cypress tests

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   cypress-run:
     # Platform recommended in cypress-io/github-action docs.
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       # Use native docker command within docker-compose
       COMPOSE_DOCKER_CLI_BUILD: 1


### PR DESCRIPTION
Cypress tests are currently not running, but hanging in queue with a message like

    Can't find any online and idle self-hosted runner in the current repository, account/organization that matches the required labels: 'ubuntu-16.04'

After some period of time, the tasks just fail.

I have a feeling that the problem is that `ubuntu-16.04` is no longer supported on github actions. The [Cypress GitHub page](https://github.com/cypress-io/github-action) shows 20.04 in use, so switching to this. Thinking the "platform recommended in ... docs" may have actually been from an old example.

Let's see if this fixes things.