### PR TITLE
Fixes to how NODE_ENV and npm modules are managed in various places

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Many convenient commands are found in the Makefile. Run `make help` for a list o
 
 First clone the repository, then navigate via command line to the root directory and run the following command to build and run the docker containers.
 
+Copy the example.env file and modify as needed (although it should just work as is for development and testing purposes).
+
+```sh
+cp example.env .env
+```
+
+
 ```sh
 docker compose up --build
 ```
@@ -104,6 +111,26 @@ To see what the environment of your containers is going to look like, run:
 
 ```sh
 docker compose convert
+```
+
+#### Production Mode Shortcuts
+
+The commands in the Makefile can be prefaced with PROD. If so, the "dev overlay" configuration in `docker-compose.dev.yml` will be ignored.
+Ports from services other than the HTTP proxy (80/443) will not be exposed. Containers will not mount local directories, watch for changes,
+or rebuild themselves. In theory this should be one way to run Polis in a production environment.
+
+You need a `prod.env` file:
+
+`cp example.env prod.env` (and update accordingly).
+
+Then you can run things like:
+
+```sh
+make PROD start
+
+make PROD start-REBUILD
+
+make PROD start-FULL-REBUILD
 ```
 
 ### Testing out your instance

--- a/client-admin/Dockerfile
+++ b/client-admin/Dockerfile
@@ -5,11 +5,15 @@
 
 FROM docker.io/node:18-alpine
 
+# Set default NODE_ENV to production unless overridden at build time with --build-arg NODE_ENV=development
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-production}
+
 WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm ci
+RUN npm ci --include=dev
 
 COPY . .
 

--- a/client-participation/Dockerfile
+++ b/client-participation/Dockerfile
@@ -5,14 +5,16 @@
 
 FROM docker.io/node:18-alpine
 
+# Set default NODE_ENV to production unless overridden at build time with --build-arg NODE_ENV=development
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-production}
+
 WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm ci
+RUN npm ci --include=dev
 
 COPY . .
-
-ARG NODE_ENV=production
 
 CMD npm run build:prod

--- a/client-report/Dockerfile
+++ b/client-report/Dockerfile
@@ -6,17 +6,23 @@
 # Gulp v3 stops us from upgrading beyond Node v11
 FROM docker.io/node:11-alpine
 
+# Set default NODE_ENV to production unless overridden at build time with --build-arg NODE_ENV=development
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-production}
+
 WORKDIR /app
 
 RUN apk add git
 
 COPY package*.json ./
 
-RUN npm ci
+RUN npm ci --include=dev
 
 COPY . .
 
-# GIT_HASH will be set properly when running `make` (see Makefile).
-ARG GIT_HASH="placeholder"
+# GIT_HASH is optional and will be set properly when running `make` (see Makefile).
+# Or may be passed in at build time with --build-arg GIT_HASH=$(git rev-parse --short HEAD)
+ARG GIT_HASH
+ENV GIT_HASH ${GIT_HASH:-placeholder}
 
 CMD npm run deploy:prod

--- a/client-report/webpack.config.js
+++ b/client-report/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.DefinePlugin({
       "process.env": {
-        "NODE_ENV": JSON.stringify("production")
+        "NODE_ENV": "production"
       }
     }),
     new webpack.optimize.UglifyJsPlugin({

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,9 +9,11 @@
 
 services:
   server:
-    command: npm run build:watch
-    environment:
-      NODE_ENV: development
+    build:
+      dockerfile: Dockerfile.dev
+      args:
+        NODE_ENV: development
+    command: npm run dev
     volumes:
       # This will mount your local polis/server directory so changes can be watched and reloaded.
       # But it will ignore your local node_modules and instead use a new container volume.
@@ -36,6 +38,9 @@ services:
       - "${POSTGRES_PORT:-5432}:5432"
 
   file-server:
+    build:
+      args:
+        NODE_ENV: development
     ports:
       - ${STATIC_FILES_PORT:-8080}:${STATIC_FILES_PORT:-8080}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     build:
       context: ./server
       dockerfile: Dockerfile
+      args:
+        NODE_ENV: production
       labels:
         polis_tag: ${TAG:-dev}
     depends_on:
@@ -94,6 +96,7 @@ services:
       labels:
         polis_tag: ${TAG:-dev}
       args:
+        NODE_ENV: production
         GIT_HASH: "${GIT_HASH:-placeholder}"
     environment:
       - EMBED_SERVICE_HOSTNAME=${EMBED_SERVICE_HOSTNAME}

--- a/file-server/Dockerfile
+++ b/file-server/Dockerfile
@@ -2,10 +2,15 @@
 #FROM client-base AS client-admin # <- switch back to basing on client admin once we upgrade other clients
 FROM docker.io/node:18-alpine AS client-admin
 
+# Set default NODE_ENV to production unless overridden at build time with --build-arg NODE_ENV=development
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-production}
+
 WORKDIR /app
 
 COPY client-admin/package*.json ./
-RUN npm ci
+
+RUN npm ci --include=dev
 
 COPY client-admin/. .
 
@@ -16,15 +21,17 @@ RUN npm run build:prod
 ##################### POLIS CLIENT PARTICIPATION #####################
 FROM docker.io/node:18-alpine AS client-participation
 
+# Set default NODE_ENV to production unless overridden at build time with --build-arg NODE_ENV=development
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-production}
+
 WORKDIR /app
 
 COPY client-participation/package*.json ./
 
