### PR TITLE
temporary disable topical comment routing for perf

### DIFF
--- a/server/src/nextComment.ts
+++ b/server/src/nextComment.ts
@@ -392,11 +392,13 @@ export async function getNextComment(
   });
 
   let next: GetCommentsParams | null = null;
-  if (shouldUseTopical) {
-    next = await getNextTopicalComment(zid!, pid!, withoutTids);
-  } else {
-    next = await getNextPrioritizedComment(zid!, pid!, withoutTids);
-  }
+  // TEMP: disable topical comment routing while we improve performance
+  // if (shouldUseTopical) {
+  //   next = await getNextTopicalComment(zid!, pid!, withoutTids);
+  // } else {
+  //   next = await getNextPrioritizedComment(zid!, pid!, withoutTids);
+  // }
+  next = await getNextPrioritizedComment(zid!, pid!, withoutTids);
 
   // If topical path yielded nothing, try prioritized as a fallback
   if (!next && shouldUseTopical) {


### PR DESCRIPTION
Reverts behavior back to classical comment prioritization, disregarding topic selections.
This is just a stopgap while the comment routing performance is being improved.