### PR TITLE
[HOTFIX] Do not de-activate comments just because strict moderation is enabled.

### DIFF
--- a/client-participation/js/strings/en_us.js
+++ b/client-participation/js/strings/en_us.js
@@ -5,13 +5,14 @@ var s = {};
 // Text on the card
 
 s.participantHelpWelcomeText =
-  "Welcome to a new kind of conversation - <em>vote</em> on other people's statements - the more the better.";
+  "Welcome to a new kind of conversation — <em>vote on other people's statements</em> — the more the better.";
 
 s.agree = "Agree";
 s.disagree = "Disagree";
 s.pass = "Pass / Unsure";
 
-s.writePrompt = "Share your perspective...";
+s.writePrompt =
+  "Share your perspective (you are not replying — submit a stand-alone idea)";
 s.anonPerson = "Anonymous";
 s.importantCheckbox = "Important/Significant";
 s.importantCheckboxDesc =
@@ -89,16 +90,15 @@ s.helpWhatDoIDoTitle = " What do I do?";
 s.helpWhatDoIDo =
   "Vote on other people's statements by clicking 'agree' or 'disagree'. Write a statement (keep each to a single idea). Invite your friends to the conversation!";
 s.writeCommentHelpText =
-  "Are your perspectives or experiences missing from the conversation? If so, <b>add them</b> in the box below.";
-s.helpWriteListIntro = "What makes for good statements?";
-s.helpWriteListStandalone = "Stand alone ideas";
-s.helpWriteListRaisNew = "New perspectives, experiences, issues";
-s.helpWriteListShort = "Clear & concise statements (limited to 140 characters)";
+  "Are your perspectives or experiences missing from the conversation? If so, <b>add them</b> in the box below — <b>one at a time</b>.";
+s.helpWriteListIntro = "What makes for a good statement?";
+s.helpWriteListStandalone = "A stand-alone idea";
+s.helpWriteListRaisNew = "A new perspective, experience, or issue";
+s.helpWriteListShort = "Clear & concise wording (limited to 140 characters)";
 s.tip = "Tip:";
 s.commentWritingTipsHintsHeader = "Tips for writing statements";
 s.tipCharLimit = "Statements are limited to {{char_limit}} characters.";
-s.tipCommentsRandom =
-  "Statements are displayed randomly and you are not replying directly to other people's statements.";
+s.tipCommentsRandom = "";
 s.tipOneIdea =
   "Break up long statements that contain multiple ideas. This makes it easier for others to vote on your statement.";
 s.tipNoQuestions =
@@ -113,11 +113,11 @@ s.commentSent =
 
 s.commentSendFailed = "There was an error submitting your statement.";
 s.commentSendFailedEmpty =
-  "There was an error submitting your statement - Statement should not be empty.";
+  "There was an error submitting your statement — Statement should not be empty.";
 s.commentSendFailedTooLong =
-  "There was an error submitting your statement - Statement is too long.";
+  "There was an error submitting your statement — Statement is too long.";
 s.commentSendFailedDuplicate =
-  "There was an error submitting your statement - An identical statement already exists.";
+  "There was an error submitting your statement — An identical statement already exists.";
 s.commentErrorDuplicate = "Duplicate! That statement already exists.";
 s.commentErrorConversationClosed =
   "This conversation is closed. No further statements can be submitted.";

--- a/client-participation/js/strings/en_us.js
+++ b/client-participation/js/strings/en_us.js
@@ -2,9 +2,10 @@
 
 var s = {};
 
-// Text on the card 
+// Text on the card
 
-s.participantHelpWelcomeText = "Welcome to a new kind of conversation - <em>vote</em> on other people's statements.";
+s.participantHelpWelcomeText =
+  "Welcome to a new kind of conversation - <em>vote</em> on other people's statements - the more the better.";
 
 s.agree = "Agree";
 s.disagree = "Disagree";
@@ -14,8 +15,8 @@ s.writePrompt = "Share your perspective...";
 s.anonPerson = "Anonymous";
 s.importantCheckbox = "Important/Significant";
 s.importantCheckboxDesc =
