### PR TITLE
Remove narrative report from menu

### DIFF
--- a/client-admin/src/components/conversation-admin/report/ReportsList.js
+++ b/client-admin/src/components/conversation-admin/report/ReportsList.js
@@ -268,11 +268,6 @@ const ReportsList = () => {
                   {hasDelphiEnabled(authUser) && (
                     <>
                       <ReportLink
-                        title="Narrative"
-                        href={`${Url.reportUrlPrefix}narrativeReport/${report.report_id}`}
-                        urlPrefix={`${Url.reportUrlPrefix}narrativeReport/${report.report_id}`}
-                      />
-                      <ReportLink
                         title="Topic"
                         href={`${Url.reportUrlPrefix}topicReport/${report.report_id}`}
                         urlPrefix={`${Url.reportUrlPrefix}topicReport/${report.report_id}`}


### PR DESCRIPTION
# What Changed

- Remove Narrative Report link (defunct)
- Improved client-admin test reliability in CI
