### PR TITLE
Fix possible bug in add-xid-whitelist logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+.clj-kondo/
 .env
-prod.env
+.envrc
+.lsp/
 .vscode/settings.json
 build/
+prod.env
+xids.csv

--- a/bin/add-xid-whitelist.clj
+++ b/bin/add-xid-whitelist.clj
@@ -8,8 +8,8 @@
 
 (defn xid-seq [filename]
   (map
-    (fn [line] (first (str/split line #",")))
-    (line-seq (io/reader filename))))
+   (fn [line] (first (str/split line #",")))
+   (line-seq (io/reader filename))))
 
 (defn xid-record [owner xid]
   {:owner owner
@@ -27,8 +27,7 @@
            xids-rest (drop batch-size xids)]
       (db/upsert! :xid_whitelist
                   :xid_whitelist_owner_xid_key
-                  (map (fn [xid]
-                         (xid-record owner-id xid)) ; process xid
+                  (map (partial xid-record owner-id)
                        xids-batch))
       (when (seq xids-rest)
         (recur (take batch-size xids-rest)
@@ -38,5 +37,3 @@
 
 (when (= *file* (System/getProperty "babashka.file"))
   (apply -main *command-line-args*))
-
-

--- a/bin/add-xid-whitelist.clj
+++ b/bin/add-xid-whitelist.clj
@@ -25,11 +25,12 @@
         owner-id (resolve-owner-id opts-map)]
     (loop [xids-batch (take batch-size xids)
            xids-rest (drop batch-size xids)]
+      (db/upsert! :xid_whitelist
+                  :xid_whitelist_owner_xid_key
+                  (map (fn [xid]
+                         (xid-record owner-id xid)) ; process xid
+                       xids-batch))
       (when (seq xids-rest)
-        (db/upsert! :xid_whitelist
-                    :xid_whitelist_owner_xid_key
-                    (map (partial xid-record owner-id)
-                         xids-batch))
         (recur (take batch-size xids-rest)
                (drop batch-size xids-rest))))
     (println "Done")))

--- a/bin/add-xid-whitelist.clj
+++ b/bin/add-xid-whitelist.clj
@@ -25,10 +25,11 @@
         owner-id (resolve-owner-id opts-map)]
     (loop [xids-batch (take batch-size xids)
            xids-rest (drop batch-size xids)]
-      (db/upsert! :xid_whitelist
-                  :xid_whitelist_owner_xid_key
-                  (map (partial xid-record owner-id)
-                       xids-batch))
+      (when (seq xids-batch)
+        (db/upsert! :xid_whitelist
+                    :xid_whitelist_owner_xid_key
+                    (map (partial xid-record owner-id)
+                         xids-batch)))
       (when (seq xids-rest)
         (recur (take batch-size xids-rest)
                (drop batch-size xids-rest))))


### PR DESCRIPTION
I'm still (after all these years) a relative clojure n00b, BUT it seems to me that this logic discards the first batch of xids when upserting the whitelist.
e.g. If I give it a list of 200 xids, only 51-200 will be upserted and the first 50 discarded.

Does this make sense?