### PR TITLE
Fix docstring of conv-man namespace

### DIFF
--- a/math/src/polismath/conv_man.clj
+++ b/math/src/polismath/conv_man.clj
@@ -1,7 +1,7 @@
 ;; Copyright (C) 2012-present, The Authors. This program is free software: you can redistribute it and/or  modify it under the terms of the GNU Affero General Public License, version 3, as published by the Free Software Foundation. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 (ns polismath.conv-man
-  "This is the namesascpe for the "
+  "This is the namespace for the conversation manager"
   (:require [polismath.math.named-matrix :as nm]
             [polismath.math.conversation :as conv]
             [polismath.math.clusters :as clust]


### PR DESCRIPTION
This PR fixes the docstring of the conversation manager namespace.