### PR TITLE
disable non functional social auth

### DIFF
--- a/client-admin/src/components/conversation-admin/conversation-config.js
+++ b/client-admin/src/components/conversation-admin/conversation-config.js
@@ -166,14 +166,6 @@ class ConversationConfig extends React.Component {
           notifications when there are new comments to vote on.
         </CheckboxField>
 
-        <CheckboxField field="auth_opt_fb" label="Facebook login prompt">
-          Show Facebook login prompt
-        </CheckboxField>
-
-        <CheckboxField field="auth_opt_tw" label="Twitter login prompt">
-          Show Twitter login prompt
-        </CheckboxField>
-
         <Heading
           as="h6"
           sx={{
@@ -186,18 +178,6 @@ class ConversationConfig extends React.Component {
 
         <CheckboxField field="strict_moderation">
           No comments shown without moderator approval
-        </CheckboxField>
-
-        <CheckboxField
-          field="auth_needed_to_write"
-          label="Require Auth to Comment">
-          Participants cannot submit comments without first connecting either
-          Facebook or Twitter
-        </CheckboxField>
-
-        <CheckboxField field="auth_needed_to_vote" label="Require Auth to Vote">
-          Participants cannot vote without first connecting either Facebook or
-          Twitter
         </CheckboxField>
       </Box>
     )

--- a/client-participation/js/templates/comment-form.handlebars
+++ b/client-participation/js/templates/comment-form.handlebars
@@ -152,44 +152,6 @@
       </span>
     </div>
 
-    {{!-- ================ CONNECT FACEBOOK / TWITTER ================ --}}
-    <div
-      id="socialButtonsCommentForm"
-      style="
-        display: none;
-        margin-top: 10px;
-        ">
-      <div class="protip"><p><i class="fa fa-microphone"></i>&nbsp; {{s.connectToPostPrompt}}</p></div>
-      {{#if auth_opt_fb}}
-      {{#unless hasFacebook}}
-        <button id="facebookButtonCommentForm" class="facebookButton" style="padding-top: 0px;">
-          <i class="svgIcon" style="
-            display: inline-block;
-            position: relative;
-            margin-inline-end: 2px;
-            top: 6px;
-            width: 25px;
-            fill: white;
-          ">{{> iconFaFacebookSquare25}}</i>
-          {{s.connectFacebook}}</button>
-      {{/unless}}
-      {{/if}}
-      {{#if auth_opt_tw}}
-      {{#unless hasTwitter}}
-        <button id="twitterButtonCommentForm" class="twitterButton" style="padding-top: 0px;">
-        <i class="svgIcon" style="
-          display: inline-block;
-          position: relative;
-          margin-inline-end: 2px;
-          top: 8px;
-          width: 25px;
-          fill: white;
-        ">{{> iconFaTwitter25}}</i>
-          {{s.connectTwitter}}</button>
-      {{/unless}}
-      {{/if}}
-    </div>
-
     {{!-- ================ LOWER CONTAINER ================ --}}
     <div
       id="comment_form_controls"

--- a/client-participation/js/templates/vote-view.handlebars
+++ b/client-participation/js/templates/vote-view.handlebars
@@ -3,6 +3,12 @@
 
 <div id="comment_shower">
 
+{{#if needSocial}}
+{{!-- ================ CONNECT FACEBOOK / TWITTER ================ --}}
+
+
+{{else}}  {{!-- !needSocial --}}
+
 {{#if empty}}
   <div  style="margin: 20px;" class="Notification Notification--warning"> {{!-- empty scenario div --}}
   {{#if subscribed}}

--- a/client-participation/js/templates/vote-view.handlebars
+++ b/client-participation/js/templates/vote-view.handlebars
@@ -3,47 +3,6 @@
 
 <div id="comment_shower">
 
-{{#if needSocial}}
-{{!-- ================ CONNECT FACEBOOK / TWITTER ================ --}}
-<div
-  id="socialButtonsVoteView"
-  style="
-    {{!-- display: none; --}}
-    margin: 10px;
-    ">
-  <div class="protip"><p><i class="fa fa-microphone"></i>&nbsp; {{s.connectToVotePrompt}}</p></div>
-  {{#if auth_opt_fb}}
-  {{#unless hasFacebook}}
-    <button id="facebookButtonVoteView" class="facebookButton" style="padding-top: 0px; margin-bottom: 4px;">
-      <i class="svgIcon" style="
-        display: inline-block;
-        position: relative;
-        margin-inline-end: 2px;
-        top: 6px;
-        width: 25px;
-        fill: white;
-      ">{{> iconFaFacebookSquare25}}</i>
-      {{s.connectFacebook}}</button>
-  {{/unless}}
-  {{/if}}
-  {{#if auth_opt_tw}}
-  {{#unless hasTwitter}}
-    <button id="twitterButtonVoteView" class="twitterButton" style="padding-top: 0px; margin-bottom: 4px;">
-    <i class="svgIcon" style="
-      display: inline-block;
-      position: relative;
-      margin-inline-end: 2px;
-      top: 8px;
-      width: 25px;
-      fill: white;
-    ">{{> iconFaTwitter25}}</i>
-      {{s.connectTwitter}}</button>
-  {{/unless}}
-  {{/if}}
-</div>
-
-{{else}}  {{!-- !needSocial --}}
-
 {{#if empty}}
   <div  style="margin: 20px;" class="Notification Notification--warning"> {{!-- empty scenario div --}}
   {{#if subscribed}}

--- a/client-participation/js/views/comment-form.js
+++ b/client-participation/js/views/comment-form.js
@@ -44,8 +44,8 @@ module.exports = Handlebones.ModelView.extend({
       Utils.shouldFocusOnTextareaWhenWritePaneShown();
     ctx.hasTwitter = userObject.hasTwitter;
     ctx.hasFacebook = userObject.hasFacebook && Constants.FB_APP_ID;
-    ctx.auth_opt_tw = preload.firstConv.auth_opt_tw;
-    ctx.auth_opt_fb = preload.firstConv.auth_opt_fb;
+    ctx.auth_opt_tw = false;
+    ctx.auth_opt_fb = false;
     ctx.s = Strings;
     ctx.desktop = !display.xs();
     ctx.hideHelp = !Utils.userCanSeeHelp() || preload.firstConv.help_type === 0;
@@ -251,7 +251,7 @@ module.exports = Handlebones.ModelView.extend({
       window.userObject.hasFacebook ||
       window.userObject.hasTwitter ||
       !_.isUndefined(xid);
-    var needsSocial = preload.firstConv.auth_needed_to_write;
+    var needsSocial = false;
     M.add(M.COMMENT_SUBMIT_CLICK);
     if (hasSocial || !needsSocial) {
       M.add(M.COMMENT_SUBMIT_INIT);

--- a/e2e/cypress/e2e/client-admin/conversation.cy.js
+++ b/e2e/cypress/e2e/client-admin/conversation.cy.js
@@ -23,14 +23,10 @@ describe('Conversation: Configure', function () {
       cy.get('input[data-test-id="write_type"]').should('be.checked')
       cy.get('input[data-test-id="help_type"]').should('be.checked')
       cy.get('input[data-test-id="subscribe_type"]').should('be.checked')
-      cy.get('input[data-test-id="auth_opt_fb"]').should('be.checked')
-      cy.get('input[data-test-id="auth_opt_tw"]').should('be.checked')
 
       // Schemes section
       cy.get('input[data-test-id="is_active"]').should('be.checked')
       cy.get('input[data-test-id="strict_moderation"]').should('not.be.checked')
-      cy.get('input[data-test-id="auth_needed_to_write"]').should('be.checked')
-      cy.get('input[data-test-id="auth_needed_to_vote"]').should('not.be.checked')
     })
 
     it('should create a new conversation with a topic and description', function () {

--- a/e2e/cypress/e2e/client-admin/share.cy.js
+++ b/e2e/cypress/e2e/client-admin/share.cy.js
@@ -8,7 +8,6 @@ describe('Share page', function () {
       .then(() => cy.visit(this.adminPath))
 
     cy.get('input[data-test-id="strict_moderation"]').check()
-    cy.get('input[data-test-id="auth_needed_to_write"]').uncheck()
   })
 
   beforeEach(function () {

--- a/e2e/cypress/e2e/client-participation/social-login.cy.js
+++ b/e2e/cypress/e2e/client-participation/social-login.cy.js
@@ -6,8 +6,9 @@ const facebookVoteBtn = 'button#facebookButtonVoteView'
 const twitterAuthOpt = 'input[data-test-id="auth_opt_tw"]'
 const twitterCommentBtn = 'button#twitterButtonCommentForm'
 const twitterVoteBtn = 'button#twitterButtonVoteView'
-
-describe('Social login buttons', function () {
+// skip this test for now
+// eslint-disable-next-line mocha/no-skipped-tests
+describe.skip('Social login buttons', function () {
   before(function () {
     cy.createConvo().then(() => {
       cy.seedComment(this.convoId)

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -1,9 +1,9 @@
 const DEFAULTS = {
   auth_needed_to_vote: false,
-  auth_needed_to_write: true,
+  auth_needed_to_write: false,
   auth_opt_allow_3rdparty: true,
-  auth_opt_fb: true,
-  auth_opt_tw: true,
+  auth_opt_fb: false,
+  auth_opt_tw: false,
 };
 
 export { DEFAULTS };


### PR DESCRIPTION
- removes login with fb/tw since it isn't functional 
- ensures existing functionality is maintained (existing conversations don't break)
- adjusts tests

**Core social auth code has not been removed. Only the bare minimum adjustments have been made in order to hide facebook / twitter authentication**