### PR TITLE
Speed up NamedMatrix updates between 40x and 200x

### DIFF
--- a/delphi/polismath/pca_kmeans_rep/named_matrix.py
+++ b/delphi/polismath/pca_kmeans_rep/named_matrix.py
@@ -181,7 +181,7 @@ class NamedMatrix:
         
         Args:
             v: The value to normalize
-            convert_na_to_0: Whether to keep NaN values as NaN or convert them to 0.0. Default False.
+            convert_na_to_0: Whether to keep NaN values as NaN or convert them to 0.0. Default True.
         """
         # Process value into normalized form
         if v is None:
@@ -293,7 +293,7 @@ class NamedMatrix:
             row: Row name
             col: Column name
             value: New value
-            normalize_value: Whether to normalize the value (clamp to -1.0, 0.0, 1.0). Default False.
+            normalize_value: Whether to normalize the value (convert positive values to 1.0, negative values to -1.0, and zero/NaN to 0.0). Default False.
 
         Note: Unlike batch_update, this method does *NOT* normalize values by default.
             
@@ -301,7 +301,7 @@ class NamedMatrix:
             A new NamedMatrix with the updated value
         """
         # Convert value to numeric if needed
-        #  like in batch update mode, we clamp at -1, 0, 1 for vote values
+        # Like in batch update mode, we normalize to -1, 0, 1 for vote values
         if value is not None:
             try:
                 # Try to convert to float
@@ -355,7 +355,7 @@ class NamedMatrix:
         
         Args:
             updates: List of (row, col, val) tuples
-            normalize_values: Whether to normalize the values (clamp to -1.0, 0.0, 1.0). Default True.
+            normalize_values: Whether to normalize the values (convert positive values to 1.0, negative values to -1.0, and zero/NaN to 0.0). Default True.
 
         Note: unlike the single update method, this method *DOES* normalize values by default.
             

--- a/delphi/polismath/pca_kmeans_rep/named_matrix.py
+++ b/delphi/polismath/pca_kmeans_rep/named_matrix.py
@@ -174,7 +174,7 @@ class NamedMatrix:
         # Ensure numeric data if requested
         if enforce_numeric:
             self._convert_to_numeric()
-    
+            elif numeric_value < 0:
     def _convert_to_numeric(self) -> None:
         """
         Convert all data in the matrix to numeric (float) values.
@@ -203,6 +203,7 @@ class NamedMatrix:
         # If matrix has object or non-numeric type, convert manually
         numeric_matrix = np.zeros(self._matrix.shape, dtype=float)
         
+        # TODO: vectorize this operation for speed
         for i in range(self._matrix.shape[0]):
             for j in range(self._matrix.shape[1]):
                 try:
@@ -278,7 +279,7 @@ class NamedMatrix:
     def update(self, 
                row: Any, 
                col: Any, 
-               value: Any) -> 'NamedMatrix':
+               normalize_value:bool = False) -> 'NamedMatrix':
         """
         Update a single value in the matrix, adding new rows/columns as needed.
         
@@ -286,13 +287,13 @@ class NamedMatrix:
             row: Row name
             col: Column name
             value: New value
+
             
         Returns:
             A new NamedMatrix with the updated value
         """
         # Convert value to numeric if needed
-        # Only normalize vote values when a flag is set or special handling is needed
-        # For regular numeric updates, preserve the value
+        #  like in batch update mode, we clamp at -1, 0, 1 for vote values
         if value is not None:
             try:
                 # Try to convert to float
@@ -301,6 +302,9 @@ class NamedMatrix:
             except (ValueError, TypeError):
                 # If conversion fails, use NaN
                 value = np.nan
+
+        if normalize_value:
+            value = self._normalize_vote_value(value, convert_na_to_0=True)
         
         # Make a copy of the current matrix
         new_matrix = self._matrix.copy()
@@ -336,12 +340,16 @@ class NamedMatrix:
         return result
     
     def batch_update(self, 
-                    updates: List[Tuple[Any, Any, Any]]) -> 'NamedMatrix':
+                    updates: List[Tuple[Any, Any, Any]],
+                    normalize_values: bool = True) -> 'NamedMatrix':
         """
         Apply multiple updates to the matrix in a single efficient operation.
         
         Args:
             updates: List of (row, col, val) tuples