-  "Check this box if you believe this statement is especially important to you or is highly relevant to the conversation, irrespective of your vote. It will give this statement higher priority compared to your other votes in the conversation analysis."
-  s.howImportantPrompt = "How important is this statement?";
+  "Check this box if you believe this statement is especially important to you or is highly relevant to the conversation, irrespective of your vote. It will give this statement higher priority compared to your other votes in the conversation analysis.";
+s.howImportantPrompt = "How important is this statement?";
 s.howImportantLow = "Low";
 s.howImportantMedium = "Medium";
 s.howImportantHigh = "High";
@@ -35,9 +36,11 @@ s.comments_remaining2 = "{{num_comments}} remaining statements";
 
 s.noCommentsYet = "There aren't any statements yet.";
 s.noCommentsYetSoWrite = "Get this conversation started by adding a statement.";
-s.noCommentsYetSoInvite = "Get this conversation started by inviting more participants, or add a statement.";
+s.noCommentsYetSoInvite =
+  "Get this conversation started by inviting more participants, or add a statement.";
 s.noCommentsYouVotedOnAll = "You've voted on all the statements.";
-s.noCommentsTryWritingOne = "If you have something to add, try writing your own statement.";
+s.noCommentsTryWritingOne =
+  "If you have something to add, try writing your own statement.";
 s.convIsClosed = "This conversation is closed.";
 s.noMoreVotingAllowed = "No further voting is allowed.";
 
@@ -49,7 +52,8 @@ s.majorityOpinion = "Majority Opinion";
 s.majorityOpinionShort = "Majority";
 s.info = "Info";
 s.helpWhatAmISeeingTitle = "What am I seeing?";
-s.helpWhatAmISeeing = "People who vote similarly are grouped. Click a group to see which viewpoints they share.";
+s.helpWhatAmISeeing =
+  "You are represented by the blue circle and grouped with others who share your perspective.";
 s.heresHowGroupVoted = "Here's how Group {{GROUP_NUMBER}} voted:";
 s.one_person = "{{x}} person";
 s.x_people = "{{x}} people";
@@ -62,43 +66,61 @@ s.topComments = "Top Statements";
 s.divisiveComments = "Divisive Statements";
 s.pctAgreed = "{{pct}}% Agreed";
 s.pctDisagreed = "{{pct}}% Disagreed";
-s.pctAgreedLong = "{{pct}}% of everyone who voted on statement {{comment_id}} agreed.";
+s.pctAgreedLong =
+  "{{pct}}% of everyone who voted on statement {{comment_id}} agreed.";
 s.pctAgreedOfGroup = "{{pct}}% of Group {{group}} Agreed";
 s.pctDisagreedOfGroup = "{{pct}}% of Group {{group}} Disagreed";
-s.pctDisagreedLong = "{{pct}}% of everyone who voted on statement {{comment_id}} disagreed.";
-s.pctAgreedOfGroupLong = "{{pct}}% of those in group {{group}} who voted on statement {{comment_id}} agreed.";
-s.pctDisagreedOfGroupLong = "{{pct}}% of those in group {{group}} who voted on statement {{comment_id}} disagreed.";
-s.participantHelpGroupsText = "People who vote similarly <span style='font-weight: 700;'>are grouped.</span> Click a group to see which viewpoints they share. <a style='font-weight: 700; cursor: pointer; text-decoration: underline' id='helpTextGroupsExpand'>...more</a>";
-s.participantHelpGroupsNotYetText = "The visualization will appear once 7 participants have begun voting";
-s.helpWhatAreGroupsDetail = "<p>You've probably seen 'recommended products' on Amazon, or 'recommended movies' on Netflix. Each of those services uses statistics to group the user with people who buy and watch similar things, then show them things that those people bought or watched.</p> <p> When a user votes on statements, they are grouped with people who voted like they did! You can see those groups below. Each is made up of people who have similar opinions. There are fascinating insights to discover in each conversation. Go ahead - click a group to see what brought them together and what makes them unique! </p>";
+s.pctDisagreedLong =
+  "{{pct}}% of everyone who voted on statement {{comment_id}} disagreed.";
+s.pctAgreedOfGroupLong =
+  "{{pct}}% of those in group {{group}} who voted on statement {{comment_id}} agreed.";
+s.pctDisagreedOfGroupLong =
+  "{{pct}}% of those in group {{group}} who voted on statement {{comment_id}} disagreed.";
+s.participantHelpGroupsText =
+  "You are represented by the blue circle and grouped with others who share your perspective.";
+s.participantHelpGroupsNotYetText =
+  "The visualization will appear once 7 participants have begun voting";
+s.helpWhatAreGroupsDetail =
+  "<p>Click on your group or others to explore each group's opinions.</p><p>Majority opinions are those most widely shared across groups.</p>";
 
 // Text about writing your own statement
 
 s.helpWhatDoIDoTitle = " What do I do?";
