### PR TITLE
include importance data in comments and votes data exports

### DIFF
--- a/server/__tests__/integration/data-export.test.ts
+++ b/server/__tests__/integration/data-export.test.ts
@@ -290,17 +290,25 @@ describe("Data Export API with Importance Enabled", () => {
     testAgent.set("Authorization", `Bearer ${token}`);
     testAgent.set("x-forwarded-proto", "http");
 
-    // Create a conversation
-    conversationId = await createConversation(agent, {
+    // Create a conversation (returns zinvite string, not zid)
+    const zinvite = await createConversation(agent, {
       topic: testTopic,
       description: testDescription,
     });
+    conversationId = zinvite; // Keep for API calls
+
+    // Get the actual zid from the zinvite
+    const { pool } = await import("../setup/db-test-helpers");
+    const zidResult = await pool.query(
+      "SELECT zid FROM zinvites WHERE zinvite = $1",
+      [zinvite]
+    );
+    const zid = zidResult.rows[0].zid;
 
     // Enable importance for this conversation using direct database access
-    const { pool } = await import("../setup/db-test-helpers");
     await pool.query(
       "UPDATE conversations SET importance_enabled = true WHERE zid = $1",
-      [conversationId]
+      [zid]
     );
 
     // Create comments

--- a/server/__tests__/integration/data-export.test.ts
+++ b/server/__tests__/integration/data-export.test.ts
@@ -207,6 +207,9 @@ describe("Data Export API", () => {
     expect(response.text).toContain("moderated");
     expect(response.text).toContain("comment-body");
 
+    // Should NOT contain importance column when importance_enabled is false
+    expect(response.text).not.toContain("importance");
+
     // Should contain all our test comments
     testData.comments.forEach((commentId) => {
       expect(response.text).toContain(commentId.toString());
@@ -227,6 +230,9 @@ describe("Data Export API", () => {
     expect(response.text).toContain("comment-id");
     expect(response.text).toContain("voter-id");
     expect(response.text).toContain("vote");
+
+    // Should NOT contain important column when importance_enabled is false
+    expect(response.text).not.toContain("important");
 
     // Verify we have the expected number of votes
     const voteLines = response.text
@@ -251,5 +257,214 @@ describe("Data Export API", () => {
 
     expect(response.status).toBe(400);
     expect(response.text).toContain("polis_err_param_parse_failed_report_id");
+  });
+});
+
+describe("Data Export API with Importance Enabled", () => {
+  let agent: Agent;
+  let testAgent: Agent;
+  let conversationId: string;
+  let testData: TestData & { highPriorityVotes: number };
+  let reportId: string;
+
+  const numParticipants = 3;
+  const numComments = 3;
+  const testTopic = "Test Importance-Enabled Conversation";
+  const testDescription = "Testing importance feature in data exports";
+
+  beforeAll(async () => {
+    // Use pooled user for JWT authentication
+    const pooledUser = getPooledTestUser(2); // Use a different user pool
+    const testUser = {
+      email: pooledUser.email,
+      hname: pooledUser.name,
+      password: pooledUser.password,
+    };
+
+    // Get JWT authenticated agent
+    const { agent: jwtAgent, token } = await getJwtAuthenticatedAgent(testUser);
+    agent = jwtAgent;
+
+    // Get agent for endpoints and authenticate it
+    testAgent = await getTestAgent();
+    testAgent.set("Authorization", `Bearer ${token}`);
+    testAgent.set("x-forwarded-proto", "http");
+
+    // Create a conversation
+    conversationId = await createConversation(agent, {
+      topic: testTopic,
+      description: testDescription,
+    });
+
+    // Enable importance for this conversation using direct database access
+    const { pool } = await import("../setup/db-test-helpers");
+    await pool.query(
+      "UPDATE conversations SET importance_enabled = true WHERE zid = $1",
+      [conversationId]
+    );
+
+    // Create comments
+    const comments: number[] = [];
+    for (let i = 1; i <= numComments; i++) {
+      const response = await agent.post("/api/v3/comments").send({
+        conversation_id: conversationId,
+        txt: `Test comment ${i} with importance`,
+      });
+      if (response.status === 200) {
+        comments.push(response.body.tid);
+      }
+    }
+
+    // Create participants and have them vote
+    const participants: Awaited<ReturnType<typeof initializeParticipant>>[] =
+      [];
+    for (let i = 0; i < numParticipants; i++) {
+      const participantData = await initializeParticipant(conversationId);
+      participants.push(participantData);
+    }
+
+    // Submit votes from each participant, marking some as high_priority
+    let totalVotes = 0;
+    let highPriorityVotes = 0;
+    for (let i = 0; i < participants.length; i++) {
+      const participantData = participants[i];
+      for (let j = 0; j < comments.length; j++) {
+        const commentId = comments[j];
+        const vote = [-1, 1, 0][Math.floor(Math.random() * 3)] as -1 | 0 | 1;
+        // Mark votes as high priority in a pattern: first participant's first 2 votes,
+        // second participant's first vote
+        const isHighPriority = (i === 0 && j < 2) || (i === 1 && j === 0);
+
+        const voteResponse = await submitVote(participantData.agent, {
+          conversation_id: conversationId,
+          tid: commentId,
+          vote,
+          high_priority: isHighPriority,
+        });
+
+        if (voteResponse.status === 200) {
+          totalVotes++;
+          if (isHighPriority) {
+            highPriorityVotes++;
+          }
+        }
+      }
+    }
+
+    testData = {
+      comments,
+      stats: {
+        totalVotes,
+      },
+      highPriorityVotes,
+    };
+
+    // Trigger math computation
+    await agent.post("/api/v3/mathUpdate").send({
+      conversation_id: conversationId,
+      math_update_type: "update",
+    });
+
+    // Wait for math computation
+    let pcaAvailable = false;
+    for (let attempt = 0; attempt < 10; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      try {
+        const pcaResponse = await agent.get(
+          `/api/v3/math/pca2?conversation_id=${conversationId}`
+        );
+        if (pcaResponse.status === 200 && pcaResponse.body) {
+          pcaAvailable = true;
+          break;
+        }
+      } catch (error) {
+        // Continue trying
+      }
+    }
+
+    if (!pcaAvailable) {
+      throw new Error("PCA data not available after waiting 10 seconds");
+    }
+
+    // Create a report
+    await agent.post("/api/v3/reports").send({
+      conversation_id: conversationId,
+    });
+
+    await wait(2000);
+
+    // Get the report ID
+    const getReportsResponse: Response = await agent.get(
+      `/api/v3/reports?conversation_id=${conversationId}`
+    );
+    reportId = getReportsResponse.body[0].report_id;
+  });
+
+  test("GET /api/v3/reportExport/:report_id/comments.csv - should include importance column", async () => {
+    const response: Response = await testAgent.get(
+      `/api/v3/reportExport/${reportId}/comments.csv`
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/csv");
+
+    // Should contain standard headers
+    expect(response.text).toContain("timestamp");
+    expect(response.text).toContain("comment-id");
+    expect(response.text).toContain("agrees");
+    expect(response.text).toContain("disagrees");
+
+    // Should contain importance column when importance_enabled is true
+    expect(response.text).toContain("importance");
+
+    // Should contain comment-body at the end
+    expect(response.text).toContain("comment-body");
+
+    // Verify the header order has importance before comment-body
+    const lines = response.text.split("\n");
+    const headerLine = lines[0];
+    const importanceIndex = headerLine.indexOf("importance");
+    const commentBodyIndex = headerLine.indexOf("comment-body");
+    expect(importanceIndex).toBeGreaterThan(-1);
+    expect(commentBodyIndex).toBeGreaterThan(importanceIndex);
+
+    // Should contain all test comments
+    testData.comments.forEach((commentId) => {
+      expect(response.text).toContain(commentId.toString());
+    });
+  });
+
+  test("GET /api/v3/reportExport/:report_id/votes.csv - should include important column", async () => {
+    const response: Response = await testAgent.get(
+      `/api/v3/reportExport/${reportId}/votes.csv`
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/csv");
+
+    // Should contain standard headers
+    expect(response.text).toContain("timestamp");
+    expect(response.text).toContain("comment-id");
+    expect(response.text).toContain("voter-id");
+    expect(response.text).toContain("vote");
+
+    // Should contain important column when importance_enabled is true
+    expect(response.text).toContain("important");
+
+    // Verify we have the expected number of votes
+    const voteLines = response.text
+      .split("\n")
+      .filter((line) => line.trim().length > 0);
+    expect(voteLines.length - 1).toBe(testData.stats.totalVotes);
+
+    // Count the number of high priority votes (lines with ",1" at the end before comment-body)
+    const highPriorityCount = response.text
+      .split("\n")
+      .slice(1) // Skip header
+      .filter((line) => line.trim().length > 0)
+      .filter((line) => line.endsWith(",1")).length;
+
+    expect(highPriorityCount).toBe(testData.highPriorityVotes);
   });
 });


### PR DESCRIPTION
# What's New

- Importance tallies now included with comments data export ONLY when `conversation.importance_enabled=true`
- Important value (0=default 1=important) included in votes data export ONLY when `conversation.importance_enabled=true`

**Comments Report with Importance**

<img width="932" height="741" alt="Screenshot 2025-10-14 at 21 39 46" src="https://github.com/user-attachments/assets/eb2ca4cb-6182-4909-bfe2-1a80f898316b" />

**Votes Report**

<img width="759" height="398" alt="Screenshot 2025-10-14 at 21 40 58" src="https://github.com/user-attachments/assets/38718a69-41fa-41f3-9c00-f035026bb2d4" />
