### PR TITLE
Fix heroku client release

### DIFF
--- a/math/src/polismath/components/config.clj
+++ b/math/src/polismath/components/config.clj
@@ -75,7 +75,8 @@
    :aws-access-key             {:path [:aws :access-key-id]}
    :webserver-username         {:path [:webserver-username]}
    :webserver-pass             {:path [:webserver-pass]}
-   :worker-zid-blocklist       {:path [:poller :zid-blocklist] :parse ->long-list}
+   :math-zid-blocklist         {:path [:poller :zid-blocklist] :parse ->long-list}
+   :math-zid-allowlist         {:path [:poller :zid-allowlist] :parse ->long-list}
    :export-server-auth-username {:path [:darwin :server-auth-username]}
    :export-server-auth-pass    {:path [:darwin :server-auth-pass]}
    :math-matrix-implementation {:path [:math :matrix-implementation] :parse ->keyword}


### PR DESCRIPTION
This applies the style of multi-stage image we're now using in the `file-server/Dockerfile` to the main `Dockerfile` for building and releasing the client images to s3 (via heroku). It specifically fixes an issue we had with `npm ci` not working for the client-report.

This all suggests that these two should be merged, though it does introduce some extra build time in different scenarios to do this. 

This also addresses at least part of https://github.com/compdemocracy/polis/issues/1378