-s.helpWhatDoIDo = "Vote on other people's statements by clicking 'agree' or 'disagree'. Write a statement (keep each to a single idea). Invite your friends to the conversation!";
-s.writeCommentHelpText = "Are your perspectives or experiences missing from the conversation? If so, <b>add them</b> in the box below.";
-s.helpWriteListIntro = "What makes a good statement?";
-s.helpWriteListStandalone = "Stand alone idea";
-s.helpWriteListRaisNew = "Raise new perspectives, experiences or issues";
-s.helpWriteListShort = "Clear & concise (limited to 140 characters)";
+s.helpWhatDoIDo =
+  "Vote on other people's statements by clicking 'agree' or 'disagree'. Write a statement (keep each to a single idea). Invite your friends to the conversation!";
+s.writeCommentHelpText =
+  "Are your perspectives or experiences missing from the conversation? If so, <b>add them</b> in the box below.";
+s.helpWriteListIntro = "What makes for good statements?";
+s.helpWriteListStandalone = "Stand alone ideas";
+s.helpWriteListRaisNew = "New perspectives, experiences, issues";
+s.helpWriteListShort = "Clear & concise statements (limited to 140 characters)";
 s.tip = "Tip:";
 s.commentWritingTipsHintsHeader = "Tips for writing statements";
 s.tipCharLimit = "Statements are limited to {{char_limit}} characters.";
-s.tipCommentsRandom = "Please remember, statements are displayed randomly and you are not replying directly to other participants' statements.";
-s.tipOneIdea = "Break up long statements that contain multiple ideas. This makes it easier for others to vote on your statement.";
-s.tipNoQuestions = "Statements should not be in the form of a question. Participants will agree or disagree with the statements you make.";
-s.commentTooLongByChars = "Statement length limit exceeded by {{CHARACTERS_COUNT}} characters.";
+s.tipCommentsRandom =
+  "Statements are displayed randomly and you are not replying directly to other people's statements.";
+s.tipOneIdea =
+  "Break up long statements that contain multiple ideas. This makes it easier for others to vote on your statement.";
+s.tipNoQuestions =
+  "Statements should not be in the form of a question. Participants will agree or disagree with the statements you make.";
+s.commentTooLongByChars =
+  "Statement length limit exceeded by {{CHARACTERS_COUNT}} characters.";
 s.submitComment = "Submit";
-s.commentSent = "Statement submitted! Only other participants will see your statement and agree or disagree.";
+s.commentSent =
+  "Statement submitted! Only other participants will see your statement and agree or disagree.";
 
 // Error notices
 
 s.commentSendFailed = "There was an error submitting your statement.";
-s.commentSendFailedEmpty = "There was an error submitting your statement - Statement should not be empty.";
-s.commentSendFailedTooLong = "There was an error submitting your statement - Statement is too long.";
-s.commentSendFailedDuplicate = "There was an error submitting your statement - An identical statement already exists.";
+s.commentSendFailedEmpty =
+  "There was an error submitting your statement - Statement should not be empty.";
+s.commentSendFailedTooLong =
+  "There was an error submitting your statement - Statement is too long.";
+s.commentSendFailedDuplicate =
+  "There was an error submitting your statement - An identical statement already exists.";
 s.commentErrorDuplicate = "Duplicate! That statement already exists.";
