### PR TITLE
Add missing jQuery require from facebook button

### DIFF
--- a/client-participation/js/util/facebookButton.js
+++ b/client-participation/js/util/facebookButton.js
@@ -2,6 +2,7 @@
 
 var Strings = require("../strings");
 var M = require("../util/metrics");
+var $ = require("jquery");
 
 // FB.getLoginStatus(function(response) {
 //   if (response.status === 'connected') {


### PR DESCRIPTION
Hi all, thanks from the great work!

I've noticed that the Facebook login functionality is broken with the issue being that `$` is undefined. Requiring the jQuery on top of the file seems to resolve the issue - however I'm not extremely experienced with JavaScript and there might be a better way to do that.

Let me know if I can help further.