### PR TITLE
postgres migration for updating the RULE to be v14 compatible

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -8,12 +8,12 @@ But if we update the database schema after your initial provisioning of your ser
 
 - Please note: **Backups are your responsibility.** These instructions assume
   the data is disposable, and do not attempt to make backups.
-    - Pull requests are welcome if you'd like to see more guidance on this.
-    - Please submit an issue if you'd like to work on enabling backups through Docker Compose.
+  - Pull requests are welcome if you'd like to see more guidance on this.
+  - Please submit an issue if you'd like to work on enabling backups through Docker Compose.
 - Your database data is stored on a docker volume, which means that it will
   persist even when you destroy all your docker containers. Be mindful of this.
-    - You can remove ALL volumes defined within a `docker-compose` file via: `docker compose down --volumes`
-    - You can remove ONE volume via `docker volume ls` and `docker volume rm <name>`
+  - You can remove ALL volumes defined within a `docker-compose` file via: `docker compose down --volumes`
+  - You can remove ONE volume via `docker volume ls` and `docker volume rm <name>`
 - SQL migrations can be found in [`server/postgres/migrations/`][] of this
   repo.
 - The path to the SQL file will be relative to its location in the docker
@@ -23,12 +23,18 @@ For example, if we add the migration file
 `server/postgres/migrations/000001_update_pwreset_table.sql`, you'd run on your
 host system:
 
-```
+```sh
 docker compose exec postgres psql --username postgres --dbname polis-dev --file=/docker-entrypoint-initdb.d/000001_update_pwreset_table.sql
 ```
+
+You can also run a local .sql file on a postgres container instance with this syntax:
+
+```sh
+docker exec -i polis-dev-postgres-1 psql -U postgres -d polis-dev < server/postgres/migrations/000006_update_votes_rule.sql
+```
+
+where `polis-dev-postgres-1` is the name of the running container (see the output of `docker ps`), `postgres` is the db username and `polis-dev` is the database.
 
 You'd do this for each new file, in numeric order.
 
    [`server/postgres/migrations/`]: /server/postgres/migrations
-
-

--- a/server/postgres/migrations/000000_initial.sql
+++ b/server/postgres/migrations/000000_initial.sql
@@ -826,7 +826,7 @@ CREATE RULE on_vote_insert_update_unique_table AS
     DO ALSO
         INSERT INTO votes_latest_unique (zid, pid, tid, vote, weight_x_32767, modified)
         values (NEW.zid, NEW.pid, NEW.tid, NEW.vote, NEW.weight_x_32767, NEW.created)
-            ON CONFLICT (zid, pid, tid) DO UPDATE SET vote = excluded.vote, modified = NEW.created;
+            ON CONFLICT (zid, pid, tid) DO UPDATE SET vote = excluded.vote, modified = excluded.modified;
 
 
 CREATE TABLE crowd_mod (

--- a/server/postgres/migrations/000006_update_votes_rule.sql
+++ b/server/postgres/migrations/000006_update_votes_rule.sql
@@ -1,0 +1,8 @@
+DROP RULE IF EXISTS on_vote_insert_update_unique_table ON votes;
+
+CREATE RULE on_vote_insert_update_unique_table AS
+    ON INSERT TO votes
+    DO ALSO
+        INSERT INTO votes_latest_unique (zid, pid, tid, vote, weight_x_32767, modified)
+        values (NEW.zid, NEW.pid, NEW.tid, NEW.vote, NEW.weight_x_32767, NEW.created)
+            ON CONFLICT (zid, pid, tid) DO UPDATE SET vote = excluded.vote, modified = excluded.modified;

--- a/server/postgres/migrations/000006_update_votes_rule.sql
+++ b/server/postgres/migrations/000006_update_votes_rule.sql
@@ -1,3 +1,8 @@
+-- This migration fixes an issue with a poorly specified rule definition in the original 000000_initial.sql schema.
+-- The old specification worked on Postgres 13, but not longer does on Postgres 14.
+-- Consequently, if you set up your Polis database prior to April 9th, 2023, and wish to upgrade to Postgres 14,
+-- you should run this migration first.
+
 DROP RULE IF EXISTS on_vote_insert_update_unique_table ON votes;
 
 CREATE RULE on_vote_insert_update_unique_table AS


### PR DESCRIPTION
ChatGPT inspired update to the `CREATE RULE` for Postgres which seems to resolve Postgres v14 compatibility.
This seems to be backwards compatible with Postgres v13 as well.

The migration to update the rule can be run as usual. It can also be run independently of pushing code or building containers from a local file using this syntax:

```sh
docker exec -i polis-dev-postgres-1 psql -U postgres -d polis-dev < server/postgres/migrations/000006_update_votes_rule.sql
```