### PR TITLE
update maildev image and use the correct ports

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,16 +44,16 @@ services:
       - ${STATIC_FILES_PORT:-8080}:${STATIC_FILES_PORT:-8080}
 
   maildev:
-    image: docker.io/maildev/maildev:1.1.1
+    image: docker.io/maildev/maildev:2.0.5
     labels:
       polis_tag: ${TAG}
     networks:
       - polis-net
     ports:
       # User interface
-      - "1080:80"
+      - "1080:1080"
       # SMTP port
-      - "25:25"
+      - "1025:1025"
 
   # TODO: Add individual entries for each of the clients, with hot-code reloading set up
   # Either:

--- a/server/src/email/senders.ts
+++ b/server/src/email/senders.ts
@@ -46,7 +46,7 @@ function getMailOptions(transportType: any) {
       return {
         // Allows running outside docker, connecting to exposed port of maildev container.
         host: isDocker() ? "maildev" : "localhost",
-        port: 25,
+        port: 1025,
         ignoreTLS: true,
       };
     case "mailgun":


### PR DESCRIPTION
This fixes a couple tests.
The maildev image uses ports 1080 and 1025.
Additionally bump the version up.
I have tested this locally and on Github CI with cypress tests.