### PR TITLE
Fix failing nightly docker image build

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -36,7 +36,11 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build full project via docker-compose
-        run: docker-compose build --parallel --build-arg GIT_HASH=${GITHUB_SHA:0:6}
+        run: |
+          docker-compose build --parallel client-admin client-participation client-report math server postgres nginx-proxy
+          # Build file-server after all client-* images, as depends_on has no effect on build order.
+          # See: https://github.com/docker/compose/issues/6802#issuecomment-573660235
+          docker-compose build file-server
 
       - name: Push images to Docker Hub
         run: docker-compose push --ignore-push-failures


### PR DESCRIPTION
The docker hub image build has been failing for a long time, and showing up as a failed badge on the README.

This should fix it.