### PR TITLE
changed knowledgeBase.js, removed react-easy-emoji redundancy

### DIFF
--- a/client-admin/src/components/landers/knowledgeBase.js
+++ b/client-admin/src/components/landers/knowledgeBase.js
@@ -7,7 +7,7 @@ const KnowledgeBase = ({ e, url, txt }) => {
   return (
     <Box sx={{ my: [3] }}>
       <Link target="_blank" href={url}>
-        <span style={{ marginRight: 12 }}>{emoji(e)}</span>
+        <span style={{ marginRight: 12 }}>{e}</span>
         {txt}
       </Link>
     </Box>


### PR DESCRIPTION
Original issue resulted from using react-easy-emoji. 

react-easy-emoji uses twemoji and more relevantly the MaxCDN ( which originally hosted the twemoji images). MaxCDN no longer host those images hence the error.

Since the code already is passing emojis as hardcoded text, the end user is downloading the emojis and so the react-easy-emoji isnt necessary. I just removed it from the knowledgeBase component and left the passed in emoji as plaintext which should work across all browsers.