### PR TITLE
default server logging to 'warn'

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@ If you are deploying to a custom domain (not `pol.is`) then you need to update b
 - **`MATH_ENV`** Set to `prod` (default), `preprod`, `dev` or arbitrary feature flag. In cases where a single database is used for multiple environments, this value is used by the API service to request the correct data. (Using a single DB for multiple environments in this fashion is no longer recommended, and so the default value of `prod` is recommended.)
 - **`MATH_LOG_LEVEL`** Used by the math service to determine how much logging to output. Reasonable values are `debug`, `info`, `warn`, and `error`. Defaults to `warn`.
 - **`SERVER_ENV_FILE`** The name of an environment file to be passed into the API Server container by docker compose. Defaults to `.env` if left blank. Used especially for building a `test` version of the project for end-to-end testing.
-- **`SERVER_LOG_LEVEL`** Used by Winston.js in the API server to determine how much logging to output. Reasonable values are `debug`, `info`, and `error`. Defaults to `info`.
+- **`SERVER_LOG_LEVEL`** Used by Winston.js in the API server to determine how much logging to output. Reasonable values are `debug`, `info`, `warn`, and `error`. Defaults to `warn`.
 
 ### Database
 

--- a/example.env
+++ b/example.env
@@ -15,7 +15,7 @@ MATH_ENV=prod
 MATH_LOG_LEVEL=
 # Optionally give the server container a distinct env_file. Useful for CI tests.
 SERVER_ENV_FILE=.env
-# Used by winston via server/utils/logger. Defaults to "info".
+# Used by winston via server/utils/logger. Defaults to "warn".
 SERVER_LOG_LEVEL=
 
 

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -2,7 +2,7 @@ import { createLogger, format, transports } from "winston";
 import Config from "../config";
 
 // See https://github.com/winstonjs/winston#logging-levels
-const logLevel = Config.logLevel || "info";
+const logLevel = Config.logLevel || "warn";
 const logToFile = Config.logToFile;
 
 const consoleTransport = new transports.Console({


### PR DESCRIPTION
# Quieter Server Logging by Default

Defaults to 'warn' instead of 'info'.

Can be overridden with `SERVER_LOG_LEVEL`