### PR TITLE
Fixes i18n string usage in client-participation

### DIFF
--- a/client-participation/js/lib/VisView.js
+++ b/client-participation/js/lib/VisView.js
@@ -469,7 +469,7 @@ module.exports = function VisView(params) {
 
 
   function updateHulls() {
-    bidToBucket = _.zipObject(_.map(nodes, "bid"), nodes);
+    bidToBucket = _.fromPairs(_.map(nodes, "bid"), nodes);
     hulls = clusters.map(function(cluster) {
       var temp = _.map(cluster, function(bid) {
         var bucket = bidToBucket[bid];

--- a/client-participation/js/stores/polis.js
+++ b/client-participation/js/stores/polis.js
@@ -1797,7 +1797,7 @@ module.exports = function(params) {
       // // Create a tidToR mapping which is a restriction of the tidToStats to just the repness. This is
       // // what code other than getCommentsForGroup is expecting; if other stuff starts wanting the prob
       // // estimates, we can change the API
-      // var tidToR = _.zipObject(_.map(triples, function(t) {return [t[0], t[1]];}));
+      // var tidToR = _.fromPairs(_.map(triples, function(t) {return [t[0], t[1]];}));
 
       // // filter out comments with insufficient repness or agreement probability
       // var filteredTriples = _.filter(triples, function(t) {

--- a/client-participation/js/util/utils.js
+++ b/client-participation/js/util/utils.js
@@ -170,18 +170,9 @@ function shouldFocusOnTextareaWhenWritePaneShown() {
   return false;
 }
 
-function parseQueryParams(s) {
-  if (!_.isString(s)) {
-    return {};
-  }
-  if (s.charAt(0) === "?") {
-    s = s.slice(1);
-  }
-  var pairStrings = s.split("&");
-  var pairArrays = _.map(pairStrings, function(pairString) {
-    return pairString.split("=");
-  });
-  return _.zipObject(pairArrays);
+function parseQueryParams(queryString) {
+  const params = new URLSearchParams(queryString);
+  return Object.fromEntries(params);
 }
 
 function toQueryParamString(o) {

--- a/client-participation/public/index.ejs
+++ b/client-participation/public/index.ejs
@@ -39,20 +39,9 @@
 
     <script> // Fire off this ajax first. it's slower than the other CDN delivered things.
       (function() {
-        function parseQueryParams(s) {
-          if (typeof s !== "string") {
-            return {};
-          }
-          if (s.charAt(0) === "?") {
-            s = s.slice(1);
-          }
-          var pairStrings = s.split("&");
-          var o = {};
-          for (var i = 0; i < pairStrings.length; i++) {
-            var pair = pairStrings[i].split("=");
-            o[pair[0]] = decodeURIComponent(pair[1]);
-          }
-          return o;
+        function parseQueryParams(queryString) {
+          const params = new URLSearchParams(queryString);
+          return Object.fromEntries(params);
         }
 
         function getXid() {
@@ -123,8 +112,6 @@
             if (response) {
               p[dst] = r.JSON ? JSON.parse(response[src]) : response[src];
             }
-
-            console.log("in index.html in participation: response, p, r, ", response, p, r)
 
             if (r.fn) {
               p[dst] = r.fn(p[dst]);


### PR DESCRIPTION
Recently when underscore was replaced with lodash in client-participation, _.object was replaced with _.zipObject but this doesn't work the same way (expects different style of arguments). Instead _.fromPairs is the lodash way of doing what _.object was used for.

Additionally, there was just a lot of needlessly complex hand-rolled query param parsing (and duplicated in two places) in client-participation. Instead a succinct and elegant solution has replaced these.

I use `Object.fromEntries()` which has been widely supported for 4 years https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries
(and anyway we have client-participation going through babel-env)