### PR TITLE
Fix comment filtering bug

### DIFF
--- a/server/__tests__/integration/comment.test.ts
+++ b/server/__tests__/integration/comment.test.ts
@@ -188,4 +188,88 @@ describe("Comment Endpoints", () => {
     expect(foundComment).toBeDefined();
     expect(foundComment!.txt).toBe(commentText);
   });
+
+  test("GET comments returns all comments in conversation, not just current participant's comments", async () => {
+    // This test verifies the fix for the issue where GET comments was incorrectly
+    // filtering to only show comments created by the current participant (pid),
+    // instead of showing all comments in the conversation.
+
+    const timestamp = Date.now();
+
+    // STEP 1: Create multiple comments by different participants
+    // Admin/owner creates a seed comment
+    const adminCommentText = `Admin seed comment ${timestamp}`;
+    const adminCommentId = await createComment(agent, conversationId, {
+      txt: adminCommentText,
+    });
+
+    // Initialize a participant and create a comment
+    const { agent: participantAgent } = await initializeParticipant(
+      conversationId
+    );
+    const participantCommentText = `Participant comment ${timestamp}`;
+    const participantCommentResponse = await submitComment(participantAgent, {
+      conversation_id: conversationId,
+      txt: participantCommentText,
+      agid: 1, // Required for anonymous participant authentication
+    });
+
+    expect(participantCommentResponse.status).toBe(200);
+    const participantCommentId = participantCommentResponse.body.tid;
+
+    // If JWT was issued after comment creation, use it for subsequent requests
+    if (
+      participantCommentResponse.body.auth &&
+      participantCommentResponse.body.auth.token
+    ) {
+      participantAgent.set(
+        "Authorization",
+        `Bearer ${participantCommentResponse.body.auth.token}`
+      );
+    }
+
+    // STEP 2: Verify that the participant can see ALL comments, not just their own
+    const allCommentsResponse: Response = await participantAgent.get(
+      `/api/v3/comments?conversation_id=${conversationId}`
+    );
+
+    expect(allCommentsResponse.status).toBe(200);
+    const allComments: Comment[] = JSON.parse(allCommentsResponse.text);
+    expect(Array.isArray(allComments)).toBe(true);
+    expect(allComments.length).toBeGreaterThanOrEqual(2);
+
+    // Verify both comments are present
+    const foundAdminComment = allComments.find(
+      (comment) => comment.tid === adminCommentId
+    );
+    const foundParticipantComment = allComments.find(
+      (comment) => comment.tid === participantCommentId
+    );
+
+    expect(foundAdminComment).toBeDefined();
+    expect(foundAdminComment!.txt).toBe(adminCommentText);
+    expect(foundParticipantComment).toBeDefined();
+    expect(foundParticipantComment!.txt).toBe(participantCommentText);
+
+    // STEP 3: Verify that admin also sees all comments
+    const adminViewResponse: Response = await agent.get(
+      `/api/v3/comments?conversation_id=${conversationId}`
+    );
+
+    expect(adminViewResponse.status).toBe(200);
+    const adminViewComments: Comment[] = JSON.parse(adminViewResponse.text);
+    expect(Array.isArray(adminViewComments)).toBe(true);
+    expect(adminViewComments.length).toBeGreaterThanOrEqual(2);
+
+    // Verify admin sees both comments too
+    const adminFoundAdminComment = adminViewComments.find(
+      (comment) => comment.tid === adminCommentId
+    );
+    const adminFoundParticipantComment = adminViewComments.find(
+      (comment) => comment.tid === participantCommentId
+    );
+
+    expect(adminFoundAdminComment).toBeDefined();
+    expect(adminFoundParticipantComment).toBeDefined();
+  });
 });

--- a/server/src/comment.ts
+++ b/server/src/comment.ts
@@ -3,14 +3,13 @@ import _ from "underscore";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { Translate } = require("@google-cloud/translate").v2;
 
+import { GetCommentsParams, ConversationInfo } from "./d";
+import { getConversationInfo } from "./conversation";
+import { MPromise } from "./utils/metered";
+import Config from "./config";
 import pg from "./db/pg-query";
 import SQL from "./db/sql";
-import { MPromise } from "./utils/metered";
 import Utils from "./utils/common";
-
-import Config from "./config";
-import { getConversationInfo } from "./conversation";
-import { CommentType, ConversationInfo } from "./d";
 
 type Row = {
   tid: number;
@@ -52,7 +51,7 @@ function getComment(zid: number, tid: number): Promise<Row | null> {
     });
 }
 
