### PR TITLE
Bumped bundlewatch limit and enable for client-participation changes

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -15,7 +15,7 @@ module.exports = {
     },
     {
       "path": "client-participation/dist/cached/*/js/polis.js",
-      "maxSize": "140 kB",
+      "maxSize": "150 kB",
     },
     {
       "path": "client-participation/dist/cached/*/js/vis_bundle.js",

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -4,15 +4,16 @@ on:
   push:
     # Required so that baseline for comparison is pushed to bundlewatch service.
     branches: ["dev"]
-    # Note: Only configured for client-admin right now.
     paths:
       - .github/workflows/bundlewatch.yml
       - client-admin/**
+      - client-participation/**
   pull_request:
     types: ["opened", "reopened", "synchronize"]
     paths:
       - .github/workflows/bundlewatch.yml
       - client-admin/**
+      - client-participation/**
 
 jobs:
   bundlewatch:


### PR DESCRIPTION
This has been failing for awhile, and was mistakenly not running for client-participation PRs during these prior changes

- #831 (146.85KB after merge, 6.3 kb jump)
- #832 (140.53KB after merge, 0.3 kb jump)
- #991 (140.14KB after merge, 1.8 kb jump)
- #992 (138.37KB after merge, 1.0 kb decrease)
- #993 (138.46KB after merge, 4.1 kb jump)
- before (134.36KB)

(so we couldn't see when the bundlesize jump was happening)

This ups the size for now from 140kb to 150kb, so no more red build. It also makes it so future PRs with changes to client-participation (and its dep packages) will check for bundlesize jumps :)

This is more reason to ditch bootstrap-sass #1107 and maybe import only specific modules of lodash