### PR TITLE
Revert debug changes in docker configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       - "polis-net"
     ports:
       - "5000:5000"
-      - "9229:9229"
 
   math:
     container_name: polis-math

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14.14.0-alpine
 
 WORKDIR /app
 
-RUN apk add postgresql-dev python-dev build-base
+RUN apk add postgresql-dev
 
 RUN apk add --no-cache --virtual .build \
   g++ git make python
@@ -14,11 +14,8 @@ RUN npm install
 RUN apk del .build
 
 COPY . .
+RUN npm run build
 
 EXPOSE 5000
-# For vscode debug
-EXPOSE 9229
 
-
-# CMD npm run build && npm run serve
-CMD npm run build:watch && npm run serve
+CMD npm run serve


### PR DESCRIPTION
Reticketed from https://github.com/compdemocracy/polis/pull/961#discussion_r768206590 (plus some other comments from @metasoarous in that PR)

Should also resolve: https://github.com/compdemocracy/polis/pull/1236#issuecomment-993109284

The one change of note is that `npm run build` should happen in a `RUN` directive in Dockerfile, not during container start in `CMD` directive.