### PR TITLE
no more pg-native; new config flag for DATABASE_SSL

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,7 @@ If you are deploying to a custom domain (not `pol.is`) then you need to update b
 
 - **`BACKFILL_COMMENT_LANG_DETECTION`** Set to `true`, if Comment Translation was enabled, to instruct the server upon the next initialization (reboot) to backfill detected language of stored comments. Default `false`.
 - **`CACHE_MATH_RESULTS`** Set this to `true` to instruct the API server to use LRU caching for results from the math service. Default is `true` if left blank.
+- **`DATABASE_SSL`** Set this to `true` for some production environments. Default is `false`.
 - **`DEV_MODE`** Set this to `true` in development and `false` otherwise. Used by API Server to make a variety of assumptions about HTTPS, logging, notifications, etc.
 - **`RUN_PERIODIC_EXPORT_TESTS`** Set this to `true` to run periodic export tests, sent to the **`ADMIN_EMAIL_DATA_EXPORT_TEST`** address.
 - **`SERVER_LOG_TO_FILE`** Set this to `true` to tell Winston.js to also write log files to server/logs/. Defaults to `false`. *Note that if using docker compose, server/logs is mounted as a persistent volume.*

--- a/example.env
+++ b/example.env
@@ -62,6 +62,8 @@ POLIS_FROM_ADDRESS="Example <team@example.com>"
 CACHE_MATH_RESULTS=
 # The following flags will all default to false if not set.
 BACKFILL_COMMENT_LANG_DETECTION=
+# Set to `true` for some production environments:
+DATABASE_SSL=
 # Set to `false` for production:
 DEV_MODE=true
 RUN_PERIODIC_EXPORT_TESTS=

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -76,6 +76,7 @@ export default {
   ) as boolean,
   cacheMathResults: isTrueOrBlank(process.env.CACHE_MATH_RESULTS) as boolean,
   databaseURL: process.env.DATABASE_URL as string,
+  databaseSSL: isTrue(process.env.DATABASE_SSL) as boolean,
   emailTransportTypes:
     process.env.EMAIL_TRANSPORT_TYPES || (null as string | null),
   encryptionPassword: process.env.ENCRYPTION_PASSWORD_00001 as string,


### PR DESCRIPTION
This should fix the two problems we've had with the streaming exports deploy:

We were using pg-native, in part for its SSL support, but it breaks pg-streaming.
But switching off pg-native breaks the heroku deploy since it needs SSL to connect to preprod and prod db.
Meanwhile local/dev/etc environments need to NOT use SSL for their db connections.

So we get yet another configuration variable:

**DATABASE_SSL** (default: false)
Must be set to `true` for heroku or similar production environments (depending on the database host)