-s.commentErrorConversationClosed = "This conversation is closed. No further statements can be submitted.";
+s.commentErrorConversationClosed =
+  "This conversation is closed. No further statements can be submitted.";
 s.commentIsEmpty = "Statement is empty";
 s.commentIsTooLong = "Statement is too long";
 s.hereIsNextStatement = "Vote success. Navigate up to see the next statement.";
@@ -107,13 +129,18 @@ s.hereIsNextStatement = "Vote success. Navigate up to see the next statement.";
 
 s.connectFacebook = "Connect Facebook";
 s.connectTwitter = "Connect Twitter";
-s.connectToPostPrompt = "Connect an identity to submit a statement. We will not post to your timeline.";
-s.connectToVotePrompt = "Connect an identity to vote. We will not post to your timeline.";
-s.socialConnectPrompt = "Optionally connect to see friends and people you follow in the visualization.";
+s.connectToPostPrompt =
+  "Connect an identity to submit a statement. We will not post to your timeline.";
+s.connectToVotePrompt =
+  "Connect an identity to vote. We will not post to your timeline.";
+s.socialConnectPrompt =
+  "Optionally connect to see friends and people you follow in the visualization.";
 s.connectFbButton = "Connect with Facebook";
 s.connectTwButton = "Connect with Twitter";
-s.polis_err_reg_fb_verification_email_sent = "Please check your email for a verification link, then return here to continue.";
-s.polis_err_reg_fb_verification_noemail_unverified = "Your Facebook account is unverified. Please verify your email address with Facebook, then return here to continue.";
+s.polis_err_reg_fb_verification_email_sent =
+  "Please check your email for a verification link, then return here to continue.";
+s.polis_err_reg_fb_verification_noemail_unverified =
+  "Your Facebook account is unverified. Please verify your email address with Facebook, then return here to continue.";
 
 // Text for the third party translation that appears on the cards
 
@@ -123,14 +150,17 @@ s.thirdPartyTranslationDisclaimer = "Translation provided by a third party";
 
 // Text about notifications and subscriptions and embedding
 
-s.notificationsAlreadySubscribed = "You are subscribed to updates for this conversation.";
+s.notificationsAlreadySubscribed =
+  "You are subscribed to updates for this conversation.";
 s.notificationsGetNotified = "Get notified when more statements arrive:";
-s.notificationsEnterEmail = "Enter your email address to get notified when more statements arrive:";
+s.notificationsEnterEmail =
+  "Enter your email address to get notified when more statements arrive:";
 s.labelEmail = "Email";
 s.notificationsSubscribeButton = "Subscribe";
 s.notificationsSubscribeErrorAlert = "Error subscribing";
 
-s.addPolisToYourSite = "<img style='height: 20px; margin: 0px 4px;' src='{{URL}}'/>";
+s.addPolisToYourSite =
+  "<img style='height: 20px; margin: 0px 4px;' src='{{URL}}'/>";
 
 // Footer
 
@@ -153,13 +183,16 @@ s.modSubmitInitialState = "Skip (none of the above), next statement";
 s.modSubmit = "Done, next statement";
 
 s.topic_good_01 = "What should we do about the pingpong room?";
-s.topic_good_01_reason = "open ended, anyone can have an opinion on answers to this question";
+s.topic_good_01_reason =
+  "open ended, anyone can have an opinion on answers to this question";
 s.topic_good_02 = "What do you think about the new proposal?";
-s.topic_good_02_reason = "open ended, anyone can have an opinion on answers to this question";
+s.topic_good_02_reason =
+  "open ended, anyone can have an opinion on answers to this question";
 s.topic_good_03 = "Can you think of anything that's slowing productivity?";
 
 s.topic_bad_01 = "everyone report your launch readiness";
