### PR TITLE
fix xid bug

### DIFF
--- a/client-participation/js/views/vote-view.js
+++ b/client-participation/js/views/vote-view.js
@@ -366,6 +366,8 @@ module.exports = Handlebones.ModelView.extend({
         that.model.set({
           needSocial: true,
         });
+      } else if (err && err.responseText === "polis_err_xid_not_whitelisted") {
+        alert("Sorry, you must be registered to vote. Please sign in or contact the conversation owner.");
       } else {
         alert("Apologies, your vote failed to send. Please check your connection and try again.");
       }

--- a/server/src/d.ts
+++ b/server/src/d.ts
@@ -203,6 +203,7 @@ export type Vote = {
   pid: any;
   lang: any;
   tid: any;
+  xid: any;
   vote: any;
   weight: any;
   starred: any;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -693,6 +693,15 @@ function initializePolisHelpers() {
               });
             });
           }
+          if (conv.use_xid_whitelist) {
+            return isXidWhitelisted(zid, uid).then((is_whitelisted: boolean) => {
+              if (is_whitelisted) {
+                return conv;
+              } else {
+                throw 'polis_err_xid_not_whitelisted';
+              }
+            });
+          }
           return conv;
         })
         .then(function (conv: any) {
@@ -8010,6 +8019,8 @@ Email verified! You can close this tab or hit the back button.
           fail(res, 403, "polis_err_conversation_is_closed", err);
         } else if (err === "polis_err_post_votes_social_needed") {
           fail(res, 403, "polis_err_post_votes_social_needed", err);
+        } else if (err === 'polis_err_xid_not_whitelisted') {
+          fail(res, 403, 'polis_err_xid_not_whitelisted', err);
         } else {
           fail(res, 500, "polis_err_vote", err);
         }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -649,6 +649,7 @@ function initializePolisHelpers() {
     pid?: any,
     zid?: any,
     tid?: any,
+    xid?: any,
     voteType?: any,
     weight?: number,
   ) {
@@ -694,7 +695,7 @@ function initializePolisHelpers() {
             });
           }
           if (conv.use_xid_whitelist) {
-            return isXidWhitelisted(zid, uid).then((is_whitelisted: boolean) => {
+            return isXidWhitelisted(conv.owner, xid).then((is_whitelisted: boolean) => {
               if (is_whitelisted) {
                 return conv;
               } else {
@@ -7013,6 +7014,7 @@ Email verified! You can close this tab or hit the back button.
     req: {
       p: {
         zid?: any;
+        xid?: any;
         uid?: any;
         txt?: any;
         pid?: any;
@@ -7031,7 +7033,7 @@ Email verified! You can close this tab or hit the back button.
     res: { json: (arg0: { tid: any; currentPid: any }) => void }
   ) {
     let zid = req.p.zid;
-    let xid = void 0; //req.p.xid;
+    let xid = req.p.xid;
     let uid = req.p.uid;
     let txt = req.p.txt;
     let pid = req.p.pid; // PID_FLOW may be undefined
@@ -7332,7 +7334,7 @@ Email verified! You can close this tab or hit the back button.
                         let createdTime = comment.created;
                         let votePromise = _.isUndefined(vote)
                           ? Promise.resolve()
-                          : votesPost(uid, pid, zid, tid, vote, 0);
+                          : votesPost(uid, pid, zid, tid, xid, vote, 0);
 
                         return (
                           votePromise
@@ -7955,6 +7957,7 @@ Email verified! You can close this tab or hit the back button.
               pid,
               zid,
               req.p.tid,
+              req.p.xid,
               req.p.vote,
               req.p.weight,
             );


### PR DESCRIPTION
Previously, using an XID allow list was enforced in concert with social integration.
Now it will be enforced with or without social integration.

Works for embedded and non-embedded conversations:

<img width="471" alt="Screenshot 2024-05-03 at 1 54 13 AM" src="https://github.com/compdemocracy/polis/assets/35609/b704186b-cc84-4dd6-ba5b-002721321580">


<img width="471" alt="Screenshot 2024-05-03 at 1 54 30 AM" src="https://github.com/compdemocracy/polis/assets/35609/f40f3f32-0f3a-430c-a8d1-0dbb58fdec20">


