### PR TITLE
update bundlewatch config

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -16,6 +16,10 @@ module.exports = {
       path: "client-participation/dist/js/*.js",
       maxSize: "450 kB",
     },
+    {
+      path: "client-report/dist/*.js",
+      maxSize: "200 kB",
+    }
   ],
   normalizeFileNames: /^.+?(\..+?)\.\w+$/,
 };

--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -1,25 +1,21 @@
 module.exports = {
-  "ci": {
-    "trackBranches": [
-      process.env.CI_BRANCH_DEFAULT,
-    ],
+  ci: {
+    trackBranches: [process.env.CI_BRANCH_DEFAULT],
+    baseBranch: process.env.CI_BRANCH_DEFAULT,
     // Allows bundlewatch GitHub Actions workflow to work on: pull_request, or push
-    "commitSha": process.env.PR_COMMIT_SHA || process.env.PUSH_COMMIT_SHA,
-    "repoBranchBase": process.env.PR_BRANCH_BASE || process.env.PUSH_BRANCH_BASE,
-    "repoCurrentBranch": process.env.PR_BRANCH || process.env.PUSH_BRANCH,
+    commitSha: process.env.PR_COMMIT_SHA || process.env.PUSH_COMMIT_SHA,
+    repoBranchBase: process.env.PR_BRANCH_BASE || process.env.PUSH_BRANCH_BASE,
+    repoCurrentBranch: process.env.PR_BRANCH || process.env.PUSH_BRANCH,
   },
-  "files": [
+  files: [
     {
-      "path": "client-admin/dist/**/*.js",
-      "maxSize": "180 kB",
+      path: "client-admin/build/static/js/*.js",
+      maxSize: "250 kB",
     },
     {
-      "path": "client-participation/dist/cached/*/js/polis.js",
-      "maxSize": "150 kB",
+      path: "client-participation/dist/js/*.js",
+      maxSize: "450 kB",
     },
-    {
-      "path": "client-participation/dist/cached/*/js/vis_bundle.js",
-      "maxSize": "200 kB",
-    },
-  ]
+  ],
+  normalizeFileNames: /^.+?(\..+?)\.\w+$/,
 };

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -3,7 +3,9 @@ name: "Bundlewatch Github Action"
 on:
   push:
     # Required so that baseline for comparison is pushed to bundlewatch service.
-    branches: ["dev"]
+    branches:
+      - edge
+      - update-bundlewatch-config
     paths:
       - .github/workflows/bundlewatch.yml
       - client-admin/**
@@ -18,25 +20,23 @@ on:
 jobs:
   bundlewatch:
     runs-on: ubuntu-latest
-    env:
-      BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v3
 
     # Both components use this version
     - name: Use Node version for app builds
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v3
       with:
-        node-version: 11.15.0
+        node-version: 18
 
     - name: Get npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 
     - name: Restore npm cache directory
-      uses: actions/cache@v2.1.5
+      uses: actions/cache@v3
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -48,7 +48,6 @@ jobs:
       run: |
         npm install
         npm run build:prod
-        mv dist/static/js/admin_bundle.*.js dist/static/js/admin_bundle.xxxxxxxx.js
 
     - name: "Install & Build: client-participation"
       working-directory: client-participation
@@ -62,18 +61,7 @@ jobs:
       run: npm install -g bundlewatch@0.2.6
 
     - name: "Run Bundlewatch"
-      # TODO: Move config to root directory, so easier to run against all components.
-      # See: https://github.com/bundlewatch/bundlewatch/pull/170
-      env:
-        CI_BRANCH_DEFAULT: ${{ github.event.repository.default_branch }}
-
-        PR_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-        PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-        # Overrides `ci.repoBranchBase` (bundlewatch config)
-        PR_BRANCH_BASE: ${{ github.event.pull_request.base.ref }}
-
-        PUSH_COMMIT_SHA: ${{ github.event.after }}
-        # PUSH_BRANCH: see below (needs processing)
-        PUSH_BRANCH_BASE: ${{ github.event.repository.default_branch }}
-      # GITHUB_REF is in format `refs/heads/branch-name`, so need to strip first part.
-      run: PUSH_BRANCH=${GITHUB_REF#refs/heads/} npx bundlewatch --config .bundlewatch.config.js
+      uses: jackyef/bundlewatch-gh-action@master
+      with:
+        bundlewatch-github-token: ${{ secrets.GITHUB_TOKEN }}
+        bundlewatch-config: .bundlewatch.config.js

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -5,7 +5,6 @@ on:
     # Required so that baseline for comparison is pushed to bundlewatch service.
     branches:
       - edge
-      - update-bundlewatch-config # remove this after merge into edge
     paths:
       - .github/workflows/bundlewatch.yml
       - client-admin/**

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -5,17 +5,19 @@ on:
     # Required so that baseline for comparison is pushed to bundlewatch service.
     branches:
       - edge
-      - update-bundlewatch-config
+      - update-bundlewatch-config # remove this after merge into edge
     paths:
       - .github/workflows/bundlewatch.yml
       - client-admin/**
       - client-participation/**
+      - client-report/**
   pull_request:
     types: ["opened", "reopened", "synchronize"]
     paths:
       - .github/workflows/bundlewatch.yml
       - client-admin/**
       - client-participation/**
+      - client-report/**
 
 jobs:
   bundlewatch:
@@ -24,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    # Both components use this version
+    # Client components all use this version
     - name: Use Node version for app builds
       uses: actions/setup-node@v3
       with:
@@ -53,12 +55,16 @@ jobs:
       working-directory: client-participation
       run: |
         npm install
-        npm run deploy:prod
-        # So directory stays consistent between builds for comparison.
-        mv dist/cached/* dist/cached/xxxxxxxxx
+        npm run build:prod
+
+    - name: "Install & Build: client-report"
+      working-directory: client-report
+      run: |
+        npm install
+        npm run build:prod
 
     - name: Install Bundlewatch
-      run: npm install -g bundlewatch@0.2.6
+      run: npm install -g bundlewatch@0.3.3
 
     - name: "Run Bundlewatch"
       uses: jackyef/bundlewatch-gh-action@master


### PR DESCRIPTION
~~**NOTE:** This is built on top of https://github.com/compdemocracy/polis/pull/1644
and so once that is merged, a lot of noise in this PR will be reduced.~~

This branch is now updated and ready to merge.

The paths used by bundlewatch were no longer valid (since going to Webpack I think).
Also, sadly, the client-participation bundle has grown (also since going to webpack).

Future work: reduce the bundle size to under 200KB or so.