### PR TITLE
Updated workflow config around npm caching

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -28,20 +28,10 @@ jobs:
     - name: Use Node version for app builds
       uses: actions/setup-node@v2.5.1
       with:
+        # Gulp usage in client-participation build caps version here.
         node-version: 11.15.0
-
-    - name: Get npm cache directory
-      id: npm-cache
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
-
-    - name: Restore npm cache directory
-      uses: actions/cache@v2.1.5
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        cache: npm
+        cache-dependency-path: '**/package-lock.json'
 
     - name: "Install & Build: client-admin"
       working-directory: client-admin

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -26,7 +26,7 @@ jobs:
 
     # Both components use this version
     - name: Use Node version for app builds
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v2.5.1
       with:
         node-version: 11.15.0
 

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -27,6 +27,9 @@ jobs:
         uses: actions/setup-node@v2.5.1
         with:
           node-version: 14.4.0
+          # For some reason, caching isn't working here right now. #TODO
+          # cache: npm
+          # cache-dependency-path: 'client-admin/package-lock.json'
 
       # See: https://github.com/taskworld/commit-status
       - name: Install commit-status CLI tool

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -24,7 +24,7 @@ jobs:
           echo "name=HAS_SECRET" >> $GITHUB_ENV
 
       - name: Use Node.js
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v2.5.1
         with:
           node-version: 14.4.0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,19 +14,8 @@ jobs:
       uses: actions/setup-node@v2.5.1
       with:
         node-version: 14.4.0
-
-    - name: Get npm cache directory
-      id: npm-cache
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
-
-    - name: Restore npm cache directory
-      uses: actions/cache@v2.1.5
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        cache: npm
+        cache-dependency-path: '**/package-lock.json'
 
     - name: "Install & Build: client-admin"
       working-directory: client-admin

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2.3.4
 
     - name: Use Node.js
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v2.5.1
       with:
         node-version: 14.4.0
 


### PR DESCRIPTION
Depends on https://github.com/compdemocracy/polis/pull/1258

Re-ticketed from https://github.com/compdemocracy/polis/pull/1258#issuecomment-1002743188

This just allows us to take advantage of the new config options in the `setup-node` action. No behaviour should change.