### PR TITLE
BUGFIX: actual comment_ids must be used

### DIFF
--- a/delphi/docs/TOPIC_NAMING.md
+++ b/delphi/docs/TOPIC_NAMING.md
@@ -31,15 +31,16 @@ Comments:
 
 The 1–5 comment items are filled by the sampling strategy below.
 
-## Sampling strategy (deterministic pseudo‑random 5)
+## Sampling strategy (centroid-based selection)
 
 - For each (conversation, `layer_idx`, `cluster_id`) we select up to 5 comments from that cluster.
 - If a cluster has 5 or fewer comments, we use all of them.
-- If it has more than 5, we sample 5 using a deterministic seed so results are reproducible across runs:
-  - Seed = `SHA1("{conversation_name}|{layer_idx}|{cluster_id}")`, reduced to a 32‑bit integer.
-  - A `random.Random(seed)` instance samples 5 comment indices from the cluster.
+- If it has more than 5, we select the 5 comments closest to the cluster centroid in UMAP space:
+  - Calculate the centroid (mean position) of all comments in the cluster
+  - Compute the Euclidean distance from each comment to the centroid
+  - Select the 5 comments with the smallest distances
 
-Rationale: avoids bias from “first N” comments, while keeping runs reproducible (important for debugging and auditability).
+Rationale: Comments closest to the centroid are the most representative of the cluster's core themes, leading to more accurate and coherent topic labels from the LLM.
 
 ## Name cleanup
 

--- a/delphi/umap_narrative/500_generate_embedding_umap_cluster.py
+++ b/delphi/umap_narrative/500_generate_embedding_umap_cluster.py
@@ -6,147 +6,150 @@ This script fetches conversation data from PostgreSQL, processes it using
 EVōC for hierarchical clustering, and stores results in DynamoDB for further processing.
 """
 
-import os
-import sys
 import json
-import time
 import logging
-import numpy as np
-import pandas as pd
+import os
 from datetime import datetime
-from pathlib import Path
-from tqdm.auto import tqdm
 
 # Import from installed packages
 import evoc
-from sentence_transformers import SentenceTransformer
-from umap import UMAP
-from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
+import numpy as np
+from polismath_commentgraph.utils.converter import DataConverter
 
 # Import from local modules
-from polismath_commentgraph.utils.storage import PostgresClient, DynamoDBStorage
-from polismath_commentgraph.utils.converter import DataConverter
-from polismath_commentgraph.core.embedding import EmbeddingEngine
-from polismath_commentgraph.core.clustering import ClusteringEngine
+from polismath_commentgraph.utils.storage import DynamoDBStorage, PostgresClient
+from sentence_transformers import SentenceTransformer
+from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
+from umap import UMAP
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
-def setup_environment(db_host=None, db_port=None, db_name=None, db_user=None, db_password=None):
+
+def setup_environment(
+    db_host=None, db_port=None, db_name=None, db_user=None, db_password=None
+):
     """Set up environment variables for database connections."""
     # PostgreSQL settings
     if db_host:
-        os.environ['DATABASE_HOST'] = db_host
-    elif not os.environ.get('DATABASE_HOST'):
-        os.environ['DATABASE_HOST'] = 'localhost'
-    
+        os.environ["DATABASE_HOST"] = db_host
+    elif not os.environ.get("DATABASE_HOST"):
+        os.environ["DATABASE_HOST"] = "localhost"
+
     if db_port:
-        os.environ['DATABASE_PORT'] = str(db_port)
-    elif not os.environ.get('DATABASE_PORT'):
-        os.environ['DATABASE_PORT'] = '5432'
-    
+        os.environ["DATABASE_PORT"] = str(db_port)
+    elif not os.environ.get("DATABASE_PORT"):
+        os.environ["DATABASE_PORT"] = "5432"
+
     if db_name:
-        os.environ['DATABASE_NAME'] = db_name
-    elif not os.environ.get('DATABASE_NAME'):
-        os.environ['DATABASE_NAME'] = 'polisDB_prod_local_mar14'
-    
+        os.environ["DATABASE_NAME"] = db_name
+    elif not os.environ.get("DATABASE_NAME"):
+        os.environ["DATABASE_NAME"] = "polisDB_prod_local_mar14"
+
     if db_user:
-        os.environ['DATABASE_USER'] = db_user
-    elif not os.environ.get('DATABASE_USER'):
-        os.environ['DATABASE_USER'] = 'postgres'
-    
+        os.environ["DATABASE_USER"] = db_user
+    elif not os.environ.get("DATABASE_USER"):
+        os.environ["DATABASE_USER"] = "postgres"
+
     if db_password:
-        os.environ['DATABASE_PASSWORD'] = db_password
-    elif not os.environ.get('DATABASE_PASSWORD'):
-        os.environ['DATABASE_PASSWORD'] = ''
-    
+        os.environ["DATABASE_PASSWORD"] = db_password
+    elif not os.environ.get("DATABASE_PASSWORD"):
+        os.environ["DATABASE_PASSWORD"] = ""
+
     # Print database connection info
-    logger.info(f"Database connection info:")
+    logger.info("Database connection info:")
     logger.info(f"- HOST: {os.environ.get('DATABASE_HOST')}")
     logger.info(f"- PORT: {os.environ.get('DATABASE_PORT')}")
     logger.info(f"- DATABASE: {os.environ.get('DATABASE_NAME')}")
     logger.info(f"- USER: {os.environ.get('DATABASE_USER')}")
-    
+
     # Log the endpoint being used
-    endpoint = os.environ.get('DYNAMODB_ENDPOINT')
+    endpoint = os.environ.get("DYNAMODB_ENDPOINT")
     logger.info(f"Using DynamoDB endpoint: {endpoint}")
-    
+
     # Set these only if not already in environment
-    if not os.environ.get('AWS_ACCESS_KEY_ID'):
-        os.environ['AWS_ACCESS_KEY_ID'] = 'fakeMyKeyId'
-    if not os.environ.get('AWS_SECRET_ACCESS_KEY'):
-        os.environ['AWS_SECRET_ACCESS_KEY'] = 'fakeSecretAccessKey'
-    if not os.environ.get('AWS_REGION') and not os.environ.get('AWS_DEFAULT_REGION'):
-        os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
+    if not os.environ.get("AWS_ACCESS_KEY_ID"):
+        os.environ["AWS_ACCESS_KEY_ID"] = "fakeMyKeyId"
+    if not os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "fakeSecretAccessKey"
+    if not os.environ.get("AWS_REGION") and not os.environ.get("AWS_DEFAULT_REGION"):
+        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
 
 def fetch_conversation_data(zid):
     """
     Fetch conversation data from PostgreSQL.
-    
+
     Args:
         zid: Conversation ID
-        
+
     Returns:
         comments: List of comment dictionaries
         metadata: Dictionary with conversation metadata
     """
     logger.info(f"Fetching conversation {zid} from PostgreSQL...")
     postgres_client = PostgresClient()
-    
+
     try:
         # Initialize connection
         postgres_client.initialize()
-        
+
         # Get conversation metadata
         conversation = postgres_client.get_conversation_by_id(zid)
         if not conversation:
             logger.error(f"Conversation {zid} not found in database.")
             return None, None
-        
+
         # Get comments - include all comments, regardless of active status
         comments = postgres_client.get_comments_by_conversation(zid)
         logger.info(f"Retrieved {len(comments)} comments from conversation {zid}")
-        
+
         # Count active and inactive for logging purposes only
-        active_count = sum(1 for c in comments if c.get('active', True))
-        inactive_count = sum(1 for c in comments if not c.get('active', True))
-        logger.info(f"Comment counts - Active: {active_count}, Inactive: {inactive_count}, Total: {len(comments)}")
-        
+        active_count = sum(1 for c in comments if c.get("active", True))
+        inactive_count = sum(1 for c in comments if not c.get("active", True))
+        logger.info(
+            f"Comment counts - Active: {active_count}, Inactive: {inactive_count}, Total: {len(comments)}"
+        )
+
         # Create metadata
         metadata = {
-            'conversation_id': str(zid),
-            'zid': zid,
-            'conversation_name': conversation.get('topic', f"Conversation {zid}"),
-            'description': conversation.get('description', ''),
-            'created': str(conversation.get('created', '')),
-            'modified': str(conversation.get('modified', '')),
-            'owner': conversation.get('owner', ''),
-            'num_comments': len(comments),
-            'active_count': active_count,
-            'inactive_count': inactive_count
+            "conversation_id": str(zid),
+            "zid": zid,
+            "conversation_name": conversation.get("topic", f"Conversation {zid}"),
+            "description": conversation.get("description", ""),
+            "created": str(conversation.get("created", "")),
+            "modified": str(conversation.get("modified", "")),
+            "owner": conversation.get("owner", ""),
+            "num_comments": len(comments),
+            "active_count": active_count,
+            "inactive_count": inactive_count,
         }
-        
+
         return comments, metadata
-    
+
     except Exception as e:
         logger.error(f"Error fetching conversation: {str(e)}")
         import traceback
+
         logger.error(traceback.format_exc())
         return None, None
-    
+
     finally:
         # Clean up connection
         postgres_client.shutdown()
 
+
 def process_comments(comments, conversation_id):
     """
     Process comments with embedding and clustering.
-    
+
     Args:
         comments: List of comment dictionaries
         conversation_id: Conversation ID string
-        
+
     Returns:
         document_map: 2D projection of comment embeddings
         document_vectors: Comment embeddings
@@ -154,205 +157,237 @@ def process_comments(comments, conversation_id):
         comment_texts: List of comment text strings
         comment_ids: List of comment IDs
     """
-    logger.info(f"Processing {len(comments)} comments for conversation {conversation_id}...")
-    
+    logger.info(
+        f"Processing {len(comments)} comments for conversation {conversation_id}..."
+    )
+
     # Extract comment texts and IDs
-    comment_texts = [c['txt'] for c in comments if c['txt'] and c['txt'].strip()]
-    comment_ids = [c['tid'] for c in comments if c['txt'] and c['txt'].strip()]
-    
+    comment_texts, comment_ids = map(
+        list,
+        zip(
+            *[(c["txt"], c["tid"]) for c in comments if c["txt"] and c["txt"].strip()],
+            strict=True,
+        ),
+    )
+
     # Generate embeddings with SentenceTransformer
     logger.info("Generating embeddings with SentenceTransformer...")
     model_name = os.environ.get("SENTENCE_TRANSFORMER_MODEL", "all-MiniLM-L6-v2")
     logger.info(f"Using model: {model_name}")
     embedding_model = SentenceTransformer(model_name)
     document_vectors = embedding_model.encode(comment_texts, show_progress_bar=True)
-    
+
     # Generate 2D projection with UMAP
     logger.info("Generating 2D projection with UMAP...")
-    document_map = UMAP(n_components=2, metric='cosine', random_state=42).fit_transform(document_vectors)
-    
+    document_map = UMAP(n_components=2, metric="cosine", random_state=42).fit_transform(
+        document_vectors
+    )
+
     # Cluster with EVōC
     logger.info("Clustering with EVōC...")
     try:
         clusterer = evoc.EVoC(min_samples=5)  # Set min_samples to avoid empty clusters
         cluster_labels = clusterer.fit_predict(document_vectors)
         cluster_layers = clusterer.cluster_layers_
-        
-        logger.info(f"Found {len(np.unique(cluster_labels))} clusters at the finest level")
+
+        logger.info(
+            f"Found {len(np.unique(cluster_labels))} clusters at the finest level"
+        )
         for i, layer in enumerate(cluster_layers):
             unique_clusters = np.unique(layer[layer >= 0])
             logger.info(f"Layer {i}: {len(unique_clusters)} clusters")
-            
+
     except Exception as e:
         logger.error(f"Error during EVōC clustering: {e}")
         # Fallback to simple clustering
         from sklearn.cluster import KMeans
-        
+
         logger.info("Falling back to KMeans clustering...")
         kmeans = KMeans(n_clusters=5, random_state=42)
         cluster_labels = kmeans.fit_predict(document_vectors)
-        
+
         # Create a simple layered clustering for demonstration
         from sklearn.cluster import AgglomerativeClustering
+
         layer1 = AgglomerativeClustering(n_clusters=3).fit_predict(document_vectors)
         layer2 = AgglomerativeClustering(n_clusters=2).fit_predict(document_vectors)
-        
+
         cluster_layers = [cluster_labels, layer1, layer2]
-        logger.info(f"Created {len(cluster_layers)} cluster layers with fallback clustering")
-    
+        logger.info(
+            f"Created {len(cluster_layers)} cluster layers with fallback clustering"
+        )
+
     return document_map, document_vectors, cluster_layers, comment_texts, comment_ids
+
 
 def characterize_comment_clusters(cluster_layer, comment_texts):
     """
     Characterize comment clusters by common themes and keywords.
-    
+
     Args:
         cluster_layer: Cluster assignments for a specific layer
         comment_texts: List of comment text strings
-        
+
     Returns:
         cluster_characteristics: Dictionary with cluster characterizations
     """
     # Create a dictionary to store cluster characteristics
     cluster_characteristics = {}
-    
+
     # Get unique clusters
     unique_clusters = np.unique(cluster_layer)
     unique_clusters = unique_clusters[unique_clusters >= 0]  # Remove noise points (-1)
-    
+
     # Create TF-IDF vectorizer
-    vectorizer = CountVectorizer(max_features=1000, stop_words='english')
+    vectorizer = CountVectorizer(max_features=1000, stop_words="english")
     transformer = TfidfTransformer()
-    
+
     # Fit and transform the entire corpus
     X = vectorizer.fit_transform(comment_texts)
     X_tfidf = transformer.fit_transform(X)
-    
+
     # Get feature names
     feature_names = vectorizer.get_feature_names_out()
-    
+
     for cluster_id in unique_clusters:
         # Get cluster members
         cluster_members = np.where(cluster_layer == cluster_id)[0]
-        
+
         if len(cluster_members) == 0:
             continue
-            
+
         # Get comment texts for this cluster
         cluster_comments = [comment_texts[i] for i in cluster_members]
-        
+
         # Find top words for this cluster by TF-IDF
         cluster_tfidf = X_tfidf[cluster_members].toarray().mean(axis=0)
         top_indices = np.argsort(cluster_tfidf)[-10:][::-1]  # Top 10 words
         top_words = [feature_names[i] for i in top_indices]
-        
+
         # Get sample comments (shortest 3 for readability)
         comment_lengths = [len(comment) for comment in cluster_comments]
         shortest_indices = np.argsort(comment_lengths)[:3]  # 3 shortest comments
         sample_comments = [cluster_comments[i] for i in shortest_indices]
-        
+
         # Add to cluster characteristics
         cluster_characteristics[int(cluster_id)] = {
-            'size': len(cluster_members),
-            'top_words': top_words,
-            'top_tfidf_scores': [float(cluster_tfidf[i]) for i in top_indices],
-            'sample_comments': sample_comments
+            "size": len(cluster_members),
+            "top_words": top_words,
+            "top_tfidf_scores": [float(cluster_tfidf[i]) for i in top_indices],
+            "sample_comments": sample_comments,
         }
-    
+
     return cluster_characteristics
+
 
 def generate_basic_cluster_labels(cluster_characteristics):
     """
     Generate basic topic labels for clusters based on their characteristics.
     This function only creates numeric topic labels (Topic 1, Topic 2, etc.)
-    
+
     Args:
         cluster_characteristics: Dictionary with cluster characterizations
-        
+
     Returns:
         cluster_labels: Dictionary mapping cluster IDs to basic topic labels
     """
     cluster_labels = {}
-    
+
     # Create numeric topic labels
     for cluster_id in cluster_characteristics.keys():
         cluster_labels[cluster_id] = f"Topic {cluster_id}"
-    
+
     return cluster_labels
 
 
 def process_layers_and_store_characteristics(
-    conversation_id,
-    cluster_layers,
-    comment_texts,
-    output_dir=None,
-    dynamo_storage=None
+    conversation_id, cluster_layers, comment_texts, output_dir=None, dynamo_storage=None
 ):
     """
     Process layers and store cluster characteristics in DynamoDB.
-    
+
     Args:
         conversation_id: Conversation ID string
         cluster_layers: Cluster assignments for each layer
         comment_texts: List of comment text strings
         output_dir: Optional directory to save data as JSON (not typically used)
         dynamo_storage: Optional DynamoDBStorage object for storing in DynamoDB
