### PR TITLE
Remove hard-coding of API URL resolution

### DIFF
--- a/client-report/gulpfile.js
+++ b/client-report/gulpfile.js
@@ -78,6 +78,9 @@ gulp.task('index', [
   index = index.replace("/dist/report_bundle.js",  '/' + [destRootRest, "js", "report_bundle.js"].join('/'));
   index = index.replace("NULL_VERSION",  versionString);
 
+  var domainWhitelist = '["' + polisConfig.domainWhitelist.join('","') + '"]';
+  index = index.replace("<%= domainWhitelist %>", domainWhitelist);
+
   // index goes to the root of the dist folder.
   var indexDest = [destRootBase, "index_report.html"].join("/");
   // fs.mkdirSync(destRootBase);

--- a/client-report/index.html
+++ b/client-report/index.html
@@ -72,6 +72,9 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
+    <script>
+      window.domainWhitelist = <%= domainWhitelist %>;
+    </script>
   </head>
 
   <body class="viewport">

--- a/client-report/polis.config.template.js
+++ b/client-report/polis.config.template.js
@@ -1,4 +1,16 @@
 module.exports = {
+  domainWhitelist: [
+    // local ports
+    "^localhost$",
+    "^127\\.0\\.0\\.1$",
+    "^192\\.168\\.1\\.140$",
+    // sample configuration for main pol.is deployment
+    "^pol\\.is",
+    ".+\\.pol\\.is$",
+    // These allow for local ip routing for remote dev deployment
+    "^(n|ssl)ip\\.io$",
+    ".+\\.(n|ssl)ip\\.io$",
+  ],
 
   //SERVICE_URL: 'http://localhost:5000',
   SERVICE_URL: 'https://preprod.pol.is',

--- a/client-report/src/util/url.js
+++ b/client-report/src/util/url.js
@@ -1,53 +1,24 @@
 // Copyright (C) 2012-present, The Authors. This program is free software: you can redistribute it and/or  modify it under the terms of the GNU Affero General Public License, version 3, as published by the Free Software Foundation. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-var prod = "https://pol.is/";
-var preprod = "https://preprod.pol.is/";
-var embed = "https://embed.pol.is/";
-var survey = "https://survey.pol.is/";
-var polisio = "https://www.polis.io/";
-var localhost = "http://localhost:5000/";
-var localhost5002 = "http://localhost:5002/";
-var localhost5010 = "http://localhost:5010/";
+// build may prepend 'devWithPreprod'
 
-var urlPrefix = prod;
-if (document.domain.indexOf("preprod") >= 0) {
-    urlPrefix = preprod;
-}
-if (document.domain.indexOf("embed") >= 0) {
-    urlPrefix = embed;
-}
-if (document.domain.indexOf("survey") >= 0) {
-    urlPrefix = survey;
-}
-if (document.domain.indexOf("polis.io") >= 0) {
-    urlPrefix = polisio;
-}
-if ((-1 === document.domain.indexOf("pol.is")) && (-1 === document.domain.indexOf("polis.io"))) {
-    urlPrefix = localhost;
+let urlPrefix = '_domainWhitelistError_'
+
+const wl = window.domainWhitelist.map(function (x) {
+  return new RegExp(x)
+})
+
+for (let i = 0; i < wl.length; i++) {
+  if (document.domain.match(wl[i])) {
+    urlPrefix = document.location.protocol + '//' + document.location.hostname
+    if (document.location.port) {
+      urlPrefix = urlPrefix + ':' + document.location.port
+    }
+    urlPrefix = urlPrefix + '/'
+    break
+  }
 }
 
-if (document.domain === "localhost" && document.location.port === "5002") {
-  urlPrefix = localhost5002;
+export default {
+  urlPrefix: urlPrefix
 }
-
-if (document.domain === "localhost" && document.location.port === "5010") {
-  urlPrefix = localhost5010;
-}
-
-if (0 === document.domain.indexOf("192.168") || (new RegExp(/\.(ssl|n)ip\.io/)).test(document.domain) ) {
-  urlPrefix = "http://" + document.location.hostname + ":" + document.location.port + "/";
-}
-
-function isPreprod() {
-  return urlPrefix === preprod;
-}
-
-function isLocalhost() {
-  return urlPrefix === localhost || urlPrefix === localhost8000;
-}
-const foo = {
-  urlPrefix: urlPrefix,
-  isPreprod: isPreprod,
-  isLocalhost: isLocalhost
-};
-export default foo;


### PR DESCRIPTION
This PR just plugs a hole in the configuration to work around hard-coded domain names in the code-base. It is a minimal change that leaves all the hard-coded names in place and uses the configured value as a back-stop.