### PR TITLE
Small Typo in the Welcome Text string for US-EN

### DIFF
--- a/client-participation/js/strings/en_us.js
+++ b/client-participation/js/strings/en_us.js
@@ -5,7 +5,7 @@ var s = {};
 // Text on the card
 
 s.participantHelpWelcomeText =
-  "Welcome to a new kind of conversation — </b>vote</b>on other people's statements — </b> the more the better.</b>";
+  "Welcome to a new kind of conversation — </b>vote</b> on other people's statements — </b> the more the better.</b>";
 
 s.agree = "Agree";
 s.disagree = "Disagree";


### PR DESCRIPTION
Added a space between 'vote' and 'on' on the participantHelpWelcomeText string in the en_us.js file. 