+            normalize_values: Whether to normalize the values (clamp to -1.0, 0.0, 1.0). Default True.
+
+        Note: unlike the single update method, this method *DOES* normalize values by default.
             
         Returns:
             Updated NamedMatrix with all changes applied at once
@@ -384,21 +392,10 @@ class NamedMatrix:
             if col not in existing_cols and col not in new_cols:
                 new_cols.add(col)
             
-            # Process value into normalized form
-            if value is not None:
-                try:
-                    numeric_value = float(value)
-                    # For vote values, normalize to -1.0, 0.0, or 1.0
-                    if numeric_value > 0:
-                        processed_value = 1.0
-                    elif numeric_value < 0:
-                        processed_value = -1.0
-                    else:
-                        processed_value = 0.0
-                except (ValueError, TypeError):
-                    processed_value = np.nan
-            else:
-                processed_value = np.nan
+            # Normalize value if requested
+            processed_value = value
+            if normalize_values:
+                processed_value = self._normalize_vote_value(value)
                 
             # Store processed value
             processed_updates[(row, col)] = processed_value
@@ -510,20 +507,6 @@ class NamedMatrix:
         
         return result
         
-    def update_many(self, 
-                   updates: List[Tuple[Any, Any, Any]]) -> 'NamedMatrix':
-        """
-        Update multiple values in the matrix.
-        
-        Args:
-            updates: List of (row, col, value) tuples
-            
-        Returns:
-            A new NamedMatrix with the updated values
-        """
-        # Use the more efficient batch_update method
-        return self.batch_update(updates)
-    
     def rowname_subset(self, rownames: List[Any]) -> 'NamedMatrix':
         """
         Create a subset of the matrix with only the specified rows.

--- a/delphi/polismath/pca_kmeans_rep/named_matrix.py
+++ b/delphi/polismath/pca_kmeans_rep/named_matrix.py
@@ -174,7 +174,34 @@ class NamedMatrix:
         # Ensure numeric data if requested
         if enforce_numeric:
             self._convert_to_numeric()
+
+    @staticmethod
+    def _normalize_vote_value(v: Any, convert_na_to_0: bool = True) -> float:
+        """ Normalize a vote value to -1.0, 0.0, or 1.0
+        
+        Args:
+            v: The value to normalize
+            convert_na_to_0: Whether to keep NaN values as NaN or convert them to 0.0. Default False.
+        """
+        # Process value into normalized form
+        if v is None:
+            return np.nan
+        
+        if not convert_na_to_0 and pd.isna(v):
+            return np.nan 
+
+        try:
+            numeric_value = float(v)
+            if numeric_value > 0:
+                return 1.0
             elif numeric_value < 0:
+                return -1.0
+            else:
+                # Note: np.nan is captured here
+                return 0.0
+        except (ValueError, TypeError):
+            return np.nan
+    
     def _convert_to_numeric(self) -> None:
         """
         Convert all data in the matrix to numeric (float) values.
@@ -206,29 +233,7 @@ class NamedMatrix:
         # TODO: vectorize this operation for speed
         for i in range(self._matrix.shape[0]):
             for j in range(self._matrix.shape[1]):
