### PR TITLE
Fix configuration overview markdown table

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ There's [been some work](https://github.com/compdemocracy/polis/pull/1341) to un
 First things first, it helps to understand a bit how the system is set up.
 
 | Component Name | Tech | Config | Description |
-|----------------|------|-------------|
+|----------------|------|--------| ----------- |
 | [`server`][dir-server] | Node.js | `ENV` (`server/docker-dev.env`) | The main server. Handles client web requests (page loads, vote activity, etc.) |
 | [`math`][dir-math] | Clojure/JVM | `ENV` (`math/docker-dev.env`) | The math engine.  |
 | [`client-participation`][dir-participation] | Javascript | `client-participation/polis.config.js` | The client code for end-users. |


### PR DESCRIPTION
Last change broke the configuration markdown table.

Current: https://github.com/compdemocracy/polis/blob/dev/docs/configuration.md
<img width="1042" alt="configuration_doc_before" src="https://user-images.githubusercontent.com/553444/190023335-9017e2c1-de03-43a3-8e70-cb787e27f557.png">

After:

<img width="1061" alt="configuration_doc_after" src="https://user-images.githubusercontent.com/553444/190023369-b2316058-2a2a-4af6-a612-a1e9956523b4.png">

