### PR TITLE
dont auto-restart pg in dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,6 +33,7 @@ services:
       CHOKIDAR_USEPOLLING: "true"
 
   postgres:
+    restart: no
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
 


### PR DESCRIPTION
On your dev machine it can be annoying for Docker to automatically restart the Polis Postgres container when you boot up, since port 5432 is often used by other Postgres instances in other projects.

This change prevents this container from automatically restarting. No impact on deployment or production.