### PR TITLE
Add instance type `dev` to process all sizes

### DIFF
--- a/delphi/scripts/job_poller.py
+++ b/delphi/scripts/job_poller.py
@@ -765,6 +765,10 @@ def poll_and_process(processor, interval=10):
                     # Small/default instances ONLY process normal-sized jobs.
                     can_process = (job_actual_size == "normal")
 
+                if instance_type == "omnipotent":
+                    # Omnipotent instances can process any job size.
+                    can_process = True
+
                 if not can_process:
                     logger.info(f"Worker instance type '{instance_type}' cannot process job '{job_to_process['job_id']}' of size '{job_actual_size}'. Skipping for now.")
                     # Sleep for the interval so this worker doesn't hammer the queue checking the same job.

--- a/delphi/scripts/job_poller.py
+++ b/delphi/scripts/job_poller.py
@@ -765,8 +765,8 @@ def poll_and_process(processor, interval=10):
                     # Small/default instances ONLY process normal-sized jobs.
                     can_process = (job_actual_size == "normal")
 
-                if instance_type == "omnipotent":
-                    # Omnipotent instances can process any job size.
+                if instance_type == "dev":
+                    # Dev instances can process any job size.
                     can_process = True
 
                 if not can_process:

--- a/example.env
+++ b/example.env
@@ -43,8 +43,9 @@ COMPOSE_PROJECT_NAME=polis-${TAG}
 # Makefile will read this to determine if local services (dynamodb, minio, ollama) should be started.
 LOCAL_SERVICES_DOCKER=true
 
-###### FOR DEV ONLY: DELPHI INSTANCE SIZE ######
-# Should be left empty for AWS deployment. See delphi/DELPHI_AUTOSCALING_SETUP.md for configuring instance size in production.
+###### DELPHI INSTANCE SIZE ######
+# Should be dev (process all jobs), large (process large jobs only), normal or small (only normal jobs).
+# Leave empty for autodetection on AWS deployment. See delphi/DELPHI_AUTOSCALING_SETUP.md for configuring instance size in production.
 INSTANCE_SIZE=dev
 
 ###### PORTS ######

--- a/example.env
+++ b/example.env
@@ -44,9 +44,8 @@ COMPOSE_PROJECT_NAME=polis-${TAG}
 LOCAL_SERVICES_DOCKER=true
 
 ###### FOR DEV ONLY: DELPHI INSTANCE SIZE ######
-# Uncomment the following *only* if you are running a local dev instance of Delphi.
-# Otherwise, see delphi/DELPHI_AUTOSCALING_SETUP.md for configuring instance size in production.
-# INSTANCE_SIZE=omnipotent
+# Should be left empty for AWS deployment. See delphi/DELPHI_AUTOSCALING_SETUP.md for configuring instance size in production.
+INSTANCE_SIZE=dev
 
 ###### PORTS ######
 API_SERVER_PORT=5000

--- a/example.env
+++ b/example.env
@@ -43,6 +43,10 @@ COMPOSE_PROJECT_NAME=polis-${TAG}
 # Makefile will read this to determine if local services (dynamodb, minio, ollama) should be started.
 LOCAL_SERVICES_DOCKER=true
 
+###### FOR DEV ONLY: DELPHI INSTANCE SIZE ######
+# Uncomment the following *only* if you are running a local dev instance of Delphi.
+# Otherwise, see delphi/DELPHI_AUTOSCALING_SETUP.md for configuring instance size in production.
+# INSTANCE_SIZE=omnipotent
 
 ###### PORTS ######
 API_SERVER_PORT=5000


### PR DESCRIPTION
Especially useful for local dev instances where we don't want to limit resources.
