### PR TITLE
Fix e2e tests (re: maildev container)

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -59,6 +59,10 @@ jobs:
       - name: Ensure embed test html is served
         run: cp e2e/cypress/fixtures/html/embed.html client-admin/embed.html
 
+      # This ensures maildev container is running for e2e tests of email features.
+      - name: Enable docker-compose dev overrides
+        run: cp docker-compose.dev.yml docker-compose.override.yml
+
       - name: Serve app via docker-compose
         run: docker-compose up --detach
 


### PR DESCRIPTION
Potential resolution for https://github.com/compdemocracy/polis/issues/1392#issuecomment-1237599567

I think the issue was that that docker-compose was split into prod file and dev files awhile back, but e2e CI workflow hasn't yet been updated to merge in the dev file when running -- the dev file helps stand up a fake mailserver that's used to exercise email features.

As context, `docker-compose.override.yml` is a special filename that is auto-read by docker without an explicit `-f docker-compose.override.yml` flag: https://docs.docker.com/compose/extends/#understanding-multiple-compose-files

This makes it easier to run development commands. Should I also swap out the `docker-compose -f docker-compose.yml -f docker-compose.dev.yml [...]` instructions in the readme for this approach?