### PR TITLE
[DRAFT] enable xids in export data with includeXid=true param

### DIFF
--- a/client-admin/src/actions/index.js
+++ b/client-admin/src/actions/index.js
@@ -1695,7 +1695,8 @@ const dataExportGet = (
   conversation_id,
   format,
   unixTimestamp,
-  untilEnabled
+  untilEnabled,
+  includeXid
 ) => {
   //       url += ("&unixTimestamp=" + ((ctx.date/1000) << 0));
 
@@ -1704,6 +1705,11 @@ const dataExportGet = (
   if (untilEnabled) {
     url += `&unixTimestamp=${unixTimestamp}`
   }
+
+  if (includeXid) {
+    url += `&includeXid=true`
+  }
+
   return $.get(url)
 }
 
@@ -1711,7 +1717,8 @@ export const startDataExport = (
   conversation_id,
   format,
   unixTimestamp,
-  untilEnabled
+  untilEnabled,
+  includeXid = false
 ) => {
   return (dispatch) => {
     dispatch(dataExportStarted())
@@ -1719,7 +1726,8 @@ export const startDataExport = (
       conversation_id,
       format,
       unixTimestamp,
-      untilEnabled
+      untilEnabled,
+      includeXid
     ).then(
       (res) => dispatch(dataExportSuccess(res)),
       (err) => dispatch(dataExportError(err))

--- a/client-admin/src/components/conversation-admin/data-export.js
+++ b/client-admin/src/components/conversation-admin/data-export.js
@@ -14,7 +14,11 @@ class DataExport extends React.Component {
   constructor(props) {
     super(props)
     const times = dateSetupUtil()
-    this.state = Object.assign({}, times, { showHelpMessage: false })
+    this.state = Object.assign({}, times, { showHelpMessage: false, includeXid: false })
+  }
+
+  handleIncludeXidToggled() {
+    this.setState({ includeXid: !this.state.includeXid })
   }
 
   handleExportClicked() {
@@ -35,7 +39,8 @@ class DataExport extends React.Component {
           this.props.zid_metadata.conversation_id,
           format,
           (dddate / 1000) << 0,
-          !!this.state.untilEnabled
+          !!this.state.untilEnabled,
+          this.state.includeXid
         )
       )
     }
@@ -121,6 +126,16 @@ class DataExport extends React.Component {
               )
             })}
           </select>
+          <div>
+            <label>
+              <input
+                type="checkbox"
+                checked={this.state.includeXid}
+                onChange={this.handleIncludeXidToggled.bind(this)}
+              />
+              Include XIDs
+            </label>
+          </div>
           <p>
             By default, the entire dataset is returned. To limit the last
             timestamp returned, enter a date here.

--- a/math/src/polismath/darwin/core.clj
+++ b/math/src/polismath/darwin/core.clj
@@ -162,6 +162,12 @@
     :zinvite (or (:zinvite params)
                  (db/get-zinvite-from-zid (:postgres darwin) (:zid params)))))
 
+(defn params-with-xid
+  [params]
+  (assoc params :include-xid (if (contains? params :include-xid)
+                              (:include-xid params)
+                              false)))
+
 
 (defn parsed-params
   "Parses the params for a request, occording to parsers."
@@ -177,7 +183,8 @@
       {})
     (params-with-zid darwin)
     (params-with-zinvite darwin)
-    (params-with-filename)))
+    (params-with-filename)
+    (params-with-xid)))
 
 
 

--- a/math/src/polismath/tasks.clj
+++ b/math/src/polismath/tasks.clj
@@ -36,11 +36,8 @@
 (defmethod dispatch-task! :generate_export_data
   [{:as poller :keys [darwin]} task-record]
   (log/debug "Dispatching generate_export_data for" task-record)
-  (let [params (assoc (:task_data task-record) :task_bucket (:task_bucket task-record))
-        ;; Need to think about security implications more thoroughly before we can really include this from
-        ;; requests triggered by server (needs thorough audit to make sure user can't trigger this via web
-        ;; api request)
-        params (dissoc task-record :include-xid)]
+  (let [params (assoc (:task_data task-record)
+                      :task_bucket (:task_bucket task-record))]
     (try
       (let [params (darwin/parsed-params darwin params)]
         (darwin/notify-of-status darwin params "processing")

--- a/server/app.ts
+++ b/server/app.ts
@@ -300,6 +300,7 @@ helpersInitialized.then(
       need("conversation_id", getStringLimitLength(1, 1000), assignToP),
       want("format", getStringLimitLength(1, 100), assignToP),
       want("unixTimestamp", getStringLimitLength(99), assignToP),
+      want("includeXid", getBool, assignToP),
       handle_GET_dataExport
     );
 

--- a/server/src/routes/dataExport.ts
+++ b/server/src/routes/dataExport.ts
@@ -9,7 +9,7 @@ AWS.config.update({ region: Config.awsRegion });
 const s3Client = new AWS.S3({ apiVersion: "2006-03-01" });
 
 function handle_GET_dataExport(
-    req: { p: { uid?: any; zid: any; unixTimestamp: number; format: any } },
+    req: { p: { uid?: any; zid: any; unixTimestamp: number; format: any; includeXid?: boolean } },
     res: { json: (arg0: {}) => void }
   ) {
     const getUserInfoForUid2 = User.getUserInfoForUid2;
@@ -21,7 +21,8 @@ function handle_GET_dataExport(
           req.p.zid,
           req.p.unixTimestamp * 1000,
           req.p.format,
-          Math.abs((Math.random() * 999999999999) >> 0)
+          Math.abs((Math.random() * 999999999999) >> 0),
+          req.p.includeXid
         )
           .then(() => {
             res.json({});

--- a/server/src/utils/common.ts
+++ b/server/src/utils/common.ts
@@ -171,7 +171,8 @@ function doAddDataExportTask(
   zid: number,
   atDate: number,
   format: string,
-  task_bucket: number
+  task_bucket: number,
+  includeXid?: boolean
 ) {
   return pgQueryP(
     "insert into worker_tasks (math_env, task_data, task_type, task_bucket) values ($1, $2, 'generate_export_data', $3);",
@@ -182,6 +183,7 @@ function doAddDataExportTask(
         zid: zid,
         "at-date": atDate,
         format: format,
+        includeXid: includeXid || false,
       },
       task_bucket, // TODO hash the params to get a consistent number?
     ]


### PR DESCRIPTION
DONE: 

- [x] Update **math** to allow `:include-xid` param
- [x] Update **server** to allow `includeXid` param

TODO:

- [ ] Expose an "Include XIDs" checkbox in client-admin reports request page
- [ ] Cypress tests