### PR TITLE
check before firing off these Twitter/FB requests

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -62,6 +62,7 @@ export default {
   databaseURL: process.env.DATABASE_URL as string,
   emailTransportTypes: process.env.EMAIL_TRANSPORT_TYPES || null as string | null,
   encryptionPassword: process.env.ENCRYPTION_PASSWORD_00001 as string,
+  fbAppId: process.env.FB_APP_ID || null as string | null,
   googleCredentialsBase64: process.env.GOOGLE_CREDENTIALS_BASE64 || null as string | null,
   googleCredsStringified: process.env.GOOGLE_CREDS_STRINGIFIED as string,
   logLevel: process.env.SERVER_LOG_LEVEL as string,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -15665,16 +15665,20 @@ Thanks for using Polis!
       // client requests these later.
       // TODO actually store these values in a cache that is shared between
       // the servers, probably just in the db.
-      getTwitterShareCountForConversation(conversation_id).catch(function (
-        err: string
-      ) {
-        logger.error("polis_err_fetching_twitter_share_count", err);
-      });
-      getFacebookShareCountForConversation(conversation_id).catch(function (
-        err: string
-      ) {
-        logger.error("polis_err_fetching_facebook_share_count", err);
-      });
+      if (Config.twitterConsumerKey) {
+        getTwitterShareCountForConversation(conversation_id).catch(function (
+          err: string
+        ) {
+          logger.error("polis_err_fetching_twitter_share_count", err);
+        });
+      }
+      if (Config.fbAppId) {
+        getFacebookShareCountForConversation(conversation_id).catch(function (
+          err: string
+        ) {
+          logger.error("polis_err_fetching_facebook_share_count", err);
+        });
+      }
     }, 100);
 
     doGetConversationPreloadInfo(conversation_id)


### PR DESCRIPTION
While watching the newly nicely formatted logs, I noticed that certain twitter and facebook requests get sent from the server no matter what.

This change prevents these requests unless credentials for those services have been provided.