### PR TITLE
Parameterize Delphi path

### DIFF
--- a/delphi/run_delphi.py
+++ b/delphi/run_delphi.py
@@ -77,7 +77,8 @@ def main():
     print(f"{YELLOW}Using Ollama model: {model}{NC}")
 
     # Set up environment for the pipeline
-    os.environ["PYTHONPATH"] = f"/app:{os.environ.get('PYTHONPATH', '')}"
+    app_path = os.environ.get('DELPHI_APP_PATH', '/app')
+    os.environ["PYTHONPATH"] = f"{app_path}:{os.environ.get('PYTHONPATH', '')}"
     os.environ["OLLAMA_HOST"] = os.environ.get("OLLAMA_HOST", "http://ollama:11434")
     # OLLAMA_MODEL is already set and checked
     max_votes = os.environ.get("MAX_VOTES")
@@ -96,7 +97,7 @@ def main():
     # Run the math pipeline
     print(f"{GREEN}Running math pipeline...{NC}")
     math_command = [
-        "python", "/app/polismath/run_math_pipeline.py",
+        "python", f"{app_path}/polismath/run_math_pipeline.py",
         f"--zid={zid}",
     ]
     if max_votes_arg:
@@ -114,7 +115,7 @@ def main():
     # Run the UMAP narrative pipeline
     print(f"{GREEN}Running UMAP narrative pipeline...{NC}")
     umap_command = [
-        "python", "/app/umap_narrative/run_pipeline.py",
+        "python", f"{app_path}/umap_narrative/run_pipeline.py",
         f"--zid={zid}",
         f"--include_moderation={args.include_moderation}",
         "--use-ollama"
@@ -128,7 +129,7 @@ def main():
     # Calculate and store comment extremity values
     print(f"{GREEN}Calculating comment extremity values...{NC}")
     extremity_command = [
-        "python", "/app/umap_narrative/501_calculate_comment_extremity.py",
+        "python", f"{app_path}/umap_narrative/501_calculate_comment_extremity.py",
         f"--zid={zid}",
         f"--include_moderation={args.include_moderation}"
     ]
@@ -147,7 +148,7 @@ def main():
     # Calculate comment priorities using group-based extremity
     print(f"{GREEN}Calculating comment priorities with group-based extremity...{NC}")
     priority_command = [
-        "python", "/app/umap_narrative/502_calculate_priorities.py",
+        "python", f"{app_path}/umap_narrative/502_calculate_priorities.py",
         f"--conversation_id={zid}",
     ]
     if verbose_arg:
@@ -164,7 +165,7 @@ def main():
         print(f"{YELLOW}Creating visualizations with datamapplot...{NC}")
 
         # Create output directory
-        output_dir = f"/app/polis_data/{zid}/python_output/comments_enhanced_multilayer"
+        output_dir = f"{app_path}/polis_data/{zid}/python_output/comments_enhanced_multilayer"
         os.makedirs(output_dir, exist_ok=True)
 
         # Generate visualizations for all available layers
@@ -230,7 +231,7 @@ def main():
         for layer_id in available_layers:
             print(f"{YELLOW}Generating visualization for layer {layer_id}...{NC}")
             datamap_command = [
-                "python", "/app/umap_narrative/700_datamapplot_for_layer.py",
+                "python", f"{app_path}/umap_narrative/700_datamapplot_for_layer.py",
                 f"--conversation_id={zid}",
                 f"--layer={layer_id}",
                 f"--output_dir={output_dir}"

--- a/delphi/scripts/job_poller.py
+++ b/delphi/scripts/job_poller.py
@@ -673,18 +673,19 @@ class JobProcessor:
             # 1. Build the command
             job_config = json.loads(job.get('job_config', '{}'))
             include_moderation = job_config.get('include_moderation', False)
+            app_path = os.environ.get('DELPHI_APP_PATH', '/app')
             if job_type == 'CREATE_NARRATIVE_BATCH':
                 model = os.environ.get("ANTHROPIC_MODEL")
                 if not model: raise ValueError("ANTHROPIC_MODEL must be set")
                 max_batch_size = job_config.get('max_batch_size', 20)
-                cmd = ['python', '/app/umap_narrative/801_narrative_report_batch.py', f'--conversation_id={conversation_id}', f'--model={model}', f'--include_moderation={include_moderation}', f'--max-batch-size={str(max_batch_size)}']
+                cmd = ['python', f'{app_path}/umap_narrative/801_narrative_report_batch.py', f'--conversation_id={conversation_id}', f'--model={model}', f'--include_moderation={include_moderation}', f'--max-batch-size={str(max_batch_size)}']
                 if job_config.get('no_cache'): cmd.append('--no-cache')
             elif job_type == 'AWAITING_NARRATIVE_BATCH':
                 cmd_job_id = job.get('batch_job_id', job_id)
-                cmd = ['python', '/app/umap_narrative/803_check_batch_status.py', f'--job-id={cmd_job_id}']
+                cmd = ['python', f'{app_path}/umap_narrative/803_check_batch_status.py', f'--job-id={cmd_job_id}']
             else: # FULL_PIPELINE
                 # Base command
-                cmd = ['python', '/app/run_delphi.py', f'--zid={conversation_id}', f'--include_moderation={include_moderation}',]
+                cmd = ['python', f'{app_path}/run_delphi.py', f'--zid={conversation_id}', f'--include_moderation={include_moderation}',]
                 # Check for report_id and append if it exists
                 report_id = job.get('report_id')
                 if report_id:

--- a/delphi/umap_narrative/701_static_datamapplot_for_layer.py
+++ b/delphi/umap_narrative/701_static_datamapplot_for_layer.py
@@ -25,7 +25,8 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 # Import directly from the existing codebase
-sys.path.insert(0, '/app')
+app_path = os.environ.get('DELPHI_APP_PATH', '/app')
+sys.path.insert(0, app_path)
 try:
     from polismath_commentgraph.utils.storage import DynamoDBStorage, PostgresClient
 except ImportError:
@@ -416,7 +417,8 @@ def generate_static_datamapplot(zid, layer_num=0, output_dir=None):
         comment_texts = load_comment_texts(zid)
         
         # Setup output directories
-        container_dir = f"/app/visualizations/{zid}"
+        app_path = os.environ.get('DELPHI_APP_PATH', '/app')
+        container_dir = f"{app_path}/visualizations/{zid}"
         host_dir = f"/visualizations/{zid}"
         local_dir = f"/Users/colinmegill/polis/delphi/visualizations/{zid}"
         


### PR DESCRIPTION
Before this PR, the Delphi python codebase had hardcoded paths to `/app/` that
made it difficult to run in different environments or directory structures,
especially for local development and algorithmic/data analysis.

This PR introduces the optional environment variable DELPHI_APP_PATH,
which, if specified, overrides `/app`.