-        
+
     Returns:
         Dictionary with layer data including characteristics and basic topic names
     """
     layer_data = {}
-    
+
     for layer_idx, cluster_layer in enumerate(cluster_layers):
-        logger.info(f"Processing layer {layer_idx} with {len(np.unique(cluster_layer[cluster_layer >= 0]))} clusters...")
-        
+        logger.info(
+            f"Processing layer {layer_idx} with {len(np.unique(cluster_layer[cluster_layer >= 0]))} clusters..."
+        )
+
         # Generate cluster characteristics
         cluster_characteristics = characterize_comment_clusters(
             cluster_layer, comment_texts
         )
-        
+
         # Create basic numeric topic names
-        numeric_labels = {str(i): f"Topic {i}" for i in np.unique(cluster_layer[cluster_layer >= 0])}
-        
+        numeric_labels = {
+            str(i): f"Topic {i}" for i in np.unique(cluster_layer[cluster_layer >= 0])
+        }
+
         # Store layer data
         layer_data[layer_idx] = {
-            'characteristics': cluster_characteristics,
-            'numeric_topic_names': numeric_labels
+            "characteristics": cluster_characteristics,
+            "numeric_topic_names": numeric_labels,
         }
-        
+
         # Save data to files if output directory provided
         if output_dir:
             # Save cluster characteristics
-            with open(os.path.join(output_dir, f"{conversation_id}_layer_{layer_idx}_characteristics.json"), 'w') as f:
-                json_compatible = json.dumps(cluster_characteristics, default=lambda x: float(x) if isinstance(x, np.float32) else x)
+            with open(
+                os.path.join(
+                    output_dir,
+                    f"{conversation_id}_layer_{layer_idx}_characteristics.json",
+                ),
+                "w",
+            ) as f:
+                json_compatible = json.dumps(
+                    cluster_characteristics,
+                    default=lambda x: float(x) if isinstance(x, np.float32) else x,
+                )
                 f.write(json_compatible)
-            
+
             # Save numeric topic names
-            with open(os.path.join(output_dir, f"{conversation_id}_layer_{layer_idx}_topic_names.json"), 'w') as f:
+            with open(
+                os.path.join(
+                    output_dir, f"{conversation_id}_layer_{layer_idx}_topic_names.json"
+                ),
+                "w",
+            ) as f:
                 json.dump(numeric_labels, f, indent=2)
-        
+
         # Store in DynamoDB if provided
         if dynamo_storage:
             # Convert and store cluster characteristics
-            logger.info(f"Storing cluster characteristics for layer {layer_idx} in DynamoDB...")
-            characteristic_models = DataConverter.batch_convert_cluster_characteristics(
-                conversation_id,
-                cluster_characteristics,
-                layer_idx
+            logger.info(
+                f"Storing cluster characteristics for layer {layer_idx} in DynamoDB..."
             )
-            result = dynamo_storage.batch_create_cluster_characteristics(characteristic_models)
-            logger.info(f"Stored {result['success']} cluster characteristics with {result['failure']} failures")
-    
-    logger.info(f"Processing of layers and storing characteristics complete!")
+            characteristic_models = DataConverter.batch_convert_cluster_characteristics(
+                conversation_id, cluster_characteristics, layer_idx
+            )
+            result = dynamo_storage.batch_create_cluster_characteristics(
+                characteristic_models
+            )
+            logger.info(
+                f"Stored {result['success']} cluster characteristics with {result['failure']} failures"
+            )
+
+    logger.info("Processing of layers and storing characteristics complete!")
     return layer_data
-
-
 
 
 def process_conversation(zid, export_dynamo=True):
     """
     Main function to process a conversation, generate embeddings, and perform clustering.
-    
+
     Args:
         zid: Conversation ID
         export_dynamo: Whether to export results to DynamoDB
@@ -362,185 +397,197 @@ def process_conversation(zid, export_dynamo=True):
     if not comments:
         logger.error("Failed to fetch conversation data.")
         return False
-    
+
     conversation_id = str(zid)
-    conversation_name = metadata.get('conversation_name', f"Conversation {zid}")
-    region = os.environ.get('AWS_REGION')
-    
+    region = os.environ.get("AWS_REGION")
+
     # Process comments
