### PR TITLE
Remove last references to xip.io from codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,11 +38,11 @@ make e2e-run-minimal
 If for whatever reason, Docker is serving your application from a remote IP or URL instead of `http://127.0.0.1`, then there are work-arounds:
 
 ```
-make e2e-run-minimal BASEURL=https://123.45.67.89.xip.io
+make e2e-run-minimal BASEURL=https://123.45.67.89.sslip.io
 make e2e-run-minimal BASEURL=https://mydomain.dev # Won't work right now
 ```
 
-(Specifically, [xip.io](https://xip.io) is a free third-party support service that allows any IP to "pretend" it's a domain.
+(Specifically, [sslip.io](https://sslip.io) is a free third-party support service that allows any IP to "pretend" it's a domain.
 There is currently a hardcoded "allow list" in the codebase,
 that lets this service work in the "development mode" that our Docker environment currently uses.)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASEURL ?= https://127.0.0.1.xip.io
+BASEURL ?= https://127.0.0.1.sslip.io
 E2E_RUN = cd e2e; CYPRESS_BASE_URL=$(BASEURL)
 
 pull: ## Pull most recent Docker container builds (nightlies)


### PR DESCRIPTION
These must have snuck in from PRs that were merged after we decided to strip out xip.io

Can we merge this small change for consistency? Thanks!

(Happy to see sslip.io get stripped out later, but for now, there are special cases in the codebase for it, mirroring what existed for xip.io in the past)