### PR TITLE
Include Xids in participant-votes summary output

### DIFF
--- a/server/src/routes/export.ts
+++ b/server/src/routes/export.ts
@@ -230,10 +230,17 @@ export async function sendParticipantVotesSummary(zid: number, res: Response) {
     return undefined;
   }
 
+  const xids = await getXids(zid);
+  function getXid(pid: number): string | undefined {
+    const xid = xids.find((row) => row.pid === pid);
+    return xid?.xid;
+  }
+
   res.setHeader("content-type", "text/csv");
   res.write(
     [
       "participant",
+      "xid",
       "group-id",
       "n-comments",
       "n-votes",
@@ -255,6 +262,7 @@ export async function sendParticipantVotesSummary(zid: number, res: Response) {
     }
     const values = [
       currentParticipantId,
+      getXid(currentParticipantId),
       getGroupId(currentParticipantId),
       participantCommentCounts.get(currentParticipantId) || 0,
       currentParticipantVotes.size,
@@ -571,4 +579,12 @@ export async function handle_GET_reportExport(
         : "polis_err_data_export";
     fail(res, 500, msg, err);
   }
+}
+
+async function getXids(zid: number): Promise<{ pid: number; xid: string }[]> {
+  const rows = await pgQueryP_readOnly(
+    "SELECT p.pid, x.xid FROM participants p LEFT JOIN xids x ON p.uid = x.uid WHERE p.zid = $1",
+    [zid]
+  );
+  return rows as { pid: number; xid: string }[];
 }

--- a/server/src/routes/export.ts
+++ b/server/src/routes/export.ts
@@ -233,7 +233,7 @@ export async function sendParticipantVotesSummary(zid: number, res: Response) {
   const xids = await getXids(zid);
   function getXid(pid: number): string | undefined {
     const xid = xids.find((row) => row.pid === pid);
-    return xid?.xid;
+    return xid?.xid || "";
   }
 
   res.setHeader("content-type", "text/csv");

--- a/server/test/export.test.ts
+++ b/server/test/export.test.ts
@@ -241,6 +241,13 @@ describe("handle_GET_reportExport", () => {
       { tid: 3, pid: 2 },
     ] as never);
 
+    // Mock pgQueryP_readOnly to return xid data
+    (queryP_readOnly as jest.Mock).mockResolvedValueOnce([
+      { pid: 1, xid: "xid-1" },
+      { pid: 1, xid: "xid-2" },
+      { pid: 2, xid: "xid-3" },
+    ] as never);
+
     // Mock getPca to return group cluster data
     (getPca as jest.Mock).mockResolvedValue({
       asPOJO: {
@@ -269,10 +276,10 @@ describe("handle_GET_reportExport", () => {
 
     expect(mockRes.setHeader).toHaveBeenCalledWith("content-type", "text/csv");
     expect(mockRes.write).toHaveBeenCalledWith(
-      "participant,group-id,n-comments,n-votes,n-agree,n-disagree,1,2,3\n"
+      "participant,xid,group-id,n-comments,n-votes,n-agree,n-disagree,1,2,3\n"
     );
     // Check if the participant rows are correctly formatted
-    expect(mockRes.write).toHaveBeenCalledWith("1,1,2,2,1,1,1,-1,\n");
+    expect(mockRes.write).toHaveBeenCalledWith("1,xid-1,1,2,2,1,1,1,-1,\n");
     expect(mockRes.end).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
# Changes

This PR will automatically include xids in the generated csv for participant-votes-summary, if xids exist.

This is fully functional, but I'm setting it as a [DRAFT] until/unless we are certain we want this on for everyone.

## Example

<img width="572" alt="Screenshot 2025-02-21 at 02 03 40" src="https://github.com/user-attachments/assets/671866de-aee3-43e8-a8f4-458c54b54f0f" />
