### PR TITLE
Quieter math logging by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
         polis_tag: ${TAG:-dev}
     environment:
       - DATABASE_URL=${DATABASE_URL}
+      - LOGGING_LEVEL=${MATH_LOG_LEVEL:-warn}
       - MATH_ENV=${MATH_ENV:-prod}
       - WEBSERVER_USERNAME=${WEBSERVER_USERNAME}
       - WEBSERVER_PASS=${WEBSERVER_PASS}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,7 @@ If you are deploying to a custom domain (not `pol.is`) then you need to update b
 - **`EMAIL_TRANSPORT_TYPES`** comma-separated list of email services to use (see [Email Transports](#email-transports) below)
 - **`GIT_HASH`** Set programmatically using `git rev-parse HEAD` (e.g. in `Makefile`) to tag docker container versions and other release assets. Can be left blank.
 - **`MATH_ENV`** Set to `prod` (default), `preprod`, `dev` or arbitrary feature flag. In cases where a single database is used for multiple environments, this value is used by the API service to request the correct data. (Using a single DB for multiple environments in this fashion is no longer recommended, and so the default value of `prod` is recommended.)
+- **`MATH_LOG_LEVEL`** Used by the math service to determine how much logging to output. Reasonable values are `debug`, `info`, `warn`, and `error`. Defaults to `warn`.
 - **`SERVER_ENV_FILE`** The name of an environment file to be passed into the API Server container by docker compose. Defaults to `.env` if left blank. Used especially for building a `test` version of the project for end-to-end testing.
 - **`SERVER_LOG_LEVEL`** Used by Winston.js in the API server to determine how much logging to output. Reasonable values are `debug`, `info`, and `error`. Defaults to `info`.
 

--- a/example.env
+++ b/example.env
@@ -11,6 +11,8 @@ EMAIL_TRANSPORT_TYPES=maildev
 GIT_HASH=
 # Options: prod, preprod, dev:
 MATH_ENV=prod
+# Options: debug, info, warn, error, fatal. Default is warn.
+MATH_LOG_LEVEL=
 # Optionally give the server container a distinct env_file. Useful for CI tests.
 SERVER_ENV_FILE=.env
 # Used by winston via server/utils/logger. Defaults to "info".

--- a/math/README.md
+++ b/math/README.md
@@ -35,6 +35,7 @@ If you're not familiar with Clojure and want a fun crash course, I highly recomm
 If you're not using the docker compose infrastructure, you can run `clj -M:dev` to get nREPL going, but this will not start math worker's processing queue (or obviously any other parts of the system).
 This may be preferable if you don't need the whole system running for whatever task you're working on.
 You can always manually start the polling system by manually running `(runner/run!)`, as described below, as long as you have the `DATABASE_URL` environment variable pointing to a database (see [`doc/configuration.md`](doc/configuration.md))
+
 ## Starting and stopping the system
 
 This application uses Stuart Sierra's Component library for REPL-reloadability.
@@ -80,11 +81,33 @@ We need to have a way of queueing up vote and moderation data updates, so that t
 
 You can see the conversation manager implementation at [`src/polismath/conv_man.clj`](src/polismath/conv_man.clj).
 
+## Logging Configuration
+
+The system's logging level defaults to `:warn` but can be configured in several ways:
+
+1. Set the `LOGGING_LEVEL` environment variable to change from the default `:warn` level:
+
+   ```bash
+   MATH_LOG_LEVEL=info docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile postgres up
+   ```
+
+2. Modify the logging level in `resources/config.edn`
+3. Set the level at runtime via the REPL:
+
+   ```clojure
+   (require '[taoensso.timbre :as timbre])
+   (timbre/set-level! :info)  ; Example of setting to a more verbose level
+   ```
+
+Available log levels (from lowest to highest): `:trace`, `:debug`, `:info`, `:warn`, `:error`, `:fatal`, `:report`
+
 ## Production setup
 
-The [`docker-compose.yml`](../docker-compose.yml) file in the root of this directory, while not yet production ready, and still containing some development time artifacts, is provided as a basis for production deployment.
+The [`docker-compose.yml`](../docker-compose.yml) file in the root of this directory is provided as a basis for production deployment.
 Outstanding issues which need to be resolved before it would be ready include ensuring only necessary ports are exposed, etc.
 The individual `Dockerfile`s that make up this infrastructure can currently be used by themselves, separate from `docker compose`, for deployment.
+
+## Requirements
 
 Nonetheless, if you wish to run this part of the system directly on a machine (outside of docker), the only requirements are that you:
 

--- a/math/resources/config.edn
+++ b/math/resources/config.edn
@@ -33,7 +33,7 @@
         ;:group-k-buffer 4}}
 
  :logging {:file "log/dev.log"
-           :level :info}
+           :level :warn}
 
  ;:math-env                   {:parse ->keyword}
  ;; Have to use :port since that's what heroku expects...

--- a/math/src/polismath/components/config.clj
+++ b/math/src/polismath/components/config.clj
@@ -51,7 +51,7 @@
                 :poll-from-days-ago 10}
    :math       {:matrix-implementation :vectorz}
    :logging    {:file "log/dev.log"
-                :level :info}})
+                :level :warn}})
 
 (defn ->long-list [x]
   (when x

--- a/math/src/polismath/system.clj
+++ b/math/src/polismath/system.clj
@@ -21,18 +21,18 @@
   "This constructs an instance of the base system components, including config, db, etc."
   [config-overrides]
   {:config               (config/create-config config-overrides)
-   ;:logger               (component/using (logger/create-logger)                 [:config])
-   :core-matrix-boot     (component/using (core-matrix-boot/create-core-matrix-booter) [:config])
-   :postgres             (component/using (postgres/create-postgres)             [:config])
-   :conversation-manager (component/using (conv-man/create-conversation-manager) [:config :core-matrix-boot :postgres])})
+   :logger              (component/using (logger/create-logger)                 [:config])
+   :core-matrix-boot     (component/using (core-matrix-boot/create-core-matrix-booter) [:config :logger])
+   :postgres             (component/using (postgres/create-postgres)             [:config :logger])
+   :conversation-manager (component/using (conv-man/create-conversation-manager) [:config :core-matrix-boot :postgres :logger])})
 
 (defn poller-system
   "Creates a base-system and assocs in darwin server related components."
   [config-overrides]
   (merge
     (base-system config-overrides)
-    {:vote-poller (component/using (poller/create-poller :votes)      [:config :postgres :conversation-manager])
-     :mod-poller  (component/using (poller/create-poller :moderation) [:config :postgres :conversation-manager])}))
+    {:vote-poller (component/using (poller/create-poller :votes)      [:config :postgres :conversation-manager :logger])
+     :mod-poller  (component/using (poller/create-poller :moderation) [:config :postgres :conversation-manager :logger])}))
 
 (defn task-system
   [config-overrides]


### PR DESCRIPTION
This changes the default logging level in `math` to `:warn`, dramatically reducing its overall log output.
This can be overridden with a new config var `MATH_LOG_LEVEL`, e.g. `MATH_LOG_LEVEL=info`.