### PR TITLE
Updated chat room link in docs.

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,11 +79,6 @@ It is NOT suited for production, but it may be in the future.
    [arch-image]: docker-architecture.png
    [arch-edit]: https://www.draw.io/#R7Vpdb5swFP01ecyEDQTy2rRrHjapUzqt3ZsHLngjGDkmkP36mWBCwCRjKHxUWh8qfP19ju%2Fx9W1n%2BmqbPjIU%2BZ%2Bpi4MZ1Nx0pt%2FPIFzqlvidGQ65wVhoucFjxM1NoDRsyG8sjUWzmLh4V2nIKQ04iapGh4YhdnjFhhijSbXZGw2qs0bIw4ph46BAtX4jLvdzq21qpX2NiecXMwNN1vxAzi%2BP0TiU882g%2Fnb8yau3qBhLtt%2F5yKXJmUl%2FmOkrRinPv7bpCgcZtAVseb%2BPF2pP62Y45G06zJcbO%2FkSWwisdTd1Vsnz5nl%2BWhw%2FFIBgV%2BAji5Rxn3o0RMFDab07bhpnw2qiVLb5RGkkjEAYf2LOD5JsFHMqTD7fBrIWp4S%2FZN0%2FmLL0KgfLvu%2FT88KhKIScHc46ZcXXYrysUHY7lop%2BKkwSuR2NmYOvYFOcRsQ8zK%2B0M%2FN2GW5nE0gSHjHdYrEe0YDhAHGyr547JI%2Bvd2pXUig%2BJIv%2FwKgcd4%2BCWM4UeiRMFZqrJCY%2B4XgToSMgiXD0KmEXQdxjxnF6dduydmHIoyZ1AkBbGpLS7UBxHv0zlysE5eZQQQWqNxLg%2BQ4zsa3RAbNgDTDNUAGDxpCAgUUHtXBiAacrcelJOkAn6dB6kw69pXTASUmHrviDExCx9zlytyScnEMsG%2FzBHtQdrP%2Fu0ModjHfpDsYldxAQcOKQSKyBju8WtjY1t7An6hZTCzDNd%2BkWOhyf3o5UdTkWA9Br3Jpf2fWJErHmMgLXzWpACeyaBORbkt1qx%2BS0ju4nx1QEdSKhtvI2AaO%2FTRYKVhHdcY%2Fh3ehomXaLhwkAg1455viaJLUFnCvLSWf%2BduVU4rBS1G5%2B5VgtNWkx1pVz97J%2Feln5ceqC72vt6xKtn%2B6Kh8nk2LX6pLeGfb98m2NGFJaidcfk6dg6Z2htdG7YjJWa3bM1W83hllCBYd4gSq6q4QJtSlXB3pBSk3sTwGlRvzp1ODZOatLH1LQJIgVHR0rNB5hGw2NocKRALawf3%2FfUQF8HUL3Eh0bKqIf5QyLVGNhM4CndIYE46xSfNALQz0vXVog2agzmAdEtXrqXt9WUOmQ4EiRd8YTWoY1y7BsIuHxf19S1x5yhKJZ%2F487xLf%2BPQH%2F4Aw%3D%3D
 
-:tada: Contributors to Docker support:
-- [@uzzal2k5](https://github.com/uzzal2k5) via [`uzzal2k5/polis_container`](https://github.com/uzzal2k5/polis_container)
-- [@crkrenn](https://github.com/crkrenn) & [@david-nadaraia](https://github.com/david-nadaraia)
-- [@patcon](https://github.com/patcon)
-- [@ballPointPenguin](https://github.com/ballPointPenguin)
 
 ## Enabling Comment Translation
 
@@ -218,11 +213,6 @@ You'd do this for each new file.
 
 Please help us out as you go in setting things up by improving the deployment code and documentation!
 
-* General/system-wide issues you come across can go in https://github.com/pol-is/polis-issues/issues, and repo specific
-issues in their respective issues lists
-* PRs improving either documentation or deployment code are welcome, but please submit an issue to discuss before making
-any substantial code changes
-* After you've made an issue, you can try to chat folks up on Gitter:
-https://gitter.im/compdemocracy/polis-dev-chat
-* There is also an old Gitter chat room but please do not post here: https://gitter.im/pol-is/polisDeployment
-
+* Well definted technical issues can go in https://github.com/compdemocracy/polis/issues, but please check to make sure you aren't submitting a duplicate issue
+* PRs improving either documentation or deployment code are welcome, but please submit an issue to discuss before making any substantial code changes
+* Questions about usage can go in https://github.com/compdemocracy/polis/discussions.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -218,7 +218,11 @@ You'd do this for each new file.
 
 Please help us out as you go in setting things up by improving the deployment code and documentation!
 
-* General/system-wide issues you come across can go in https://github.com/pol-is/polis-issues/issues, and repo specific issues in their respective issues lists
-* PRs improving either documentation or deployment code are welcome, but please submit an issue to discuss before making any substantial code changes
-* After you've made an issue, you can try to chat folks up at https://gitter.im/pol-is/polisDeployment
+* General/system-wide issues you come across can go in https://github.com/pol-is/polis-issues/issues, and repo specific
+issues in their respective issues lists
+* PRs improving either documentation or deployment code are welcome, but please submit an issue to discuss before making
+any substantial code changes
+* After you've made an issue, you can try to chat folks up on Gitter:
+https://gitter.im/compdemocracy/polis-dev-chat
+* There is also an old Gitter chat room but please do not post here: https://gitter.im/pol-is/polisDeployment
 


### PR DESCRIPTION
Hi, I am new to this project and was spending some time looking over the documentation when I noticed the link to the Gitter chat room was outdated. So, I have updated it with the new one. If there are other plans with the docs folder please let me know.