-s.topic_bad_01_reason = "people from various teams will be voting on the responses, but may not have enough knowledge to vote confidently.";
+s.topic_bad_01_reason =
+  "people from various teams will be voting on the responses, but may not have enough knowledge to vote confidently.";
 s.topic_bad_02 = "what are our launch blockers?";
 s.topic_bad_02_reason = "";
 

--- a/client-participation/js/templates/comment-form.handlebars
+++ b/client-participation/js/templates/comment-form.handlebars
@@ -25,7 +25,7 @@
       {{!-- present all hints to screen reader --}}
 
       {{#if hideHelp}}
-        {{!-- even if help text is hidden, still screen read the main comment box label/prompt --}}
+        {{!-- even if help text is hidden, still screen read the main comment box label/prompt Jan2025 n/m show always --}}
         <label for="comment_form_textarea">
           {{{s.writeCommentHelpText}}}
         </label>

--- a/client-participation/js/templates/comment-form.handlebars
+++ b/client-participation/js/templates/comment-form.handlebars
@@ -26,8 +26,7 @@
 
       {{#if hideHelp}}
         {{!-- even if help text is hidden, still screen read the main comment box label/prompt --}}
-        <label for="comment_form_textarea"
-               style="display:none;">
+        <label for="comment_form_textarea">
           {{{s.writeCommentHelpText}}}
         </label>
       {{else}}

--- a/client-participation/js/templates/profilePicView.handlebars
+++ b/client-participation/js/templates/profilePicView.handlebars
@@ -9,7 +9,7 @@
       margin-inline-end: 10px;
       min-height: 37px;
       min-width: 37px;
-      border-radius: 3px;
-      border: 1px solid rgba(0,0,0, 0.1);
+      border-radius: 4px;
+      border: 4px solid rgb(49, 169, 244);
     ">
 </img>

--- a/math/Dockerfile
+++ b/math/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/clojure:tools-deps-bullseye
+FROM docker.io/clojure:temurin-17-tools-deps
 
 WORKDIR /app
 COPY . .

--- a/math/system.properties
+++ b/math/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=21
+java.runtime.version=17

--- a/math/system.properties
+++ b/math/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=1.8
+java.runtime.version=21

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -6716,15 +6716,6 @@ Email verified! You can close this tab or hit the back button.
         classifications.push("spammy");
         logger.info("active=false because (spammy && conv.spam_filter)");
       }
-      if (spammy && conv.spam_filter) {
-        active = false;
-        classifications.push("spammy");
-        logger.info("active=false because (spammy && conv.spam_filter)");
-      }
-      if (conv.strict_moderation) {
-        active = false;
-        logger.info("active=false because (conv.strict_moderation)");
-      }
 
       let mod = 0;
       if (is_moderator && is_seed) {


### PR DESCRIPTION
When strict moderation is enabled, new comments were being automatically flagged as `inactive` resulting in false negative messaging regarding the spam/toxicity filter.

However we already use the `comment.mod` value to track comments which need moderation. There is no need to mark them `inactive` unless an actual filter is triggered.

Also in this PR is the help text improvements https://github.com/compdemocracy/polis/pull/1886
and java version updates for 'math'.

Result:

<img width="618" alt="Screenshot 2025-01-29 at 01 24 49" src="https://github.com/user-attachments/assets/04a5a0d8-7182-4159-b9b6-328bfe08b27a" />

Strict Moderation ON:

- all user comments will appear in the moderation tab and must be approved
- only comments which were flagged by an actual filter will show a warning message
- any comment, flagged or not, can be approved and shown to voters

Strict Moderation OFF:

- user comments that are flagged as spam/toxic will not be shown to voters unless approved
- other user comments will be shown to voters, unless/until they are rejected by moderator 

Moderation can be toggled ON/OFF with the expected effect:

- Unmoderated comments will be either hidden or shown to voters accordingly

TODO (future PR)

[ ] Cypress tests for the above states
[ ] Adjust the warning in client-admin depending on if Jigsaw is active for that deployment or not
