### PR TITLE
fix bug with running on custom postgres port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,11 +72,14 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:?error}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?error}
       - POSTGRES_USER=${POSTGRES_USER:?error}
+      - PGPORT=${POSTGRES_PORT:-5432}
     networks:
       - "polis-net"
     volumes:
       - "backups:/backups"
       - "postgres:/var/lib/postgresql/data"
+    expose:
+      - ${POSTGRES_PORT:-5432}
 
   nginx-proxy:
     image: docker.io/compdem/polis-nginx-proxy:${TAG:-dev}


### PR DESCRIPTION
The ability to override is important for dev machines which already have postgres running locally/natively on the host machine. An earlier attempt was made to fix this, but failed because the `ports` mapping in the dev overlay file does not change the port the other containers use to access the container, just how the port is exposed to the host system (for utility connection, etc). The fix so that everything internal and external all uses the same port involves setting the `PGPORT` setting, so that the postgres container actually uses this port internally, and the `expose` declaration, which ensures that this port is then exposed to the rest of the network.