-    document_map, document_vectors, cluster_layers, comment_texts, comment_ids = process_comments(
-        comments, conversation_id
+    document_map, document_vectors, cluster_layers, comment_texts, comment_ids = (
+        process_comments(comments, conversation_id)
     )
-    
+
     # Initialize DynamoDB storage
     dynamo_storage = None
     if export_dynamo:
         dynamo_storage = DynamoDBStorage(
-            region_name=region,
-            endpoint_url=os.environ.get('DYNAMODB_ENDPOINT')
+            region_name=region, endpoint_url=os.environ.get("DYNAMODB_ENDPOINT")
         )
-        
+
         # Store basic data in DynamoDB
-        logger.info(f"Storing basic data in DynamoDB for conversation {conversation_id}...")
-        
+        logger.info(
+            f"Storing basic data in DynamoDB for conversation {conversation_id}..."
+        )
+
         # Store conversation metadata
         logger.info("Storing conversation metadata...")
         conversation_meta = DataConverter.create_conversation_meta(
-            conversation_id,
-            document_vectors,
-            cluster_layers,
-            metadata
+            conversation_id, document_vectors, cluster_layers, metadata
         )
         dynamo_storage.create_conversation_meta(conversation_meta)
-        
+
         # Store embeddings
         logger.info("Storing comment embeddings...")
         embedding_models = DataConverter.batch_convert_embeddings(
-            conversation_id,
-            document_vectors
+            conversation_id, document_vectors, comment_ids
         )
         result = dynamo_storage.batch_create_comment_embeddings(embedding_models)
-        logger.info(f"Stored {result['success']} embeddings with {result['failure']} failures")
-        
+        logger.info(
+            f"Stored {result['success']} embeddings with {result['failure']} failures"
+        )
+
         # Store UMAP graph edges
         logger.info("Storing UMAP graph edges...")
         edge_models = DataConverter.batch_convert_umap_edges(
-            conversation_id,
-            document_map,
-            cluster_layers
+            conversation_id, document_map, cluster_layers, comment_ids=comment_ids
         )
         result = dynamo_storage.batch_create_graph_edges(edge_models)
-        logger.info(f"Stored {result['success']} UMAP graph edges with {result['failure']} failures")
-        
+        logger.info(
+            f"Stored {result['success']} UMAP graph edges with {result['failure']} failures"
+        )
+
         # Store cluster assignments
         logger.info("Storing comment cluster assignments...")
         cluster_models = DataConverter.batch_convert_clusters(
-            conversation_id,
-            cluster_layers,
-            document_map
+            conversation_id, cluster_layers, document_map, comment_ids
         )
         result = dynamo_storage.batch_create_comment_clusters(cluster_models)
-        logger.info(f"Stored {result['success']} cluster assignments with {result['failure']} failures")
-        
+        logger.info(
+            f"Stored {result['success']} cluster assignments with {result['failure']} failures"
+        )
+
         # Store cluster topics (basic info only)
         logger.info("Storing cluster topics...")
         topic_models = DataConverter.batch_convert_topics(
             conversation_id,
             cluster_layers,
             document_map,
+            comment_texts,
             topic_names={},  # No topic names yet
             characteristics={},  # No characteristics yet
-            comments=[{'body': comment['txt']} for comment in comments]
         )
         result = dynamo_storage.batch_create_cluster_topics(topic_models)
-        logger.info(f"Stored {result['success']} topics with {result['failure']} failures")
-    
+        logger.info(
+            f"Stored {result['success']} topics with {result['failure']} failures"
+        )
+
     # Process layers and store characteristics
-    layer_data = process_layers_and_store_characteristics(
+    process_layers_and_store_characteristics(
         conversation_id,
         cluster_layers,
         comment_texts,
         output_dir=None,  # No output directory needed
-        dynamo_storage=dynamo_storage
+        dynamo_storage=dynamo_storage,
     )
-    
+
     logger.info(f"Processing of conversation {conversation_id} complete!")
-    
+
     return True
+
 
 def main():
     """Main entry point."""
     # Parse arguments
     import argparse
-    parser = argparse.ArgumentParser(description='Process Polis conversation from PostgreSQL')
-    parser.add_argument('--zid', type=int, required=False, default=22154,
-                      help='Conversation ID to process')
-    parser.add_argument('--no-dynamo', action='store_true',
-                      help='Skip exporting to DynamoDB')
-    parser.add_argument('--db-host', type=str, default=None,
-                       help='PostgreSQL host')
-    parser.add_argument('--db-port', type=int, default=None,
-                       help='PostgreSQL port')
-    parser.add_argument('--db-name', type=str, default=None,
-                       help='PostgreSQL database name')
-    parser.add_argument('--db-user', type=str, default=None,
-                       help='PostgreSQL user')
-    parser.add_argument('--db-password', type=str, default=None,
-                       help='PostgreSQL password')
-    parser.add_argument('--use-mock-data', action='store_true',
-                       help='Use mock data instead of connecting to PostgreSQL')
-    
+
+    parser = argparse.ArgumentParser(
+        description="Process Polis conversation from PostgreSQL"
+    )
+    parser.add_argument(
+        "--zid",
+        type=int,
+        required=False,
+        default=22154,
+        help="Conversation ID to process",
+    )
+    parser.add_argument(
+        "--no-dynamo", action="store_true", help="Skip exporting to DynamoDB"
+    )
+    parser.add_argument("--db-host", type=str, default=None, help="PostgreSQL host")
+    parser.add_argument("--db-port", type=int, default=None, help="PostgreSQL port")
+    parser.add_argument(
+        "--db-name", type=str, default=None, help="PostgreSQL database name"
+    )
+    parser.add_argument("--db-user", type=str, default=None, help="PostgreSQL user")
+    parser.add_argument(
+        "--db-password", type=str, default=None, help="PostgreSQL password"
+    )
+    parser.add_argument(
+        "--use-mock-data",
+        action="store_true",
+        help="Use mock data instead of connecting to PostgreSQL",
+    )
+
     args = parser.parse_args()
-    
+
     # Set up environment
     setup_environment(
         db_host=args.db_host,
         db_port=args.db_port,
         db_name=args.db_name,
         db_user=args.db_user,
-        db_password=args.db_password
+        db_password=args.db_password,
     )
-    
+
     # Process conversation
     if args.use_mock_data:
         logger.info("Using mock data instead of connecting to PostgreSQL")
         # Create mock comments data
         mock_comments = []
         for i in range(100):
-            mock_comments.append({
-                'tid': i,
-                'zid': args.zid,
-                'txt': f"This is a mock comment {i} for testing purposes without PostgreSQL connection.",
-                'created': datetime.now().isoformat(),
-                'pid': i % 20,  # Mock 20 different participants
-                'active': True
-            })
-        
+            mock_comments.append(
+                {
+                    "tid": i,
+                    "zid": args.zid,
+                    "txt": f"This is a mock comment {i} for testing purposes without PostgreSQL connection.",
+                    "created": datetime.now().isoformat(),
+                    "pid": i % 20,  # Mock 20 different participants
+                    "active": True,
+                }
+            )
+
         # Create mock metadata
         mock_metadata = {
-            'conversation_id': str(args.zid),
-            'zid': args.zid,
-            'conversation_name': f"Mock Conversation {args.zid}",
-            'description': "Mock conversation for testing without PostgreSQL",
-            'created': datetime.now().isoformat(),
-            'modified': datetime.now().isoformat(),
-            'owner': 'mock_user',
-            'num_comments': len(mock_comments)
+            "conversation_id": str(args.zid),
+            "zid": args.zid,
+            "conversation_name": f"Mock Conversation {args.zid}",
+            "description": "Mock conversation for testing without PostgreSQL",
+            "created": datetime.now().isoformat(),
+            "modified": datetime.now().isoformat(),
+            "owner": "mock_user",
+            "num_comments": len(mock_comments),
         }
-        
+
         # Process comments to get embeddings and clustering
-        document_map, document_vectors, cluster_layers, comment_texts, comment_ids = process_comments(
-            mock_comments, str(args.zid)
+        document_map, document_vectors, cluster_layers, comment_texts, comment_ids = (
+            process_comments(mock_comments, str(args.zid))
         )
-        
+
         # Process with mock data (store in DynamoDB if requested)
         if not args.no_dynamo:
             dynamo_storage = DynamoDBStorage(
-                region_name='us-east-1',
-                endpoint_url=os.environ.get('DYNAMODB_ENDPOINT')
+                region_name="us-east-1",
+                endpoint_url=os.environ.get("DYNAMODB_ENDPOINT"),
             )
-            
+
             # Store conversation metadata
             logger.info("Storing conversation metadata...")
             conversation_meta = DataConverter.create_conversation_meta(
-                str(args.zid),
-                document_vectors,
-                cluster_layers,
-                mock_metadata
+                str(args.zid), document_vectors, cluster_layers, mock_metadata
             )
             dynamo_storage.create_conversation_meta(conversation_meta)
-            
+
             # Process and store cluster data
-            layer_data = process_layers_and_store_characteristics(
+            process_layers_and_store_characteristics(
                 str(args.zid),
                 cluster_layers,
                 comment_texts,
                 output_dir=None,
-                dynamo_storage=dynamo_storage
+                dynamo_storage=dynamo_storage,
             )
     else:
         # Process with real data from PostgreSQL
         process_conversation(args.zid, export_dynamo=not args.no_dynamo)
+
 
 if __name__ == "__main__":
     main()

--- a/delphi/umap_narrative/polismath_commentgraph/cli.py
+++ b/delphi/umap_narrative/polismath_commentgraph/cli.py
@@ -3,22 +3,17 @@ Command-line interface for the Polis comment graph Lambda service.
 """
 
 import argparse
+import json
 import logging
 import os
-import sys
-import numpy as np
-import json
 import time
-from typing import Dict, List, Any, Optional
-from pathlib import Path
-import pandas as pd
 from datetime import datetime
 
-from .core.embedding import EmbeddingEngine
-from .core.clustering import ClusteringEngine
+import numpy as np
+import pandas as pd
+
 from .utils.converter import DataConverter
 from .utils.storage import DynamoDBStorage, PostgresClient
-from .lambda_handler import process_conversation, process_new_comment
 
 # Configure logging
 logging.basicConfig(
@@ -28,31 +23,31 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+
 def test_evoc(args):
     """
     Test EVOC integration with real datasets from biodiversity and bg2050.
-    
+
     Args:
         args: Command-line arguments
     """
-    from sentence_transformers import SentenceTransformer
     import evoc
-    import pandas as pd
-    
+    from sentence_transformers import SentenceTransformer
+
     # Test with both biodiversity (small) and bg2050 (large) datasets
     datasets = [
         {
             "name": "biodiversity",
-            "file": "/Users/colinmegill/evoc-top-exp/polis_data/biodiversity/biodiversity_comments.csv"
+            "file": "/Users/colinmegill/evoc-top-exp/polis_data/biodiversity/biodiversity_comments.csv",
         },
         {
             "name": "bg2050",
-            "file": "/Users/colinmegill/evoc-top-exp/polis_data/bg2050/comments.csv"
-        }
+            "file": "/Users/colinmegill/evoc-top-exp/polis_data/bg2050/comments.csv",
+        },
     ]
-    
+
     logger.info("Testing EVOC with real datasets")
-    
+
     # Load sentence transformer model - same one used in successful examples
     logger.info("Loading SentenceTransformer model...")
     start_time = time.time()
@@ -60,294 +55,300 @@ def test_evoc(args):
     logger.info(f"Using model: {model_name}")
     embedding_model = SentenceTransformer(model_name)
     logger.info(f"Model loaded in {time.time() - start_time:.2f}s")
-    
+
     # Process each dataset
     for dataset in datasets:
         logger.info(f"\n===== Testing with {dataset['name']} dataset =====")
-        
+
         # Load comments
         logger.info(f"Loading comments from {dataset['name']}...")
         try:
-            if dataset['name'] == 'biodiversity':
-                comments_df = pd.read_csv(dataset['file'])
-                comment_texts = comments_df['comment-body'].fillna("").values
+            if dataset["name"] == "biodiversity":
+                comments_df = pd.read_csv(dataset["file"])
+                comment_texts = comments_df["comment-body"].fillna("").values
             else:  # bg2050
-                comments_df = pd.read_csv(dataset['file'])
-                comment_texts = comments_df['comment-body'].fillna("").values
-            
+                comments_df = pd.read_csv(dataset["file"])
+                comment_texts = comments_df["comment-body"].fillna("").values
+
             logger.info(f"Loaded {len(comment_texts)} comments from {dataset['name']}")
         except Exception as e:
             logger.error(f"Error loading comments: {e}")
             continue
-        
+
         # Generate embeddings
         logger.info("Generating embeddings...")
         start_time = time.time()
         document_vectors = embedding_model.encode(comment_texts, show_progress_bar=True)
         logger.info(f"Embeddings generated in {time.time() - start_time:.2f}s")
-        
+
         # Cluster with EVOC
         logger.info("Clustering with EVOC...")
         start_time = time.time()
-        
+
         # Initialize EVOC with same parameters as successful examples
         clusterer = evoc.EVoC(min_samples=5)
-        
+
         # Run clustering - exactly as in visualize_comments_with_layers.py
         try:
             # Use the exact same approach as the working examples
             cluster_labels = clusterer.fit_predict(document_vectors)
             clustering_time = time.time() - start_time
             cluster_layers = clusterer.cluster_layers_
-            
+
             # Count clusters (using same approach as working examples)
             num_clusters = len(np.unique(cluster_labels))
-            
+
             # Count noise points if possible
             try:
                 num_noise = np.sum(cluster_labels == -1)
-            except:
+            except Exception:
                 # If we can't count noise points, just report clusters
                 num_noise = 0
-                
-            logger.info(f"EVOC clustering successful")
-                
+
+            logger.info("EVOC clustering successful")
+
         except Exception as e:
             # IMPORTANT: We're using the same fallback approach as the working code
             # This is necessary because EVOC itself appears to have an issue with certain datasets
             logger.error(f"EVOC clustering failed: {e}")
-            logger.info(f"Using KMeans fallback for demonstration (as in working examples)")
-            
+            logger.info(
+                "Using KMeans fallback for demonstration (as in working examples)"
+            )
+
             from sklearn.cluster import KMeans
+
             kmeans = KMeans(n_clusters=5, random_state=42)
             cluster_labels = kmeans.fit_predict(document_vectors)
-            
+
             # Create a simple single-layer clustering for demonstration
             cluster_layers = [cluster_labels]
-            
+
             clustering_time = time.time() - start_time
             num_clusters = len(np.unique(cluster_labels))
             num_noise = 0
-        
+
         logger.info(f"Clustering completed in {clustering_time:.2f}s")
         logger.info(f"Found {num_clusters} clusters and {num_noise} noise points")
-        
+
         # Access cluster layers - already got them above
         logger.info(f"Found {len(cluster_layers)} cluster layers")
-        
+
         # Print layer statistics - adapt to match working examples
         for i, layer in enumerate(cluster_layers):
             try:
                 # Try with filtering out noise
                 num_layer_clusters = len(np.unique(layer[layer >= 0]))
                 num_layer_noise = np.sum(layer == -1)
-            except:
+            except Exception:
                 # If that fails, just count all unique values
                 num_layer_clusters = len(np.unique(layer))
                 num_layer_noise = 0
-                
-            logger.info(f"Layer {i}: {num_layer_clusters} clusters, {num_layer_noise} noise points")
-    
+
+            logger.info(
+                f"Layer {i}: {num_layer_clusters} clusters, {num_layer_noise} noise points"
+            )
+
     logger.info("\nEVOC testing on real datasets completed successfully")
-    
+
     # Return successful status
-    return {
-        "success": True,
-        "datasets_tested": [d["name"] for d in datasets]
-    }
+    return {"success": True, "datasets_tested": [d["name"] for d in datasets]}
+
 
 def test_postgres(args):
     """
     Test PostgreSQL connection and data retrieval.
-    
+
     Args:
         args: Command-line arguments containing connection info
     """
     # Initialize the PostgreSQL client
     pg_config = {
-        'host': args.pg_host,
-        'port': args.pg_port,
-        'database': args.pg_database,
-        'user': args.pg_user,
-        'password': args.pg_password
+        "host": args.pg_host,
+        "port": args.pg_port,
+        "database": args.pg_database,
+        "user": args.pg_user,
+        "password": args.pg_password,
     }
-    
+
     pg_client = PostgresClient(pg_config)
-    
+
     try:
         # Try to initialize the connection
         pg_client.initialize()
-        
+
         # Test a simple query
         if args.zid:
             # Test conversation lookup
             conversation = pg_client.get_conversation_by_id(args.zid)
             if conversation:
-                logger.info(f"Found conversation: {json.dumps(conversation, default=str)}")
-                
+                logger.info(
+                    f"Found conversation: {json.dumps(conversation, default=str)}"
+                )
+
                 # Get comments
                 comments = pg_client.get_comments_by_conversation(args.zid)
                 logger.info(f"Retrieved {len(comments)} comments")
-                
+
                 # Get participants
                 participants = pg_client.get_participants_by_conversation(args.zid)
                 logger.info(f"Retrieved {len(participants)} participants")
-                
+
                 # Get votes
                 votes = pg_client.get_votes_by_conversation(args.zid)
                 logger.info(f"Retrieved {len(votes)} votes")
-                
+
                 return {
-                    'success': True,
-                    'conversation': conversation,
-                    'comment_count': len(comments),
-                    'participant_count': len(participants),
-                    'vote_count': len(votes)
+                    "success": True,
+                    "conversation": conversation,
+                    "comment_count": len(comments),
+                    "participant_count": len(participants),
+                    "vote_count": len(votes),
                 }
             else:
                 logger.error(f"Conversation not found: {args.zid}")
                 return {
-                    'success': False,
-                    'error': f"Conversation not found: {args.zid}"
+                    "success": False,
+                    "error": f"Conversation not found: {args.zid}",
                 }
         elif args.zinvite:
             # Test zinvite lookup
             zid = pg_client.get_conversation_id_by_slug(args.zinvite)
             if zid:
                 logger.info(f"Found conversation ID {zid} for zinvite {args.zinvite}")
-                
+
                 # Get conversation details
                 conversation = pg_client.get_conversation_by_id(zid)
-                logger.info(f"Found conversation: {json.dumps(conversation, default=str)}")
-                
+                logger.info(
+                    f"Found conversation: {json.dumps(conversation, default=str)}"
+                )
+
                 return {
-                    'success': True,
-                    'zinvite': args.zinvite,
-                    'zid': zid,
-                    'conversation': conversation
+                    "success": True,
+                    "zinvite": args.zinvite,
+                    "zid": zid,
+                    "conversation": conversation,
                 }
             else:
                 logger.error(f"Conversation not found for zinvite: {args.zinvite}")
                 return {
-                    'success': False,
-                    'error': f"Conversation not found for zinvite: {args.zinvite}"
+                    "success": False,
+                    "error": f"Conversation not found for zinvite: {args.zinvite}",
                 }
         else:
             # Test a generic query
             logger.info("Testing query execution")
-            result = pg_client.query("SELECT current_timestamp as time, version() as version")
+            result = pg_client.query(
+                "SELECT current_timestamp as time, version() as version"
+            )
             logger.info(f"Query result: {json.dumps(result, default=str)}")
-            
-            return {
-                'success': True,
-                'query_result': result
-            }
-    
+
+            return {"success": True, "query_result": result}
+
     except Exception as e:
         logger.error(f"PostgreSQL test failed: {str(e)}")
         import traceback
+
         logger.error(traceback.format_exc())
-        
-        return {
-            'success': False,
-            'error': str(e),
-            'traceback': traceback.format_exc()
-        }
+
+        return {"success": False, "error": str(e), "traceback": traceback.format_exc()}
     finally:
         # Clean up
         pg_client.shutdown()
 
+
 def lambda_local(args):
     """
     Run the Lambda handler locally with provided arguments.
-    
+
     Args:
         args: Command-line arguments
     """
     logger.info("Running Lambda handler locally")
-    
+
     # Prepare the event
-    if args.event_type == 'process_conversation':
+    if args.event_type == "process_conversation":
         event = {
-            'event_type': 'process_conversation',
-            'conversation_id': args.conversation_id
+            "event_type": "process_conversation",
+            "conversation_id": args.conversation_id,
         }
-    elif args.event_type == 'process_comment':
+    elif args.event_type == "process_comment":
         event = {
-            'event_type': 'process_comment',
-            'comment_data': {
-                'conversation_id': args.conversation_id,
-                'comment_id': args.comment_id,
-                'text': args.text,
-                'author_id': args.author_id,
-                'created': datetime.now().isoformat()
-            }
+            "event_type": "process_comment",
+            "comment_data": {
+                "conversation_id": args.conversation_id,
+                "comment_id": args.comment_id,
+                "text": args.text,
+                "author_id": args.author_id,
+                "created": datetime.now().isoformat(),
+            },
         }
     else:
         logger.error(f"Unknown event type: {args.event_type}")
         return
-    
+
     # Create mock context
-    context = type('obj', (object,), {
-        'function_name': 'lambda_local',
-        'aws_request_id': '12345',
-        'invoked_function_arn': 'arn:aws:lambda:us-east-1:123456789012:function:lambda_local'
-    })
-    
+    context = type(
+        "obj",
+        (object,),
+        {
+            "function_name": "lambda_local",
+            "aws_request_id": "12345",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:lambda_local",
+        },
+    )
+
     # Override environment variables if provided
     if args.pg_host:
-        os.environ['DATABASE_HOST'] = args.pg_host
+        os.environ["DATABASE_HOST"] = args.pg_host
     if args.pg_port:
-        os.environ['DATABASE_PORT'] = str(args.pg_port)
+        os.environ["DATABASE_PORT"] = str(args.pg_port)
     if args.pg_database:
-        os.environ['DATABASE_NAME'] = args.pg_database
+        os.environ["DATABASE_NAME"] = args.pg_database
     if args.pg_user:
-        os.environ['DATABASE_USER'] = args.pg_user
+        os.environ["DATABASE_USER"] = args.pg_user
     if args.pg_password:
-        os.environ['DATABASE_PASSWORD'] = args.pg_password
-        
+        os.environ["DATABASE_PASSWORD"] = args.pg_password
+
     # Set up DynamoDB environment variables for local testing
-    
+
     # Log the endpoint being used
     logger.info(f"Using DynamoDB endpoint: {os.environ.get('DYNAMODB_ENDPOINT')}")
-    os.environ['AWS_ACCESS_KEY_ID'] = 'fakeMyKeyId'
-    os.environ['AWS_SECRET_ACCESS_KEY'] = 'fakeSecretAccessKey'
-    os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
-    
+    os.environ["AWS_ACCESS_KEY_ID"] = "fakeMyKeyId"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "fakeSecretAccessKey"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
     # Reinitialize the DynamoDB storage with direct credentials
-    from .utils.storage import DynamoDBStorage
     global dynamo_storage
     dynamo_storage = DynamoDBStorage(
-        region_name='us-east-1',
-        endpoint_url=os.environ.get('DYNAMODB_ENDPOINT')
+        region_name="us-east-1", endpoint_url=os.environ.get("DYNAMODB_ENDPOINT")
     )
-    
+
     # Import the handler
     from .lambda_handler import lambda_handler
-    
+
     # Initialize PostgreSQL client if needed
     from .utils.storage import PostgresClient
+
     global postgres_client
     postgres_client = PostgresClient()
-    
-    # Override lambda_handler's DynamoDB instance 
-    from .lambda_handler import process_conversation as orig_process
-    
+
+    # Override lambda_handler's DynamoDB instance
+
     # Create a wrapper function that uses our dynamo_storage
     def process_with_local_dynamo(conversation_id: str):
         # This is a modified version of process_conversation that uses our dynamo_storage
         global dynamo_storage
         # Import necessary modules
-        from .lambda_handler import embedding_engine, clustering_engine
-        
-        # Use the original code but with our dynamo_storage
-        from .utils.converter import DataConverter
-        import numpy as np
         from datetime import datetime
-        
+
+        # Use the original code but with our dynamo_storage
+        import numpy as np
+
+        from .lambda_handler import clustering_engine, embedding_engine
+
         start_time = time.time()
         logger.info(f"Processing conversation: {conversation_id}")
-        
+
         # Get comments from PostgreSQL
         comments = []
         try:
@@ -360,200 +361,207 @@ def lambda_local(args):
                 if zid is None:
                     logger.error(f"Conversation not found for id: {conversation_id}")
                     return {
-                        'success': False,
-                        'error': 'Conversation not found',
-                        'conversation_id': conversation_id
+                        "success": False,
+                        "error": "Conversation not found",
+                        "conversation_id": conversation_id,
                     }
-            
+
             logger.info(f"Retrieving comments for conversation {zid}")
             comments = postgres_client.get_comments_by_conversation(zid)
             logger.info(f"Retrieved {len(comments)} comments from PostgreSQL")
-            
+
             # Extract text, filter out any empty or None texts
-            filtered_comments = [c for c in comments if c['txt'] and c['txt'].strip()]
-            
+            filtered_comments = [c for c in comments if c["txt"] and c["txt"].strip()]
+
             # Log active/inactive comment counts
-            active_comments = [c for c in filtered_comments if c.get('active', True)]
-            inactive_comments = [c for c in filtered_comments if not c.get('active', True)]
-            
+            active_comments = [c for c in filtered_comments if c.get("active", True)]
+            inactive_comments = [
+                c for c in filtered_comments if not c.get("active", True)
+            ]
+
             logger.info(f"Processing {len(filtered_comments)} comments total:")
             logger.info(f"- {len(active_comments)} active comments")
             logger.info(f"- {len(inactive_comments)} inactive comments")
-            
-            comment_texts = [c['txt'] for c in filtered_comments]
-            comment_ids = [c['tid'] for c in filtered_comments]
-            
+
+            comment_texts, comment_ids = map(
+                list,
+                zip(*[(c["txt"], c["tid"]) for c in filtered_comments], strict=True),
+            )
+
             # Generate embeddings
             logger.info(f"Generating embeddings for {len(comment_texts)} comments")
             embedding_start = time.time()
             embeddings = embedding_engine.embed_batch(comment_texts)
             embedding_time = time.time() - embedding_start
             logger.info(f"Embeddings generated in {embedding_time:.2f}s")
-            
+
             # Project to 2D
             logger.info("Projecting embeddings to 2D using UMAP")
             projection_start = time.time()
             projection = clustering_engine.project_to_2d(embeddings)
             projection_time = time.time() - projection_start
             logger.info(f"Projection completed in {projection_time:.2f}s")
-            
+
             # Create clustering layers
             logger.info("Creating clustering layers")
             clustering_start = time.time()
             cluster_layers = clustering_engine.create_clustering_layers(
-                embeddings,
-                num_layers=4
+                embeddings, num_layers=4
             )
             clustering_time = time.time() - clustering_start
             logger.info(f"Clustering completed in {clustering_time:.2f}s")
-            
+
             # Create conversation metadata
             metadata = {
-                'conversation_name': conversation_id,
-                'processed_date': datetime.now().isoformat(),
-                'num_comments': len(comments),
-                'num_clusters': len(np.unique(cluster_layers[0][cluster_layers[0] >= 0])),
-                'cluster_layers': [len(np.unique(layer[layer >= 0])) for layer in cluster_layers]
+                "conversation_name": conversation_id,
+                "processed_date": datetime.now().isoformat(),
+                "num_comments": len(comments),
+                "num_clusters": len(
+                    np.unique(cluster_layers[0][cluster_layers[0] >= 0])
+                ),
+                "cluster_layers": [
+                    len(np.unique(layer[layer >= 0])) for layer in cluster_layers
+                ],
             }
-            
+
             # Store in DynamoDB
             logger.info("Storing results in DynamoDB")
             dynamo_start = time.time()
-            
+
             # Create and store conversation metadata
             conversation_meta = DataConverter.create_conversation_meta(
-                conversation_id,
-                embeddings,
-                cluster_layers,
-                metadata
+                conversation_id, embeddings, cluster_layers, metadata
             )
             dynamo_storage.create_conversation_meta(conversation_meta)
-            
+
             # Convert and store embeddings
             embedding_models = DataConverter.batch_convert_embeddings(
-                conversation_id,
-                embeddings,
-                projection
+                conversation_id, embeddings, comment_ids
             )
-            
+
             # Batch store embeddings
             result = dynamo_storage.batch_create_comment_embeddings(embedding_models)
-            logger.info(f"Stored {result['success']} embeddings with {result['failure']} failures")
-            
+            logger.info(
+                f"Stored {result['success']} embeddings with {result['failure']} failures"
+            )
+
             # Convert and store clusters
             cluster_models = DataConverter.batch_convert_clusters(
-                conversation_id,
-                cluster_layers,
-                projection
+                conversation_id, cluster_layers, projection, comment_ids
             )
-            
+
             # Batch store clusters
             result = dynamo_storage.batch_create_comment_clusters(cluster_models)
-            logger.info(f"Stored {result['success']} cluster assignments with {result['failure']} failures")
-            
+            logger.info(
+                f"Stored {result['success']} cluster assignments with {result['failure']} failures"
+            )
+
             # Convert and store topics
             topic_models = DataConverter.batch_convert_topics(
                 conversation_id,
                 cluster_layers,
                 projection,
+                comment_texts,
                 topic_names={},  # No topic names yet
                 characteristics={},  # No characteristics yet
-                comments=[{'body': comment_text} for comment_text in comment_texts]
             )
-            
+
             # Batch store topics
             result = dynamo_storage.batch_create_cluster_topics(topic_models)
-            logger.info(f"Stored {result['success']} topics with {result['failure']} failures")
-            
+            logger.info(
+                f"Stored {result['success']} topics with {result['failure']} failures"
+            )
+
             # Create comment texts and store
             text_models = []
             for i, comment in enumerate(comments):
                 text_model = DataConverter.create_comment_text(
                     conversation_id,
                     comment_ids[i] if i < len(comment_ids) else i,
-                    comment['txt'],
-                    created=str(comment.get('created', '')),
-                    author_id=str(comment.get('pid', ''))
+                    comment["txt"],
+                    created=str(comment.get("created", "")),
+                    author_id=str(comment.get("pid", "")),
                 )
                 text_models.append(text_model)
-            
+
             # Store texts
             result = dynamo_storage.batch_create_comment_texts(text_models)
-            logger.info(f"Stored {result['success']} comment texts with {result['failure']} failures")
-            
+            logger.info(
+                f"Stored {result['success']} comment texts with {result['failure']} failures"
+            )
+
             dynamo_time = time.time() - dynamo_start
             logger.info(f"DynamoDB storage completed in {dynamo_time:.2f}s")
-            
+
             total_time = time.time() - start_time
             logger.info(f"Total processing time: {total_time:.2f}s")
-            
+
             return {
-                'success': True,
-                'conversation_id': conversation_id,
-                'num_comments': len(comments),
-                'num_clusters': metadata['num_clusters'],
-                'processing_time': {
-                    'total': total_time,
-                    'embedding': embedding_time,
-                    'projection': projection_time,
-                    'clustering': clustering_time,
-                    'storage': dynamo_time
-                }
+                "success": True,
+                "conversation_id": conversation_id,
+                "num_comments": len(comments),
+                "num_clusters": metadata["num_clusters"],
+                "processing_time": {
+                    "total": total_time,
+                    "embedding": embedding_time,
+                    "projection": projection_time,
+                    "clustering": clustering_time,
+                    "storage": dynamo_time,
+                },
             }
         except Exception as e:
             import traceback
+
             logger.error(f"Error processing conversation: {str(e)}")
             logger.error(traceback.format_exc())
             return {
-                'success': False,
-                'error': str(e),
-                'traceback': traceback.format_exc(),
-                'conversation_id': conversation_id
+                "success": False,
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+                "conversation_id": conversation_id,
             }
-    
+
     # Override lambda_handler to use our process_with_local_dynamo
-    if args.event_type == 'process_conversation':
-        from .lambda_handler import lambda_handler as orig_lambda_handler
-        
+    if args.event_type == "process_conversation":
         # Create a custom handler that uses our function
         def lambda_with_local_dynamo(event, context):
             try:
                 # Parse the incoming event
                 from .lambda_handler import parse_event
+
                 data = parse_event(event)
-                
+
                 # Get conversation ID
-                conversation_id = data.get('conversation_id')
+                conversation_id = data.get("conversation_id")
                 if not conversation_id:
                     return {
-                        'statusCode': 400,
-                        'body': json.dumps({
-                            'error': 'Missing conversation_id',
-                            'event': event
-                        })
+                        "statusCode": 400,
+                        "body": json.dumps(
+                            {"error": "Missing conversation_id", "event": event}
+                        ),
                     }
-                    
+
                 # Process with our local function
                 result = process_with_local_dynamo(conversation_id)
-                
-                return {
-                    'statusCode': 200,
-                    'body': json.dumps(result, default=str)
-                }
+
+                return {"statusCode": 200, "body": json.dumps(result, default=str)}
             except Exception as e:
                 import traceback
+
                 logger.error(f"Error processing Lambda event: {str(e)}")
                 logger.error(traceback.format_exc())
-                
+
                 return {
-                    'statusCode': 500,
-                    'body': json.dumps({
-                        'error': str(e),
-                        'trace': traceback.format_exc(),
-                        'event': event
-                    })
+                    "statusCode": 500,
+                    "body": json.dumps(
+                        {
+                            "error": str(e),
+                            "trace": traceback.format_exc(),
+                            "event": event,
+                        }
+                    ),
                 }
-        
+
         # Execute our handler
         start_time = time.time()
         result = lambda_with_local_dynamo(event, context)
@@ -561,42 +569,89 @@ def lambda_local(args):
     else:
         # For other event types, use the original handler
         from .lambda_handler import lambda_handler
-        
+
         # Execute the handler
         start_time = time.time()
         result = lambda_handler(event, context)
         end_time = time.time()
-    
+
     logger.info(f"Lambda execution completed in {end_time - start_time:.2f}s")
     logger.info(f"Result: {json.dumps(result, default=str)}")
-    
+
     return result
+
 
 def main():
     parser = argparse.ArgumentParser(description="Polis Comment Graph CLI")
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
-    
+
     # Test EVOC wrapper command
-    test_parser = subparsers.add_parser("test-evoc", help="Test EVOC wrapper implementation")
-    test_parser.add_argument("--min-cluster-size", type=int, default=5, help="Minimum cluster size")
-    test_parser.add_argument("--min-samples", type=int, default=5, help="Minimum samples")
-    test_parser.add_argument("--num-layers", type=int, default=4, help="Number of cluster layers")
-    
+    test_parser = subparsers.add_parser(
+        "test-evoc", help="Test EVOC wrapper implementation"
+    )
+    test_parser.add_argument(
+        "--min-cluster-size", type=int, default=5, help="Minimum cluster size"
+    )
+    test_parser.add_argument(
+        "--min-samples", type=int, default=5, help="Minimum samples"
+    )
+    test_parser.add_argument(
+        "--num-layers", type=int, default=4, help="Number of cluster layers"
+    )
+
     # Test PostgreSQL connection
-    postgres_parser = subparsers.add_parser("test-postgres", help="Test PostgreSQL connection")
-    postgres_parser.add_argument("--pg-host", default=os.environ.get("DATABASE_HOST", "localhost"), help="PostgreSQL host")
-    postgres_parser.add_argument("--pg-port", type=int, default=int(os.environ.get("DATABASE_PORT", "5432")), help="PostgreSQL port")
-    postgres_parser.add_argument("--pg-database", default=os.environ.get("DATABASE_NAME", "polis"), help="PostgreSQL database")
-    postgres_parser.add_argument("--pg-user", default=os.environ.get("DATABASE_USER", "postgres"), help="PostgreSQL user")
-    postgres_parser.add_argument("--pg-password", default=os.environ.get("DATABASE_PASSWORD", ""), help="PostgreSQL password")
-    postgres_parser.add_argument("--zid", type=int, help="Test with a specific conversation ID")
-    postgres_parser.add_argument("--zinvite", help="Test with a specific conversation invite code")
-    
+    postgres_parser = subparsers.add_parser(
+        "test-postgres", help="Test PostgreSQL connection"
+    )
+    postgres_parser.add_argument(
+        "--pg-host",
+        default=os.environ.get("DATABASE_HOST", "localhost"),
+        help="PostgreSQL host",
+    )
+    postgres_parser.add_argument(
+        "--pg-port",
+        type=int,
+        default=int(os.environ.get("DATABASE_PORT", "5432")),
+        help="PostgreSQL port",
+    )
+    postgres_parser.add_argument(
+        "--pg-database",
+        default=os.environ.get("DATABASE_NAME", "polis"),
+        help="PostgreSQL database",
+    )
+    postgres_parser.add_argument(
+        "--pg-user",
+        default=os.environ.get("DATABASE_USER", "postgres"),
+        help="PostgreSQL user",
+    )
+    postgres_parser.add_argument(
+        "--pg-password",
+        default=os.environ.get("DATABASE_PASSWORD", ""),
+        help="PostgreSQL password",
+    )
+    postgres_parser.add_argument(
+        "--zid", type=int, help="Test with a specific conversation ID"
+    )
+    postgres_parser.add_argument(
+        "--zinvite", help="Test with a specific conversation invite code"
+    )
+
     # Run Lambda handler locally
-    lambda_parser = subparsers.add_parser("lambda-local", help="Run Lambda handler locally")
-    lambda_parser.add_argument("--event-type", choices=["process_conversation", "process_comment"], default="process_conversation", help="Type of event to simulate")
-    lambda_parser.add_argument("--conversation-id", required=True, help="Conversation ID")
-    lambda_parser.add_argument("--comment-id", type=int, help="Comment ID (for process_comment)")
+    lambda_parser = subparsers.add_parser(
+        "lambda-local", help="Run Lambda handler locally"
+    )
+    lambda_parser.add_argument(
+        "--event-type",
+        choices=["process_conversation", "process_comment"],
+        default="process_conversation",
+        help="Type of event to simulate",
+    )
+    lambda_parser.add_argument(
+        "--conversation-id", required=True, help="Conversation ID"
+    )
+    lambda_parser.add_argument(
+        "--comment-id", type=int, help="Comment ID (for process_comment)"
+    )
     lambda_parser.add_argument("--text", help="Comment text (for process_comment)")
     lambda_parser.add_argument("--author-id", help="Author ID (for process_comment)")
     lambda_parser.add_argument("--pg-host", help="PostgreSQL host")
@@ -604,9 +659,9 @@ def main():
     lambda_parser.add_argument("--pg-database", help="PostgreSQL database")
     lambda_parser.add_argument("--pg-user", help="PostgreSQL user")
     lambda_parser.add_argument("--pg-password", help="PostgreSQL password")
-    
+
     args = parser.parse_args()
-    
+
     if args.command == "test-evoc":
         test_evoc(args)
     elif args.command == "test-postgres":
@@ -615,6 +670,7 @@ def main():
         lambda_local(args)
     else:
         parser.print_help()
+
 
 if __name__ == "__main__":
     main()

--- a/delphi/umap_narrative/polismath_commentgraph/lambda_handler.py
+++ b/delphi/umap_narrative/polismath_commentgraph/lambda_handler.py
@@ -10,23 +10,22 @@ import logging
 import os
 import time
 import traceback
-from typing import Dict, Any, List, Optional
-import numpy as np
 from datetime import datetime
-import base64
+from typing import Any, Dict, List
 
-from .core.embedding import EmbeddingEngine
+import boto3
+import numpy as np
+
 from .core.clustering import ClusteringEngine
-from .utils.storage import DynamoDBStorage, PostgresClient
-from .utils.converter import DataConverter
+from .core.embedding import EmbeddingEngine
 from .schemas.dynamo_models import (
-    ConversationMeta,
-    CommentEmbedding,
     CommentCluster,
-    ClusterTopic,
-    UMAPGraphEdge
+    CommentEmbedding,
+    UMAPGraphEdge,
     # CommentText - removed to avoid duplication with PostgreSQL
 )
+from .utils.converter import DataConverter
+from .utils.storage import DynamoDBStorage, PostgresClient
 
 # Configure logging
 logging.basicConfig(
@@ -41,42 +40,44 @@ clustering_engine = ClusteringEngine()
 dynamo_storage = DynamoDBStorage()
 postgres_client = PostgresClient()
 
+
 def parse_event(event: Dict[str, Any]) -> Dict[str, Any]:
     """
     Parse the Lambda event to extract needed information.
-    
+
     Args:
         event: Lambda event object
-        
+
     Returns:
         Parsed event data
     """
     logger.info(f"Parsing event: {json.dumps(event, default=str)}")
-    
+
     # Check if this is an SNS event
-    if 'Records' in event and len(event['Records']) > 0:
-        record = event['Records'][0]
-        if 'Sns' in record:
+    if "Records" in event and len(event["Records"]) > 0:
+        record = event["Records"][0]
+        if "Sns" in record:
             # Parse SNS message
-            message = json.loads(record['Sns']['Message'])
+            message = json.loads(record["Sns"]["Message"])
             logger.info(f"Parsed SNS message: {json.dumps(message, default=str)}")
             return message
-        elif 'eventSource' in record and record['eventSource'] == 'aws:sqs':
+        elif "eventSource" in record and record["eventSource"] == "aws:sqs":
             # Parse SQS message
-            message = json.loads(record['body'])
+            message = json.loads(record["body"])
             logger.info(f"Parsed SQS message: {json.dumps(message, default=str)}")
             return message
-        
+
     # If not an SNS/SQS event, return the event as is
     return event
+
 
 def get_comment_data(conversation_id: str) -> List[Dict[str, Any]]:
     """
     Get comment data from PostgreSQL.
-    
+
     Args:
         conversation_id: Conversation ID string
-        
+
     Returns:
         List of comments
     """
@@ -90,188 +91,199 @@ def get_comment_data(conversation_id: str) -> List[Dict[str, Any]]:
             if zid is None:
                 logger.error(f"Conversation not found for id: {conversation_id}")
                 return []
-                
+
         logger.info(f"Retrieving comments for conversation {zid}")
-        
+
         # Get all comments for this conversation
         comments = postgres_client.get_comments_by_conversation(zid)
         logger.info(f"Retrieved {len(comments)} comments from PostgreSQL")
-        
+
         # Format comments for processing
         comment_data = []
         for comment in comments:
-            comment_data.append({
-                'comment_id': comment['tid'],
-                'text': comment['txt'],
-                'created': comment.get('created', ''),
-                'author_id': comment.get('pid', '')
-            })
-            
+            comment_data.append(
+                {
+                    "comment_id": comment["tid"],
+                    "text": comment["txt"],
+                    "created": comment.get("created", ""),
+                    "author_id": comment.get("pid", ""),
+                }
+            )
+
         return comment_data
     except Exception as e:
         logger.error(f"Error getting comment data: {str(e)}")
         logger.error(traceback.format_exc())
         return []
 
+
 def process_conversation(conversation_id: str) -> Dict[str, Any]:
     """
     Process a conversation with EVOC clustering.
-    
+
     Args:
         conversation_id: Conversation ID
-        
+
     Returns:
         Processing results
     """
     start_time = time.time()
     logger.info(f"Processing conversation: {conversation_id}")
-    
+
     # Get comments from PostgreSQL
     comment_data = get_comment_data(conversation_id)
-    
+
     if not comment_data:
         logger.error(f"No comments found for conversation: {conversation_id}")
         return {
-            'success': False,
-            'error': 'No comments found',
-            'conversation_id': conversation_id
+            "success": False,
+            "error": "No comments found",
+            "conversation_id": conversation_id,
         }
-    
+
     # Extract text and IDs
-    comments = [c['text'] for c in comment_data]
-    comment_ids = [c['comment_id'] for c in comment_data]
-    
+    comments = [c["text"] for c in comment_data]
+    comment_ids = [c["comment_id"] for c in comment_data]
+
     # Generate embeddings
     logger.info(f"Generating embeddings for {len(comments)} comments")
     embedding_start = time.time()
     embeddings = embedding_engine.embed_batch(comments)
     embedding_time = time.time() - embedding_start
     logger.info(f"Embeddings generated in {embedding_time:.2f}s")
-    
+
     # Project to 2D
     logger.info("Projecting embeddings to 2D using UMAP")
     projection_start = time.time()
     projection = clustering_engine.project_to_2d(embeddings)
     projection_time = time.time() - projection_start
     logger.info(f"Projection completed in {projection_time:.2f}s")
-    
+
     # Create clustering layers
     logger.info("Creating clustering layers")
     clustering_start = time.time()
     cluster_layers = clustering_engine.create_clustering_layers(
-        embeddings,
-        num_layers=4
+        embeddings, num_layers=4
     )
     clustering_time = time.time() - clustering_start
     logger.info(f"Clustering completed in {clustering_time:.2f}s")
-    
+
     # Create conversation metadata
     metadata = {
-        'conversation_name': conversation_id,
-        'processed_date': datetime.now().isoformat(),
-        'num_comments': len(comments),
-        'num_clusters': len(np.unique(cluster_layers[0][cluster_layers[0] >= 0])),
-        'cluster_layers': [len(np.unique(layer[layer >= 0])) for layer in cluster_layers]
+        "conversation_name": conversation_id,
+        "processed_date": datetime.now().isoformat(),
+        "num_comments": len(comments),
+        "num_clusters": len(np.unique(cluster_layers[0][cluster_layers[0] >= 0])),
+        "cluster_layers": [
+            len(np.unique(layer[layer >= 0])) for layer in cluster_layers
+        ],
     }
-    
+
     # Store in DynamoDB
     logger.info("Storing results in DynamoDB")
     dynamo_start = time.time()
-    
+
     # Create and store conversation metadata
     conversation_meta = DataConverter.create_conversation_meta(
-        conversation_id,
-        embeddings,
-        cluster_layers,
-        metadata
+        conversation_id, embeddings, cluster_layers, metadata
     )
     dynamo_storage.create_conversation_meta(conversation_meta)
-    
+
     # Convert and store embeddings
     embedding_models = []
     for i, embedding in enumerate(embeddings):
         # Calculate nearest neighbors
-        distances = np.sqrt(np.sum((projection - projection[i])**2, axis=1))
+        distances = np.sqrt(np.sum((projection - projection[i]) ** 2, axis=1))
         nearest_indices = np.argsort(distances)[1:6]  # Skip self
         nearest_distances = distances[nearest_indices]
-        
+
         model = DataConverter.create_comment_embedding(
-            conversation_id,
-            comment_ids[i] if i < len(comment_ids) else i,
-            embedding
+            conversation_id, comment_ids[i] if i < len(comment_ids) else i, embedding
         )
-        
+
         embedding_models.append(model)
-    
+
     # Batch store embeddings
     result = dynamo_storage.batch_create_comment_embeddings(embedding_models)
-    logger.info(f"Stored {result['success']} embeddings with {result['failure']} failures")
-    
+    logger.info(
+        f"Stored {result['success']} embeddings with {result['failure']} failures"
+    )
+
     # Convert and store clusters
     cluster_models = DataConverter.batch_convert_clusters(
-        conversation_id,
-        cluster_layers,
-        projection
+        conversation_id, cluster_layers, projection, comment_ids
     )
-    
+
     # Batch store clusters
     result = dynamo_storage.batch_create_comment_clusters(cluster_models)
-    logger.info(f"Stored {result['success']} cluster assignments with {result['failure']} failures")
-    
+    logger.info(
+        f"Stored {result['success']} cluster assignments with {result['failure']} failures"
+    )
+
     # Convert and store topics
     topic_models = DataConverter.batch_convert_topics(
         conversation_id,
         cluster_layers,
         projection,
+        comments,  # This is comment_texts from process_comments
         topic_names={},  # No topic names yet
         characteristics={},  # No characteristics yet
-        comments=[{'body': comment} for comment in comments]
     )
-    
+
     # Batch store topics
     result = dynamo_storage.batch_create_cluster_topics(topic_models)
     logger.info(f"Stored {result['success']} topics with {result['failure']} failures")
-    
+
     # Create and store graph edges
     edges = []
-    
+
     # Calculate threshold distance for significant connections
     all_distances = []
     for i in range(min(100, len(projection))):
-        distances = np.sqrt(np.sum((projection - projection[i])**2, axis=1))
+        distances = np.sqrt(np.sum((projection - projection[i]) ** 2, axis=1))
         all_distances.extend(distances)
     all_distances = np.array(all_distances)
     distance_threshold = np.percentile(all_distances, 5)  # Bottom 5% of distances
-    
+
     # Generate sample edges
     generated_edges = set()
     for i in range(len(projection)):
         # Find nearest neighbors
-        distances = np.sqrt(np.sum((projection - projection[i])**2, axis=1))
+        distances = np.sqrt(np.sum((projection - projection[i]) ** 2, axis=1))
         nearest_indices = np.argsort(distances)[1:6]  # Skip self
         nearest_distances = distances[nearest_indices]
-        
-        for j, (neighbor_idx, distance) in enumerate(zip(nearest_indices, nearest_distances)):
+
+        for j, (neighbor_idx, distance) in enumerate(
+            zip(nearest_indices, nearest_distances)
+        ):
             # Only create edge once (avoid duplicates)
             edge_key = tuple(sorted([i, neighbor_idx]))
             if edge_key in generated_edges:
                 continue
-            
+
             generated_edges.add(edge_key)
-            
+
             # Only include significant connections
             if distance > distance_threshold:
                 continue
-            
+
             # Determine shared cluster layers
             shared_layers = []
             for layer_id, layer in enumerate(cluster_layers):
-                if layer[i] >= 0 and layer[neighbor_idx] >= 0 and layer[i] == layer[neighbor_idx]:
+                if (
+                    layer[i] >= 0
+                    and layer[neighbor_idx] >= 0
+                    and layer[i] == layer[neighbor_idx]
+                ):
                     shared_layers.append(layer_id)
-            
+
             comment_id_i = comment_ids[i] if i < len(comment_ids) else i
-            comment_id_j = comment_ids[neighbor_idx] if neighbor_idx < len(comment_ids) else neighbor_idx
-            
+            comment_id_j = (
+                comment_ids[neighbor_idx]
+                if neighbor_idx < len(comment_ids)
+                else neighbor_idx
+            )
+
             edge = DataConverter.create_graph_edge(
                 conversation_id,
                 comment_id_i,
@@ -279,187 +291,197 @@ def process_conversation(conversation_id: str) -> Dict[str, Any]:
                 distance,
                 distance,
                 True,
-                shared_layers
+                shared_layers,
             )
-            
+
             edges.append(edge)
-    
+
     # Batch store edges
     result = dynamo_storage.batch_create_graph_edges(edges)
-    logger.info(f"Stored {result['success']} graph edges with {result['failure']} failures")
-    
+    logger.info(
+        f"Stored {result['success']} graph edges with {result['failure']} failures"
+    )
+
     # Create and store comment texts
     text_models = []
-    
+
     for i, comment_data_item in enumerate(comment_data):
-        comment_id = comment_data_item['comment_id']
-        text = comment_data_item['text']
-        created = comment_data_item.get('created', '')
-        author_id = comment_data_item.get('author_id', '')
-        
+        comment_id = comment_data_item["comment_id"]
+        text = comment_data_item["text"]
+        created = comment_data_item.get("created", "")
+        author_id = comment_data_item.get("author_id", "")
+
         model = DataConverter.create_comment_text(
-            conversation_id,
-            comment_id,
-            text,
-            created=created,
-            author_id=author_id
+            conversation_id, comment_id, text, created=created, author_id=author_id
         )
-        
+
         text_models.append(model)
-    
+
     # Batch store texts
     result = dynamo_storage.batch_create_comment_texts(text_models)
-    logger.info(f"Stored {result['success']} comment texts with {result['failure']} failures")
-    
+    logger.info(
+        f"Stored {result['success']} comment texts with {result['failure']} failures"
+    )
+
     dynamo_time = time.time() - dynamo_start
     logger.info(f"DynamoDB storage completed in {dynamo_time:.2f}s")
-    
+
     total_time = time.time() - start_time
     logger.info(f"Total processing time: {total_time:.2f}s")
-    
+
     return {
-        'success': True,
-        'conversation_id': conversation_id,
-        'num_comments': len(comments),
-        'num_clusters': metadata['num_clusters'],
-        'processing_time': {
-            'total': total_time,
-            'embedding': embedding_time,
-            'projection': projection_time,
-            'clustering': clustering_time,
-            'storage': dynamo_time
-        }
+        "success": True,
+        "conversation_id": conversation_id,
+        "num_comments": len(comments),
+        "num_clusters": metadata["num_clusters"],
+        "processing_time": {
+            "total": total_time,
+            "embedding": embedding_time,
+            "projection": projection_time,
+            "clustering": clustering_time,
+            "storage": dynamo_time,
+        },
     }
+
 
 def process_new_comment(comment_data: Dict[str, Any]) -> Dict[str, Any]:
     """
     Process a single new comment and update DynamoDB.
-    
+
     Args:
         comment_data: Comment data including conversation_id, comment_id, and text
-        
+
     Returns:
         Processing results
     """
     start_time = time.time()
     logger.info(f"Processing new comment: {json.dumps(comment_data, default=str)}")
-    
+
     # Extract data
-    conversation_id = comment_data.get('conversation_id')
-    comment_id = comment_data.get('comment_id')
-    text = comment_data.get('text')
-    author_id = comment_data.get('author_id')
-    created = comment_data.get('created')
-    
+    conversation_id = comment_data.get("conversation_id")
+    comment_id = comment_data.get("comment_id")
+    text = comment_data.get("text")
+
     if not all([conversation_id, comment_id, text]):
         logger.error("Missing required fields in comment data")
         return {
-            'success': False,
-            'error': 'Missing required fields',
-            'comment_data': comment_data
+            "success": False,
+            "error": "Missing required fields",
+            "comment_data": comment_data,
         }
-    
+
     # Generate embedding for new comment
-    logger.info(f"Generating embedding for comment {comment_id} in conversation {conversation_id}")
+    logger.info(
+        f"Generating embedding for comment {comment_id} in conversation {conversation_id}"
+    )
     embedding = embedding_engine.embed_text(text)
-    
+
     # Get existing data from DynamoDB
     meta = dynamo_storage.get_conversation_meta(conversation_id)
     if not meta:
         logger.error(f"Conversation {conversation_id} not found in DynamoDB")
         return {
-            'success': False,
-            'error': 'Conversation not found',
-            'conversation_id': conversation_id
+            "success": False,
+            "error": "Conversation not found",
+            "conversation_id": conversation_id,
         }
-    
+
     # Get all existing comment embeddings
-    table = dynamo_storage.dynamodb.Table(dynamo_storage.table_names['comment_embeddings'])
-    response = table.query(
-        KeyConditionExpression=Key('conversation_id').eq(conversation_id)
+    table = dynamo_storage.dynamodb.Table(
+        dynamo_storage.table_names["comment_embeddings"]
     )
-    existing_embeddings = response.get('Items', [])
-    
-    # Handle pagination if needed
-    while 'LastEvaluatedKey' in response:
-        response = table.query(
-            KeyConditionExpression=Key('conversation_id').eq(conversation_id),
-            ExclusiveStartKey=response['LastEvaluatedKey']
+    response = table.query(
+        KeyConditionExpression=boto3.dynamodb.conditions.Key("conversation_id").eq(
+            conversation_id
         )
-        existing_embeddings.extend(response.get('Items', []))
-    
+    )
+    existing_embeddings = response.get("Items", [])
+
+    # Handle pagination if needed
+    while "LastEvaluatedKey" in response:
+        response = table.query(
+            KeyConditionExpression=boto3.dynamodb.conditions.Key("conversation_id").eq(
+                conversation_id
+            ),
+            ExclusiveStartKey=response["LastEvaluatedKey"],
+        )
+        existing_embeddings.extend(response.get("Items", []))
+
     # Convert to numpy array
     existing_vectors = []
     for item in existing_embeddings:
-        existing_vectors.append(np.array(item['embedding']['vector']))
-    
+        existing_vectors.append(np.array(item["embedding"]["vector"]))
+
     existing_vectors = np.array(existing_vectors)
-    
+
     # Add new embedding to the array
     all_vectors = np.concatenate([existing_vectors, embedding.reshape(1, -1)])
-    
+
     # Project to 2D
     projection = clustering_engine.project_to_2d(all_vectors)
-    
+
     # New comment's projection is the last one
     new_projection = projection[-1]
-    
+
     # Create clusters using all vectors
     cluster_layers = clustering_engine.create_clustering_layers(
-        all_vectors,
-        num_layers=4
+        all_vectors, num_layers=4
     )
-    
+
     # Extract cluster assignments for the new comment
     new_clusters = {}
     for layer_idx, layer in enumerate(cluster_layers):
         new_clusters[f"layer{layer_idx}_cluster_id"] = int(layer[-1])
-    
+
     # Calculate nearest neighbors
-    distances = np.sqrt(np.sum((projection[:-1] - new_projection)**2, axis=1))
+    distances = np.sqrt(np.sum((projection[:-1] - new_projection) ** 2, axis=1))
     nearest_indices = np.argsort(distances)[:5]
     nearest_distances = distances[nearest_indices]
-    
+
     # Create nearest neighbor indices and distances - these are indices in the original list
     nearest_neighbor_indices = []
     for idx in nearest_indices:
-        nearest_neighbor_indices.append(int(existing_embeddings[idx]['comment_id']))
-    
+        nearest_neighbor_indices.append(int(existing_embeddings[idx]["comment_id"]))
+
     # Create and store comment embedding
     embedding_model = CommentEmbedding(
         conversation_id=conversation_id,
         comment_id=int(comment_id),
-        embedding=DataConverter.create_embedding_model(embedding)
+        embedding=DataConverter.create_embedding_model(embedding),
     )
-    
+
     dynamo_storage.create_comment_embedding(embedding_model)
-    
+
     # Create and store comment cluster
     cluster_model = CommentCluster(
-        conversation_id=conversation_id,
-        comment_id=int(comment_id),
-        **new_clusters
+        conversation_id=conversation_id, comment_id=int(comment_id), **new_clusters
     )
-    
+
     dynamo_storage.create_comment_cluster(cluster_model)
-    
+
     # Note: Comment texts are not stored in DynamoDB
     # They are kept in PostgreSQL as the single source of truth
     # This avoids data duplication and ensures consistency
-    
+
     # Create and store graph edges to nearest neighbors
     edges = []
-    for i, (neighbor_idx, distance) in enumerate(zip(nearest_indices, nearest_distances)):
-        neighbor_id = int(existing_embeddings[neighbor_idx]['comment_id'])
-        
+    for i, (neighbor_idx, distance) in enumerate(
+        zip(nearest_indices, nearest_distances)
+    ):
+        neighbor_id = int(existing_embeddings[neighbor_idx]["comment_id"])
+
         # Determine shared cluster layers
         shared_layers = []
         for layer_id, layer in enumerate(cluster_layers):
             new_cluster = layer[-1]
             neighbor_cluster = layer[neighbor_idx]
-            if new_cluster >= 0 and neighbor_cluster >= 0 and new_cluster == neighbor_cluster:
+            if (
+                new_cluster >= 0
+                and neighbor_cluster >= 0
+                and new_cluster == neighbor_cluster
+            ):
                 shared_layers.append(layer_id)
-        
+
         edge = UMAPGraphEdge(
             conversation_id=conversation_id,
             edge_id=f"{comment_id}_{neighbor_id}",
@@ -468,100 +490,90 @@ def process_new_comment(comment_data: Dict[str, Any]) -> Dict[str, Any]:
             weight=1.0 - distance,  # Convert distance to similarity
             distance=float(distance),
             is_nearest_neighbor=True,
-            shared_cluster_layers=shared_layers
+            shared_cluster_layers=shared_layers,
         )
-        
+
         edges.append(edge)
-    
+
     # Store edges
     for edge in edges:
         dynamo_storage.create_graph_edge(edge)
-    
+
     total_time = time.time() - start_time
     logger.info(f"Processed new comment in {total_time:.2f}s")
-    
+
     return {
-        'success': True,
-        'conversation_id': conversation_id,
-        'comment_id': comment_id,
-        'processing_time': total_time,
-        'cluster_assignments': new_clusters
+        "success": True,
+        "conversation_id": conversation_id,
+        "comment_id": comment_id,
+        "processing_time": total_time,
+        "cluster_assignments": new_clusters,
     }
+
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """
     AWS Lambda handler function.
-    
+
     Args:
         event: Lambda event object
         context: Lambda context object
-        
+
     Returns:
         Lambda response
     """
     try:
         # Parse the incoming event
         data = parse_event(event)
-        
+
         # Determine the type of event
-        event_type = data.get('event_type', 'process_conversation')
-        
-        if event_type == 'process_conversation':
+        event_type = data.get("event_type", "process_conversation")
+
+        if event_type == "process_conversation":
             # Process an entire conversation
-            conversation_id = data.get('conversation_id')
+            conversation_id = data.get("conversation_id")
             if not conversation_id:
                 return {
-                    'statusCode': 400,
-                    'body': json.dumps({
-                        'error': 'Missing conversation_id',
-                        'event': event
-                    })
+                    "statusCode": 400,
+                    "body": json.dumps(
+                        {"error": "Missing conversation_id", "event": event}
+                    ),
                 }
-                
+
             result = process_conversation(conversation_id)
-            
-            return {
-                'statusCode': 200,
-                'body': json.dumps(result, default=str)
-            }
-            
-        elif event_type == 'process_comment':
+
+            return {"statusCode": 200, "body": json.dumps(result, default=str)}
+
+        elif event_type == "process_comment":
             # Process a single new comment
-            comment_data = data.get('comment_data')
+            comment_data = data.get("comment_data")
             if not comment_data:
                 return {
-                    'statusCode': 400,
-                    'body': json.dumps({
-                        'error': 'Missing comment_data',
-                        'event': event
-                    })
+                    "statusCode": 400,
+                    "body": json.dumps(
+                        {"error": "Missing comment_data", "event": event}
+                    ),
                 }
-                
+
             result = process_new_comment(comment_data)
-            
-            return {
-                'statusCode': 200,
-                'body': json.dumps(result, default=str)
-            }
-            
+
+            return {"statusCode": 200, "body": json.dumps(result, default=str)}
+
         else:
             return {
-                'statusCode': 400,
-                'body': json.dumps({
-                    'error': f'Unknown event_type: {event_type}',
-                    'event': event
-                })
+                "statusCode": 400,
+                "body": json.dumps(
+                    {"error": f"Unknown event_type: {event_type}", "event": event}
+                ),
             }
-            
+
     except Exception as e:
         logger.error(f"Error processing Lambda event: {str(e)}")
         logger.error(traceback.format_exc())
-        
+
         return {
-            'statusCode': 500,
-            'body': json.dumps({
-                'error': str(e),
-                'trace': traceback.format_exc(),
-                'event': event
-            })
+            "statusCode": 500,
+            "body": json.dumps(
+                {"error": str(e), "trace": traceback.format_exc(), "event": event}
+            ),
         }

--- a/delphi/umap_narrative/polismath_commentgraph/utils/converter.py
+++ b/delphi/umap_narrative/polismath_commentgraph/utils/converter.py
@@ -2,35 +2,35 @@
 Utilities for converting between data formats for the Polis comment graph microservice.
 """
 
-import numpy as np
-import json
-import os
-from typing import Dict, List, Any, Optional, Tuple, Union
 import logging
+import os
 from datetime import datetime
 from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from ..schemas.dynamo_models import (
+    ClusterCharacteristic,
+    ClusterLayer,
+    ClusterReference,
+    ClusterTopic,
+    CommentCluster,
+    CommentEmbedding,
+    ConversationMeta,
+    Coordinates,
+    Embedding,
+    EnhancedTopicName,
+    EVOCParameters,
+    LLMTopicName,
+    UMAPGraphEdge,
+    # CommentText - removed to avoid duplicating data in DynamoDB
+    UMAPParameters,
+)
 
 # Configure logging
 logger = logging.getLogger(__name__)
-from ..schemas.dynamo_models import (
-    ConversationMeta,
-    CommentEmbedding,
-    CommentCluster,
-    ClusterTopic,
-    UMAPGraphEdge,
-    ClusterCharacteristic,
-    EnhancedTopicName,
-    LLMTopicName,
-    # CommentText - removed to avoid duplicating data in DynamoDB
-    UMAPParameters,
-    EVOCParameters,
-    ClusterLayer,
-    Embedding,
-    Coordinates,
-    ClusterReference
-)
 
-logger = logging.getLogger(__name__)
 
 class DataConverter:
     """
@@ -38,76 +38,80 @@ class DataConverter:
     Handles conversion of NumPy arrays, JSON files, and CSV data to the
     appropriate schema models.
     """
-    
+
     @staticmethod
     def convert_floats_to_decimal(obj: Any) -> Any:
         """
         Recursively converts all floating-point numbers to Decimal for DynamoDB compatibility.
-        
+
         Args:
             obj: Input object to convert
-            
+
         Returns:
             Object with all floating-point numbers converted to Decimal
         """
         if isinstance(obj, float):
             return Decimal(str(obj))
         elif isinstance(obj, dict):
-            return {k: DataConverter.convert_floats_to_decimal(v) for k, v in obj.items()}
+            return {
+                k: DataConverter.convert_floats_to_decimal(v) for k, v in obj.items()
+            }
         elif isinstance(obj, list):
             return [DataConverter.convert_floats_to_decimal(item) for item in obj]
         elif isinstance(obj, np.ndarray):
-            return [DataConverter.convert_floats_to_decimal(item) for item in obj.tolist()]
+            return [
+                DataConverter.convert_floats_to_decimal(item) for item in obj.tolist()
+            ]
         elif isinstance(obj, np.float32) or isinstance(obj, np.float64):
             return Decimal(str(obj))
         elif isinstance(obj, np.int32) or isinstance(obj, np.int64):
             return int(obj)
         return obj
-    
+
     @staticmethod
     def prepare_for_dynamodb(item: Dict[str, Any]) -> Dict[str, Any]:
         """
         Prepare a dictionary for storage in DynamoDB by converting floats to Decimals.
-        
+
         Args:
             item: Dictionary to prepare
-            
+
         Returns:
             Dictionary with all floating-point numbers converted to Decimal
         """
         return DataConverter.convert_floats_to_decimal(item)
-    
+
     @staticmethod
     def numpy_to_list(array: np.ndarray) -> List:
         """
         Convert a NumPy array to a Python list.
-        
+
         Args:
             array: NumPy array to convert
-            
+
         Returns:
             Python list representation of the array
         """
         if array is None:
             return []
         return array.tolist()
-    
+
     @staticmethod
     def create_conversation_meta(
         conversation_id: str,
         document_vectors: np.ndarray,
         cluster_layers: List[np.ndarray],
-        metadata: Dict[str, Any] = None
+        metadata: Dict[str, Any] = None,
     ) -> ConversationMeta:
         """
         Create a ConversationMeta model from raw data.
-        
+
         Args:
             conversation_id: ID of the conversation
             document_vectors: Embedding vectors for all comments
             cluster_layers: List of cluster label arrays, one per layer
             metadata: Additional metadata dictionary
-            
+
         Returns:
             ConversationMeta model object
         """
@@ -116,57 +120,55 @@ class DataConverter:
         for i, layer in enumerate(cluster_layers):
             # Count non-noise clusters
             num_clusters = len(np.unique(layer[layer >= 0]))
-            
+
             # Create layer description
-            description = 'Fine-grained grouping'
+            description = "Fine-grained grouping"
             if i == len(cluster_layers) - 1:
-                description = 'Coarse grouping'
+                description = "Coarse grouping"
             elif i > 0:
-                description = f'Medium grouping (layer {i})'
-            
+                description = f"Medium grouping (layer {i})"
+
             cluster_layer_info.append(
                 ClusterLayer(
-                    layer_id=i,
-                    num_clusters=num_clusters,
-                    description=description
+                    layer_id=i, num_clusters=num_clusters, description=description
                 )
             )
-        
+
         # Create UMAP parameters (with defaults)
         umap_params = UMAPParameters()
-        
+
         # Create EVOC parameters (with defaults)
         evoc_params = EVOCParameters()
-        
+
         # Create the model
         meta = ConversationMeta(
             conversation_id=conversation_id,
             processed_date=datetime.now().isoformat(),
             num_comments=len(document_vectors),
-            num_participants=metadata.get('num_participants', 0) if metadata else 0,
-            embedding_model=os.environ.get("SENTENCE_TRANSFORMER_MODEL", "all-MiniLM-L6-v2"),
+            num_participants=metadata.get("num_participants", 0) if metadata else 0,
+            embedding_model=os.environ.get(
+                "SENTENCE_TRANSFORMER_MODEL", "all-MiniLM-L6-v2"
+            ),
             umap_parameters=umap_params,
             evoc_parameters=evoc_params,
             cluster_layers=cluster_layer_info,
-            metadata=metadata or {}
+            metadata=metadata or {},
         )
-        
+
         return meta
-    
+
     @staticmethod
     def create_comment_embedding(
-        conversation_id: str,
-        comment_id: int,
-        vector: np.ndarray
+        conversation_id: str, comment_id: int, vector: np.ndarray
     ) -> CommentEmbedding:
         """
         Create a CommentEmbedding model from raw data.
-        
+
         Args:
             conversation_id: ID of the conversation
             comment_id: ID of the comment
             vector: Embedding vector
-            
+
         Returns:
             CommentEmbedding model object
         """
@@ -174,83 +176,87 @@ class DataConverter:
         embedding = Embedding(
             vector=vector.tolist() if isinstance(vector, np.ndarray) else vector,
             dimensions=len(vector),
-            model=os.environ.get("SENTENCE_TRANSFORMER_MODEL", "all-MiniLM-L6-v2")
+            model=os.environ.get("SENTENCE_TRANSFORMER_MODEL", "all-MiniLM-L6-v2"),
         )
-        
+
         # Create the model with just the embedding vector
         model = CommentEmbedding(
             conversation_id=conversation_id,
             comment_id=int(comment_id),
-            embedding=embedding
+            embedding=embedding,
         )
-        
+
         return model
-    
+
     @staticmethod
     def create_comment_cluster(
         conversation_id: str,
         comment_id: int,
-        cluster_layers: List[np.ndarray],
-        distances: Optional[Dict[str, float]] = None,
-        confidences: Optional[Dict[str, float]] = None
+        cluster_layers: list[np.ndarray],
+        comment_index: int,
+        distances: dict[str, float] | None = None,
+        confidences: dict[str, float] | None = None,
     ) -> CommentCluster:
         """
         Create a CommentCluster model from raw data.
-        
+
         Args:
             conversation_id: ID of the conversation
             comment_id: ID of the comment
             cluster_layers: List of cluster label arrays, one per layer
+            comment_index: Index of the comment in the arrays (for layer access)
             distances: Optional dictionary of distances to centroids
             confidences: Optional dictionary of cluster confidence scores
-            
+
         Returns:
             CommentCluster model object
         """
         # Create base data dictionary
         data = {
-            'conversation_id': conversation_id,
-            'comment_id': comment_id,  # Will be converted to Decimal by Pydantic model
-            'is_outlier': False
+            "conversation_id": conversation_id,
+            "comment_id": comment_id,  # Will be converted to Decimal by Pydantic model
+            "is_outlier": False,
         }
-        
+
         # Add layer cluster IDs
         for i, layer in enumerate(cluster_layers):
-            if comment_id < len(layer):
+            if comment_index < len(layer):
                 # Ensure proper conversion path for numpy values
                 # First convert to a Python float via string to avoid precision issues
                 # Then convert to int for cluster IDs (or keep as -1 for outliers)
                 try:
-                    if layer[comment_id] >= 0:
-                        cluster_id = int(float(str(layer[comment_id])))
+                    if layer[comment_index] >= 0:
+                        cluster_id = int(float(str(layer[comment_index])))
                     else:
                         cluster_id = -1
-                    data[f'layer{i}_cluster_id'] = cluster_id
+                    data[f"layer{i}_cluster_id"] = cluster_id
                 except (ValueError, TypeError) as e:
-                    logger.warning(f"Conversion error for cluster ID at layer {i}, comment {comment_id}: {e}")
+                    logger.warning(
+                        f"Conversion error for cluster ID at layer {i}, comment {comment_id} (index {comment_index}): {e}"
+                    )
                     # Use a safe default
-                    data[f'layer{i}_cluster_id'] = 0
-                
+                    data[f"layer{i}_cluster_id"] = 0
+
                 # Mark as outlier if any layer has -1
                 if cluster_id == -1:
-                    data['is_outlier'] = True
-        
+                    data["is_outlier"] = True
+
         # Add distances and confidences if available
         if distances:
             # Convert all float values to Decimal for DynamoDB compatibility
-            data['distance_to_centroid'] = {k: float(v) for k, v in distances.items()}
-        
+            data["distance_to_centroid"] = {k: float(v) for k, v in distances.items()}
+
         if confidences:
             # Convert all float values to Decimal for DynamoDB compatibility
-            data['cluster_confidence'] = {k: float(v) for k, v in confidences.items()}
-        
+            data["cluster_confidence"] = {k: float(v) for k, v in confidences.items()}
+
         # Create the model directly from the data dict
         # The model creation will use pydantic to validate the types
         # DataConverter.prepare_for_dynamodb will handle the proper conversion to Decimal
         model = CommentCluster(**DataConverter.prepare_for_dynamodb(data))
-        
+
         return model
-    
+
     @staticmethod
     def create_cluster_topic(
         conversation_id: str,
@@ -263,11 +269,11 @@ class DataConverter:
         top_words: Optional[List[str]] = None,
         top_tfidf_scores: Optional[List[float]] = None,
         parent_cluster: Optional[Dict[str, int]] = None,
-        child_clusters: Optional[List[Dict[str, int]]] = None
+        child_clusters: Optional[List[Dict[str, int]]] = None,
     ) -> ClusterTopic:
         """
         Create a ClusterTopic model from raw data.
-        
+
         Args:
             conversation_id: ID of the conversation
             layer_id: ID of the layer
@@ -280,38 +286,41 @@ class DataConverter:
             top_tfidf_scores: Optional list of TF-IDF scores
             parent_cluster: Optional parent cluster reference
             child_clusters: Optional list of child cluster references
-            
+
         Returns:
             ClusterTopic model object
         """
         # Create cluster key
-        cluster_key = f'layer{layer_id}_{cluster_id}'
-        
+        cluster_key = f"layer{layer_id}_{cluster_id}"
+
         # Create centroid coordinates
         centroid_coords = Coordinates(
-            x=float(centroid[0]) if isinstance(centroid, np.ndarray) else float(centroid['x']),
-            y=float(centroid[1]) if isinstance(centroid, np.ndarray) else float(centroid['y'])
+            x=float(centroid[0])
+            if isinstance(centroid, np.ndarray)
+            else float(centroid["x"]),
+            y=float(centroid[1])
+            if isinstance(centroid, np.ndarray)
+            else float(centroid["y"]),
         )
-        
+
         # Create parent cluster reference if provided
         parent_ref = None
         if parent_cluster:
             parent_ref = ClusterReference(
-                layer_id=parent_cluster['layer_id'],
-                cluster_id=parent_cluster['cluster_id']
+                layer_id=parent_cluster["layer_id"],
+                cluster_id=parent_cluster["cluster_id"],
             )
-        
+
         # Create child cluster references if provided
         child_refs = None
         if child_clusters:
             child_refs = [
                 ClusterReference(
-                    layer_id=child['layer_id'],
-                    cluster_id=child['cluster_id']
+                    layer_id=child["layer_id"], cluster_id=child["cluster_id"]
                 )
                 for child in child_clusters
             ]
-        
+
         # Create the model
         model = ClusterTopic(
             conversation_id=conversation_id,
@@ -325,11 +334,11 @@ class DataConverter:
             top_words=top_words,
             top_tfidf_scores=top_tfidf_scores,
             parent_cluster=parent_ref,
-            child_clusters=child_refs
+            child_clusters=child_refs,
         )
-        
+
         return model
-    
+
     @staticmethod
     def create_graph_edge(
         conversation_id: str,
@@ -339,11 +348,11 @@ class DataConverter:
         distance: float,
         is_nearest_neighbor: bool,
         shared_layers: List[int],
-        position: Optional[np.ndarray] = None
+        position: Optional[np.ndarray] = None,
     ) -> UMAPGraphEdge:
         """
         Create a UMAPGraphEdge model from raw data.
-        
+
         Args:
             conversation_id: ID of the conversation
             source_id: ID of the source comment
@@ -353,24 +362,21 @@ class DataConverter:
             is_nearest_neighbor: Whether this is a nearest neighbor edge
             shared_layers: List of layer IDs where both comments are in the same cluster
             position: Optional 2D coordinates for the node (only used when source_id = target_id)
-            
+
         Returns:
             UMAPGraphEdge model object
         """
         # For standard edges (not nodes), ensure source_id < target_id
         if source_id != target_id and source_id > target_id:
             source_id, target_id = target_id, source_id
-            
-        edge_id = f'{source_id}_{target_id}'
-        
+
+        edge_id = f"{source_id}_{target_id}"
+
         # Create coordinates object if provided and this is a node
         position_coords = None
         if position is not None and source_id == target_id:
-            position_coords = Coordinates(
-                x=float(position[0]),
-                y=float(position[1])
-            )
-        
+            position_coords = Coordinates(x=float(position[0]), y=float(position[1]))
+
         # Create the model
         model = UMAPGraphEdge(
             conversation_id=conversation_id,
@@ -381,11 +387,11 @@ class DataConverter:
             distance=float(distance),
             is_nearest_neighbor=bool(is_nearest_neighbor),
             shared_cluster_layers=shared_layers,
-            position=position_coords
+            position=position_coords,
         )
-        
+
         return model
-    
+
     @staticmethod
     def create_cluster_characteristic(
         conversation_id: str,
@@ -394,11 +400,11 @@ class DataConverter:
         size: int,
         top_words: List[str],
         top_tfidf_scores: List[float],
-        sample_comments: List[str]
+        sample_comments: List[str],
     ) -> ClusterCharacteristic:
         """
         Create a ClusterCharacteristic model from raw data.
-        
+
         Args:
             conversation_id: ID of the conversation
             layer_id: ID of the layer
@@ -407,7 +413,7 @@ class DataConverter:
             top_words: List of top words in the cluster
             top_tfidf_scores: List of TF-IDF scores for the top words
             sample_comments: List of sample comments from the cluster
-            
+
         Returns:
             ClusterCharacteristic model object
         """
@@ -419,27 +425,24 @@ class DataConverter:
             size=size,
             top_words=top_words,
             top_tfidf_scores=top_tfidf_scores,
-            sample_comments=sample_comments
+            sample_comments=sample_comments,
         )
-        
+
         return model
-    
+
     @staticmethod
     def create_enhanced_topic_name(
-        conversation_id: str,
-        layer_id: int,
-        cluster_id: int,
-        topic_name: str
+        conversation_id: str, layer_id: int, cluster_id: int, topic_name: str
     ) -> EnhancedTopicName:
         """
         Create an EnhancedTopicName model from raw data.
-        
+
         Args:
             conversation_id: ID of the conversation
             layer_id: ID of the layer
             cluster_id: ID of the cluster
             topic_name: Enhanced topic name
-            
+
         Returns:
             EnhancedTopicName model object
         """
@@ -448,11 +451,11 @@ class DataConverter:
             conversation_id=conversation_id,
             layer_id=layer_id,
             cluster_id=cluster_id,
-            topic_name=topic_name
+            topic_name=topic_name,
         )
-        
+
         return model
-    
+
     @staticmethod
     def create_llm_topic_name(
         conversation_id: str,
@@ -460,11 +463,11 @@ class DataConverter:
         cluster_id: int,
         topic_name: str,
         model_name: str = "unknown",
-        job_id: Optional[str] = None  # Added job_id
+        job_id: Optional[str] = None,  # Added job_id
     ) -> LLMTopicName:
         """
         Create an LLMTopicName model from raw data.
-        
+
         Args:
             conversation_id: ID of the conversation
             layer_id: ID of the layer
@@ -472,487 +475,568 @@ class DataConverter:
             topic_name: LLM-generated topic name
             model_name: Name of the LLM model used
             job_id: ID of the job that generated this topic name
-            
+
         Returns:
             LLMTopicName model object
         """
         if not job_id:
             # Fallback if job_id is not provided, though it should be
-            logger.warning("job_id not provided to create_llm_topic_name, using 'unknown_job'")
+            logger.warning(
+                "job_id not provided to create_llm_topic_name, using 'unknown_job'"
+            )
             job_id = "unknown_job"
 
         # Create the model
         model = LLMTopicName(
             conversation_id=conversation_id,
-            topic_key=f"{job_id}#{layer_id}#{cluster_id}", # New topic_key format
-            layer_id=layer_id, # Stored for easier filtering if needed, though part of key
+            topic_key=f"{job_id}#{layer_id}#{cluster_id}",  # New topic_key format
+            layer_id=layer_id,  # Stored for easier filtering if needed, though part of key
             cluster_id=cluster_id,
             topic_name=topic_name,
             model_name=model_name,
             created_at=datetime.now().isoformat(),
-            job_id=job_id # Store job_id as a top-level attribute
+            job_id=job_id,  # Store job_id as a top-level attribute
         )
-        
+
         return model
-    
+
     @staticmethod
     def batch_convert_cluster_characteristics(
         conversation_id: str,
         characteristics_dict: Dict[str, Dict[str, Any]],
-        layer_id: int
+        layer_id: int,
     ) -> List[ClusterCharacteristic]:
         """
         Convert batch of cluster characteristics from dictionary to model objects.
-        
+
         Args:
             conversation_id: ID of the conversation
             characteristics_dict: Dictionary of cluster characteristics
             layer_id: Layer ID for the characteristics
-            
+
         Returns:
             List of ClusterCharacteristic model objects
         """
         characteristics = []
-        
+
         for cluster_id_str, characteristic_data in characteristics_dict.items():
             try:
                 cluster_id = int(cluster_id_str)
-                
+
                 characteristic = DataConverter.create_cluster_characteristic(
                     conversation_id=conversation_id,
                     layer_id=layer_id,
                     cluster_id=cluster_id,
-                    size=characteristic_data.get('size', 0),
-                    top_words=characteristic_data.get('top_words', []),
-                    top_tfidf_scores=characteristic_data.get('top_tfidf_scores', []),
-                    sample_comments=characteristic_data.get('sample_comments', [])
+                    size=characteristic_data.get("size", 0),
+                    top_words=characteristic_data.get("top_words", []),
+                    top_tfidf_scores=characteristic_data.get("top_tfidf_scores", []),
+                    sample_comments=characteristic_data.get("sample_comments", []),
                 )
-                
+
                 characteristics.append(characteristic)
             except (ValueError, KeyError) as e:
-                logger.error(f"Error converting cluster characteristic {cluster_id_str}: {e}")
-        
+                logger.error(
+                    f"Error converting cluster characteristic {cluster_id_str}: {e}"
+                )
+
         return characteristics
-    
+
     @staticmethod
     def batch_convert_enhanced_topic_names(
-        conversation_id: str,
-        topic_names_dict: Dict[str, str],
-        layer_id: int
+        conversation_id: str, topic_names_dict: Dict[str, str], layer_id: int
     ) -> List[EnhancedTopicName]:
         """
         Convert batch of enhanced topic names from dictionary to model objects.
-        
+
         Args:
             conversation_id: ID of the conversation
             topic_names_dict: Dictionary of enhanced topic names
             layer_id: Layer ID for the topic names
-            
+
         Returns:
             List of EnhancedTopicName model objects
         """
         topic_names = []
-        
+
         for cluster_id_str, topic_name in topic_names_dict.items():
             try:
                 cluster_id = int(cluster_id_str)
-                
+
                 enhanced_topic_name = DataConverter.create_enhanced_topic_name(
                     conversation_id=conversation_id,
                     layer_id=layer_id,
                     cluster_id=cluster_id,
-                    topic_name=topic_name
+                    topic_name=topic_name,
                 )
-                
+
                 topic_names.append(enhanced_topic_name)
             except ValueError as e:
-                logger.error(f"Error converting enhanced topic name {cluster_id_str}: {e}")
-        
+                logger.error(
+                    f"Error converting enhanced topic name {cluster_id_str}: {e}"
+                )
+
         return topic_names
-    
+
     @staticmethod
     def batch_convert_llm_topic_names(
         conversation_id: str,
         topic_names_dict: Dict[str, str],
         layer_id: int,
         model_name: str = "unknown",
-        job_id: Optional[str] = None # Added job_id
+        job_id: Optional[str] = None,  # Added job_id
     ) -> List[LLMTopicName]:
         """
         Convert batch of LLM-generated topic names from dictionary to model objects.
-        
+
         Args:
             conversation_id: ID of the conversation
             topic_names_dict: Dictionary of LLM-generated topic names
             layer_id: Layer ID for the topic names
             model_name: Name of the LLM model used
             job_id: ID of the job that generated these topic names
-            
+
         Returns:
             List of LLMTopicName model objects
         """
         topic_names = []
-        
+
         for cluster_id_str, topic_name in topic_names_dict.items():
             try:
                 cluster_id = int(cluster_id_str)
-                
+
                 llm_topic_name = DataConverter.create_llm_topic_name(
                     conversation_id=conversation_id,
                     layer_id=layer_id,
                     cluster_id=cluster_id,
                     topic_name=topic_name,
                     model_name=model_name,
-                    job_id=job_id
+                    job_id=job_id,
                 )
-                
+
                 topic_names.append(llm_topic_name)
             except ValueError as e:
                 logger.error(f"Error converting LLM topic name {cluster_id_str}: {e}")
-        
+
         return topic_names
-    
+
     @staticmethod
     # ======================================================
     # REMOVED: create_comment_text method
     # Comment texts are stored in PostgreSQL as the single source of truth
     # This eliminates data duplication and ensures data consistency
     # ======================================================
-    
+
     @staticmethod
     def batch_convert_embeddings(
         conversation_id: str,
-        document_vectors: np.ndarray
-    ) -> List[CommentEmbedding]:
+        document_vectors: np.ndarray,
+        comment_ids: list[int] | None = None,
+    ) -> list[CommentEmbedding]:
         """
         Convert batch of embeddings from NumPy arrays to model objects.
-        
+
         Args:
             conversation_id: ID of the conversation
             document_vectors: Matrix of embedding vectors
-            
+            comment_ids: List of comment IDs corresponding to the vectors
+
         Returns:
             List of CommentEmbedding model objects
         """
         embeddings = []
-        
+
         for i in range(len(document_vectors)):
+            comment_id = comment_ids[i]
+
             # Create model with just the embedding vectors
             # UMAP coordinates and nearest neighbors are stored exclusively in UMAPGraph
             embedding = DataConverter.create_comment_embedding(
                 conversation_id=conversation_id,
-                comment_id=i,
-                vector=document_vectors[i]
+                comment_id=comment_id,
+                vector=document_vectors[i],
             )
-            
+
             embeddings.append(embedding)
-        
+
         return embeddings
-        
+
     @staticmethod
     def batch_convert_umap_edges(
         conversation_id: str,
         document_map: np.ndarray,
-        cluster_layers: List[np.ndarray],
-        k_neighbors: int = 5
-    ) -> List[UMAPGraphEdge]:
+        cluster_layers: list[np.ndarray],
+        k_neighbors: int = 5,
+        comment_ids: list[int] | None = None,
+    ) -> list[UMAPGraphEdge]:
         """
         Convert UMAP projection data to graph edges and nodes with positions.
-        
+
         Args:
             conversation_id: ID of the conversation
             document_map: Matrix of 2D coordinates
             cluster_layers: List of cluster label arrays
             k_neighbors: Number of nearest neighbors to store
-            
+            comment_ids: List of comment IDs corresponding to the coordinates
+
         Returns:
             List of UMAPGraphEdge model objects (both edges and nodes)
         """
         edges = []
         generated_edges = set()