-                try:
-                    val = self._matrix.iloc[i, j]
-                    
-                    if pd.isna(val) or val is None:
-                        numeric_matrix[i, j] = np.nan
-                    else:
-                        try:
-                            # Try to convert to float
-                            numeric_value = float(val)
-                            
-                            # For vote values, normalize to -1.0, 0.0, or 1.0
-                            if numeric_value > 0:
-                                numeric_matrix[i, j] = 1.0
-                            elif numeric_value < 0:
-                                numeric_matrix[i, j] = -1.0
-                            else:
-                                numeric_matrix[i, j] = 0.0
-                        except (ValueError, TypeError):
-                            # If conversion fails, use NaN
-                            numeric_matrix[i, j] = np.nan
-                except IndexError:
-                    # Handle out of bounds access
-                    continue
+                numeric_matrix[i, j] = self._normalize_vote_value(self._matrix.iloc[i, j], convert_na_to_0=True)
         
         # Create a new DataFrame with the numeric values
         self._matrix = pd.DataFrame(
@@ -279,6 +284,7 @@ class NamedMatrix:
     def update(self, 
                row: Any, 
                col: Any, 
+               value: Any,
                normalize_value:bool = False) -> 'NamedMatrix':
         """
         Update a single value in the matrix, adding new rows/columns as needed.
@@ -287,7 +293,9 @@ class NamedMatrix:
             row: Row name
             col: Column name
             value: New value
+            normalize_value: Whether to normalize the value (clamp to -1.0, 0.0, 1.0). Default False.
 
+        Note: Unlike batch_update, this method does *NOT* normalize values by default.
             
         Returns:
             A new NamedMatrix with the updated value
@@ -444,9 +452,24 @@ class NamedMatrix:
                     for i, row_idx in enumerate(row_indices):
                         for j, col_idx in enumerate(col_indices):
                             matrix_copy.values[row_idx, col_idx] = existing_data[i, j]
-                    
+
+                    copy_time = time.time() - copy_start
                     if should_report:
-                        logger.info(f"[{time.time() - start_time:.2f}s] Copied {total_values} values in {time.time() - copy_start:.2f}s")
+                        logger.info(f"[{time.time() - start_time:.2f}s] Copied {total_values} values in {copy_time:.2f}s")
+                    
+                    # Reindex will automatically align and copy values, filling missing with NaN
+                    start_time_ju = time.time()
+                    matrix_copy_ju = self._matrix.reindex(index=all_rows, columns=all_cols, fill_value=np.nan)
+                    copy_time_ju = time.time() - start_time_ju
+                    logger.info(f"[{time.time() - start_time:.2f}s] Copied {total_values} values in {copy_time_ju:.2f}s using reindex")
+                    logger.info(f"Speed up reindex: {copy_time / copy_time_ju:.2f}x")
+
+                    # compare matrix_copy and matrix_copy_ju
+                    if not matrix_copy.equals(matrix_copy_ju):
+                        logger.warning(f"[{time.time() - start_time:.2f}s] Warning: reindex result differs from manual copy")
+                    else:
+                        logger.info(f"[{time.time() - start_time:.2f}s] Verified reindex matches manual copy")
+
                 
                 except Exception as e:
                     # Fallback to slower method if vectorized approach fails

--- a/delphi/polismath/pca_kmeans_rep/named_matrix.py
+++ b/delphi/polismath/pca_kmeans_rep/named_matrix.py
@@ -416,84 +416,11 @@ class NamedMatrix:
         all_rows = sorted(list(existing_rows) + list(new_rows))
         all_cols = sorted(list(existing_cols) + list(new_cols))
         
-        # Create a new DataFrame with all rows and columns at once
-        # This creates a clean DataFrame without fragmentation
-        matrix_creation_start = time.time()
-        if new_rows or new_cols or self._matrix.empty:
-            # Create new DataFrame with all rows and columns
-            matrix_copy = pd.DataFrame(
-                index=all_rows,
-                columns=all_cols,
-                dtype=float
-            )
-            
-            # Fill with NaN
-            matrix_copy.values[:] = np.nan
-            
-            if should_report:
-                logger.info(f"[{time.time() - start_time:.2f}s] New DataFrame created in {time.time() - matrix_creation_start:.2f}s")
-                logger.info(f"[{time.time() - start_time:.2f}s] Copying existing values...")
-            
-            # Copy existing values from original matrix
-            if not self._matrix.empty:
-                copy_start = time.time()
-                total_values = len(self._matrix.index) * len(self._matrix.columns)
-                
-                # Use vectorized operations if possible to copy faster
-                try:
-                    # Extract existing data as a numpy array
-                    existing_data = self._matrix.values
-                    
-                    # Convert to row/column indices in the new matrix
-                    row_indices = [all_rows.index(row) for row in self._matrix.index]
-                    col_indices = [all_cols.index(col) for col in self._matrix.columns]
-                    
-                    # Use advanced indexing to copy values
-                    for i, row_idx in enumerate(row_indices):
-                        for j, col_idx in enumerate(col_indices):
-                            matrix_copy.values[row_idx, col_idx] = existing_data[i, j]
-
-                    copy_time = time.time() - copy_start
-                    if should_report:
-                        logger.info(f"[{time.time() - start_time:.2f}s] Copied {total_values} values in {copy_time:.2f}s")
-                    
-                    # Reindex will automatically align and copy values, filling missing with NaN
-                    start_time_ju = time.time()
-                    matrix_copy_ju = self._matrix.reindex(index=all_rows, columns=all_cols, fill_value=np.nan)
-                    copy_time_ju = time.time() - start_time_ju
-                    logger.info(f"[{time.time() - start_time:.2f}s] Copied {total_values} values in {copy_time_ju:.2f}s using reindex")
-                    logger.info(f"Speed up reindex: {copy_time / copy_time_ju:.2f}x")
-
-                    # compare matrix_copy and matrix_copy_ju
-                    if not matrix_copy.equals(matrix_copy_ju):
-                        logger.warning(f"[{time.time() - start_time:.2f}s] Warning: reindex result differs from manual copy")
-                    else:
-                        logger.info(f"[{time.time() - start_time:.2f}s] Verified reindex matches manual copy")
-
-                
-                except Exception as e:
-                    # Fallback to slower method if vectorized approach fails
-                    if should_report:
-                        logger.warning(f"[{time.time() - start_time:.2f}s] Vectorized copy failed: {e}, falling back to element-wise copy")
-                    
-                    # Element-wise copy
-                    for i, row in enumerate(self._matrix.index):
-                        for j, col in enumerate(self._matrix.columns):
-                            matrix_copy.at[row, col] = self._matrix.iloc[i, j]
-                            
-                            # Report progress for large matrices
-                            if should_report and total_values > REPORT_THRESHOLD and (i * len(self._matrix.columns) + j + 1) % PROGRESS_INTERVAL == 0:
-                                copied = i * len(self._matrix.columns) + j + 1
-                                pct = (copied / total_values) * 100
-                                logger.info(f"[{time.time() - start_time:.2f}s] Copied {copied}/{total_values} values ({pct:.1f}%)")
-                    
-                    if should_report:
-                        logger.info(f"[{time.time() - start_time:.2f}s] Completed element-wise copy in {time.time() - copy_start:.2f}s")
-        else:
-            # No new rows or columns needed, just make a copy
-            matrix_copy = self._matrix.copy()
-            if should_report:
-                logger.info(f"[{time.time() - start_time:.2f}s] No resizing needed, created copy in {time.time() - matrix_creation_start:.2f}s")
+        # Use vectorized operations if possible to copy faster
+        # Reindex will automatically align and copy values, filling missing with NaN
+        if should_report:
+            logger.info(f"[{time.time() - start_time:.2f}s] Copying existing values...")
+        matrix_copy = self._matrix.reindex(index=all_rows, columns=all_cols, fill_value=np.nan, copy=True)
         
         # Apply all updates at once
         if should_report:

--- a/delphi/tests/test_named_matrix.py
+++ b/delphi/tests/test_named_matrix.py
@@ -118,7 +118,7 @@ class TestNamedMatrix:
         assert nmat.colnames() == ['c1', 'c2', 'c3']
         assert np.array_equal(nmat.values, df.values)
     
-    def test_update(self):
+    def test_update_normalized(self):
         """Test updating a single value in the matrix."""
         nmat = NamedMatrix(
             np.array([[1, 2], [3, 4]]),
@@ -127,7 +127,7 @@ class TestNamedMatrix:
         )
         
         # Update existing value
-        nmat2 = nmat.update('r1', 'c1', 10)
+        nmat2 = nmat.update('r1', 'c1', 10, normalize_value=True)
         # The implementation normalizes values to 1.0, -1.0, or 0.0 for vote data
         # So 10 becomes 1.0
         assert nmat2.matrix.loc['r1', 'c1'] == 1.0
@@ -136,22 +136,22 @@ class TestNamedMatrix:
         assert nmat.matrix.loc['r1', 'c1'] == 1
         
         # Update with new row
-        nmat3 = nmat.update('r3', 'c1', 5)
+        nmat3 = nmat.update('r3', 'c1', 5, normalize_value=True)
         assert nmat3.matrix.loc['r3', 'c1'] == 1.0  # 5 is normalized to 1.0
         assert nmat3.rownames() == ['r1', 'r2', 'r3']
         
         # Update with new column
-        nmat4 = nmat.update('r1', 'c3', 6)
+        nmat4 = nmat.update('r1', 'c3', 6, normalize_value=True)
         assert nmat4.matrix.loc['r1', 'c3'] == 1.0  # 6 is normalized to 1.0
         assert nmat4.colnames() == ['c1', 'c2', 'c3']
         
         # Update with new row and column
-        nmat5 = nmat.update('r3', 'c3', 9)
+        nmat5 = nmat.update('r3', 'c3', 9, normalize_value=True)
         assert nmat5.matrix.loc['r3', 'c3'] == 1.0  # 9 is normalized to 1.0
         assert nmat5.rownames() == ['r1', 'r2', 'r3']
         assert nmat5.colnames() == ['c1', 'c2', 'c3']
     
-    def test_update_many(self):
+    def test_batch_update(self):
         """Test updating multiple values."""
         nmat = NamedMatrix(
             np.array([[1, 2], [3, 4]]),
@@ -160,7 +160,7 @@ class TestNamedMatrix:
         )
         
         updates = [('r1', 'c1', 10), ('r2', 'c2', 20), ('r3', 'c3', 30)]
-        nmat2 = nmat.update_many(updates)
+        nmat2 = nmat.batch_update(updates)
         
         # Values are normalized to 1.0, -1.0, or 0.0
         assert nmat2.matrix.loc['r1', 'c1'] == 1.0  # 10 becomes 1.0

--- a/delphi/tests/test_named_matrix.py
+++ b/delphi/tests/test_named_matrix.py
@@ -257,29 +257,134 @@ class TestNamedMatrix:
         assert subset.colnames() == ['c1', 'c2', 'c3']
 
 
+    def test_batch_update_large_scale(self):
+        """Test large-scale batch update with proper index ordering and NaN handling."""
+        # Set random seed for reproducibility
+        np.random.seed(42)
+
+        # Create a 1000x400 random matrix with named rows and columns
+        original_rows = 1000
+        original_cols = 400
+        original_data = np.random.rand(original_rows, original_cols)
+
+        # Generate row and column names with leading zeros (4 digits)
+        rownames = [f"row_{i:04d}_original" for i in range(original_rows)]
+        colnames = [f"col_{j:04d}_original" for j in range(original_cols)]
+
+        # Initialize the NamedMatrix A
+        A = NamedMatrix(original_data, rownames, colnames)
+
+        # Create new block B with:
+        # - rows: row_0005_new through row_0010_new (6 rows)
+        # - columns: column_0020_new through column_0030_new (11 columns)
+        new_row_indices = list(range(5, 11))  # 05 to 10 inclusive
+        new_col_indices = list(range(20, 31))  # 20 to 30 inclusive
+
+        new_rownames = [f"row_{i:04d}_new" for i in new_row_indices]
+        new_colnames = [f"col_{j:04d}_new" for j in new_col_indices]
+
+        # Generate random data for block B
+        B_data = np.random.rand(len(new_rownames), len(new_colnames))
+
+        # Create batch updates for all cells in block B
+        updates = []
+        for i, row in enumerate(new_rownames):
+            for j, col in enumerate(new_colnames):
+                updates.append((row, col, B_data[i, j]))
+
+        # Apply batch update
+        A_updated = A.batch_update(updates, normalize_values=False)
+
+        # Test 1: The subset at new indices matches B
+        subset_new = A_updated.matrix.loc[new_rownames, new_colnames]
+        assert subset_new.shape == B_data.shape, \
+            f"New block shape mismatch: expected {B_data.shape}, got {subset_new.shape}"
+
+        for i, row in enumerate(new_rownames):
+            for j, col in enumerate(new_colnames):
+                expected = B_data[i, j]
+                actual = subset_new.loc[row, col]
+                assert abs(actual - expected) < 1e-10, \
+                    f"Value mismatch at ({row}, {col}): expected {expected}, got {actual}"
+
+        # Test 2: Original data outside new indices is unchanged
+        for i, row in enumerate(rownames):
+            for j, col in enumerate(colnames):
+                expected = original_data[i, j]
+                actual = A_updated.matrix.loc[row, col]
+                assert abs(actual - expected) < 1e-10, \
+                    f"Original value changed at ({row}, {col}): expected {expected}, got {actual}"
+
+        # Test 3: Check alphabetic ordering of row and column indices
+        final_rownames = A_updated.rownames()
+        final_colnames = A_updated.colnames()
+
+        # Verify rows are sorted alphabetically
+        assert final_rownames == sorted(final_rownames), \
+            "Row names are not in alphabetic order"
+
+        # Verify columns are sorted alphabetically
+        assert final_colnames == sorted(final_colnames), \
+            "Column names are not in alphabetic order"
+
+        # Verify specific interweaving for rows
+        # Expected pattern: row_0004_original, row_0005_new, row_0005_original, row_0006_new, ...new
+        lower_unchanged_row = "row_0004_original"
+        assert final_rownames.index(lower_unchanged_row) == A.rownames().index(lower_unchanged_row), "wrong index for lower unchanged row" 
+        for i in new_row_indices:
+            original_name = f"row_{i:04d}_original"
+            idx_original_name = final_rownames.index(original_name)
+            new_name = f"row_{i:04d}_new"
+            idx_new_name = final_rownames.index(new_name)
+            assert idx_original_name == idx_new_name + 1, f"row {original_name} is as idx {idx_original_name} but should be before {new_name} at idx {idx_new_name}"
+
+        lower_unchanged_col = "col_0019_original"
+        assert final_colnames.index(lower_unchanged_col) == A.colnames().index(lower_unchanged_col) , "wrong index for lower unchanged column"
+        for i in new_col_indices:
+            original_name = f"col_{i:04d}_original"
+            idx_original_name = final_colnames.index(original_name)
+            new_name = f"col_{i:04d}_new"
+            idx_new_name = final_colnames.index(new_name)
+            assert idx_original_name == idx_new_name + 1, f"col {original_name} is as idx {idx_original_name} but should be before {new_name} at idx {idx_new_name}"
+
+        # Test 4: Existing rows at new columns are NaN
+        for row in rownames:
+            for col in new_colnames:
+                value = A_updated.matrix.loc[row, col]
+                assert pd.isna(value), \
+                    f"Expected NaN at existing row {row} and new column {col}, but got {value}"
+
+        # Test 5: Existing columns at new rows are NaN
+        for row in new_rownames:
+            for col in colnames:
+                value = A_updated.matrix.loc[row, col]
+                assert pd.isna(value), \
+                    f"Expected NaN at new row {row} and existing column {col}, but got {value}"
+
+
 class TestCreateNamedMatrix:
     """Tests for the create_named_matrix function."""
-    
+
     def test_create_with_lists(self):
         """Test creating a NamedMatrix from lists."""
         data = [[1, 2, 3], [4, 5, 6]]
         rownames = ['r1', 'r2']
         colnames = ['c1', 'c2', 'c3']
-        
+
         nmat = create_named_matrix(data, rownames, colnames)
-        
+
         assert nmat.rownames() == rownames
         assert nmat.colnames() == colnames
         assert np.array_equal(nmat.values, np.array(data))
-    
+
     def test_create_with_numpy(self):
         """Test creating a NamedMatrix from a numpy array."""
         data = np.array([[1, 2, 3], [4, 5, 6]])
         rownames = ['r1', 'r2']
         colnames = ['c1', 'c2', 'c3']
-        
+
         nmat = create_named_matrix(data, rownames, colnames)
-        
+
         assert nmat.rownames() == rownames
         assert nmat.colnames() == colnames
         assert np.array_equal(nmat.values, data)

--- a/delphi/tests/test_named_matrix.py
+++ b/delphi/tests/test_named_matrix.py
@@ -336,7 +336,7 @@ class TestNamedMatrix:
             idx_original_name = final_rownames.index(original_name)
             new_name = f"row_{i:04d}_new"
             idx_new_name = final_rownames.index(new_name)
-            assert idx_original_name == idx_new_name + 1, f"row {original_name} is as idx {idx_original_name} but should be before {new_name} at idx {idx_new_name}"
+            assert idx_original_name == idx_new_name + 1, f"row {original_name} is at idx {idx_original_name} but should be before {new_name} at idx {idx_new_name}"
 
         lower_unchanged_col = "col_0019_original"
         assert final_colnames.index(lower_unchanged_col) == A.colnames().index(lower_unchanged_col) , "wrong index for lower unchanged column"
@@ -345,7 +345,7 @@ class TestNamedMatrix:
             idx_original_name = final_colnames.index(original_name)
             new_name = f"col_{i:04d}_new"
             idx_new_name = final_colnames.index(new_name)
-            assert idx_original_name == idx_new_name + 1, f"col {original_name} is as idx {idx_original_name} but should be before {new_name} at idx {idx_new_name}"
+            assert idx_original_name == idx_new_name + 1, f"col {original_name} is at idx {idx_original_name} but should be before {new_name} at idx {idx_new_name}"
 
         # Test 4: Existing rows at new columns are NaN
         for row in rownames:


### PR DESCRIPTION
~**⚠️ IMPORTANT: Please review #2267 first, as this PR is stacked upon it and thus includes it.**~ [Edit: Stacking removed.]


Copying values around in Named matrices is taking a *lot* of time when running Delphi, more than it should. This PR fixes that. And fixes the corresponding existing tests while we're at it, and add more thorough ones ;-)

- **Factorize named matrix vote normalization option**
  The tests are also fixed (was breaking), while keeping the same behavior as before.
  
  Weirdly, update() does not normalize the values being set, whereas batch_update() does.
  And _convert_to_numeric() keeps NaN values as NaN, whereas batch_update() converts them to 0.0 by default.
  This is not very consistent, but I have kept the same behavior for backward compatibility.
  Since not all Delphi tests are passing, I could not verify whether other parts of the pipeline depend on this behaviour.
 
- **Add deeper test**
  We do a proper large update with new rows and new columns in the middle of the existing matrix.

- **Speed up named matrix computation**
  Using pandas `reindex` methods avoids a *lot* of copying values in for loops. Tip: do _not_ use for loops in Python :)  
  
 Fixes #2261 .
