### PR TITLE
expose comment-clusters.csv report

### DIFF
--- a/client-report/src/components/RawDataExport.jsx
+++ b/client-report/src/components/RawDataExport.jsx
@@ -90,6 +90,16 @@ const RawDataExport = ({ conversation, report_id }) => {
           {getDownloadFilename("comment-groups", conversation)}
         </a>
       </p>
+      <p style={{ wordBreak: "break-all", fontFamily: "monospace" }}>
+        {`Comment clusters: `}
+        <a
+          download={getDownloadFilename("comment-clusters", conversation)}
+          href={`//${window.location.hostname}/api/v3/reportExport/${report_id}/comment-clusters.csv`}
+          type="text/csv"
+        >
+          {getDownloadFilename("comment-clusters", conversation)}
+        </a>
+      </p>
 
       <div style={{ marginTop: "3em" }}>
         <p style={{ wordBreak: "break-all", fontFamily: "monospace" }}>
@@ -109,6 +119,9 @@ const RawDataExport = ({ conversation, report_id }) => {
         </p>
         <p style={{ wordBreak: "break-all", fontFamily: "monospace" }}>
           {`$ curl ${window.location.protocol}//${window.location.hostname}/api/v3/reportExport/${report_id}/comment-groups.csv`}
+        </p>
+        <p style={{ wordBreak: "break-all", fontFamily: "monospace" }}>
+          {`$ curl ${window.location.protocol}//${window.location.hostname}/api/v3/reportExport/${report_id}/comment-clusters.csv`}
         </p>
       </div>
 

--- a/e2e/cypress/e2e/client-report/report-functionality.cy.js
+++ b/e2e/cypress/e2e/client-report/report-functionality.cy.js
@@ -456,6 +456,7 @@ describe('Reports - Functionality & Features', () => {
         'votes.csv',
         'participant-votes.csv',
         'comment-groups.csv',
+        'comment-clusters.csv',
       ]
 
       // Check that export links exist


### PR DESCRIPTION
# Proposal

Handy way to inspect the exact clusters with comment text and layer info

<img width="1361" height="154" alt="Screenshot 2025-10-15 at 22 11 37" src="https://github.com/user-attachments/assets/9a4edbff-edf2-435b-b3bd-ec290e8e2fa5" />

Depends on https://github.com/compdemocracy/polis/pull/2229