-        
+
         # Calculate threshold distance for significant connections
         all_distances = []
         for i in range(min(100, len(document_map))):
-            distances = np.sqrt(np.sum((document_map - document_map[i])**2, axis=1))
+            distances = np.sqrt(np.sum((document_map - document_map[i]) ** 2, axis=1))
             all_distances.extend(distances)
         all_distances = np.array(all_distances)
         distance_threshold = np.percentile(all_distances, 5)  # Bottom 5% of distances
-        
+
         # Generate nodes with positions first
         for i in range(len(document_map)):
+            comment_id = comment_ids[i]
+
             # Create a self-edge (node) with position
             node = DataConverter.create_graph_edge(
                 conversation_id=conversation_id,
-                source_id=i,
-                target_id=i,  # Self-edge = node
-                weight=1.0,   # Self-similarity is maximum
-                distance=0.0, # Self-distance is zero
+                source_id=comment_id,
+                target_id=comment_id,  # Self-edge = node
+                weight=1.0,  # Self-similarity is maximum
+                distance=0.0,  # Self-distance is zero
                 is_nearest_neighbor=False,
-                shared_layers=[layer_id for layer_id, layer in enumerate(cluster_layers) 
-                              if i < len(layer) and layer[i] >= 0],
-                position=document_map[i]  # Store actual UMAP coordinates
+                shared_layers=[
+                    layer_id
+                    for layer_id, layer in enumerate(cluster_layers)
+                    if i < len(layer) and layer[i] >= 0
+                ],
+                position=document_map[i],  # Store actual UMAP coordinates
             )
