### PR TITLE
specify bullseye debian base for math dockerfile

### DIFF
--- a/math/Dockerfile
+++ b/math/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/clojure:tools-deps
+FROM docker.io/clojure:tools-deps-bullseye
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
fixes a problem where the math container may fail to start due to ubuntu+jvm issues