-RUN npm ci
+RUN npm ci --include=dev
 
 COPY client-participation/. .
-
-ARG NODE_ENV=production
 
 RUN npm run build:prod
 
@@ -35,18 +42,23 @@ RUN npm run build:prod
 # FROM client-base AS client-report
 FROM docker.io/node:11-alpine as client-report
 
+# Set default NODE_ENV to production unless overridden at build time with --build-arg NODE_ENV=development
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-production}
+
 WORKDIR /app
 
 RUN apk add git
 
 COPY client-report/package*.json ./
 
-RUN npm ci
+RUN npm ci --include=dev
 
 COPY client-report/. .
 
 # GIT_HASH will be set properly when running `make` (see Makefile).
-ARG GIT_HASH="placeholder"
+ARG GIT_HASH
+ENV GIT_HASH ${GIT_HASH:-placeholder}
 
 RUN npm run deploy:prod
 
@@ -54,6 +66,10 @@ RUN npm run deploy:prod
 
 ############################ FILE SERVER ############################
 FROM docker.io/node:18-alpine
+
+# Set default NODE_ENV to production unless overridden at build time with --build-arg NODE_ENV=development
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-production}
 
 WORKDIR /app
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM docker.io/node:18-alpine
 
+# Set default NODE_ENV to production unless overridden at build time with --build-arg NODE_ENV=development
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-production}
+
 WORKDIR /app
 
 COPY package*.json ./
@@ -16,11 +20,7 @@ RUN apk add libpq-dev
 RUN apk add --no-cache --virtual .build \
   g++ make python3
 
-# This is useful for development situations when node_modules is a volume and would
-# otherwise persist across container rebuilds.
-RUN rm -rf node_modules
-
-RUN npm ci
+RUN npm ci --include=dev
 
 RUN apk del .build
 

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -1,0 +1,25 @@
+# To build locally, for example:
+# docker build -t polis-server:local -f Dockerfile.dev .
+# To run locally, for example:
+# docker run --rm --name polis-server --env-file .env --network polis-dev_polis_net \
+#  -p 5000:5000 polis-server:local
+
+FROM docker.io/node:18-alpine
+
+# Set default NODE_ENV to development unless overridden at build time with --build-arg NODE_ENV=production
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-development}
+
+WORKDIR /app
+
+COPY package*.json ./
+
+# Unlike the production Dockerfile, we won't remove these build dependencies.
+# So we can use them to re-install and re-build the client assets during development.
+RUN apk add --no-cache libpq-dev g++ make python3
+
+COPY . .
+
+EXPOSE 5000
+
+CMD npm run dev


### PR DESCRIPTION
ok it turns out that `npm install` (and `npm ci`) do omit devDependencies by default **if** NODE_ENV=production :eyeroll:

Since the Dockerfiles, and in other situations, we want to run things like `npm run build` which require dev dependencies like webpack and typescript, we need to include these with `--include=dev`.

I also created a Dockerfile.dev for `server` -- which is where this all came about in the first place -- to better handle node_modules while reloading and rebuild the dev server.


Longer version:

previously the node_modules are only being installed at build time (of the container) which takes place _before_ docker compose mounts the ephemeral /app/node_modules volume onto the container. So when that volume is mounted it can clobber the built node_modules. Fine. But you can't rebuild them because in the (now production) Dockerfile we remove the packages that are required (<cough> python) to install node_modules.
For development you should be able to change package.json and rebuild/re-install and re-run server, and now you can 🪄 