-            
+
             edges.append(node)
-        
+
         # Generate edges between nodes
         for i in range(len(document_map)):
+            source_comment_id = comment_ids[i]
+
             # Find nearest neighbors
-            distances = np.sqrt(np.sum((document_map - document_map[i])**2, axis=1))
-            nearest_indices = np.argsort(distances)[1:k_neighbors+1]  # Skip self
+            distances = np.sqrt(np.sum((document_map - document_map[i]) ** 2, axis=1))
+            nearest_indices = np.argsort(distances)[1 : k_neighbors + 1]  # Skip self
             nearest_distances = distances[nearest_indices]
-            
-            for j, (neighbor_idx, distance) in enumerate(zip(nearest_indices, nearest_distances)):
+
+            for _j, (neighbor_idx, distance) in enumerate(
+                zip(nearest_indices, nearest_distances, strict=False)
+            ):
+                target_comment_id = comment_ids[neighbor_idx]
+
                 # Only create edge once (avoid duplicates)
-                edge_key = tuple(sorted([i, neighbor_idx]))
+                edge_key = tuple(sorted([source_comment_id, target_comment_id]))
                 if edge_key in generated_edges:
                     continue
-                
+
                 generated_edges.add(edge_key)
-                
+
                 # Only include significant connections
                 if distance > distance_threshold:
                     continue
