### PR TITLE
copypasta repair

### DIFF
--- a/server/src/auth/create-user.ts
+++ b/server/src/auth/create-user.ts
@@ -132,9 +132,14 @@ function createUser(req: any, res: any) {
                       );
                       return;
                     }
-                    cookies.addCookies(req, res, token, uid).then(function () {
-                      res.json(response_data);
-                    })
+                    cookies.addCookies(req, res, token, uid)
+                      .then(
+                        res.json({
+                          uid: uid,
+                          hname: hname,
+                          email: email
+                        })
+                      )
                       .catch(function (err: any) {
                         fail(res, 500, "polis_err_adding_user", err);
                       });


### PR DESCRIPTION
Oops I was a little too quick on that last fix. `response_data` is used by the _other_ addCookies callback.