### PR TITLE
Improvements to e2e tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,12 @@ You can then run a minimal test suite with:
 make e2e-run-minimal
 ```
 
+You can also run a subset of tests (even just one) with:
+
+```
+make e2e-run-subset TEST_FILTER=kitchensink
+```
+
 If for whatever reason, Docker is serving your application from a remote IP or URL instead of `http://127.0.0.1`, then there are work-arounds:
 
 ```

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ e2e-run-standalone: ## Run E2E tests: standalone (no credentials required)
 e2e-run-secret: ## Run E2E tests: secret (credentials required)
 	$(E2E_RUN) npm run e2e:secret
 
+e2e-run-subset: ## Run E2E tests: filter tests by TEST_FILTER envvar
+	$(E2E_RUN) ./node_modules/.bin/cypress run --spec **/*$(TEST_FILTER)*.spec.js --browser=chrome --no-exit
+
 e2e-run-all: ## Run E2E tests: all
 	$(E2E_RUN) npm run e2e:all
 

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ e2e-run-standalone: ## Run E2E tests: standalone (no credentials required)
 e2e-run-secret: ## Run E2E tests: secret (credentials required)
 	$(E2E_RUN) npm run e2e:secret
 
-e2e-run-subset: ## Run E2E tests: filter tests by TEST_FILTER envvar
-	$(E2E_RUN) ./node_modules/.bin/cypress run --spec **/*$(TEST_FILTER)*.spec.js --browser=chrome --no-exit
+e2e-run-subset: ## Run E2E tests: filter tests by TEST_FILTER envvar (without browser exit)
+	$(E2E_RUN) npm run e2e:subset
 
 e2e-run-all: ## Run E2E tests: all
 	$(E2E_RUN) npm run e2e:all

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ e2e-prepare: ## Prepare to run Cypress E2E tests
 	@# Testing embeds requires a override of a file prior to build.
 	cp e2e/cypress/fixtures/html/embed.html client-admin/embed.html
 
-e2e-run-minimal: ## Run E2E tests: minimal (for nightly builds)
+e2e-run-minimal: ## Run E2E tests: minimal (smoke test)
 	$(E2E_RUN) npm run e2e:minimal
 
 e2e-run-standalone: ## Run E2E tests: standalone (no credentials required)

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,5 +1,6 @@
 {
   "chromeWebSecurity": false,
+  "videoCompression": 15,
   "apiPath": "/api/v3",
   "ignoreTestFiles": "**/examples/*.spec.js",
   "baseUrl": "http://localhost"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "eslint --fix .",
     "test": "npm run e2e:all",
     "e2e:all": "cypress run --spec 'cypress/integration/polis/**' --browser=chrome",
-    "e2e:minimal": "cypress run --spec '**/polis/**/!(*.secrets).spec.js,!**/embeds.spec.js' --browser=chrome",
+    "e2e:minimal": "cypress run --spec '**/kitchensink.spec.js' --browser=chrome",
     "e2e:standalone": "cypress run --spec '**/polis/**/!(*.secrets).spec.js' --browser=chrome",
     "e2e:secret": "cypress run --spec '**/(*.secrets).spec.js' --browser=chrome"
   },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,7 +11,8 @@
     "e2e:all": "cypress run --spec 'cypress/integration/polis/**' --browser=chrome",
     "e2e:minimal": "cypress run --spec '**/kitchensink.spec.js' --browser=chrome",
     "e2e:standalone": "cypress run --spec '**/polis/**/!(*.secrets).spec.js' --browser=chrome",
-    "e2e:secret": "cypress run --spec '**/(*.secrets).spec.js' --browser=chrome"
+    "e2e:secret": "cypress run --spec '**/(*.secrets).spec.js' --browser=chrome",
+    "e2e:subset": "cypress run --spec **/*${TEST_FILTER:-kitchensink}*.spec.js --browser=chrome --no-exit"
   },
   "author": "Benjamin Rosas <ben@aliencyb.org>",
   "devDependencies": {


### PR DESCRIPTION
After running a bunch of local e2e testing the past few days (incl extensively for diagnosing #961), I've realized some changes would be helpful:

- don't compress the videos as much, as the low framerate on those downloaded from a CI run makes it hard to diagnose
- add (and document) an easy way to fun an arbitary e2e test (`make e2e-run-subset TEST_FILTER=some-partial-name`
- convert `make e2e-run-minimal` from being a big suite to a single kitchensink smoke test

If it looks good, this is ready for merge. Thanks!