-                
+
                 # Determine shared cluster layers
                 shared_layers = []
                 for layer_id, layer in enumerate(cluster_layers):
-                    if (i < len(layer) and neighbor_idx < len(layer) and 
-                        layer[i] >= 0 and layer[neighbor_idx] >= 0 and 
-                        layer[i] == layer[neighbor_idx]):
+                    if (
+                        i < len(layer)
+                        and neighbor_idx < len(layer)
+                        and layer[i] >= 0
+                        and layer[neighbor_idx] >= 0
+                        and layer[i] == layer[neighbor_idx]
+                    ):
                         shared_layers.append(layer_id)
-                
+
                 # Create edge
                 edge = DataConverter.create_graph_edge(
                     conversation_id=conversation_id,
-                    source_id=i,
-                    target_id=neighbor_idx,
+                    source_id=source_comment_id,
+                    target_id=target_comment_id,
                     weight=1.0 - distance,  # Convert distance to similarity
                     distance=float(distance),
                     is_nearest_neighbor=True,
-                    shared_layers=shared_layers
+                    shared_layers=shared_layers,
                 )
-                
+
                 edges.append(edge)
-        
+
         return edges
-    
+
     @staticmethod
     def batch_convert_clusters(
         conversation_id: str,
-        cluster_layers: List[np.ndarray],
-        document_map: np.ndarray
-    ) -> List[CommentCluster]:
+        cluster_layers: list[np.ndarray],
+        document_map: np.ndarray,
+        comment_ids: list[int] | None = None,
+    ) -> list[CommentCluster]:
         """
         Convert batch of clusters from NumPy arrays to model objects.
-        
+
         Args:
             conversation_id: ID of the conversation
             cluster_layers: List of cluster label arrays
             document_map: Matrix of 2D coordinates
-            
+            comment_ids: List of comment IDs corresponding to the coordinates
+
         Returns:
             List of CommentCluster model objects
         """
         clusters = []
