### PR TITLE
allow server log output to be set as "console" or "file"

### DIFF
--- a/example.env
+++ b/example.env
@@ -20,6 +20,8 @@ COMPOSE_PROJECT_NAME=polis-${TAG}
 SERVER_ENV_FILE=.env
 # Used by winston via server/utils/logger. Defaults to "info".
 SERVER_LOG_LEVEL=
+# Where to send server logs. Options: console, file. If blank, it is determined by NODE_ENV.
+SERVER_LOG_TRANSPORT=
 # (Deprecated) Settings for submitting web requests to the math worker.
 WEBSERVER_PASS=ws-pass
 WEBSERVER_USERNAME=ws-user

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -65,6 +65,7 @@ export default {
   emailTransportTypes: process.env.EMAIL_TRANSPORT_TYPES || null as string | null,
   encryptionPassword: process.env.ENCRYPTION_PASSWORD_00001 as string,
   fbAppId: process.env.FB_APP_ID || null as string | null,
+  logTransport: process.env.SERVER_LOG_TRANSPORT as string,
   logLevel: process.env.SERVER_LOG_LEVEL as string,
   mailgunApiKey: process.env.MAILGUN_API_KEY || (null as string | null),
   mailgunDomain: process.env.MAILGUN_DOMAIN || (null as string | null),

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -1,6 +1,15 @@
 import { createLogger, format, transports } from "winston";
 import Config from "../config";
 
+// Use the console transport in development, and the file transport in production,
+// unless the logTransport config is set.
+let transport = "console";
+if (Config.logTransport) {
+  transport = Config.logTransport;
+} else if (Config.nodeEnv === "production") {
+  transport = "file";
+}
+
 const logger = createLogger({
   level: Config.logLevel || 'info',
   exitOnError: false,
@@ -33,11 +42,7 @@ const logger = createLogger({
   ],
 });
 
-//
-// If we're not in production then log to the `console` with the format:
-// `${info.level}: ${info.message} JSON.stringify({ ...rest }) `
-//
-if (Config.nodeEnv !== "production") {
+if (transport === "console") {
   logger.add(
     new transports.Console({
       format: format.combine(format.colorize(), format.simple()),


### PR DESCRIPTION
Default behavior:
If NODE_ENV = 'production', logs are written to files in the `server/logs` directory (mounted persistent volume)
otherwise logs go to standard out in the console.

Setting SERVER_LOG_TRANSPORT to either 'file' or 'console' will overwrite that