### PR TITLE
Add localhost port 5010 to allowlist

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1121,6 +1121,7 @@ function initializePolisHelpers() {
     ...Config.whitelistItems,
     "localhost:5000",
     "localhost:5001",
+    "localhost:5010",
     "facebook.com",
     "api.twitter.com",
     "", // for API


### PR DESCRIPTION
When running client-report using `npm start` (and the remaining Polis components through docker), client-report starts on port 5010 by default, but can not reach the API (port 5000) due to allowlist issues, which in my case presented itself as CORS issues on the preflight.