-        
+
         # Generate distances to centroids and confidences
         distances_map = {}
         confidence_map = {}
-        
-        for comment_id in range(len(document_map)):
+
+        for comment_index in range(len(document_map)):
+            comment_id = comment_ids[comment_index]
             distances = {}
             confidences = {}
-            
+
             for layer_id, layer in enumerate(cluster_layers):
-                if comment_id < len(layer):
-                    cluster_id = layer[comment_id]
-                    
+                if comment_index < len(layer):
+                    cluster_id = layer[comment_index]
+
                     if cluster_id >= 0:
                         # Find all comments in this cluster
                         cluster_indices = np.where(layer == cluster_id)[0]
-                        
+
                         if len(cluster_indices) > 0:
                             # Calculate centroid
                             centroid = np.mean(document_map[cluster_indices], axis=0)
-                            
+
                             # Calculate distance
-                            distance = np.sqrt(np.sum((document_map[comment_id] - centroid)**2))
-                            distances[f'layer{layer_id}'] = float(distance)
-                            
+                            distance = np.sqrt(
+                                np.sum((document_map[comment_index] - centroid) ** 2)
+                            )
+                            distances[f"layer{layer_id}"] = float(distance)
+
                             # Simple confidence score based on distance
                             max_distance = 5.0  # Assuming UMAP usually keeps points within this range
-                            confidence = max(0.0, min(1.0, 1.0 - (distance / max_distance)))
-                            confidences[f'layer{layer_id}'] = float(confidence)
-            
+                            confidence = max(
+                                0.0, min(1.0, 1.0 - (distance / max_distance))
+                            )
+                            confidences[f"layer{layer_id}"] = float(confidence)
+
             if distances:
                 distances_map[comment_id] = distances
-            
+
             if confidences:
                 confidence_map[comment_id] = confidences
-        
+
         # Create cluster models
-        for comment_id in range(min(len(layer) for layer in cluster_layers) if cluster_layers else 0):
+        for comment_index in range(len(document_map)):
+            comment_id = comment_ids[comment_index]
+
             # Create model
             cluster = DataConverter.create_comment_cluster(
                 conversation_id=conversation_id,
                 comment_id=comment_id,
                 cluster_layers=cluster_layers,
+                comment_index=comment_index,
                 distances=distances_map.get(comment_id),
-                confidences=confidence_map.get(comment_id)
+                confidences=confidence_map.get(comment_id),
             )
-            
+
             clusters.append(cluster)
-        
+
         return clusters
-    
+
     @staticmethod
     def batch_convert_topics(
         conversation_id: str,
         cluster_layers: List[np.ndarray],
         document_map: np.ndarray,
-        topic_names: Dict[str, Dict[str, str]] = None,
-        characteristics: Dict[str, Dict[str, Any]] = None,
-        comments: List[Dict[str, Any]] = None
-    ) -> List[ClusterTopic]:
+        comment_texts: list[str],
+        topic_names: dict[str, dict[str, str]] = None,
+        characteristics: dict[str, dict[str, Any]] = None,
+    ) -> list[ClusterTopic]:
         """
         Convert batch of topics from raw data to model objects.
-        
+
         Args:
             conversation_id: ID of the conversation
             cluster_layers: List of cluster label arrays
             document_map: Matrix of 2D coordinates
+            comment_texts: List of comment text strings
             topic_names: Optional dictionary of topic names by layer and cluster ID
             characteristics: Optional dictionary of cluster characteristics
-            comments: Optional list of comment dictionaries
-            
         Returns:
             List of ClusterTopic model objects
         """
         topics = []
-        
+
         # Determine parent-child relationships between layers
         parent_child_map = {}
-        
+
         for layer_id in range(len(cluster_layers)):
             if layer_id > 0:
                 # This layer has parents
                 parent_layer_id = layer_id - 1
-                
+
                 # Initialize the parent map for this layer
-                if f'layer{layer_id}' not in parent_child_map:
-                    parent_child_map[f'layer{layer_id}'] = {'parents': {}, 'children': {}}
-                
+                if f"layer{layer_id}" not in parent_child_map:
+                    parent_child_map[f"layer{layer_id}"] = {
+                        "parents": {},
+                        "children": {},
+                    }
+
                 # Initialize the children map for the parent layer
