### PR TITLE
Job ids as primary keys.

### DIFF
--- a/delphi/create_dynamodb_tables.py
+++ b/delphi/create_dynamodb_tables.py
@@ -285,11 +285,10 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         'Delphi_UMAPConversationConfig': {
             'KeySchema': [
                 {'AttributeName': 'job_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                {'AttributeName': 'conversation_id', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
                 {'AttributeName': 'job_id', 'AttributeType': 'S'},
-                {'AttributeName': 'entity_id', 'AttributeType': 'S'},
                 {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
             ],
             'GlobalSecondaryIndexes': [
@@ -310,11 +309,11 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         'Delphi_CommentEmbeddings': {
             'KeySchema': [
                 {'AttributeName': 'job_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                {'AttributeName': 'comment_id', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
                 {'AttributeName': 'job_id', 'AttributeType': 'S'},
-                {'AttributeName': 'entity_id', 'AttributeType': 'N'},
+                {'AttributeName': 'comment_id', 'AttributeType': 'N'},
                 {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
             ],
             'GlobalSecondaryIndexes': [
@@ -322,7 +321,7 @@ def create_evoc_tables(dynamodb, delete_existing=False):
                     'IndexName': 'ConversationIdIndex',
                     'KeySchema': [
                         {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                        {'AttributeName': 'comment_id', 'KeyType': 'RANGE'}
                     ],
                     'Projection': {'ProjectionType': 'ALL'},
                     'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
@@ -336,11 +335,11 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         'Delphi_CommentHierarchicalClusterAssignments': {
             'KeySchema': [
                 {'AttributeName': 'job_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                {'AttributeName': 'comment_id', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
                 {'AttributeName': 'job_id', 'AttributeType': 'S'},
-                {'AttributeName': 'entity_id', 'AttributeType': 'N'},
+                {'AttributeName': 'comment_id', 'AttributeType': 'N'},
                 {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
             ],
             'GlobalSecondaryIndexes': [
@@ -348,7 +347,7 @@ def create_evoc_tables(dynamodb, delete_existing=False):
                     'IndexName': 'ConversationIdIndex',
                     'KeySchema': [
                         {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                        {'AttributeName': 'comment_id', 'KeyType': 'RANGE'}
                     ],
                     'Projection': {'ProjectionType': 'ALL'},
                     'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
@@ -362,11 +361,11 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         'Delphi_CommentClustersStructureKeywords': {
             'KeySchema': [
                 {'AttributeName': 'job_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                {'AttributeName': 'cluster_key', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
                 {'AttributeName': 'job_id', 'AttributeType': 'S'},
-                {'AttributeName': 'entity_id', 'AttributeType': 'S'},
+                {'AttributeName': 'cluster_key', 'AttributeType': 'S'},
                 {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
             ],
             'GlobalSecondaryIndexes': [
@@ -374,7 +373,7 @@ def create_evoc_tables(dynamodb, delete_existing=False):
                     'IndexName': 'ConversationIdIndex',
                     'KeySchema': [
                         {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                        {'AttributeName': 'cluster_key', 'KeyType': 'RANGE'}
                     ],
                     'Projection': {'ProjectionType': 'ALL'},
                     'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
@@ -388,11 +387,11 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         'Delphi_UMAPGraph': {
             'KeySchema': [
                 {'AttributeName': 'job_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                {'AttributeName': 'edge_id', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
                 {'AttributeName': 'job_id', 'AttributeType': 'S'},
-                {'AttributeName': 'entity_id', 'AttributeType': 'S'},
+                {'AttributeName': 'edge_id', 'AttributeType': 'S'},
                 {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
             ],
             'GlobalSecondaryIndexes': [
@@ -400,7 +399,7 @@ def create_evoc_tables(dynamodb, delete_existing=False):
                     'IndexName': 'ConversationIdIndex',
                     'KeySchema': [
                         {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                        {'AttributeName': 'edge_id', 'KeyType': 'RANGE'}
                     ],
                     'Projection': {'ProjectionType': 'ALL'},
                     'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
@@ -416,11 +415,11 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         'Delphi_CommentClustersFeatures': {
             'KeySchema': [
                 {'AttributeName': 'job_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                {'AttributeName': 'cluster_key', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
                 {'AttributeName': 'job_id', 'AttributeType': 'S'},
-                {'AttributeName': 'entity_id', 'AttributeType': 'S'},
+                {'AttributeName': 'cluster_key', 'AttributeType': 'S'},
                 {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
             ],
             'GlobalSecondaryIndexes': [
@@ -428,7 +427,7 @@ def create_evoc_tables(dynamodb, delete_existing=False):
                     'IndexName': 'ConversationIdIndex',
                     'KeySchema': [
                         {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                        {'AttributeName': 'cluster_key', 'KeyType': 'RANGE'}
                     ],
                     'Projection': {'ProjectionType': 'ALL'},
                     'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
@@ -442,11 +441,11 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         'Delphi_CommentClustersLLMTopicNames': {
             'KeySchema': [
                 {'AttributeName': 'job_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                {'AttributeName': 'topic_key', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
                 {'AttributeName': 'job_id', 'AttributeType': 'S'},
-                {'AttributeName': 'entity_id', 'AttributeType': 'S'},
+                {'AttributeName': 'topic_key', 'AttributeType': 'S'},
                 {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
             ],
             'GlobalSecondaryIndexes': [
@@ -454,7 +453,7 @@ def create_evoc_tables(dynamodb, delete_existing=False):
                     'IndexName': 'ConversationIdIndex',
                     'KeySchema': [
                         {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                        {'AttributeName': 'topic_key', 'KeyType': 'RANGE'}
                     ],
                     'Projection': {'ProjectionType': 'ALL'},
                     'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}

--- a/delphi/create_dynamodb_tables.py
+++ b/delphi/create_dynamodb_tables.py
@@ -284,10 +284,23 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         # Core tables
         'Delphi_UMAPConversationConfig': {
             'KeySchema': [
-                {'AttributeName': 'conversation_id', 'KeyType': 'HASH'}
+                {'AttributeName': 'job_id', 'KeyType': 'HASH'},
+                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
+                {'AttributeName': 'job_id', 'AttributeType': 'S'},
+                {'AttributeName': 'entity_id', 'AttributeType': 'S'},
                 {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
+            ],
+            'GlobalSecondaryIndexes': [
+                {
+                    'IndexName': 'ConversationIdIndex',
+                    'KeySchema': [
+                        {'AttributeName': 'conversation_id', 'KeyType': 'HASH'}
+                    ],
+                    'Projection': {'ProjectionType': 'ALL'},
+                    'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
+                }
             ],
             'ProvisionedThroughput': {
                 'ReadCapacityUnits': 5,
@@ -296,12 +309,24 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         },
         'Delphi_CommentEmbeddings': {
             'KeySchema': [
-                {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'comment_id', 'KeyType': 'RANGE'}
+                {'AttributeName': 'job_id', 'KeyType': 'HASH'},
+                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
-                {'AttributeName': 'conversation_id', 'AttributeType': 'S'},
-                {'AttributeName': 'comment_id', 'AttributeType': 'N'}
+                {'AttributeName': 'job_id', 'AttributeType': 'S'},
+                {'AttributeName': 'entity_id', 'AttributeType': 'N'},
+                {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
+            ],
+            'GlobalSecondaryIndexes': [
+                {
+                    'IndexName': 'ConversationIdIndex',
+                    'KeySchema': [
+                        {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
+                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                    ],
+                    'Projection': {'ProjectionType': 'ALL'},
+                    'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
+                }
             ],
             'ProvisionedThroughput': {
                 'ReadCapacityUnits': 5,
@@ -310,12 +335,24 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         },
         'Delphi_CommentHierarchicalClusterAssignments': {
             'KeySchema': [
-                {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'comment_id', 'KeyType': 'RANGE'}
+                {'AttributeName': 'job_id', 'KeyType': 'HASH'},
+                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
-                {'AttributeName': 'conversation_id', 'AttributeType': 'S'},
-                {'AttributeName': 'comment_id', 'AttributeType': 'N'}
+                {'AttributeName': 'job_id', 'AttributeType': 'S'},
+                {'AttributeName': 'entity_id', 'AttributeType': 'N'},
+                {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
+            ],
+            'GlobalSecondaryIndexes': [
+                {
+                    'IndexName': 'ConversationIdIndex',
+                    'KeySchema': [
+                        {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
+                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                    ],
+                    'Projection': {'ProjectionType': 'ALL'},
+                    'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
+                }
             ],
             'ProvisionedThroughput': {
                 'ReadCapacityUnits': 5,
@@ -324,12 +361,24 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         },
         'Delphi_CommentClustersStructureKeywords': {
             'KeySchema': [
-                {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'cluster_key', 'KeyType': 'RANGE'}
+                {'AttributeName': 'job_id', 'KeyType': 'HASH'},
+                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
-                {'AttributeName': 'conversation_id', 'AttributeType': 'S'},
-                {'AttributeName': 'cluster_key', 'AttributeType': 'S'}
+                {'AttributeName': 'job_id', 'AttributeType': 'S'},
+                {'AttributeName': 'entity_id', 'AttributeType': 'S'},
+                {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
+            ],
+            'GlobalSecondaryIndexes': [
+                {
+                    'IndexName': 'ConversationIdIndex',
+                    'KeySchema': [
+                        {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
+                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                    ],
+                    'Projection': {'ProjectionType': 'ALL'},
+                    'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
+                }
             ],
             'ProvisionedThroughput': {
                 'ReadCapacityUnits': 5,
@@ -338,12 +387,24 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         },
         'Delphi_UMAPGraph': {
             'KeySchema': [
-                {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'edge_id', 'KeyType': 'RANGE'}
+                {'AttributeName': 'job_id', 'KeyType': 'HASH'},
+                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
-                {'AttributeName': 'conversation_id', 'AttributeType': 'S'},
-                {'AttributeName': 'edge_id', 'AttributeType': 'S'}
+                {'AttributeName': 'job_id', 'AttributeType': 'S'},
+                {'AttributeName': 'entity_id', 'AttributeType': 'S'},
+                {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
+            ],
+            'GlobalSecondaryIndexes': [
+                {
+                    'IndexName': 'ConversationIdIndex',
+                    'KeySchema': [
+                        {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
+                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                    ],
+                    'Projection': {'ProjectionType': 'ALL'},
+                    'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
+                }
             ],
             'ProvisionedThroughput': {
                 'ReadCapacityUnits': 5,
@@ -354,12 +415,24 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         # Extended tables
         'Delphi_CommentClustersFeatures': {
             'KeySchema': [
-                {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'cluster_key', 'KeyType': 'RANGE'}
+                {'AttributeName': 'job_id', 'KeyType': 'HASH'},
+                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
-                {'AttributeName': 'conversation_id', 'AttributeType': 'S'},
-                {'AttributeName': 'cluster_key', 'AttributeType': 'S'}
+                {'AttributeName': 'job_id', 'AttributeType': 'S'},
+                {'AttributeName': 'entity_id', 'AttributeType': 'S'},
+                {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
+            ],
+            'GlobalSecondaryIndexes': [
+                {
+                    'IndexName': 'ConversationIdIndex',
+                    'KeySchema': [
+                        {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
+                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                    ],
+                    'Projection': {'ProjectionType': 'ALL'},
+                    'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
+                }
             ],
             'ProvisionedThroughput': {
                 'ReadCapacityUnits': 5,
@@ -368,12 +441,24 @@ def create_evoc_tables(dynamodb, delete_existing=False):
         },
         'Delphi_CommentClustersLLMTopicNames': {
             'KeySchema': [
-                {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
-                {'AttributeName': 'topic_key', 'KeyType': 'RANGE'}
+                {'AttributeName': 'job_id', 'KeyType': 'HASH'},
+                {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
             ],
             'AttributeDefinitions': [
-                {'AttributeName': 'conversation_id', 'AttributeType': 'S'},
-                {'AttributeName': 'topic_key', 'AttributeType': 'S'}
+                {'AttributeName': 'job_id', 'AttributeType': 'S'},
+                {'AttributeName': 'entity_id', 'AttributeType': 'S'},
+                {'AttributeName': 'conversation_id', 'AttributeType': 'S'}
+            ],
+            'GlobalSecondaryIndexes': [
+                {
+                    'IndexName': 'ConversationIdIndex',
+                    'KeySchema': [
+                        {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
+                        {'AttributeName': 'entity_id', 'KeyType': 'RANGE'}
+                    ],
+                    'Projection': {'ProjectionType': 'ALL'},
+                    'ProvisionedThroughput': {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
+                }
             ],
             'ProvisionedThroughput': {
                 'ReadCapacityUnits': 5,

--- a/delphi/docs/JOB_ID_PRIMARY_KEY_DESIGN.md
+++ b/delphi/docs/JOB_ID_PRIMARY_KEY_DESIGN.md
@@ -1,0 +1,320 @@
+# Job ID Primary Key Design Document
+
+## Overview
+
+This document outlines the design for restructuring the Delphi DynamoDB schema to use `job_id` as the primary key for all tables. This approach optimizes for job-based queries, which represent our most common access pattern, while maintaining a clean and simple data model.
+
+## Background
+
+During our previous implementation effort, we learned that most of our DynamoDB queries are scoped by `job_id`. Having `job_id` as a secondary attribute accessed through a Global Secondary Index (GSI) resulted in performance inefficiencies and occasional schema validation errors.
+
+Analysis of our query patterns shows that optimizing for job-based access would provide significant performance improvements and cost savings. This document outlines a fresh approach that makes `job_id` the primary key for all tables.
+
+## Design Goals
+
+1. **Performance Optimization**: Ensure fast, strongly consistent reads for job-based queries
+2. **Simplicity**: Maintain a clean data model without complex composite keys
+3. **Cost Efficiency**: Minimize DynamoDB read/write costs by optimizing for common access patterns
+4. **Consistency**: Establish a uniform approach across all DynamoDB tables
+5. **Flexibility**: Allow for future addition of GSIs if query patterns evolve
+6. **Job Tree Support**: Maintain hierarchical job relationships (parent-child, root jobs)
+7. **Clean Implementation**: Start fresh from edge branch rather than extending the current approach
+
+## Primary Key Design
+
+### Key Structure
+
+For all tables, we will standardize on the following key structure:
+
+```
+Primary Key:
+- HASH key (Partition key): job_id
+- RANGE key (Sort key): original attribute (comment_id, cluster_key, etc. specific to each table)
+```
+
+Where:
+- `job_id` is a UUID that uniquely identifies a processing job
+- Each table uses its own natural identifier as the range key (comment_id, cluster_key, etc.)
+- `conversation_id` is stored as a regular attribute, not part of the key
+
+### Table-Specific Key Structures
+
+| Table | Current Primary Key | New Primary Key | Range Key Type |
+|-------|---------------------|-----------------|----------------|
+| Delphi_CommentEmbeddings | (conversation_id, comment_id) | (job_id, comment_id) | Number |
+| Delphi_CommentHierarchicalClusterAssignments | (conversation_id, comment_id) | (job_id, comment_id) | Number |
+| Delphi_CommentClustersStructureKeywords | (conversation_id, cluster_key) | (job_id, cluster_key) | String |
+| Delphi_UMAPGraph | (conversation_id, edge_id) | (job_id, edge_id) | String |
+| Delphi_CommentClustersLLMTopicNames | (conversation_id, topic_key) | (job_id, topic_key) | String |
+| Delphi_CommentExtremity | (conversation_id, comment_id) | (job_id, comment_id) | Number |
+
+### Example Item Structure
+
+```json
+{
+  "job_id": "f84d63ed-3b42-448e-9a1d-3474137f4e80",
+  "comment_id": 123,
+  "conversation_id": "36324",
+  "embedding": { ... },
+  "created_at": "2025-07-24T08:30:37.214Z",
+  "parent_job_id": "parent-uuid-here",
+  "root_job_id": "root-uuid-here",
+  "job_stage": "UMAP"
+}
+```
+
+## Secondary Indexes (Optional)
+
+While not implemented initially, we maintain the flexibility to add these GSIs if needed:
+
+```
+Optional GSI (ConversationIndex):
+- HASH key: conversation_id
+- RANGE key: created_at
+```
+
+This GSI would allow efficient querying of all items for a specific conversation, sorted by creation time.
+
+## Data Model Changes
+
+### Pydantic Model Updates
+
+The Pydantic models in `dynamo_models.py` will be updated to reflect the new primary key structure:
+
+```python
+class CommentEmbedding(BaseModel):
+    """Embedding vector for a comment with UMAP projection coordinates."""
+    # Primary key fields
+    job_id: str
+    comment_id: int
+    
+    # Regular attributes
+    conversation_id: str
+    created_at: str = Field(default_factory=lambda: datetime.now().isoformat())
+    
+    # Job tree fields (optional)
+    parent_job_id: Optional[str] = None
+    root_job_id: Optional[str] = None
+    job_stage: Optional[str] = None
+    
+    # Entity-specific fields
+    embedding: Embedding
+    # ... other fields
+```
+
+Similar updates will be made for all other models.
+
+### DataConverter Class Updates
+
+The `DataConverter` class methods will be updated to properly construct models with the new key structure:
+
+```python
+@staticmethod
+def create_comment_embedding(
+    conversation_id: str,
+    comment_id: int,
+    vector: np.ndarray,
+    job_id: str,  # Now required
+    parent_job_id: Optional[str] = None,
+    root_job_id: Optional[str] = None,
+    job_stage: Optional[str] = None
+) -> CommentEmbedding:
+    """Create a CommentEmbedding model from raw data."""
+    # Create embedding object
+    embedding = Embedding(
+        vector=vector.tolist() if isinstance(vector, np.ndarray) else vector,
+        dimensions=len(vector),
+        model='all-MiniLM-L6-v2'
+    )
+    
+    # Create model data
+    model_data = {
+        'job_id': job_id,
+        'comment_id': int(comment_id),
+        'conversation_id': conversation_id,
+        'embedding': embedding,
+        'created_at': datetime.now().isoformat()
+    }
+    
+    # Add job tree fields if provided
+    if parent_job_id:
+        model_data['parent_job_id'] = parent_job_id
+    if root_job_id:
+        model_data['root_job_id'] = root_job_id
+    if job_stage:
+        model_data['job_stage'] = job_stage
+    
+    # Create the model
+    model = CommentEmbedding(**model_data)
+    
+    return model
+```
+
+## Storage Class Updates
+
+The storage classes that interact with DynamoDB will need to be updated to use the new key structure:
+
+```python
+def get_comment_embeddings_by_job(self, job_id):
+    """Get all comment embeddings for a specific job."""
+    response = self.comment_embeddings_table.query(
+        KeyConditionExpression=Key('job_id').eq(job_id)
+    )
+    return response.get('Items', [])
+
+def get_comment_embedding(self, job_id, comment_id):
+    """Get a specific comment embedding."""
+    response = self.comment_embeddings_table.get_item(
+        Key={
+            'job_id': job_id,
+            'comment_id': comment_id
+        }
+    )
+    return response.get('Item')
+    
+def get_comment_embeddings_by_job_and_conversation(self, job_id, conversation_id):
+    """Get all comment embeddings for a specific job and conversation."""
+    # Since conversation_id is not part of the key, we need to use a filter expression
+    response = self.comment_embeddings_table.query(
+        KeyConditionExpression=Key('job_id').eq(job_id),
+        FilterExpression=Attr('conversation_id').eq(conversation_id)
+    )
+    return response.get('Items', [])
+```
+
+## Query Patterns
+
+### Common Query Patterns
+
+1. **Get all data for a specific job**:
+   ```python
+   response = table.query(
+       KeyConditionExpression=Key('job_id').eq(job_id)
+   )
+   ```
+
+2. **Get a specific item**:
+   ```python
+   response = table.get_item(
+       Key={
+           'job_id': job_id,
+           'comment_id': comment_id  # Or cluster_key, edge_id, etc. depending on the table
+       }
+   )
+   ```
+
+3. **Get all data for a specific job and conversation**:
+   ```python
+   # Using filter expression (less efficient)
+   response = table.query(
+       KeyConditionExpression=Key('job_id').eq(job_id),
+       FilterExpression=Attr('conversation_id').eq(conversation_id)
+   )
+   ```
+
+4. **Optional - If GSI is added later - Get all data for a specific conversation**:
+   ```python
+   response = table.query(
+       IndexName='ConversationIndex',
+       KeyConditionExpression=Key('conversation_id').eq(conversation_id)
+   )
+   ```
+
+## Implementation Approach
+
+Since we'll be reprocessing all data with the new code rather than migrating existing data, our approach is simplified:
+
+1. **Schema Design and Code Update**:
+   - Update all DynamoDB table schemas in `create_dynamodb_tables.py`
+   - Update Pydantic models in `dynamo_models.py`
+   - Update DataConverter and storage classes to use the new schema
+
+2. **Table Recreation**:
+   - Delete existing tables (with --delete-existing flag)
+   - Create new tables with the updated schema
+
+3. **Data Reprocessing**:
+   - Run full pipeline jobs to reprocess conversations with the new schema
+   - No need for data migration since all data will be newly generated
+
+4. **Validation**:
+   - Verify that new data is being correctly stored with the new schema
+   - Confirm that all queries work as expected
+
+## Implementation Plan
+
+1. **Phase 1: Preparation (Week 1)**
+   - Create design document with detailed schema for each table
+   - Create a new branch based on `edge`
+   - Update Pydantic models in `dynamo_models.py`
+   - Update `create_dynamodb_tables.py` to support the new schema
+
+2. **Phase 2: Core System Updates (Week 2)**
+   - Update DataConverter class methods to make job_id required
+   - Update storage classes to use the new key structure
+   - Implement proper job tree support (parent-child relationships)
+   - Modify run_pipeline.py, run_delphi.py, and run_delphi.sh to pass job_id properly
+
+3. **Phase 3: Visualization and Report Generation (Week 3)**
+   - Update 700_datamapplot_for_layer.py to use job_id directly
+   - Update 702_consensus_divisive_datamapplot.py for job_id primary key
+   - Update 801_narrative_report_batch.py for job-based data retrieval
+   - Ensure visualizations use consistent job_id throughout
+
+4. **Phase 4: API and Web UI Updates (Week 4)**
+   - Create job tree management API endpoints
+   - Implement job selection UI in the CommentsReport component
+   - Create visualization proxy for S3/Minio access
+   - Add job management interfaces to the UI
+
+5. **Phase 5: Testing and Deployment (Week 5)**
+   - Set up test environment with the new schema
+   - Develop end-to-end test script for the full pipeline
+   - Deploy to staging environment
+   - Create documentation for the new job-based system
+
+## Trade-offs
+
+### Advantages
+
+1. **Simplicity**: Clean data model without complex composite keys
+2. **Type Preservation**: Entity IDs maintain their native types (no string conversion)
+3. **Direct Access**: Simplified key structure for direct item retrieval
+4. **Performance**: Optimized for the most common query pattern (by job_id)
+
+### Disadvantages
+
+1. **Less Efficient Filtering**: Querying by job_id and conversation_id requires a filter expression, which is less efficient than a key condition
+2. **Potential GSI Need**: May require adding a GSI later if querying by conversation_id becomes a common pattern
+3. **Uniqueness Constraint**: Requires ensuring uniqueness of range key values (comment_id, cluster_key, etc.) within a job (usually guaranteed by the nature of the data)
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Temporary service disruption | Medium | Schedule reprocessing during low-traffic periods, maintain clear communication about the update |
+| Performance regression for job+conversation queries | Medium | Monitor query performance, add GSI if needed |
+| Code compatibility issues | Medium | Comprehensive testing of all components in isolated environment before deployment |
+| Missing data during transition | Low | Ensure full reprocessing of all required conversations before decommissioning old system |
+
+## Lessons Learned from Previous Implementation
+
+During our previous implementation attempt, we encountered several challenges that inform this new design:
+
+1. **Consistency is Critical**: Having different primary key structures across tables created confusion and bugs
+
+2. **DynamoDB Validation Errors**: We encountered "One of the required keys was not given a value" errors when tables had mismatched schemas and model definitions
+
+3. **Job Tree Implementation**: Supporting parent-child relationships between jobs requires specific GSIs and proper data modeling
+
+4. **UI Integration Challenges**: Ensuring job_id is propagated to the UI required proxy mechanisms for accessing S3/Minio visualizations
+
+5. **Required vs. Optional Fields**: Making job_id optional led to inconsistent usage; the new design makes it required
+
+6. **Parameter Passing**: Using environment variables for job_id was problematic due to race conditions; explicit parameter passing is preferred
+
+## Conclusion
+
+Moving to a `job_id`-based primary key structure will optimize our DynamoDB tables for the most common access pattern - querying by job_id. This approach maintains a clean and simple data model without complex composite keys, while still providing the flexibility to add GSIs for other query patterns if needed.
+
+By implementing this design as a fresh start from the edge branch, we can avoid the inconsistencies and technical debt that accumulated in our previous attempt. The standardized approach will make the codebase more maintainable and improve performance for our most common query patterns.

--- a/delphi/docs/JOB_ID_PRIMARY_KEY_IMPLEMENTATION.md
+++ b/delphi/docs/JOB_ID_PRIMARY_KEY_IMPLEMENTATION.md
@@ -1,0 +1,145 @@
+# Job ID Primary Key Implementation
+
+This document describes the implementation of the job_id primary key schema for DynamoDB tables in the Delphi analytics pipeline.
+
+## Overview
+
+The Delphi analytics pipeline has been updated to use job_id as the primary hash key for all DynamoDB tables. This optimizes for job-based queries which are the most common access pattern while maintaining the ability to query by conversation_id through Global Secondary Indexes (GSIs).
+
+## Key Design Principles
+
+1. All tables use job_id as the primary hash key (partition key)
+2. Each table uses its own natural identifier as the range key (comment_id, cluster_key, etc.)
+3. All tables have a ConversationIdIndex GSI for querying by conversation_id
+4. The job_id is generated at the start of each pipeline run and passed through the entire pipeline
+
+## Implementation Steps
+
+1. Updated all model classes in `dynamo_models.py` to use job_id as primary key and specific attribute names as range keys
+2. Updated the table creation script in `create_dynamodb_tables.py` to use the new schema
+3. Updated the converter methods in `converter.py` to require job_id parameter
+4. Modified `run_pipeline.py` to pass job_id to all converter methods
+
+## Table Schema Changes
+
+| Table Name | Old Schema | New Schema |
+|------------|------------|------------|
+| Delphi_UMAPConversationConfig | Hash: conversation_id | Hash: job_id, Range: conversation_id |
+| Delphi_CommentEmbeddings | Hash: conversation_id, Range: comment_id | Hash: job_id, Range: comment_id |
+| Delphi_CommentHierarchicalClusterAssignments | Hash: conversation_id, Range: comment_id | Hash: job_id, Range: comment_id |
+| Delphi_CommentClustersStructureKeywords | Hash: conversation_id, Range: cluster_key | Hash: job_id, Range: cluster_key |
+| Delphi_UMAPGraph | Hash: conversation_id, Range: edge_id | Hash: job_id, Range: edge_id |
+| Delphi_CommentClustersFeatures | Hash: conversation_id, Range: cluster_key | Hash: job_id, Range: cluster_key |
+| Delphi_CommentClustersLLMTopicNames | Hash: conversation_id, Range: topic_key | Hash: job_id, Range: topic_key |
+
+## Job ID Generation and Propagation
+
+The job_id is generated in `run_pipeline.py` at the start of processing:
+
+```python
+# Generate a job_id for this pipeline run
+job_id = os.environ.get("DELPHI_JOB_ID", f"pipeline_run_{uuid.uuid4()}")
+logger.info(f"Using job_id: {job_id} for this pipeline run.")
+```
+
+For jobs started via the job poller (`job_poller.py`), the job_id is passed as an environment variable:
+
+```python
+env = os.environ.copy()
+env['DELPHI_JOB_ID'] = job_id
+env['DELPHI_REPORT_ID'] = str(job.get('report_id', conversation_id))
+```
+
+## Global Secondary Indexes
+
+Each table has a ConversationIdIndex GSI with the following structure:
+
+```
+IndexName: 'ConversationIdIndex',
+KeySchema: [
+    {'AttributeName': 'conversation_id', 'KeyType': 'HASH'},
+    {'AttributeName': '<table-specific-range-key>', 'KeyType': 'RANGE'}
+]
+```
+
+This allows querying data by conversation_id when job_id is not known.
+
+## Query Patterns
+
+### Primary Access Pattern (by job_id)
+
+```python
+# Query by job_id (hash key)
+response = table.query(
+    KeyConditionExpression=Key('job_id').eq(job_id)
+)
+
+# Query by job_id and range key for specific item
+response = table.get_item(
+    Key={
+        'job_id': job_id,
+        'comment_id': comment_id  # or cluster_key, edge_id, etc.
+    }
+)
+```
+
+### Secondary Access Pattern (by conversation_id)
+
+```python
+# Query by conversation_id using GSI
+response = table.query(
+    IndexName='ConversationIdIndex',
+    KeyConditionExpression=Key('conversation_id').eq(conversation_id)
+)
+```
+
+## System Recreation Instructions
+
+If you need to recreate the tables with the new schema:
+
+1. Delete the existing tables (optional if you want to start fresh):
+   ```bash
+   docker exec polis-dev-delphi-1 python3 -c "
+   import boto3
+   client = boto3.client('dynamodb', endpoint_url='http://dynamodb:8000', region_name='us-east-1')
+   tables = client.list_tables()['TableNames']
+   for table in tables:
+       if table.startswith('Delphi_'):
+           print(f'Deleting {table}...')
+           client.delete_table(TableName=table)
+   "
+   ```
+
+2. Create the new tables with the job_id primary key schema:
+   ```bash
+   docker exec polis-dev-delphi-1 python /app/create_dynamodb_tables.py
+   ```
+
+3. Ensure the pipeline code passes job_id to all converter methods in `run_pipeline.py`.
+
+## Troubleshooting
+
+If you encounter "job_id parameter is required" errors, verify that job_id is being passed to the following methods in `run_pipeline.py`:
+
+1. `DataConverter.create_conversation_meta`
+2. `DataConverter.batch_convert_embeddings`
+3. `DataConverter.batch_convert_umap_edges`
+4. `DataConverter.batch_convert_clusters`
+5. `DataConverter.batch_convert_topics`
+6. `DataConverter.batch_convert_cluster_characteristics`
+7. `DataConverter.batch_convert_llm_topic_names`
+
+## Verification
+
+To verify the tables are using the correct schema:
+
+```python
+import boto3
+client = boto3.client('dynamodb', endpoint_url='http://dynamodb:8000', region_name='us-east-1')
+table_info = client.describe_table(TableName='Delphi_CommentEmbeddings')
+print('KeySchema:', table_info['Table']['KeySchema'])
+print('GSIs:', [{'IndexName': gsi['IndexName'], 'KeySchema': gsi['KeySchema']} 
+              for gsi in table_info['Table'].get('GlobalSecondaryIndexes', [])])
+```
+
+The output should show job_id as the HASH key and the appropriate attribute as the RANGE key.

--- a/delphi/umap_narrative/polismath_commentgraph/schemas/dynamo_models.py
+++ b/delphi/umap_narrative/polismath_commentgraph/schemas/dynamo_models.py
@@ -49,7 +49,8 @@ class ClusterReference(BaseModel):
 
 class ConversationMeta(BaseModel):
     """Metadata for a conversation."""
-    conversation_id: str
+    job_id: str  # Primary hash key
+    conversation_id: str  # Primary range key and used in GSI
     processed_date: str
     num_comments: int
     num_participants: int = 0
@@ -65,15 +66,17 @@ class CommentEmbedding(BaseModel):
     
     Note: UMAP coordinates are stored as "position" in UMAPGraph table where source_id = target_id = comment_id.
     Nearest neighbors are stored as edges in UMAPGraph where either source_id or target_id = comment_id."""
-    conversation_id: str
-    comment_id: int
+    job_id: str  # Primary hash key
+    comment_id: int  # Primary range key
+    conversation_id: str  # Regular attribute, used in GSI
     embedding: Embedding
 
 
 class CommentCluster(BaseModel):
     """Cluster assignments for a single comment across layers."""
-    conversation_id: str
-    comment_id: int
+    job_id: str  # Primary hash key
+    comment_id: int  # Primary range key
+    conversation_id: str  # Regular attribute, used in GSI
     is_outlier: bool = False
     # We'll add layer-specific cluster IDs dynamically during initialization
     layer0_cluster_id: Optional[int] = None
@@ -87,8 +90,9 @@ class CommentCluster(BaseModel):
 
 class ClusterTopic(BaseModel):
     """Topic information for a cluster."""
-    conversation_id: str
-    cluster_key: str  # format: "layer{layer_id}_{cluster_id}"
+    job_id: str  # Primary hash key
+    cluster_key: str  # Primary range key, format: "layer{layer_id}_{cluster_id}"
+    conversation_id: str  # Regular attribute, used in GSI
     layer_id: int
     cluster_id: int
     topic_label: str
@@ -106,8 +110,9 @@ class UMAPGraphEdge(BaseModel):
     
     Note: When source_id equals target_id, this represents a node with its position.
     Otherwise, this represents an edge between two nodes."""
-    conversation_id: str
-    edge_id: str  # format: "{source_id}_{target_id}"
+    job_id: str  # Primary hash key
+    edge_id: str  # Primary range key, format: "{source_id}_{target_id}"
+    conversation_id: str  # Regular attribute, used in GSI
     source_id: int
     target_id: int
     weight: float
@@ -119,8 +124,9 @@ class UMAPGraphEdge(BaseModel):
 
 class ClusterCharacteristic(BaseModel):
     """Characteristics of a cluster based on TF-IDF analysis."""
-    conversation_id: str
-    cluster_key: str  # format: "layer{layer_id}_{cluster_id}"
+    job_id: str  # Primary hash key
+    cluster_key: str  # Primary range key, format: "layer{layer_id}_{cluster_id}"
+    conversation_id: str  # Regular attribute, used in GSI
     layer_id: int
     cluster_id: int
     size: int
@@ -138,8 +144,9 @@ class ClusterCharacteristic(BaseModel):
 
 class EnhancedTopicName(BaseModel):
     """Enhanced topic name with keywords, based on TF-IDF analysis."""
-    conversation_id: str
-    topic_key: str  # format: "layer{layer_id}_{cluster_id}"
+    job_id: str  # Primary hash key
+    topic_key: str  # Primary range key, format: "layer{layer_id}_{cluster_id}"
+    conversation_id: str  # Regular attribute, used in GSI
     layer_id: int
     cluster_id: int
     topic_name: str  # Format: "Keywords: word1, word2, word3, ..."
@@ -154,8 +161,9 @@ class EnhancedTopicName(BaseModel):
 
 class LLMTopicName(BaseModel):
     """LLM-generated topic name."""
-    conversation_id: str
-    topic_key: str  # format: "layer{layer_id}_{cluster_id}"
+    job_id: str  # Primary hash key
+    topic_key: str  # Primary range key, format: "layer{layer_id}_{cluster_id}"
+    conversation_id: str  # Regular attribute, used in GSI
     layer_id: int
     cluster_id: int
     topic_name: str  # LLM-generated name

--- a/delphi/umap_narrative/polismath_commentgraph/utils/converter.py
+++ b/delphi/umap_narrative/polismath_commentgraph/utils/converter.py
@@ -96,7 +96,8 @@ class DataConverter:
         conversation_id: str,
         document_vectors: np.ndarray,
         cluster_layers: List[np.ndarray],
-        metadata: Dict[str, Any] = None
+        metadata: Dict[str, Any] = None,
+        job_id: str = None
     ) -> ConversationMeta:
         """
         Create a ConversationMeta model from raw data.
@@ -137,8 +138,13 @@ class DataConverter:
         # Create EVOC parameters (with defaults)
         evoc_params = EVOCParameters()
         
+        # job_id is now required
+        if not job_id:
+            raise ValueError("job_id parameter is required for create_conversation_meta")
+            
         # Create the model
         meta = ConversationMeta(
+            job_id=job_id,
             conversation_id=conversation_id,
             processed_date=datetime.now().isoformat(),
             num_comments=len(document_vectors),
@@ -156,7 +162,8 @@ class DataConverter:
     def create_comment_embedding(
         conversation_id: str,
         comment_id: int,
-        vector: np.ndarray
+        vector: np.ndarray,
+        job_id: str = None
     ) -> CommentEmbedding:
         """
         Create a CommentEmbedding model from raw data.
@@ -176,10 +183,15 @@ class DataConverter:
             model='all-MiniLM-L6-v2'
         )
         
+        # job_id is now required
+        if not job_id:
+            raise ValueError("job_id parameter is required for create_comment_embedding")
+            
         # Create the model with just the embedding vector
         model = CommentEmbedding(
-            conversation_id=conversation_id,
+            job_id=job_id,
             comment_id=int(comment_id),
+            conversation_id=conversation_id,
             embedding=embedding
         )
         
@@ -191,7 +203,8 @@ class DataConverter:
         comment_id: int,
         cluster_layers: List[np.ndarray],
         distances: Optional[Dict[str, float]] = None,
-        confidences: Optional[Dict[str, float]] = None
+        confidences: Optional[Dict[str, float]] = None,
+        job_id: str = None
     ) -> CommentCluster:
         """
         Create a CommentCluster model from raw data.
@@ -206,10 +219,15 @@ class DataConverter:
         Returns:
             CommentCluster model object
         """
+        # job_id is now required
+        if not job_id:
+            raise ValueError("job_id parameter is required for create_comment_cluster")
+            
         # Create base data dictionary
         data = {
-            'conversation_id': conversation_id,
+            'job_id': job_id,
             'comment_id': comment_id,  # Will be converted to Decimal by Pydantic model
+            'conversation_id': conversation_id,
             'is_outlier': False
         }
         
@@ -262,7 +280,8 @@ class DataConverter:
         top_words: Optional[List[str]] = None,
         top_tfidf_scores: Optional[List[float]] = None,
         parent_cluster: Optional[Dict[str, int]] = None,
-        child_clusters: Optional[List[Dict[str, int]]] = None
+        child_clusters: Optional[List[Dict[str, int]]] = None,
+        job_id: str = None
     ) -> ClusterTopic:
         """
         Create a ClusterTopic model from raw data.
@@ -283,6 +302,10 @@ class DataConverter:
         Returns:
             ClusterTopic model object
         """
+        # job_id is now required
+        if not job_id:
+            raise ValueError("job_id parameter is required for create_cluster_topic")
+            
         # Create cluster key
         cluster_key = f'layer{layer_id}_{cluster_id}'
         
@@ -313,8 +336,9 @@ class DataConverter:
         
         # Create the model
         model = ClusterTopic(
-            conversation_id=conversation_id,
+            job_id=job_id,
             cluster_key=cluster_key,
+            conversation_id=conversation_id,
             layer_id=layer_id,
             cluster_id=cluster_id,
             topic_label=topic_label,
@@ -338,7 +362,8 @@ class DataConverter:
         distance: float,
         is_nearest_neighbor: bool,
         shared_layers: List[int],
-        position: Optional[np.ndarray] = None
+        position: Optional[np.ndarray] = None,
+        job_id: str = None
     ) -> UMAPGraphEdge:
         """
         Create a UMAPGraphEdge model from raw data.
@@ -356,6 +381,10 @@ class DataConverter:
         Returns:
             UMAPGraphEdge model object
         """
+        # job_id is now required
+        if not job_id:
+            raise ValueError("job_id parameter is required for create_graph_edge")
+            
         # For standard edges (not nodes), ensure source_id < target_id
         if source_id != target_id and source_id > target_id:
             source_id, target_id = target_id, source_id
@@ -372,8 +401,9 @@ class DataConverter:
         
         # Create the model
         model = UMAPGraphEdge(
-            conversation_id=conversation_id,
+            job_id=job_id,
             edge_id=edge_id,
+            conversation_id=conversation_id,
             source_id=int(source_id),
             target_id=int(target_id),
             weight=float(weight),
@@ -393,7 +423,8 @@ class DataConverter:
         size: int,
         top_words: List[str],
         top_tfidf_scores: List[float],
-        sample_comments: List[str]
+        sample_comments: List[str],
+        job_id: str = None
     ) -> ClusterCharacteristic:
         """
         Create a ClusterCharacteristic model from raw data.
@@ -410,8 +441,17 @@ class DataConverter:
         Returns:
             ClusterCharacteristic model object
         """
+        # job_id is now required
+        if not job_id:
+            raise ValueError("job_id parameter is required for create_cluster_characteristic")
+            
+        # Create cluster key for entity_id
+        cluster_key = f'layer{layer_id}_{cluster_id}'
+            
         # Create the model
         model = ClusterCharacteristic(
+            job_id=job_id,
+            cluster_key=cluster_key,
             conversation_id=conversation_id,
             layer_id=layer_id,
             cluster_id=cluster_id,
@@ -428,7 +468,8 @@ class DataConverter:
         conversation_id: str,
         layer_id: int,
         cluster_id: int,
-        topic_name: str
+        topic_name: str,
+        job_id: str = None
     ) -> EnhancedTopicName:
         """
         Create an EnhancedTopicName model from raw data.
@@ -442,8 +483,17 @@ class DataConverter:
         Returns:
             EnhancedTopicName model object
         """
+        # job_id is now required
+        if not job_id:
+            raise ValueError("job_id parameter is required for create_enhanced_topic_name")
+            
+        # Create topic key for entity_id
+        topic_key = f'layer{layer_id}_{cluster_id}'
+            
         # Create the model
         model = EnhancedTopicName(
+            job_id=job_id,
+            topic_key=topic_key,
             conversation_id=conversation_id,
             layer_id=layer_id,
             cluster_id=cluster_id,
@@ -459,7 +509,7 @@ class DataConverter:
         cluster_id: int,
         topic_name: str,
         model_name: str = "unknown",
-        job_id: Optional[str] = None  # Added job_id
+        job_id: str = None
     ) -> LLMTopicName:
         """
         Create an LLMTopicName model from raw data.
@@ -475,21 +525,20 @@ class DataConverter:
         Returns:
             LLMTopicName model object
         """
+        # job_id is now required
         if not job_id:
-            # Fallback if job_id is not provided, though it should be
-            logger.warning("job_id not provided to create_llm_topic_name, using 'unknown_job'")
-            job_id = "unknown_job"
+            raise ValueError("job_id parameter is required for create_llm_topic_name")
 
         # Create the model
         model = LLMTopicName(
+            job_id=job_id,
+            topic_key=f"layer{layer_id}_{cluster_id}",
             conversation_id=conversation_id,
-            topic_key=f"{job_id}#{layer_id}#{cluster_id}", # New topic_key format
-            layer_id=layer_id, # Stored for easier filtering if needed, though part of key
+            layer_id=layer_id,
             cluster_id=cluster_id,
             topic_name=topic_name,
             model_name=model_name,
-            created_at=datetime.now().isoformat(),
-            job_id=job_id # Store job_id as a top-level attribute
+            created_at=datetime.now().isoformat()
         )
         
         return model
@@ -498,7 +547,8 @@ class DataConverter:
     def batch_convert_cluster_characteristics(
         conversation_id: str,
         characteristics_dict: Dict[str, Dict[str, Any]],
-        layer_id: int
+        layer_id: int,
+        job_id: str = None
     ) -> List[ClusterCharacteristic]:
         """
         Convert batch of cluster characteristics from dictionary to model objects.
@@ -524,7 +574,8 @@ class DataConverter:
                     size=characteristic_data.get('size', 0),
                     top_words=characteristic_data.get('top_words', []),
                     top_tfidf_scores=characteristic_data.get('top_tfidf_scores', []),
-                    sample_comments=characteristic_data.get('sample_comments', [])
+                    sample_comments=characteristic_data.get('sample_comments', []),
+                    job_id=job_id
                 )
                 
                 characteristics.append(characteristic)
@@ -537,7 +588,8 @@ class DataConverter:
     def batch_convert_enhanced_topic_names(
         conversation_id: str,
         topic_names_dict: Dict[str, str],
-        layer_id: int
+        layer_id: int,
+        job_id: str = None
     ) -> List[EnhancedTopicName]:
         """
         Convert batch of enhanced topic names from dictionary to model objects.
@@ -560,7 +612,8 @@ class DataConverter:
                     conversation_id=conversation_id,
                     layer_id=layer_id,
                     cluster_id=cluster_id,
-                    topic_name=topic_name
+                    topic_name=topic_name,
+                    job_id=job_id
                 )
                 
                 topic_names.append(enhanced_topic_name)
@@ -575,7 +628,7 @@ class DataConverter:
         topic_names_dict: Dict[str, str],
         layer_id: int,
         model_name: str = "unknown",
-        job_id: Optional[str] = None # Added job_id
+        job_id: str = None
     ) -> List[LLMTopicName]:
         """
         Convert batch of LLM-generated topic names from dictionary to model objects.
@@ -621,7 +674,8 @@ class DataConverter:
     @staticmethod
     def batch_convert_embeddings(
         conversation_id: str,
-        document_vectors: np.ndarray
+        document_vectors: np.ndarray,
+        job_id: str = None
     ) -> List[CommentEmbedding]:
         """
         Convert batch of embeddings from NumPy arrays to model objects.
@@ -641,7 +695,8 @@ class DataConverter:
             embedding = DataConverter.create_comment_embedding(
                 conversation_id=conversation_id,
                 comment_id=i,
-                vector=document_vectors[i]
+                vector=document_vectors[i],
+                job_id=job_id
             )
             
             embeddings.append(embedding)
@@ -653,7 +708,8 @@ class DataConverter:
         conversation_id: str,
         document_map: np.ndarray,
         cluster_layers: List[np.ndarray],
-        k_neighbors: int = 5
+        k_neighbors: int = 5,
+        job_id: str = None
     ) -> List[UMAPGraphEdge]:
         """
         Convert UMAP projection data to graph edges and nodes with positions.
@@ -690,7 +746,8 @@ class DataConverter:
                 is_nearest_neighbor=False,
                 shared_layers=[layer_id for layer_id, layer in enumerate(cluster_layers) 
                               if i < len(layer) and layer[i] >= 0],
-                position=document_map[i]  # Store actual UMAP coordinates
+                position=document_map[i],  # Store actual UMAP coordinates
+                job_id=job_id
             )
             
             edges.append(node)
@@ -730,7 +787,8 @@ class DataConverter:
                     weight=1.0 - distance,  # Convert distance to similarity
                     distance=float(distance),
                     is_nearest_neighbor=True,
-                    shared_layers=shared_layers
+                    shared_layers=shared_layers,
+                    job_id=job_id
                 )
                 
                 edges.append(edge)
@@ -741,7 +799,8 @@ class DataConverter:
     def batch_convert_clusters(
         conversation_id: str,
         cluster_layers: List[np.ndarray],
-        document_map: np.ndarray
+        document_map: np.ndarray,
+        job_id: str = None
     ) -> List[CommentCluster]:
         """
         Convert batch of clusters from NumPy arrays to model objects.
@@ -799,7 +858,8 @@ class DataConverter:
                 comment_id=comment_id,
                 cluster_layers=cluster_layers,
                 distances=distances_map.get(comment_id),
-                confidences=confidence_map.get(comment_id)
+                confidences=confidence_map.get(comment_id),
+                job_id=job_id
             )
             
             clusters.append(cluster)
@@ -813,7 +873,8 @@ class DataConverter:
         document_map: np.ndarray,
         topic_names: Dict[str, Dict[str, str]] = None,
         characteristics: Dict[str, Dict[str, Any]] = None,
-        comments: List[Dict[str, Any]] = None
+        comments: List[Dict[str, Any]] = None,
+        job_id: str = None
     ) -> List[ClusterTopic]:
         """
         Convert batch of topics from raw data to model objects.
@@ -964,7 +1025,8 @@ class DataConverter:
                     top_words=top_words,
                     top_tfidf_scores=top_tfidf_scores,
                     parent_cluster=parent_cluster,
-                    child_clusters=child_clusters
+                    child_clusters=child_clusters,
+                    job_id=job_id
                 )
                 
                 topics.append(topic)

--- a/delphi/umap_narrative/polismath_commentgraph/utils/storage.py
+++ b/delphi/umap_narrative/polismath_commentgraph/utils/storage.py
@@ -1163,13 +1163,14 @@ class DynamoDBStorage:
             'failure': failure_count
         }
     
-    def get_cluster_characteristics_by_layer(self, conversation_id, layer_id):
+    def get_cluster_characteristics_by_layer(self, job_id, layer_id, conversation_id=None):
         """
         Retrieve all cluster characteristics for a specific layer.
         
         Args:
-            conversation_id: ID of the conversation
+            job_id: ID of the job - used as the primary key for DynamoDB queries
             layer_id: Layer ID to retrieve characteristics for
+            conversation_id: Optional ID of the conversation (for filtering)
             
         Returns:
             List of cluster characteristic dictionaries
@@ -1177,9 +1178,9 @@ class DynamoDBStorage:
         table = self.dynamodb.Table(self.table_names['cluster_characteristics'])
         
         try:
-            # Query by conversation ID and filter by layer_id
+            # Query by job_id as primary key and filter by layer_id
             response = table.query(
-                KeyConditionExpression=Key('conversation_id').eq(conversation_id),
+                KeyConditionExpression=Key('job_id').eq(job_id),
                 FilterExpression=Attr('layer_id').eq(layer_id)
             )
             
@@ -1188,7 +1189,7 @@ class DynamoDBStorage:
             # Handle pagination if needed
             while 'LastEvaluatedKey' in response:
                 response = table.query(
-                    KeyConditionExpression=Key('conversation_id').eq(conversation_id),
+                    KeyConditionExpression=Key('job_id').eq(job_id),
                     FilterExpression=Attr('layer_id').eq(layer_id),
                     ExclusiveStartKey=response['LastEvaluatedKey']
                 )
@@ -1196,7 +1197,7 @@ class DynamoDBStorage:
             
             logger.info(
                 f"Retrieved {len(characteristics)} cluster characteristics for layer {layer_id} "
-                f"in conversation {conversation_id}"
+                f"in job {job_id}"
             )
             return characteristics
         except ClientError as e:

--- a/delphi/umap_narrative/run_pipeline.py
+++ b/delphi/umap_narrative/run_pipeline.py
@@ -1198,7 +1198,8 @@ def process_conversation(zid, export_dynamo=True, use_ollama=False):
             conversation_id,
             document_vectors,
             cluster_layers,
-            metadata
+            metadata,
+            job_id=job_id
         )
         dynamo_storage.create_conversation_meta(conversation_meta)
         


### PR DESCRIPTION
In this design the job_id replaces conversation_id as primary key. The overall design aims to keep each run's results as immutably stored under the job_id. Jobs can have parent jobs to track their dependencies and scopes. This will also allow the frontend to expose different job_id runs to users.