### PR TITLE
Refactor the docker-compose.yaml to support scaling the server container

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ If you are using an older version (and don't want to upgrade), you'll need to se
 
 After cloning the repository, navigate via command line to the root directory and run the following command to build and run the docker containers:
 
-```
-docker comopse -f docker-compose.yml -f docker-compose.dev.yml up --build
+```sh
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 ```
 
 If you get a permission error, try running this command with `sudo`.
@@ -74,13 +74,15 @@ To avoid having to use `sudo` in the future (on a Linux or Windows machine with 
 
 Once you've built, you can run the following when you want to run the project:
 
-`docker compose -f docker-compose.yml -f docker-compose.dev.yml up`
+```sh
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
 
 That's it!
 
 ### Testing out your instance
 
-You can now test your setup by visiting `http://localhost:80/` (or localhost:5000).
+You can now test your setup by visiting `http://localhost:80/`.
 
 Once the index page loads, you can create an account using the `/createuser` path. You'll be logged in right away; email validation is not required.
 
@@ -92,6 +94,19 @@ However, as you go on (and especially if you are setting up a production deploym
 At the moment, there are a number of configuration files and environment variable options scattered across the repository.
 There _is_ currently an open PR which seeks to unify the configuration options which we're actively working on: https://github.com/compdemocracy/polis/pull/1341
 
+### Scaling the polis server
+
+If you plan on running a large conversations or lots of conversations at once,
+you might bump into performance issues.
+
+Assuming that the host has enough resources to run multiple instances of the
+polis server container, you can start polis using the following command:
+
+```sh
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --scale server=3
+```
+
+Where `3` is the number of replicas you'd like to use.
 
 ### Miscellaneous & troubleshooting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ version: "3.4"
 
 services:
   server:
-    container_name: polis-server
     env_file: ./server/docker-dev.env
     image: docker.io/compdem/polis-server:${TAG}
     build:
@@ -28,8 +27,8 @@ services:
       - "file-server"
     networks:
       - "polis-net"
-    ports:
-      - "5000:5000"
+    # Scale the server container to a given number of instances.
+    scale: 1
 
   math:
     container_name: polis-math


### PR DESCRIPTION
Resolves https://github.com/compdemocracy/polis/issues/1352.

## Changelog

* Remove the `container_name` from the `server` to allow docker compose to dynamically create the service names.
* Remove the `ports` from the `server` as we can't have multiple services bind to the same port.
* Update `README.md` to mention scaling
* Update `REAMDE.md` to remove mention of `localhost:5000`

## Concerns

* My only worry with this PR is that it removes the port 5000 from the production docker-compose and even though the service is exposed through the nginx-proxy, someone might be using it already for some reason. -- The alternative is to leave the ports in, but mention in the REAMDE that you'll need to comment it out if you wish to scale the server up.

## Notes

* Unfortunately I can't find a sane way of getting auto scaling natively in docker-compose that might be fit for production use.