-                if f'layer{parent_layer_id}' not in parent_child_map:
-                    parent_child_map[f'layer{parent_layer_id}'] = {'parents': {}, 'children': {}}
-                
-                # Create the maps
-                for comment_id in range(len(cluster_layers[0])):
-                    if comment_id < len(cluster_layers[layer_id]) and comment_id < len(cluster_layers[parent_layer_id]):
-                        current_cluster = cluster_layers[layer_id][comment_id]
-                        parent_cluster = cluster_layers[parent_layer_id][comment_id]
-                        
+                if f"layer{parent_layer_id}" not in parent_child_map:
+                    parent_child_map[f"layer{parent_layer_id}"] = {
+                        "parents": {},
+                        "children": {},
+                    }
+
+                # Create the parent-child relationship maps
+                for comment_index in range(len(cluster_layers[0])):
+                    if comment_index < len(
+                        cluster_layers[layer_id]
+                    ) and comment_index < len(cluster_layers[parent_layer_id]):
+                        current_cluster = cluster_layers[layer_id][comment_index]
+                        parent_cluster = cluster_layers[parent_layer_id][comment_index]
+
                         if current_cluster >= 0 and parent_cluster >= 0:
                             # Update parent map
-                            if current_cluster not in parent_child_map[f'layer{layer_id}']['parents']:
-                                parent_child_map[f'layer{layer_id}']['parents'][current_cluster] = {}
-                            
-                            if parent_cluster not in parent_child_map[f'layer{layer_id}']['parents'][current_cluster]:
-                                parent_child_map[f'layer{layer_id}']['parents'][current_cluster][parent_cluster] = 0
-                            
-                            parent_child_map[f'layer{layer_id}']['parents'][current_cluster][parent_cluster] += 1
-                            
+                            if (
+                                current_cluster
+                                not in parent_child_map[f"layer{layer_id}"]["parents"]
+                            ):
+                                parent_child_map[f"layer{layer_id}"]["parents"][
+                                    current_cluster
+                                ] = {}
+
+                            if (
+                                parent_cluster
+                                not in parent_child_map[f"layer{layer_id}"]["parents"][
+                                    current_cluster
+                                ]
+                            ):
+                                parent_child_map[f"layer{layer_id}"]["parents"][
+                                    current_cluster
+                                ][parent_cluster] = 0
+
+                            parent_child_map[f"layer{layer_id}"]["parents"][
+                                current_cluster
+                            ][parent_cluster] += 1
+
                             # Update children map
-                            if parent_cluster not in parent_child_map[f'layer{parent_layer_id}']['children']:
-                                parent_child_map[f'layer{parent_layer_id}']['children'][parent_cluster] = {}
-                            
-                            if current_cluster not in parent_child_map[f'layer{parent_layer_id}']['children'][parent_cluster]:
-                                parent_child_map[f'layer{parent_layer_id}']['children'][parent_cluster][current_cluster] = 0
-                            
-                            parent_child_map[f'layer{parent_layer_id}']['children'][parent_cluster][current_cluster] += 1
-        
+                            if (
+                                parent_cluster
+                                not in parent_child_map[f"layer{parent_layer_id}"][
+                                    "children"
+                                ]
+                            ):
+                                parent_child_map[f"layer{parent_layer_id}"]["children"][
+                                    parent_cluster
+                                ] = {}
+
+                            if (
+                                current_cluster
+                                not in parent_child_map[f"layer{parent_layer_id}"][
+                                    "children"
+                                ][parent_cluster]
+                            ):
+                                parent_child_map[f"layer{parent_layer_id}"]["children"][
+                                    parent_cluster
+                                ][current_cluster] = 0
+
+                            parent_child_map[f"layer{parent_layer_id}"]["children"][
+                                parent_cluster
+                            ][current_cluster] += 1
+
         # Process each layer
         for layer_id, layer in enumerate(cluster_layers):
             # Get unique clusters (excluding noise)
             unique_clusters = np.unique(layer)
             unique_clusters = unique_clusters[unique_clusters >= 0]
-            
+
             # Get layer characteristics and names
             layer_chars = {}
-            if characteristics and f'layer{layer_id}' in characteristics:
-                layer_chars = characteristics[f'layer{layer_id}']
-            
+            if characteristics and f"layer{layer_id}" in characteristics:
+                layer_chars = characteristics[f"layer{layer_id}"]
+
             layer_names = {}
-            if topic_names and f'layer{layer_id}' in topic_names:
-                layer_names = topic_names[f'layer{layer_id}']
-            
+            if topic_names and f"layer{layer_id}" in topic_names:
+                layer_names = topic_names[f"layer{layer_id}"]
+
             # Process each cluster
             for cluster_id in unique_clusters:
                 cluster_id_int = int(cluster_id)
-                
+
                 # Get comments in this cluster
                 cluster_indices = np.where(layer == cluster_id)[0]
-                
+
                 # Calculate centroid
-                centroid = np.mean(document_map[cluster_indices], axis=0) if len(cluster_indices) > 0 else np.zeros(2)
-                
+                centroid = (
+                    np.mean(document_map[cluster_indices], axis=0)
+                    if len(cluster_indices) > 0
+                    else np.zeros(2)
+                )
+
                 # Get topic name
-                topic_label = layer_names.get(str(cluster_id_int), f'Cluster {cluster_id_int}')
-                
+                topic_label = layer_names.get(
+                    str(cluster_id_int), f"Cluster {cluster_id_int}"
+                )
+
                 # Get sample comments
                 sample_comments = []
-                if comments:
-                    # Try to get actual comments
-                    for idx in cluster_indices[:min(3, len(cluster_indices))]:
-                        if idx < len(comments):
-                            try:
-                                comment_text = comments[idx].get('comment', comments[idx].get('body', ''))
-                                if comment_text:
-                                    sample_comments.append(comment_text)
-                            except:
-                                pass
-                
+                # Try to get actual comments using cluster_indices as indices into comment_texts
+                for idx in cluster_indices[: min(3, len(cluster_indices))]:
+                    if idx < len(comment_texts):
+                        comment_text = comment_texts[idx]
+                        if comment_text:
+                            sample_comments.append(comment_text)
+
                 # If no actual comments, use placeholders
                 if not sample_comments:
-                    sample_comments = [f'Sample comment for cluster {cluster_id_int}']
-                
+                    sample_comments = [f"Sample comment for cluster {cluster_id_int}"]
+
                 # Get characteristics
                 chars = {}
                 if str(cluster_id_int) in layer_chars:
                     chars = layer_chars[str(cluster_id_int)]
-                
+
                 # Get top words and TF-IDF scores if available
-                top_words = chars.get('top_words')
-                top_tfidf_scores = chars.get('top_tfidf_scores')
-                
+                top_words = chars.get("top_words")
+                top_tfidf_scores = chars.get("top_tfidf_scores")
+
                 # Determine parent cluster
                 parent_cluster = None
-                if f'layer{layer_id}' in parent_child_map and 'parents' in parent_child_map[f'layer{layer_id}']:
-                    parents = parent_child_map[f'layer{layer_id}']['parents'].get(cluster_id_int, {})
+                if (
+                    f"layer{layer_id}" in parent_child_map
+                    and "parents" in parent_child_map[f"layer{layer_id}"]
+                ):
+                    parents = parent_child_map[f"layer{layer_id}"]["parents"].get(
+                        cluster_id_int, {}
+                    )
                     if parents:
                         # Get most common parent
                         parent_id = max(parents.items(), key=lambda x: x[1])[0]
                         parent_cluster = {
-                            'layer_id': layer_id - 1,
-                            'cluster_id': int(parent_id)
+                            "layer_id": layer_id - 1,
+                            "cluster_id": int(parent_id),
                         }
-                
+
                 # Determine child clusters
                 child_clusters = None
-                if f'layer{layer_id}' in parent_child_map and 'children' in parent_child_map[f'layer{layer_id}']:
-                    children = parent_child_map[f'layer{layer_id}']['children'].get(cluster_id_int, {})
+                if (
+                    f"layer{layer_id}" in parent_child_map
+                    and "children" in parent_child_map[f"layer{layer_id}"]
+                ):
+                    children = parent_child_map[f"layer{layer_id}"]["children"].get(
+                        cluster_id_int, {}
+                    )
                     if children:
                         # Get all children
                         child_clusters = [
-                            {
-                                'layer_id': layer_id + 1,
-                                'cluster_id': int(child_id)
-                            }
+                            {"layer_id": layer_id + 1, "cluster_id": int(child_id)}
                             for child_id in children.keys()
                         ]
-                
+
                 # Create model
                 topic = DataConverter.create_cluster_topic(
                     conversation_id=conversation_id,
@@ -965,9 +1049,9 @@ class DataConverter:
                     top_words=top_words,
                     top_tfidf_scores=top_tfidf_scores,
                     parent_cluster=parent_cluster,
-                    child_clusters=child_clusters
+                    child_clusters=child_clusters,
                 )
-                
+
                 topics.append(topic)
-        
+
         return topics

--- a/delphi/umap_narrative/run_pipeline.py
+++ b/delphi/umap_narrative/run_pipeline.py
@@ -6,11 +6,9 @@ This script fetches conversation data from PostgreSQL, processes it using
 EVōC for clustering, and generates interactive visualizations with topic labeling.
 """
 
-import hashlib
 import json
 import logging
 import os
-import random
 import time
 import traceback
 import uuid  # For generating job_id
@@ -285,6 +283,7 @@ def generate_cluster_topic_labels(
     layer_idx=0,
     conversation_name=None,
     use_ollama=False,
+    document_map=None,
 ):
     """
     Generate topic labels for clusters based on their characteristics.
@@ -293,8 +292,10 @@ def generate_cluster_topic_labels(
         cluster_characteristics: Dictionary with cluster characterizations
         comment_texts: List of comment text strings (used for Ollama naming)
         layer: Cluster assignments for the current layer (used for Ollama naming)
+        layer_idx: Index of the current layer
         conversation_name: Name of the conversation (used for Ollama naming)
         use_ollama: Whether to use Ollama for topic naming
+        document_map: 2D UMAP coordinates for selecting representative comments
 
     Returns:
         cluster_labels: Dictionary mapping cluster IDs to topic labels
@@ -414,19 +415,30 @@ def generate_cluster_topic_labels(
 
                 # Get comments for this cluster
                 cluster_indices = np.where(layer == cluster_id)[0]
-                cluster_indices_list = [int(i) for i in cluster_indices.tolist()]
-                # Deterministic pseudo-random sample of up to 5 indices per (conversation, layer, cluster)
-                if len(cluster_indices_list) > 5:
-                    seed_material = (
-                        f"{conversation_name}|{layer_idx}|{cluster_id}".encode("utf-8")
+
+                # Select the 5 most representative comments (closest to centroid)
+                if len(cluster_indices) > 5 and document_map is not None:
+                    # Calculate centroid of the cluster in document_map space
+                    centroid = np.mean(document_map[cluster_indices], axis=0)
+
+                    # Calculate distance from each comment to the centroid
+                    distances = np.sqrt(
+                        np.sum((document_map[cluster_indices] - centroid) ** 2, axis=1)
                     )
-                    seed_int = int(hashlib.sha1(seed_material).hexdigest(), 16) % (
-                        2**32
+
+                    # Get indices of the 5 comments closest to centroid
+                    closest_indices = np.argsort(distances)[:5]
+                    selected_indices = cluster_indices[closest_indices].tolist()
+
+                    logger.info(
+                        f"Selected {len(selected_indices)} most representative comments "
+                        f"for layer {layer_idx}, cluster {cluster_id} "
+                        f"(distances: {distances[closest_indices]})"
                     )
-                    rng = random.Random(seed_int)
-                    selected_indices = rng.sample(cluster_indices_list, 5)
                 else:
-                    selected_indices = cluster_indices_list
+                    # If 5 or fewer comments, use all of them
+                    selected_indices = cluster_indices.tolist()
+
                 selected_comments = [comment_texts[i] for i in selected_indices]
 
                 # Get topic name
@@ -1098,6 +1110,7 @@ def process_layers_and_create_visualizations(
                 layer_idx=layer_idx,
                 conversation_name=conversation_name,
                 use_ollama=True,
+                document_map=document_map,
             )
 
             # Save LLM topic names

--- a/delphi/umap_narrative/run_pipeline.py
+++ b/delphi/umap_narrative/run_pipeline.py
@@ -6,26 +6,28 @@ This script fetches conversation data from PostgreSQL, processes it using
 EVōC for clustering, and generates interactive visualizations with topic labeling.
 """
 
-import os
-import json
-import uuid  # For generating job_id
-import time
-import logging
-import random
 import hashlib
-import numpy as np
+import json
+import logging
+import os
+import random
+import time
+import traceback
+import uuid  # For generating job_id
 from datetime import datetime
+
+import datamapplot
 
 # Import from installed packages
 import evoc
-import datamapplot
-from sentence_transformers import SentenceTransformer
-from umap import UMAP
-from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
+import numpy as np
+from polismath_commentgraph.utils.converter import DataConverter
 
 # Import from local modules
-from polismath_commentgraph.utils.storage import PostgresClient, DynamoDBStorage
-from polismath_commentgraph.utils.converter import DataConverter
+from polismath_commentgraph.utils.storage import DynamoDBStorage, PostgresClient
+from sentence_transformers import SentenceTransformer
+from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
+from umap import UMAP
 
 # Configure logging
 logging.basicConfig(
@@ -157,8 +159,13 @@ def process_comments(comments, conversation_id):
     )
 
     # Extract comment texts and IDs
-    comment_texts = [c["txt"] for c in comments if c["txt"] and c["txt"].strip()]
-    comment_ids = [c["tid"] for c in comments if c["txt"] and c["txt"].strip()]
+    comment_texts, comment_ids = map(
+        list,
+        zip(
+            *[(c["txt"], c["tid"]) for c in comments if c["txt"] and c["txt"].strip()],
+            strict=True,
+        ),
+    )
 
     # Generate embeddings with SentenceTransformer
     logger.info("Generating embeddings with SentenceTransformer...")
@@ -189,6 +196,7 @@ def process_comments(comments, conversation_id):
 
     except Exception as e:
         logger.error(f"Error during EVōC clustering: {e}")
+        logger.error(traceback.format_exc())
         # Fallback to simple clustering
         from sklearn.cluster import KMeans
 
@@ -1352,9 +1360,7 @@ def process_conversation(
         logger.info(f"Using DynamoDB endpoint from environment: {endpoint_url}")
         region = os.environ.get("AWS_REGION", "us-east-1")
 
-        dynamo_storage = DynamoDBStorage(
-            region_name=region, endpoint_url=endpoint_url
-        )
+        dynamo_storage = DynamoDBStorage(region_name=region, endpoint_url=endpoint_url)
 
         # Store basic data in DynamoDB
         logger.info(
@@ -1371,7 +1377,7 @@ def process_conversation(
         # Store embeddings
         logger.info("Storing comment embeddings...")
         embedding_models = DataConverter.batch_convert_embeddings(
-            conversation_id, document_vectors
+            conversation_id, document_vectors, comment_ids
         )
         result = dynamo_storage.batch_create_comment_embeddings(embedding_models)
         logger.info(
@@ -1381,7 +1387,7 @@ def process_conversation(
         # Store UMAP graph edges
         logger.info("Storing UMAP graph edges...")
         edge_models = DataConverter.batch_convert_umap_edges(
-            conversation_id, document_map, cluster_layers
+            conversation_id, document_map, cluster_layers, comment_ids=comment_ids
         )
         result = dynamo_storage.batch_create_graph_edges(edge_models)
         logger.info(
@@ -1391,7 +1397,7 @@ def process_conversation(
         # Store cluster assignments
         logger.info("Storing comment cluster assignments...")
         cluster_models = DataConverter.batch_convert_clusters(
-            conversation_id, cluster_layers, document_map
+            conversation_id, cluster_layers, document_map, comment_ids
         )
         result = dynamo_storage.batch_create_comment_clusters(cluster_models)
         logger.info(
@@ -1404,9 +1410,9 @@ def process_conversation(
             conversation_id,
             cluster_layers,
             document_map,
+            comment_texts,
             topic_names={},  # No topic names yet
             characteristics={},  # No characteristics yet
-            comments=[{"body": comment["txt"]} for comment in comments],
         )
         result = dynamo_storage.batch_create_cluster_topics(topic_models)
         logger.info(
@@ -1525,17 +1531,6 @@ def main():
         document_map, document_vectors, cluster_layers, comment_texts, comment_ids = (
             process_comments(mock_comments, str(args.zid))
         )
-
-        # Store in DynamoDB if requested
-        if not args.no_dynamo:
-            store_in_dynamo(
-                str(args.zid),
-                document_vectors,
-                document_map,
-                cluster_layers,
-                mock_comments,
-                comment_ids,
-            )
 
         # Process each layer and create visualizations
         output_dir = os.path.join(


### PR DESCRIPTION
Fixes a critical bug that was causing comment id mixups when moderation filtering is enabled.

This PR includes the changes from https://github.com/compdemocracy/polis/pull/2226 to use centroid proximity when selecting comments for topic generation.

Auto-formatting was enabled in my IDE. If you prefer a PR without the auto-formatting noise, I can prepare one.