### PR TITLE
Reduced bundlesize for vis_bundle.js

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -19,7 +19,7 @@ module.exports = {
     },
     {
       "path": "client-participation/dist/cached/*/js/vis_bundle.js",
-      "maxSize": "200 kB",
+      "maxSize": "115 kB",
     },
   ]
 };

--- a/client-participation/package-lock.json
+++ b/client-participation/package-lock.json
@@ -2881,11 +2881,6 @@
         }
       }
     },
-    "d3-voronoi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
-      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
-    },
     "d3-zoom": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
@@ -11193,33 +11188,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "victory": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/victory/-/victory-0.20.0.tgz",
-      "integrity": "sha1-GZH849If0XO3fkNe3Ru7be5imgE=",
-      "requires": {
-        "victory-chart": "^20.0.0",
-        "victory-core": "^15.2.0",
-        "victory-pie": "^11.1.1"
-      }
-    },
-    "victory-chart": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-20.0.0.tgz",
-      "integrity": "sha1-pRHNSMN9S7Ws87WDYUNN5kEg/g8=",
-      "requires": {
-        "d3-voronoi": "^1.1.2",
-        "lodash": "^4.17.4",
-        "victory-core": "^15.1.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        }
-      }
-    },
     "victory-core": {
       "version": "15.2.0",
       "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-15.2.0.tgz",
@@ -11237,36 +11205,6 @@
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        }
-      }
-    },
-    "victory-pie": {
-      "version": "11.4.2",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-11.4.2.tgz",
-      "integrity": "sha1-MzciaWvqK5c/y1QgGXchxbAhCd4=",
-      "requires": {
-        "d3-shape": "^1.0.0",
-        "lodash": "^4.17.4",
-        "victory-core": "^17.0.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        },
-        "victory-core": {
-          "version": "17.2.7",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-17.2.7.tgz",
-          "integrity": "sha1-uYsjWI/xACg8qJI3L4xxXO9TR1E=",
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.4"
-          }
         }
       }
     },

--- a/client-participation/package.json
+++ b/client-participation/package.json
@@ -49,7 +49,7 @@
     "simple-lru-cache": "0.0.1",
     "thorax": "^2.0.3",
     "underscore": "^1.12.1",
