### PR TITLE
Resolves #1181 - Enforce User/Conversation ID

### DIFF
--- a/math/src/polismath/runner.clj
+++ b/math/src/polismath/runner.clj
@@ -219,6 +219,9 @@
       ;; Help message
       (:help options)
       (utils/exit 0 (usage summary))
+      ;; Require ID or user, if they don't exist append to error vector before checking if errors exist
+      (not (or (:zid options) (:zinvite options) (:user-id options)))
+      (conj errors "Run must specify either -Z, -z, or -u to produce output")
       ;; Error in parsing (this should really catch the below condition as well
       errors
       (utils/exit 1 (apply str "Found the following errors:\n"


### PR DESCRIPTION
Resolves #1181 

Manually add error message if no user or conversation ID found. Not 100% sure how to test, guidance would be appreciated! First contribution so let me know if format needs to be changed as well.