### PR TITLE
Postgres v16 update

### DIFF
--- a/server/Dockerfile-db
+++ b/server/Dockerfile-db
@@ -1,4 +1,4 @@
-FROM docker.io/postgres:13.4-alpine
+FROM docker.io/postgres:14.7-alpine
 
 # Used when no existing database on postgres volume, including first initialization.
 # See: docs/deployment.md#database-migrations

--- a/server/Dockerfile-db
+++ b/server/Dockerfile-db
@@ -1,4 +1,4 @@
-FROM docker.io/postgres:14.7-alpine
+FROM docker.io/postgres:16-alpine
 
 # Used when no existing database on postgres volume, including first initialization.
 # See: docs/deployment.md#database-migrations


### PR DESCRIPTION
This only changes the Postgres version for docker deployments, and local development (if using docker for your db).