### PR TITLE
WIP: Feature/crkrenn/e2e cypress 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 
-# BASEURL ?= https://127.0.0.1.sslip.io
-BASEURL ?= http://127.0.0.1
+BASEURL ?= https://127.0.0.1.sslip.io
 E2E_RUN = cd e2e; CYPRESS_BASE_URL=$(BASEURL)
 
 pull: ## Pull most recent Docker container builds (nightlies)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
-BASEURL ?= https://127.0.0.1.sslip.io
+# BASEURL ?= https://127.0.0.1.sslip.io
+BASEURL ?= http://127.0.0.1
 E2E_RUN = cd e2e; CYPRESS_BASE_URL=$(BASEURL)
 
 pull: ## Pull most recent Docker container builds (nightlies)

--- a/e2e-12/REAME.md
+++ b/e2e-12/REAME.md
@@ -1,0 +1,2 @@
+TTD: test API with python
+continue test development

--- a/e2e-12/cypress.config.js
+++ b/e2e-12/cypress.config.js
@@ -1,0 +1,8 @@
+const { defineConfig } = require('cypress')
+
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost'
+  }
+})

--- a/e2e-12/cypress/e2e/polis/client-admin/create_user.cy.js
+++ b/e2e-12/cypress/e2e/polis/client-admin/create_user.cy.js
@@ -1,0 +1,48 @@
+describe('Create User page', () => {
+  beforeEach(() => {
+    const [name, email, password] = ['Dummy', 'test@polis.test', 'testpassword']
+
+    // cy.server()
+    // cy.intercept({
+    //   method: 'POST',
+    //   // path: '/auth/new'
+    //   path: Cypress.config().apiPath + '/auth/new'
+    // }).as('authNew')
+
+    cy.visit('/createuser')
+
+    cy.get('input#createUserNameInput').type(name)
+    cy.get('input#createUserEmailInput').type(email)
+    cy.get('input#createUserPasswordInput').type(password)
+    cy.get('input#createUserPasswordRepeatInput').type(password)
+  })
+
+  it('does not create a new user with existing email address', function () {
+    // Attempt to recreate existing user.
+    cy.fixture('users.json').then(users => {
+      const existingUser = users.moderator
+      cy.get('input#createUserEmailInput').clear().type(existingUser.email)
+      cy.get('button#createUserButton').click()
+    })
+
+    // cy.wait('@authNew').then(xhr => {
+    //   cy.wrap(xhr).its('status').should('eq', 403)
+    //   cy.wrap(xhr).its('response.body').should('eq', 'polis_err_reg_user_with_that_email_exists')
+    // })
+    cy.contains('form', 'Email address already in use')
+    cy.location('pathname').should('eq', '/createuser')
+  })
+
+  it('creates a new user', function () {
+    const randomInt = Math.floor(Math.random() * 10000)
+    const newUser = {
+      email: `user${randomInt}@polis.test`
+    }
+
+    cy.get('input#createUserEmailInput').clear().type(newUser.email)
+    cy.get('button#createUserButton').click()
+
+    // cy.wait('@authNew').its('status').should('eq', 200)
+    cy.location('pathname').should('eq', '/')
+  })
+})

--- a/e2e-12/cypress/e2e/polis/client-admin/home.cy.js
+++ b/e2e-12/cypress/e2e/polis/client-admin/home.cy.js
@@ -1,0 +1,12 @@
+describe('Home Page', () => {
+  beforeEach(() => cy.visit('/'))
+
+  it('bare Url redirects to /home', () => {
+    cy.location('pathname').should('eq', '/home')
+  })
+
+  it('has Sign up and Sign in links', () => {
+    cy.get('#root').find('a[href="/createuser"]')
+    cy.get('#root').find('a[href="/signin"]').should('have.length', 2)
+  })
+})

--- a/e2e-12/cypress/e2e/polis/client-admin/public_pages.cy.js
+++ b/e2e-12/cypress/e2e/polis/client-admin/public_pages.cy.js
@@ -1,0 +1,11 @@
+describe('Public pages', () => {
+  it('renders Privacy Policy', function () {
+    cy.visit('/privacy')
+    cy.get('h1').should('contain', 'Privacy Policy')
+  })
+
+  it('renders Terms of Use', function () {
+    cy.visit('/tos')
+    cy.get('h1').should('contain', 'Terms of')
+  })
+})

--- a/e2e-12/cypress/e2e/spec.cy.js
+++ b/e2e-12/cypress/e2e/spec.cy.js
@@ -1,0 +1,5 @@
+describe('empty spec', () => {
+  it('passes', () => {
+    cy.visit('https://example.cypress.io')
+  })
+})

--- a/e2e-12/cypress/fixtures/example.json
+++ b/e2e-12/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/e2e-12/cypress/fixtures/users.json
+++ b/e2e-12/cypress/fixtures/users.json
@@ -1,0 +1,12 @@
+{
+  "moderator": {
+    "name": "Dummy Moderator",
+    "email": "moderator@polis.test",
+    "password": "testpassword"
+  },
+  "participant": {
+    "name": "Dummy Participant",
+    "email": "participant@polis.test",
+    "password": "testpassword"
+  }
+}

--- a/e2e-12/cypress/support/commands.js
+++ b/e2e-12/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/e2e-12/cypress/support/e2e.js
+++ b/e2e-12/cypress/support/e2e.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/e2e.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/e2e-12/package.json
+++ b/e2e-12/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "polis-cypress",
+  "version": "0.0.1",
+  "description": "End to End testing for pol.is",
+  "devDependencies": {
+    "cypress": "^12.0.1"
+  }
+}


### PR DESCRIPTION
@metasoarous

Would you both be supportive of a pull request that migrated the existing cypress tests from cypress version 6.8.0 to version 12.0.1? 

There have been significant improvements since version 6.8, and I think the migrated version will be easier to maintain, extend, and further robustify. This should go a long way towards resolving https://github.com/compdemocracy/polis/issues/1392. 

I've started the process on this pull request. 

Please let me know what you think. 

Thanks!

-Chris