### PR TITLE
Remove unused bootstrap@3.4.1 dependency

### DIFF
--- a/client-participation/package-lock.json
+++ b/client-participation/package-lock.json
@@ -1219,11 +1219,6 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-0.1.3.tgz",
       "integrity": "sha512-G6TadQPFofmOhzkzgtVSOYaosjpnPyVCDeZ4J7oPF74OmhM2++fXUdwu7NULTwgntK5KIMcls1UslwAY2btL6g=="
     },
-    "bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
-    },
     "bootstrap-sass": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.4.1.tgz",

--- a/client-participation/package.json
+++ b/client-participation/package.json
@@ -14,7 +14,6 @@
     "autosize": "^3.0.3",
     "backbone": "github:pol-is/backbone#polis",
     "boolean": "^0.1.3",
-    "bootstrap": "^3.4.1",
     "bootstrap-sass": "^3.4.1",
     "brain": "~0.6.3",
     "combine-css": "0.0.2",


### PR DESCRIPTION
Re-ticketed from https://github.com/compdemocracy/polis/issues/1107#issuecomment-984992075

Since this was unused, it wasn't inflating bundle, but it's not needed.