### PR TITLE
Fixed: TypeScript linenumbers on server stacktraces

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -39,6 +39,7 @@
         "request-promise": "~4.2.6",
         "response-time": "~2.3.1",
         "simple-oauth2": "~0.2.1",
+        "source-map-support": "~0.5.21",
         "sql": "~0.34.0",
         "underscore": "~1.12.1",
         "valid-url": "~1.0.9",
@@ -74,7 +75,6 @@
         "jest": "^29.4.1",
         "nodemon": "~2.0.20",
         "prettier": "~2.2.1",
-        "source-map-support": "~0.5.21",
         "supertest": "^6.3.3",
         "ts-jest": "^29.0.5",
         "typescript": "~4.3.5"
@@ -8183,7 +8183,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8192,7 +8191,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -15723,14 +15721,12 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -73,6 +73,7 @@
         "jest": "^29.4.1",
         "nodemon": "~2.0.20",
         "prettier": "~2.2.1",
+        "source-map-support": "~0.5.21",
         "supertest": "^6.3.3",
         "ts-jest": "^29.0.5",
         "typescript": "~4.3.5"
@@ -5561,6 +5562,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/jest-runtime": {
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.4.1.tgz",
@@ -8168,9 +8179,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -13631,6 +13642,18 @@
         "jest-worker": "^29.4.1",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
+      },
+      "dependencies": {
+        "source-map-support": {
+          "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
       }
     },
     "jest-runtime": {
@@ -15685,9 +15708,9 @@
       "devOptional": true
     },
     "source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -63,6 +63,7 @@
         "@types/replacestream": "~4.0.0",
         "@types/request-promise": "4.1.48",
         "@types/response-time": "~2.3.4",
+        "@types/source-map-support": "~0.5.6",
         "@types/supertest": "^2.0.12",
         "@types/underscore": "~1.11.1",
         "@types/valid-url": "~1.0.3",
@@ -1664,6 +1665,15 @@
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/source-map-support": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==",
+      "dev": true,
+      "dependencies": {
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -10652,6 +10662,15 @@
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/source-map-support": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.0"
       }
     },
     "@types/stack-utils": {

--- a/server/package.json
+++ b/server/package.json
@@ -56,6 +56,7 @@
     "response-time": "~2.3.1",
     "simple-oauth2": "~0.2.1",
     "sql": "~0.34.0",
+    "source-map-support": "~0.5.21",
     "underscore": "~1.12.1",
     "valid-url": "~1.0.9",
     "winston": "~3.8.2"
@@ -90,7 +91,6 @@
     "jest": "^29.4.1",
     "nodemon": "~2.0.20",
     "prettier": "~2.2.1",
-    "source-map-support": "~0.5.21",
     "supertest": "^6.3.3",
     "ts-jest": "^29.0.5",
     "typescript": "~4.3.5"

--- a/server/package.json
+++ b/server/package.json
@@ -89,6 +89,7 @@
     "jest": "^29.4.1",
     "nodemon": "~2.0.20",
     "prettier": "~2.2.1",
+    "source-map-support": "~0.5.21",
     "supertest": "^6.3.3",
     "ts-jest": "^29.0.5",
     "typescript": "~4.3.5"

--- a/server/package.json
+++ b/server/package.json
@@ -79,6 +79,7 @@
     "@types/replacestream": "~4.0.0",
     "@types/request-promise": "4.1.48",
     "@types/response-time": "~2.3.4",
+    "@types/source-map-support": "~0.5.6",
     "@types/supertest": "^2.0.12",
     "@types/underscore": "~1.11.1",
     "@types/valid-url": "~1.0.3",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -8,11 +8,9 @@ const prodHostname = process.env.API_PROD_HOSTNAME || "pol.is";
 const serverPort = parseInt(process.env.API_SERVER_PORT || process.env.PORT || "5000", 10) as number;
 const shouldUseTranslationAPI = isTrue(process.env.SHOULD_USE_TRANSLATION_API) as boolean;
 
-if(devMode) {
-  import('source-map-support').then((sourceMapSupport) => {
-      sourceMapSupport.install();
-  });
-}
+import('source-map-support').then((sourceMapSupport) => {
+    sourceMapSupport.install();
+});
 
 export default {
   domainOverride: domainOverride as string | null,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -8,8 +8,11 @@ const prodHostname = process.env.API_PROD_HOSTNAME || "pol.is";
 const serverPort = parseInt(process.env.API_SERVER_PORT || process.env.PORT || "5000", 10) as number;
 const shouldUseTranslationAPI = isTrue(process.env.SHOULD_USE_TRANSLATION_API) as boolean;
 
-/* Do NOT use source-map-support in production as it uses the non-standard stack property of Errors */
-if(devMode) { require('source-map-support').install(); }
+if(devMode) {
+  import('source-map-support').then((sourceMapSupport) => {
+      sourceMapSupport.install();
+  });
+}
 
 export default {
   domainOverride: domainOverride as string | null,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -8,6 +8,9 @@ const prodHostname = process.env.API_PROD_HOSTNAME || "pol.is";
 const serverPort = parseInt(process.env.API_SERVER_PORT || process.env.PORT || "5000", 10) as number;
 const shouldUseTranslationAPI = isTrue(process.env.SHOULD_USE_TRANSLATION_API) as boolean;
 
+/* Do NOT use source-map-support in production as it uses the non-standard stack property of Errors */
+if(devMode) { require('source-map-support').install(); }
+
 export default {
   domainOverride: domainOverride as string | null,
   isDevMode: devMode as boolean,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -12,7 +12,7 @@
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
+    "sourceMap": true,                              /* Generates corresponding '.map' file. */
     // "outFile": "./dist/app.js" /* Concatenate and emit output to single file. */,
     "outDir": "./dist" /* Redirect output structure to the directory. */,
     "rootDir": "./" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,


### PR DESCRIPTION
Closes https://github.com/compdemocracy/polis/issues/1382

Full credit to https://github.com/SebastianRuan

Rebase and clean-up from [original PR](https://github.com/compdemocracy/polis/pull/1509) 

NOTE: This is currently configured to only run if devMode === true. However I don't think running in production is a problem since this is a server concern and would not be getting sent to browsers.