-function getComments(o: CommentType): Promise<Row[]> {
+function getComments(o: GetCommentsParams): Promise<Row[]> {
   const commentListPromise = o.moderation
     ? _getCommentsForModerationList(o as any)
     : _getCommentsList(o as any);
@@ -213,9 +212,6 @@ function _getCommentsList(o: {
         let q = SQL.sql_comments
           .select(SQL.sql_comments.star())
           .where(SQL.sql_comments.zid.equals(o.zid));
-        if (!_.isUndefined(o.pid)) {
-          q = q.and(SQL.sql_comments.pid.equals(o.pid));
-        }
         if (!_.isUndefined(o.tids)) {
           q = q.and(SQL.sql_comments.tid.in(o.tids));
         }

--- a/server/src/d.ts
+++ b/server/src/d.ts
@@ -70,7 +70,7 @@ export type CommentOptions = {
 
 type ModerationState = -1 | 0 | 1;
 
-export type CommentType = {
+export type GetCommentsParams = {
   zid: number;
   not_voted_by_pid?: number;
   include_social?: any;

--- a/server/src/routes/comments.ts
+++ b/server/src/routes/comments.ts
@@ -4,7 +4,7 @@ import { parse } from "csv-parse/sync";
 import badwords from "badwords/object";
 
 import { addParticipant } from "../participant";
-import { CommentOptions, CommentType } from "../d";
+import { CommentOptions, GetCommentsParams } from "../d";
 import { createAnonUser, issueAnonymousJWT, issueXidJWT } from "../auth";
 import { checkLegacyCookieAndIssueJWT } from "../auth/legacyCookies";
 import { detectLanguage, getComment, getComments } from "../comment";
@@ -180,7 +180,7 @@ function handle_GET_comments(
   res: any
 ): void {
   // The function is designed to work with partial parameters, where most fields are optional
-  getComments(req.p as CommentType)
+  getComments(req.p as GetCommentsParams)
     .then(function (comments: any[]) {
       if (req.p.rid) {
         return pg
@@ -1113,7 +1113,7 @@ function handle_GET_nextComment(
     req.p.lang
   )
     .then(
-      function (c: CommentType | null) {
+      function (c: GetCommentsParams | null) {
         if (req.timedout) {
           return;
         }

--- a/server/src/server-helpers.ts
+++ b/server/src/server-helpers.ts
@@ -1,7 +1,7 @@
 import _ from "underscore";
 import LruCache from "lru-cache";
 
-import { CommentType, UserInfo } from "./d";
+import { GetCommentsParams, UserInfo } from "./d";
 import { generateToken } from "./auth";
 import { getBidsForPids } from "./routes/math";
 import { getConversationHasMetadata } from "./routes/metadata";
@@ -489,7 +489,7 @@ function getNextComment(
     })}`
   );
   return getNextPrioritizedComment(zid, pid, withoutTids, include_social).then(
-    (c: CommentType) => {
+    (c: GetCommentsParams) => {
       if (lang && c) {
         const firstTwoCharsOfLang = lang.substr(0, 2);
         return getCommentTranslations(zid, c.tid).then((translations: any) => {
@@ -594,7 +594,7 @@ function getNextPrioritizedComment(
   pid: number,
   withoutTids?: string | any[],
   include_social?: any
-): Promise<CommentType | null> {
+): Promise<GetCommentsParams | null> {
   logger.debug(
     `getNextPrioritizedComment ${JSON.stringify({
       zid,
@@ -603,7 +603,7 @@ function getNextPrioritizedComment(
       include_social,
     })}`
   );
-  const params: Partial<CommentType> = {
+  const params: Partial<GetCommentsParams> = {
     zid: zid,
     not_voted_by_pid: pid,
     include_social: include_social,
@@ -613,7 +613,7 @@ function getNextPrioritizedComment(
   }
   // What should we set timestamp to below in getPca? Is 0 ok? What triggers updates?
   return Promise.all([
-    getComments(params as CommentType),
+    getComments(params as GetCommentsParams),
     getPca(zid, 0),
     getNumberOfCommentsRemaining(zid, pid),
   ]).then((results: any[]) => {


### PR DESCRIPTION
## Root cause

There was redundancy in comment filtering, using either `not_voted_by=pid` and just `pid=pid` to filter out comments voted by a participant. The old code was probably not including pid in the request object normally. Now with the new auth and better participant handling, pid is generally present in the request and should not be used to filter comments.

## Solution

Remove filtering by pid UNLESS `not_voted_by=pid` is explicitly included. This is the expected behavior.

### Additional changes

- added a test
- renamed confusingly named `CommentType` to `GetCommentsParams`