-    "victory": "^0.20.0",
+    "victory-core": "^15.1.0",
     "webpack-stream": "^6.0.0"
   },
   "devDependencies": {

--- a/client-participation/vis2/components/barChart.js
+++ b/client-participation/vis2/components/barChart.js
@@ -1,5 +1,5 @@
 import React from "react";
-import _ from "lodash";
+import reduce from "lodash/reduce";
 
 const BarChart = ({selectedComment, groupVotes, groups, translate}) => {
 
@@ -17,23 +17,23 @@ const BarChart = ({selectedComment, groupVotes, groups, translate}) => {
 
   // it's the global barchart, so add everything up
   if (groups) {
-    ptptCount = _.reduce(groups, (accumulator, group, key) => {
+    ptptCount = reduce(groups, (accumulator, group, key) => {
       return accumulator += group["n-members"]
     }, 0);
 
-    commentCount = _.reduce(groups, (accumulator, group, key) => {
+    commentCount = reduce(groups, (accumulator, group, key) => {
       return accumulator += group.votes[selectedComment.tid].S
     }, 0);
 
-    commentAgreeCount = _.reduce(groups, (accumulator, group, key) => {
+    commentAgreeCount = reduce(groups, (accumulator, group, key) => {
       return accumulator += group.votes[selectedComment.tid].A
     }, 0);
 
-    commentDisagreeCount = _.reduce(groups, (accumulator, group, key) => {
+    commentDisagreeCount = reduce(groups, (accumulator, group, key) => {
       return accumulator += group.votes[selectedComment.tid].D
     }, 0);
 
-    commentPassCount = _.reduce(groups, (accumulator, group, key) => {
+    commentPassCount = reduce(groups, (accumulator, group, key) => {
       return accumulator += (group.votes[selectedComment.tid].S - (group.votes[selectedComment.tid].A + group.votes[selectedComment.tid].D))
     }, 0);
   }

--- a/client-participation/vis2/components/barChartCompact.js
+++ b/client-participation/vis2/components/barChartCompact.js
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "lodash";
 import * as globals from "./globals";
 
 const BarChartCompact = ({selectedComment, groupVotes, translate}) => {

--- a/client-participation/vis2/components/barChartsForGroupVotes.js
+++ b/client-participation/vis2/components/barChartsForGroupVotes.js
@@ -1,5 +1,6 @@
 import React from "react";
-import _ from "lodash";
+import each from "lodash/each";
+import maxBy from "lodash/maxBy";
 import * as globals from "./globals";
 import BarChartCompact from "./barChartCompact";
 import closestPoint from "../util/closestPointOnPath";
@@ -43,7 +44,7 @@ const BarChartsForGroupVotes = ({
         dist: Math.sqrt(dx*dx + dy*dy),
       };
     });
-    let pt = _.maxBy(candidates, (c) => {
+    let pt = maxBy(candidates, (c) => {
       return -c.dist;
     }).pt;
 
@@ -64,7 +65,7 @@ const BarChartsForGroupVotes = ({
 
   const drawBarChartsForGroupVotesOnSelectedComment = () => {
     let arr = []
-    _.each(groups, (group, i) => {
+    each(groups, (group, i) => {
 
       const closestPair = getLabelAnchorForHull(hullElems[group.id]);
 

--- a/client-participation/vis2/components/curate.js
+++ b/client-participation/vis2/components/curate.js
@@ -1,4 +1,5 @@
-import _ from "lodash";
+import isNull from "lodash/isNull";
+import map from "lodash/map";
 import React from "react";
 import * as globals from "./globals";
 
@@ -17,9 +18,9 @@ class Button extends React.Component {
         marginRight: 5,
         cursor: "pointer",
         padding: "6px 12px",
-        fontWeight: (!_.isNull(this.props.selectedTidCuration) && this.props.selectedTidCuration === this.props.identifier) ? 700 : 500,
-        backgroundColor: (!_.isNull(this.props.selectedTidCuration) && this.props.selectedTidCuration === this.props.identifier) ? "#03a9f4" : "rgb(235,235,235)",
-        color: (!_.isNull(this.props.selectedTidCuration) && this.props.selectedTidCuration === this.props.identifier) ? "rgb(255,255,255)" : "rgb(100,100,100)",
+        fontWeight: (!isNull(this.props.selectedTidCuration) && this.props.selectedTidCuration === this.props.identifier) ? 700 : 500,
+        backgroundColor: (!isNull(this.props.selectedTidCuration) && this.props.selectedTidCuration === this.props.identifier) ? "#03a9f4" : "rgb(235,235,235)",
+        color: (!isNull(this.props.selectedTidCuration) && this.props.selectedTidCuration === this.props.identifier) ? "rgb(255,255,255)" : "rgb(100,100,100)",
         borderRadius: 4,
       }}
       onClick={this.handleClick.bind(this)}>
@@ -71,7 +72,7 @@ class Curate extends React.Component {
             {this.props.Strings.group_123}
           </p>
           {
-            _.map(this.props.math["group-votes"], (group) => {
+            map(this.props.math["group-votes"], (group) => {
               return (
                 <Button
                   key={globals.groupLabels[group.id]}

--- a/client-participation/vis2/components/exploreTid.js
+++ b/client-participation/vis2/components/exploreTid.js
@@ -1,4 +1,5 @@
-import _ from "lodash";
+import isNumber from "lodash/isNumber";
+import find from "lodash/find";
 import React from "react";
 import * as globals from "./globals";
 import BarChart from "./barChart";
@@ -10,12 +11,12 @@ const DataSentence = ({math, selectedTidCuration, selectedComment, repfulFor, St
 
   let markup = null;
 
-  if (_.isNumber(selectedTidCuration)) {
+  if (isNumber(selectedTidCuration)) {
     const gid = selectedTidCuration;
     const tid = selectedComment.tid;
     const groupVotes = math["group-votes"][gid];
 
-    const repness = _.find(math.repness[gid], (r) => { return r.tid === selectedComment.tid })
+    const repness = find(math.repness[gid], (r) => { return r.tid === selectedComment.tid })
     let repfulForAgree = repness["repful-for"] === "agree";
     const v = groupVotes.votes[tid];
     const denominator = v.S; // (seen)
@@ -58,8 +59,8 @@ const DataSentence = ({math, selectedTidCuration, selectedComment, repfulFor, St
       </div>
     )
   } else if (selectedTidCuration === globals.tidCuration.majority) {
-    const repfulForAgree = _.find(math.consensus.agree, (r) => { return r.tid === selectedComment.tid });
-    const repfulForDisagree = _.find(math.consensus.disagree, (r) => { return r.tid === selectedComment.tid });
+    const repfulForAgree = find(math.consensus.agree, (r) => { return r.tid === selectedComment.tid });
+    const repfulForDisagree = find(math.consensus.disagree, (r) => { return r.tid === selectedComment.tid });
     const repness = repfulForAgree || repfulForDisagree;
 
     const percent = (repness["n-success"] / repness["n-trials"] * 100) >> 0;
@@ -118,7 +119,7 @@ class ExploreTid extends React.Component {
     let currentVote = null;
     if (this.props.selectedComment) {
       let selectedTid = this.props.selectedComment.tid;
-      let voteForSelectedComment = _.find(this.props.votesByMe, (v) => {
+      let voteForSelectedComment = find(this.props.votesByMe, (v) => {
         return v.tid === selectedTid;
       });
       currentVote = voteForSelectedComment && voteForSelectedComment.vote;
@@ -181,7 +182,7 @@ class ExploreTid extends React.Component {
     // Conditionally show change votes buttons
     let buttons = null;
     if (window.preload.firstConv.is_active) {
-      if (!_.isNumber(currentVote)) {
+      if (!isNumber(currentVote)) {
         buttons = <span>{agreeButton} {disagreeButton} {passButton}</span>
       } else if (currentVote === window.polisTypes.reactions.pass) {
         buttons = <span>Change vote: {agreeButton} {disagreeButton}</span>
@@ -193,7 +194,7 @@ class ExploreTid extends React.Component {
     }
 
     let changeVotesElements = null;
-    if (!_.isNumber(currentVote)) {
+    if (!isNumber(currentVote)) {
       changeVotesElements = <span> {buttons}</span>
     } else if (currentVote === window.polisTypes.reactions.pass) {
       changeVotesElements = <span> You passed. {buttons}</span>

--- a/client-participation/vis2/components/gear.js
+++ b/client-participation/vis2/components/gear.js
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "lodash";
 
 const Gear = ({conversation_id}) => {
   return (

--- a/client-participation/vis2/components/graph.js
+++ b/client-participation/vis2/components/graph.js
@@ -1,5 +1,7 @@
 import React from "react";
-import _ from "lodash";
+import keyBy from "lodash/keyBy";
+import isUndefined from "lodash/isUndefined";
+import isNumber from "lodash/isNumber";
 // import {ReactSVGPanZoom} from 'react-svg-pan-zoom';
 import * as globals from "./globals";
 import graphUtil from "../util/graphUtil";
@@ -45,7 +47,7 @@ class Graph extends React.Component {
       return;
     }
 
-    let tidsToShowSet = _.keyBy(nextProps.tidsToShow);
+    let tidsToShowSet = keyBy(nextProps.tidsToShow);
 
     let {
       xx,
@@ -63,11 +65,11 @@ class Graph extends React.Component {
     } = graphUtil(nextProps.comments, nextProps.math, nextProps.badTids, nextProps.ptptois);
 
     commentsPoints = commentsPoints.filter((c) => {
-      return !_.isUndefined(tidsToShowSet[c.tid]);
+      return !isUndefined(tidsToShowSet[c.tid]);
     });
 
     let tidCarouselComments = nextProps.comments.filter((c) => {
-      return !_.isUndefined(tidsToShowSet[c.tid]);
+      return !isUndefined(tidsToShowSet[c.tid]);
     });
 
     let selectedComment = this.state.selectedComment
@@ -180,16 +182,16 @@ class Graph extends React.Component {
               report={this.props.report}/>
             <Hulls
               handleClick={this.handleCurateButtonClick.bind(this)}
-              selectedGroup={_.isNumber(this.state.selectedTidCuration) ? this.state.selectedTidCuration : null}
+              selectedGroup={isNumber(this.state.selectedTidCuration) ? this.state.selectedTidCuration : null}
               getHullElems={this.getHullElems.bind(this)}
               hulls={this.state.hulls} />
             <Participants
-              selectedGroup={_.isNumber(this.state.selectedTidCuration) ? this.state.selectedTidCuration : null}
+              selectedGroup={isNumber(this.state.selectedTidCuration) ? this.state.selectedTidCuration : null}
               points={this.state.baseClustersScaled}
               ptptois={this.state.ptptoisProjected}/>
             <HullLabels
               handleClick={this.handleCurateButtonClick.bind(this)}
-              selectedGroup={_.isNumber(this.state.selectedTidCuration) ? this.state.selectedTidCuration : null}
+              selectedGroup={isNumber(this.state.selectedTidCuration) ? this.state.selectedTidCuration : null}
               groups={this.props.math["group-votes"] || window.preload.firstMath["group-votes"] /* for labels */}
               centroids={this.state.groupCentroids}
               />

--- a/client-participation/vis2/components/graphAxes.js
+++ b/client-participation/vis2/components/graphAxes.js
@@ -1,8 +1,9 @@
 import React from "react";
+import isNumber from "lodash/isNumber";
 import * as globals from "./globals";
 
 const GraphAxes = ({yCenter, xCenter, report}) => {
-  if (!_.isNumber(yCenter) || !_.isNumber(xCenter) || !report) {
+  if (!isNumber(yCenter) || !isNumber(xCenter) || !report) {
     return null;
   }
   let padding = 0;

--- a/client-participation/vis2/components/graphComments.js
+++ b/client-participation/vis2/components/graphComments.js
@@ -1,5 +1,7 @@
 import React from "react";
-import _ from "lodash";
+import each from "lodash/each";
+import isNumber from "lodash/isNumber";
+import isNull from "lodash/isNull";
 import * as globals from "./globals";
 
 /* https://bl.ocks.org/mbostock/2206590 */
@@ -57,7 +59,7 @@ class GraphComment extends React.Component {
 class GraphComments extends React.Component {
 
   drawComments() {
-    let shouldShowOnlyOneGroup = _.isNumber(this.props.showOnlyGroup);
+    let shouldShowOnlyOneGroup = isNumber(this.props.showOnlyGroup);
 
     return this.props.points.map((pt, i) => {
 
@@ -65,21 +67,21 @@ class GraphComments extends React.Component {
       let antiRepfulForGid = null;
       if (globals.shouldColorizeTidsByRepfulness) {
         let tid = pt.tid;
-        _.each(this.props.repfulAgreeTidsByGroup, (tids, gid) => {
+        each(this.props.repfulAgreeTidsByGroup, (tids, gid) => {
           if (tids && tids.indexOf(tid) >= 0) {
             // console.log('rep', tid, gid);
             repfulForGid = Number(gid);
           }
         });
-        _.each(this.props.repfulDisageeTidsByGroup, (tids, gid) => {
+        each(this.props.repfulDisageeTidsByGroup, (tids, gid) => {
           if (tids && tids.indexOf(tid) >= 0) {
             // console.log('!rep', tid, gid);
             antiRepfulForGid = Number(gid);
           }
         });
-        if (!_.isNull(repfulForGid) && repfulForGid === this.props.showOnlyGroup) {
+        if (!isNull(repfulForGid) && repfulForGid === this.props.showOnlyGroup) {
           color = globals.groupColor(repfulForGid);
-        } else if (!_.isNull(antiRepfulForGid)) {
+        } else if (!isNull(antiRepfulForGid)) {
           color = globals.antiRepfulColor;
         }
       }

--- a/client-participation/vis2/components/graphParticipants.js
+++ b/client-participation/vis2/components/graphParticipants.js
@@ -1,7 +1,7 @@
 import React from "react";
 import _ from "lodash";
 import * as globals from "./globals";
-import {VictoryAnimation} from "victory";
+import {VictoryAnimation} from "victory-core";
 
 const Participant = ({ptpt, tweenX, tweenY}) => {
   let picSize = ptpt.picture_size;

--- a/client-participation/vis2/components/graphParticipants.js
+++ b/client-participation/vis2/components/graphParticipants.js
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "lodash";
 import * as globals from "./globals";
 import {VictoryAnimation} from "victory-core";
 

--- a/client-participation/vis2/components/header.js
+++ b/client-participation/vis2/components/header.js
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "lodash";
 import Logo from "./hexLogo";
 import Gear from "./gear";
 

--- a/client-participation/vis2/components/hexLogo.js
+++ b/client-participation/vis2/components/hexLogo.js
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "lodash";
 
 const HexLogo = () => {
   return (

--- a/client-participation/vis2/components/hull.js
+++ b/client-participation/vis2/components/hull.js
@@ -1,6 +1,6 @@
 import React from "react";
 import * as globals from "./globals";
-import {VictoryAnimation} from "victory";
+import {VictoryAnimation} from "victory-core";
 
 class Hull extends React.Component {
   render () {

--- a/client-participation/vis2/components/tidCarousel.js
+++ b/client-participation/vis2/components/tidCarousel.js
@@ -1,6 +1,7 @@
 import React from "react";
 import * as globals from "./globals";
-import _ from "lodash";
+import isNull from "lodash/isNull";
+import map from "lodash/map";
 
 class PaginateButton extends React.Component {
 
@@ -98,7 +99,7 @@ class TidCarousel extends React.Component {
 
   render() {
 
-    if (_.isNull(this.props.selectedTidCuration)) { return null }
+    if (isNull(this.props.selectedTidCuration)) { return null }
 
     return (
       <div style={{
@@ -125,7 +126,7 @@ class TidCarousel extends React.Component {
             {this.props.Strings.comment_123}
           </p>
           {
-            this.props.commentsToShow && _.map(
+            this.props.commentsToShow && map(
               this.props.commentsToShow.slice(
                 (this.state.page * this.state.perPage),
                 ((this.state.page * this.state.perPage) + this.state.perPage)

--- a/client-participation/vis2/util/graphUtil.js
+++ b/client-participation/vis2/util/graphUtil.js
@@ -1,5 +1,12 @@
 import * as globals from "../components/globals";
-import _ from "lodash";
+import clone from "lodash/clone";
+import min from "lodash/min";
+import max from "lodash/max";
+import keyBy from "lodash/keyBy";
+import maxBy from "lodash/maxBy";
+import minBy from "lodash/minBy";
+import assign from "lodash/assign";
+import each from "lodash/each";
 import createHull from "hull.js";
 
 import { forceSimulation, forceCollide, forceX, forceY } from 'd3-force';
@@ -54,32 +61,32 @@ function getGroupCornerAssignments(math) {
   for (let i = 0; i < 4; i++) { // nw
     candidate.nw = {
       gid: i,
-      pos: clusters[i] && _.clone(clusters[i].center),
+      pos: clusters[i] && clone(clusters[i].center),
     };
     for (let j = 0; j < 4; j++) { // sw
       if (j === i) { continue; }
       candidate.sw = {
         gid: j,
-        pos: clusters[j] && _.clone(clusters[j].center),
+        pos: clusters[j] && clone(clusters[j].center),
       };
 
       for (let k = 0; k < 4; k++) { // ne
         if (k === i || k === j) { continue; }
         candidate.ne = {
           gid: k,
-          pos: clusters[k] && _.clone(clusters[k].center),
+          pos: clusters[k] && clone(clusters[k].center),
         };
 
         for (let m = 0; m < 4; m++) { // se
           if (m === i || m === j || m === k) { continue; }
           candidate.se = {
             gid: m,
-            pos: clusters[m] && _.clone(clusters[m].center),
+            pos: clusters[m] && clone(clusters[m].center),
           };
 
           let score = getScore(candidate);
           if (score < bestScore) {
-            bestCandidate = _.clone(candidate);
+            bestCandidate = clone(candidate);
             bestScore = score;
           }
         }
@@ -117,7 +124,7 @@ function mixedForce(arrays, strength) {
 
 const doMapCornerPointer = (corner, xx, yy) => {
   if (corner.pos) {
-    corner.pos = _.clone(corner.pos);
+    corner.pos = clone(corner.pos);
     corner.pos[0] = xx(corner.pos[0]);
     corner.pos[1] = yy(corner.pos[1]);
   }
@@ -127,7 +134,7 @@ const graphUtil = (comments, math, badTids, ptptois) => {
     const allXs = [];
     const allYs = [];
 
-    const commentsByTid = _.keyBy(comments, "tid");
+    const commentsByTid = keyBy(comments, "tid");
 
     // comments
     const commentsPoints = [];
@@ -191,25 +198,25 @@ const graphUtil = (comments, math, badTids, ptptois) => {
 
 
     let border = 20;
-    let minClusterX = _.min(allXs);
-    let maxClusterX = _.max(allXs);
-    let minClusterY = _.min(allYs);
-    let maxClusterY = _.max(allYs);
+    let minClusterX = min(allXs);
+    let maxClusterX = max(allXs);
+    let minClusterY = min(allYs);
+    let maxClusterY = max(allYs);
     const xx = d3.scaleLinear().domain([minClusterX, maxClusterX]).range([border, globals.side - border]);
     const yy = d3.scaleLinear().domain([minClusterY, maxClusterY]).range([border, globals.svgHeightWithoutPadding - border]);
 
     const xCenter = xx(0);
     const yCenter = yy(0);
 
-    var greatestAbsPtptX = (_.maxBy(baseClusters, (pt) => { return Math.abs(pt.x); }) || {x: 1}).x;
-    var greatestAbsPtptY = (_.maxBy(baseClusters, (pt) => { return Math.abs(pt.y); }) || {y: 1}).y;
-    var greatestAbsCommentX = (_.maxBy(commentsPoints, (pt) => { return Math.abs(pt.x); }) || {x: 1}).x;
-    var greatestAbsCommentY = (_.maxBy(commentsPoints, (pt) => { return Math.abs(pt.y); }) || {y: 1}).y;
+    var greatestAbsPtptX = (maxBy(baseClusters, (pt) => { return Math.abs(pt.x); }) || {x: 1}).x;
+    var greatestAbsPtptY = (maxBy(baseClusters, (pt) => { return Math.abs(pt.y); }) || {y: 1}).y;
+    var greatestAbsCommentX = (maxBy(commentsPoints, (pt) => { return Math.abs(pt.x); }) || {x: 1}).x;
+    var greatestAbsCommentY = (maxBy(commentsPoints, (pt) => { return Math.abs(pt.y); }) || {y: 1}).y;
 
-    var maxCommentX = (_.maxBy(commentsPoints, (pt) => { return pt.x; }) || {x: 1}).x;
-    var minCommentX = (_.minBy(commentsPoints, (pt) => { return pt.x; }) || {x: 1}).x;
-    var maxCommentY = (_.maxBy(commentsPoints, (pt) => { return pt.y; }) || {y: 1}).y;
-    var minCommentY = (_.minBy(commentsPoints, (pt) => { return pt.y; }) || {y: 1}).y;
+    var maxCommentX = (maxBy(commentsPoints, (pt) => { return pt.x; }) || {x: 1}).x;
+    var minCommentX = (minBy(commentsPoints, (pt) => { return pt.x; }) || {x: 1}).x;
+    var maxCommentY = (maxBy(commentsPoints, (pt) => { return pt.y; }) || {y: 1}).y;
+    var minCommentY = (minBy(commentsPoints, (pt) => { return pt.y; }) || {y: 1}).y;
 
     // xGreatestMapped = xCenter + xScale * maxCommentX
     // globals.side - border = xCenter + xScale * maxCommentX
@@ -234,7 +241,7 @@ const graphUtil = (comments, math, badTids, ptptois) => {
       Math.abs(yScaleCandidateForTopSide));
 
     const baseClustersScaled = baseClusters.map((p) => {
-      return _.assign({}, p, {
+      return assign({}, p, {
         gid: p.gid,
         bid: p.bid,
         x: xx(p.x),
@@ -257,7 +264,7 @@ const graphUtil = (comments, math, badTids, ptptois) => {
     });
 
     let ptptoisProjected = ptptois.map((p) => {
-      let p2 = _.clone(p);
+      let p2 = clone(p);
       p2.x = xx(p.x);
       p2.y = yy(p.y);
       return p2;
@@ -280,7 +287,7 @@ const graphUtil = (comments, math, badTids, ptptois) => {
 
     const hulls = [];
 
-    _.each(pointsForHullGeneration, (group) => {
+    each(pointsForHullGeneration, (group) => {
       const pairs = group.map((g) => { /* create an array of arrays */
         return [g.x, g.y]
       })

--- a/client-participation/vis2/vis2.js
+++ b/client-participation/vis2/vis2.js
@@ -1,6 +1,6 @@
-
 import * as globals from "./components/globals";
-import _ from "lodash";
+import each from "lodash/each";
+import keyBy from "lodash/keyBy";
 import Graph from "./components/graph";
 import Header from "./components/header";
 import React from 'react';
@@ -49,7 +49,7 @@ class Root extends React.Component {
     let repfulAgreeTidsByGroup = {};
     let repfulDisageeTidsByGroup = {};
     if (mathResult.repness) {
-      _.each(mathResult.repness, (entries, gid) => {
+      each(mathResult.repness, (entries, gid) => {
         entries.forEach((entry) => {
           if (entry['repful-for'] === 'agree') {
             repfulAgreeTidsByGroup[gid] = repfulAgreeTidsByGroup[gid] || [];
@@ -62,7 +62,7 @@ class Root extends React.Component {
       });
     }
 
-    let badTids = _.keyBy(this.props.math_main['mod-out']);
+    let badTids = keyBy(this.props.math_main['mod-out']);
 
     comments = comments.filter((c) => {
       return !c.is_meta;


### PR DESCRIPTION
While poking around with trying to minimize the bundlesize for lodash (re: https://github.com/compdemocracy/polis/pull/1223), I found some other huge savings.

- https://github.com/compdemocracy/polis/pull/1225/commits/749a3090b11db6e6f1103fc02b73546d5200a114 require `victory-core` rather than full `victory`, since we're only using it for `<VictoryAnimation>`
  - 192.81 kb => 123.33 kb = **-69 kb** (36% reduction!!!)
- https://github.com/compdemocracy/polis/pull/1225/commits/1532ffb322d6f993acdafa00e01e98c18771a214 use direct imports of lodash modules rather than importing whole top-level package
  - 123.33 kb => 111.95 kb = **-11 kb** (6% reduction)

EDIT: rebased so reviewer can see extent of each atomic commit :)