### PR TITLE
switch from npm ci to npm install in client dockerfiles

### DIFF
--- a/client-participation/Dockerfile
+++ b/client-participation/Dockerfile
@@ -15,7 +15,7 @@ RUN npm install -g npm@6.9.2
 
 COPY package*.json ./
 
-RUN npm ci
+RUN npm install
 
 RUN apk del .build
 

--- a/client-report/Dockerfile
+++ b/client-report/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN apk add git --no-cache
 
 COPY package*.json ./
-RUN npm ci
+RUN npm install
 
 COPY polis.config.template.js polis.config.js
 # If polis.config.js exists on host, will override template here.


### PR DESCRIPTION
Using ci can hang in certain cases, and can generally cause development headaches