### PR TITLE
Robustify data diagnostics 

### DIFF
--- a/delphi/polismath/conversation/conversation.py
+++ b/delphi/polismath/conversation/conversation.py
@@ -206,6 +206,8 @@ class Conversation:
             batch_start = time.time()
             result.raw_rating_mat = result.raw_rating_mat.batch_update(vote_updates)
             logger.info(f"[{time.time() - start_time:.2f}s] Batch update completed in {time.time() - batch_start:.2f}s")
+        else:
+            logger.info(f"[{time.time() - start_time:.2f}s] No new votes to apply.")
         
         # Update last updated timestamp
         result.last_updated = max(

--- a/delphi/polismath/conversation/conversation.py
+++ b/delphi/polismath/conversation/conversation.py
@@ -122,8 +122,9 @@ class Conversation:
         null_count = 0
         
         # Progress tracking
-        progress_interval = 10000  # Report every N votes
+        progress_interval = 200000  # Report every N votes
         
+        # TODO: we could probably vectorize this further for speed...
         for i, vote in enumerate(vote_data):
             # Report progress for large datasets
             if i > 0 and i % progress_interval == 0:

--- a/delphi/polismath/pca_kmeans_rep/named_matrix.py
+++ b/delphi/polismath/pca_kmeans_rep/named_matrix.py
@@ -379,72 +379,76 @@ class NamedMatrix:
         
         if should_report:
             logger.info(f"[{time.time() - start_time:.2f}s] Found {len(existing_rows)} existing rows and {len(existing_cols)} existing columns")
-            logger.info(f"[{time.time() - start_time:.2f}s] First pass: identifying new rows/columns and processing values")
-        
-        # First pass: identify new rows/columns and process values
-        new_rows = set()
-        new_cols = set()
-        processed_updates = {}  # (row, col) -> processed_value
-        
-        for i, (row, col, value) in enumerate(updates):
-            # Progress reporting
-            if should_report and i > 0 and i % PROGRESS_INTERVAL == 0:
-                progress_pct = (i / total_updates) * 100
-                elapsed = time.time() - start_time
-                remaining = (elapsed / i) * (total_updates - i) if i > 0 else 0
-                logger.info(f"[{elapsed:.2f}s] Processed {i}/{total_updates} updates ({progress_pct:.1f}%) - Est. remaining: {remaining:.2f}s")
-            
-            # Track new rows and columns
-            if row not in existing_rows and row not in new_rows:
-                new_rows.add(row)
-            if col not in existing_cols and col not in new_cols:
-                new_cols.add(col)
-            
-            # Normalize value if requested
-            processed_value = value
-            if normalize_values:
-                processed_value = self._normalize_vote_value(value)
-                
-            # Store processed value
-            processed_updates[(row, col)] = processed_value
-        
+
+        # Vectorized batch processing of updates
+
+        # Step 1: Convert the list to a DataFrame with columns "row", "col", "value"
+        if should_report:
+            logger.info(f"[{time.time() - start_time:.2f}s] Converting updates to DataFrame...")
+
+        updates_df = pd.DataFrame(updates, columns=['row', 'col', 'value'])
+
+        # Step 2: Keep only the last update for each (row, col) pair
+        original_count = len(updates_df)
+        updates_df = updates_df.drop_duplicates(subset=['row', 'col'], keep='last')
+        unique_count = len(updates_df)
+        duplicates_removed = original_count - unique_count
+
+        if should_report:
+            logger.info(f"[{time.time() - start_time:.2f}s] Removed {duplicates_removed} duplicate updates "
+                       f"({duplicates_removed/original_count*100:.1f}%), kept {unique_count} unique updates")
+
+        # Step 3: Normalize values if requested using vectorized operations
+        if normalize_values:
+            if should_report:
+                logger.info(f"[{time.time() - start_time:.2f}s] Normalizing values...")
+
+            # Vectorized normalization: convert to numeric, then apply sign function
+            values = pd.to_numeric(updates_df['value'], errors='coerce')
+
+            # Apply normalization: positive -> 1.0, negative -> -1.0, zero/NaN -> 0.0
+            normalized = np.sign(values)
+            # Convert NaN from np.sign (which returns NaN for NaN input) to 0.0
+            normalized = normalized.fillna(0.0)
+
+            updates_df['value'] = normalized
+
+        # Step 4: Get new rows and columns by set difference
+        if should_report:
+            logger.info(f"[{time.time() - start_time:.2f}s] Identifying new rows and columns...")
+
+        all_update_rows = set(updates_df['row'].unique())
+        all_update_cols = set(updates_df['col'].unique())
+
+        new_rows = all_update_rows - existing_rows
+        new_cols = all_update_cols - existing_cols
+
         if should_report:
             logger.info(f"[{time.time() - start_time:.2f}s] Found {len(new_rows)} new rows and {len(new_cols)} new columns")
-            logger.info(f"[{time.time() - start_time:.2f}s] Creating new matrix with {len(existing_rows) + len(new_rows)} rows and {len(existing_cols) + len(new_cols)} columns")
-        
-        # Create complete row and column lists (existing + new)
+
+        # Step 5: Create complete row and column lists and reindex
         all_rows = sorted(list(existing_rows) + list(new_rows))
         all_cols = sorted(list(existing_cols) + list(new_cols))
-        
-        # Use vectorized operations if possible to copy faster
-        # Reindex will automatically align and copy values, filling missing with NaN
+
         if should_report:
-            logger.info(f"[{time.time() - start_time:.2f}s] Copying existing values...")
+            logger.info(f"[{time.time() - start_time:.2f}s] Creating new matrix with {len(all_rows)} rows and {len(all_cols)} columns")
+            logger.info(f"[{time.time() - start_time:.2f}s] Reindexing existing matrix...")
+
         matrix_copy = self._matrix.reindex(index=all_rows, columns=all_cols, fill_value=np.nan, copy=True)
-        
-        # Apply all updates at once
+
+        # Step 6: Apply all updates at once
         if should_report:
-            logger.info(f"[{time.time() - start_time:.2f}s] Applying {len(processed_updates)} updates...")
-        
+            logger.info(f"[{time.time() - start_time:.2f}s] Applying {unique_count} updates...")
+
         update_start = time.time()
-        update_count = 0
-        
-        for (row, col), value in processed_updates.items():
-            matrix_copy.at[row, col] = value
-            update_count += 1
-            
-            # Report progress for large update sets
-            if should_report and update_count % PROGRESS_INTERVAL == 0:
-                progress_pct = (update_count / len(processed_updates)) * 100
-                elapsed = time.time() - update_start
-                estimated_total = (elapsed / update_count) * len(processed_updates)
-                remaining = estimated_total - elapsed
-                logger.info(f"[{time.time() - start_time:.2f}s] Applied {update_count}/{len(processed_updates)} updates ({progress_pct:.1f}%) - Est. remaining: {remaining:.2f}s")
-        
+
+        # Use .at for efficient individual cell updates
+        for idx, row_data in updates_df.iterrows():
+            matrix_copy.at[row_data['row'], row_data['col']] = row_data['value']
+
         if should_report:
             logger.info(f"[{time.time() - start_time:.2f}s] Updates applied in {time.time() - update_start:.2f}s")
-            logger.info(f"[{time.time() - start_time:.2f}s] Creating result NamedMatrix...")
-        
+
         # Create a new NamedMatrix with the updated data
         result = NamedMatrix.__new__(NamedMatrix)
         result._matrix = matrix_copy
@@ -598,6 +602,15 @@ class NamedMatrix:
         """
         return (f"NamedMatrix with {len(self.rownames())} rows and "
                 f"{len(self.colnames())} columns\n{self._matrix}")
+
+    def memory_usage_mb(self) -> float:
+        """
+        Estimate the memory usage of the matrix in megabytes.
+        
+        Returns:
+            Estimated memory usage in MB
+        """
+        return self._matrix.memory_usage(deep=True).sum() / (1024 * 1024)
 
 
 # Utility functions

--- a/delphi/polismath/pca_kmeans_rep/named_matrix.py
+++ b/delphi/polismath/pca_kmeans_rep/named_matrix.py
@@ -181,7 +181,7 @@ class NamedMatrix:
         
         Args:
             v: The value to normalize
-            convert_na_to_0: Whether to keep NaN values as NaN or convert them to 0.0. Default True.
+            convert_na_to_0: Whether to keep NaN values as NaN (and NA converts to NaN), or convert them to 0.0. Default True.
         """
         # Process value into normalized form
         if v is None:
@@ -197,7 +197,7 @@ class NamedMatrix:
             elif numeric_value < 0:
                 return -1.0
             else:
-                # Note: np.nan is captured here
+                # Note: np.nan is captured here if it has not been captured in (not convert_na_to_0)
                 return 0.0
         except (ValueError, TypeError):
             return np.nan
@@ -406,7 +406,7 @@ class NamedMatrix:
             # Vectorized normalization: convert to numeric, then apply sign function
             values = pd.to_numeric(updates_df['value'], errors='coerce')
 
-            # Apply normalization: positive -> 1.0, negative -> -1.0, zero/NaN -> 0.0
+            # Apply normalization: positive -> 1.0, negative -> -1.0, zero -> 0.0, nan -> nan
             normalized = np.sign(values)
             # Convert NaN from np.sign (which returns NaN for NaN input) to 0.0
             normalized = normalized.fillna(0.0)

--- a/delphi/polismath/pca_kmeans_rep/named_matrix.py
+++ b/delphi/polismath/pca_kmeans_rep/named_matrix.py
@@ -187,7 +187,7 @@ class NamedMatrix:
         if v is None:
             return np.nan
         
-        if not convert_na_to_0 and pd.isna(v):
+        if pd.isna(v) and not convert_na_to_0:
             return np.nan 
 
         try:
@@ -293,26 +293,42 @@ class NamedMatrix:
             row: Row name
             col: Column name
             value: New value
-            normalize_value: Whether to normalize the value (convert positive values to 1.0, negative values to -1.0, and zero/NaN to 0.0). Default False.
+            normalize_value: Whether to normalize the value (convert positive values to 1.0, negative values to -1.0, and zero to 0.0). Default False.
 
         Note: Unlike batch_update, this method does *NOT* normalize values by default.
+
+        Using the legacy behaviour here:
+            update with strings:
+                normalize_value = True ->  NaN
+                normalize_value = False (default) ->  NaN
+
+            update with NaN:
+                normalize_values = True ->  0.0
+                normalize_values = False (default) ->  NaN
+
             
         Returns:
             A new NamedMatrix with the updated value
         """
         # Convert value to numeric if needed
         # Like in batch update mode, we normalize to -1, 0, 1 for vote values
+        if pd.isna(value):
+            if normalize_value:
+                value = 0.0
+
+        if type(value) == str:
+            value = np.nan
+
         if value is not None:
             try:
                 # Try to convert to float
                 numeric_value = float(value)
                 value = numeric_value
+                if normalize_value:
+                    value = self._normalize_vote_value(value, convert_na_to_0=False)
             except (ValueError, TypeError):
                 # If conversion fails, use NaN
                 value = np.nan
-
-        if normalize_value:
-            value = self._normalize_vote_value(value, convert_na_to_0=True)
         
         # Make a copy of the current matrix
         new_matrix = self._matrix.copy()
@@ -358,6 +374,16 @@ class NamedMatrix:
             normalize_values: Whether to normalize the values (convert positive values to 1.0, negative values to -1.0, and zero/NaN to 0.0). Default True.
 
         Note: unlike the single update method, this method *DOES* normalize values by default.
+        
+        Using legacy behaviour:
+         
+            batch_update  with strings:
+                normalize_values = True (default) -> NaN
+                normalize_values = False -> NaN
+
+            batch_update with NaN:
+                normalize_values = True (default) -> return 0.0 (as per legacy behavior)
+                normalize_values = False -> NaN
             
         Returns:
             Updated NamedMatrix with all changes applied at once
@@ -394,6 +420,10 @@ class NamedMatrix:
         unique_count = len(updates_df)
         duplicates_removed = original_count - unique_count
 
+        # Spot all strings in updates_df by 0.0
+        are_strings = updates_df['value'].apply(lambda v: isinstance(v, str))
+        updates_df.loc[are_strings,'value'] = np.nan
+
         if should_report:
             logger.info(f"[{time.time() - start_time:.2f}s] Removed {duplicates_removed} duplicate updates "
                        f"({duplicates_removed/original_count*100:.1f}%), kept {unique_count} unique updates")
@@ -403,15 +433,19 @@ class NamedMatrix:
             if should_report:
                 logger.info(f"[{time.time() - start_time:.2f}s] Normalizing values...")
 
+
             # Vectorized normalization: convert to numeric, then apply sign function
             values = pd.to_numeric(updates_df['value'], errors='coerce')
 
             # Apply normalization: positive -> 1.0, negative -> -1.0, zero -> 0.0, nan -> nan
             normalized = np.sign(values)
-            # Convert NaN from np.sign (which returns NaN for NaN input) to 0.0
-            normalized = normalized.fillna(0.0)
+            normalized.fillna(0.0, inplace=True)  # Convert NaN to 0.0 as per legacy behavior
 
             updates_df['value'] = normalized
+
+
+        # Revert all strings to NaN
+        updates_df.loc[are_strings,'value'] = np.nan
 
         # Step 4: Get new rows and columns by set difference
         if should_report:

--- a/delphi/polismath/run_math_pipeline.py
+++ b/delphi/polismath/run_math_pipeline.py
@@ -193,6 +193,36 @@ def fetch_moderation(conn, conversation_id):
         'mod_out_ptpts': mod_out_ptpts
     }
 
+import sys
+
+def memory_usage_mb(obj, seen=None):
+    return memory_usage(obj) / (1024 * 1024)
+
+def memory_usage(obj, seen=None):
+    """Recursively calculate size of objects"""
+    size = sys.getsizeof(obj)
+    if seen is None:
+        seen = set()
+    
+    obj_id = id(obj)
+    if obj_id in seen:
+        return 0
+    
+    # Mark as seen to avoid counting duplicates
+    seen.add(obj_id)
+    
+    # Handle different types
+    if isinstance(obj, dict):
+        size += sum([memory_usage(v, seen) for v in obj.values()])
+        size += sum([memory_usage(k, seen) for k in obj.keys()])
+    elif hasattr(obj, '__dict__'):
+        size += memory_usage(obj.__dict__, seen)
+    elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes, bytearray)):
+        size += sum([memory_usage(i, seen) for i in obj])
+    
+    return size
+
+
 def main():
     parser = argparse.ArgumentParser(description='Run math pipeline for a Polis conversation')
     parser.add_argument('--zid', type=int, required=True, help='Conversation ID to process')
@@ -277,6 +307,7 @@ def main():
             
             transform_time = time.time()
             logger.info(f"[{time.time() - start_time:.2f}s] Data transformation completed in {transform_time - db_fetch_time:.2f}s")
+            logger.info(f"[{time.time() - start_time:.2f}s] Size of votes list of dict: {memory_usage_mb(votes_list):.2f} MB")
             
             batch_votes = {'votes': votes_list}
             update_start = time.time()
@@ -285,7 +316,9 @@ def main():
             
             logger.info(f"[{time.time() - start_time:.2f}s] Vote update completed in {update_end - update_start:.2f}s")
             logger.info(f"[{time.time() - start_time:.2f}s] Total batch processing time: {time.time() - batch_start_time:.2f}s")
+            logger.info(f"[{time.time() - start_time:.2f}s] Memory used by the matrix of votes so far: {conv.raw_rating_mat.memory_usage_mb():.2f} MB")
 
+        
         logger.info(f"[{time.time() - start_time:.2f}s] Running final computation with detailed timing...")
         
         # PCA computation

--- a/delphi/polismath/run_math_pipeline.py
+++ b/delphi/polismath/run_math_pipeline.py
@@ -213,12 +213,12 @@ def memory_usage(obj, seen=None):
     
     # Handle different types
     if isinstance(obj, dict):
-        size += sum([memory_usage(v, seen) for v in obj.values()])
-        size += sum([memory_usage(k, seen) for k in obj.keys()])
+        size += sum(memory_usage(v, seen) for v in obj.values())
+        size += sum(memory_usage(k, seen) for k in obj.keys())
     elif hasattr(obj, '__dict__'):
         size += memory_usage(obj.__dict__, seen)
     elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes, bytearray)):
-        size += sum([memory_usage(i, seen) for i in obj])
+        size += sum(memory_usage(i, seen) for i in obj)
     
     return size
 

--- a/delphi/scripts/participation_timeline.py
+++ b/delphi/scripts/participation_timeline.py
@@ -453,7 +453,7 @@ def process_zinvite(conn, zinvite, output_dir, stats_only=False):
         matrix_size = n_participants * n_comments
         sparseness_percentage = ((matrix_size - n_unique_pairs) / matrix_size * 100) if matrix_size > 0 else 0
 
-        print(f"  Duplicate (participant, comment) pairs: {n_duplicate_pairs} ({duplicate_percentage:.2f}% of total votes)")
+        print(f"  Duplicated (participant, comment) pairs: {n_duplicate_pairs} ({duplicate_percentage:.2f}% of total votes)")
         print(f"  Vote matrix sparseness: {sparseness_percentage:.2f}% ({n_participants} participants × {n_comments} comments)")
 
         # If stats-only mode, stop here

--- a/delphi/scripts/participation_timeline.py
+++ b/delphi/scripts/participation_timeline.py
@@ -3,11 +3,12 @@
 Generate participation timeline visualizations for Polis conversations.
 
 Usage:
-    python participation_timeline.py <zinvite1> [zinvite2 ...]
+    python participation_timeline.py [--stats-only] <zinvite1> [zinvite2 ...]
 """
 
 import sys
 import os
+import argparse
 import psycopg2
 import pandas as pd
 import numpy as np
@@ -420,7 +421,7 @@ def print_statistics(sorted_matrix, participant_df, all_days):
     print(f"    Peak participation: {daily_participants.max()} people on {all_days[peak_day]}")
 
 
-def process_zinvite(conn, zinvite, output_dir):
+def process_zinvite(conn, zinvite, output_dir, stats_only=False):
     """Process a single zinvite."""
     print(f"\n{'='*60}")
     print(f"Processing zinvite: {zinvite}")
@@ -439,6 +440,26 @@ def process_zinvite(conn, zinvite, output_dir):
         # Load and process data
         print(f"  Loading votes...")
         votes_df = load_votes(conn, zid)
+
+        # Calculate duplicate statistics
+        total_votes = len(votes_df)
+        unique_pairs = votes_df[['pid', 'tid']].drop_duplicates()
+        n_unique_pairs = len(unique_pairs)
+        n_duplicate_pairs = total_votes - n_unique_pairs
+        duplicate_percentage = (n_duplicate_pairs / total_votes * 100) if total_votes > 0 else 0
+
+        n_participants = votes_df['pid'].nunique()
+        n_comments = votes_df['tid'].nunique()
+        matrix_size = n_participants * n_comments
+        sparseness_percentage = ((matrix_size - n_unique_pairs) / matrix_size * 100) if matrix_size > 0 else 0
+
+        print(f"  Duplicate (participant, comment) pairs: {n_duplicate_pairs} ({duplicate_percentage:.2f}% of total votes)")
+        print(f"  Vote matrix sparseness: {sparseness_percentage:.2f}% ({n_participants} participants × {n_comments} comments)")
+
+        # If stats-only mode, stop here
+        if stats_only:
+            print(f"\n  ✓ Statistics printed for {zinvite} (stats-only mode)")
+            return True
 
         print(f"  Computing participation matrix...")
         participation_matrix, participants, all_days, start_date = compute_participation_matrix(votes_df)
@@ -465,21 +486,26 @@ def process_zinvite(conn, zinvite, output_dir):
 
 def main():
     """Main entry point."""
-    if len(sys.argv) < 2:
-        print("Usage: python participation_timeline.py <zinvite1> [zinvite2 ...]")
-        print("\nExample:")
-        print("  python participation_timeline.py 3yjmwkrw4c 69hm3zfanb")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description='Generate participation timeline visualizations for Polis conversations.',
+        epilog='Example: python participation_timeline.py 3yjmwkrw4c 69hm3zfanb'
+    )
+    parser.add_argument('zinvites', nargs='+', help='One or more zinvite codes to process')
+    parser.add_argument('--stats-only', action='store_true',
+                        help='Only print statistics without generating visualizations')
 
-    zinvites = sys.argv[1:]
+    args = parser.parse_args()
 
     print(f"Participation Timeline Generator")
-    print(f"Processing {len(zinvites)} zinvite(s)")
+    print(f"Processing {len(args.zinvites)} zinvite(s)")
+    if args.stats_only:
+        print(f"Mode: Statistics only (no visualizations)")
 
-    # Create output directory
+    # Create output directory (only needed if not stats-only)
     output_dir = './timeline_output'
-    os.makedirs(output_dir, exist_ok=True)
-    print(f"Output directory: {output_dir}")
+    if not args.stats_only:
+        os.makedirs(output_dir, exist_ok=True)
+        print(f"Output directory: {output_dir}")
 
     # Connect to database
     print("\nConnecting to database...")
@@ -490,8 +516,8 @@ def main():
     successful = 0
     failed = 0
 
-    for zinvite in zinvites:
-        if process_zinvite(conn, zinvite, output_dir):
+    for zinvite in args.zinvites:
+        if process_zinvite(conn, zinvite, output_dir, stats_only=args.stats_only):
             successful += 1
         else:
             failed += 1
@@ -503,10 +529,11 @@ def main():
     print(f"\n{'='*60}")
     print(f"SUMMARY")
     print(f"{'='*60}")
-    print(f"  Total: {len(zinvites)}")
+    print(f"  Total: {len(args.zinvites)}")
     print(f"  Successful: {successful}")
     print(f"  Failed: {failed}")
-    print(f"  Output: {output_dir}/")
+    if not args.stats_only:
+        print(f"  Output: {output_dir}/")
     print()
 
 

--- a/delphi/tests/test_named_matrix.py
+++ b/delphi/tests/test_named_matrix.py
@@ -455,3 +455,76 @@ class TestCreateNamedMatrix:
         assert nmat.rownames() == rownames
         assert nmat.colnames() == colnames
         assert np.array_equal(nmat.values, data)
+
+
+class TestNaNHandling:
+    """Tests for NaN handling in NamedMatrix update methods."""
+
+    def test_batch_update_converts_nan_to_zero_with_normalization(self):
+        """
+        Test that batch_update converts NaN values to 0.0 when normalize_values=True (default).
+
+        1. Creates a NamedMatrix
+        2. Prepares an update with a np.nan in the update
+        3. Calls batch_update on the matrix with that update
+        4. Checks that the NaN is now 0.0
+        """
+        # Step 1: Create a NamedMatrix
+        matrix = NamedMatrix(
+            matrix=np.array([[1.0, -1.0], [0.0, 1.0]]),
+            rownames=['row1', 'row2'],
+            colnames=['col1', 'col2']
+        )
+
+        # Step 2: Prepare an update with a np.nan in the update
+        updates = [
+            ('row1', 'col1', np.nan),  # Update existing cell with NaN
+            ('row2', 'col2', np.nan),  # Update another existing cell with NaN
+            ('row3', 'col3', np.nan),  # Add new cell with NaN
+        ]
+
+        # Step 3: Call batch_update on the matrix with that update (normalize_values=True is default)
+        updated_matrix = matrix.batch_update(updates, normalize_values=True)
+
+        # Step 4: Check that the NaN is now 0.0
+        assert updated_matrix.matrix.loc['row1', 'col1'] == 0.0, \
+            f"Expected 0.0 for row1,col1 but got {updated_matrix.matrix.loc['row1', 'col1']}"
+        assert updated_matrix.matrix.loc['row2', 'col2'] == 0.0, \
+            f"Expected 0.0 for row2,col2 but got {updated_matrix.matrix.loc['row2', 'col2']}"
+        assert updated_matrix.matrix.loc['row3', 'col3'] == 0.0, \
+            f"Expected 0.0 for new cell row3,col3 but got {updated_matrix.matrix.loc['row3', 'col3']}"
+
+        # Verify no NaN values remain in updated cells
+        assert not np.isnan(updated_matrix.matrix.loc['row1', 'col1']), \
+            "NaN found in row1,col1 when it should be 0.0"
+        assert not np.isnan(updated_matrix.matrix.loc['row2', 'col2']), \
+            "NaN found in row2,col2 when it should be 0.0"
+        assert not np.isnan(updated_matrix.matrix.loc['row3', 'col3']), \
+            "NaN found in row3,col3 when it should be 0.0"
+
+    def test_update_preserves_nan_without_normalization(self):
+        """
+        Test that update() (not batch) keeps NaN values as NaN when normalize_value=False (default).
+
+        1. Creates a NamedMatrix
+        2. Uses update() with np.nan
+        3. Checks that the NaN is still nan
+        """
+        # Step 1: Create a NamedMatrix
+        matrix = NamedMatrix(
+            matrix=np.array([[1.0, -1.0], [0.0, 1.0]]),
+            rownames=['row1', 'row2'],
+            colnames=['col1', 'col2']
+        )
+
+        # Step 2: Use update() with np.nan (normalize_value=False is the default for update())
+        updated_matrix = matrix.update('row1', 'col1', np.nan, normalize_value=False)
+
+        # Step 3: Check that the NaN is still NaN
+        assert np.isnan(updated_matrix.matrix.loc['row1', 'col1']), \
+            f"Expected NaN for row1,col1 but got {updated_matrix.matrix.loc['row1', 'col1']}"
+
+        # Also test adding a new cell with NaN
+        updated_matrix2 = matrix.update('row3', 'col3', np.nan, normalize_value=False)
+        assert np.isnan(updated_matrix2.matrix.loc['row3', 'col3']), \
+            f"Expected NaN for new cell row3,col3 but got {updated_matrix2.matrix.loc['row3', 'col3']}"

--- a/delphi/tests/test_named_matrix.py
+++ b/delphi/tests/test_named_matrix.py
@@ -361,6 +361,73 @@ class TestNamedMatrix:
                 assert pd.isna(value), \
                     f"Expected NaN at new row {row} and existing column {col}, but got {value}"
 
+    def test_batch_update_last_value_wins(self):
+        """Test that when multiple updates target the same cell, the last value wins."""
+        # Create a simple 2x2 matrix
+        nmat = NamedMatrix(
+            np.array([[1, 2], [3, 4]]),
+            ['r1', 'r2'],
+            ['c1', 'c2']
+        )
+
+        # Test 1: Multiple updates to the same existing cell
+        updates = [
+            ('r1', 'c1', 10),
+            ('r1', 'c1', 20),
+            ('r1', 'c1', 30),  # This should be the final value
+        ]
+        nmat2 = nmat.batch_update(updates, normalize_values=False)
+        assert nmat2.matrix.loc['r1', 'c1'] == 30, \
+            f"Expected last value 30, got {nmat2.matrix.loc['r1', 'c1']}"
+
+        # Test 2: Multiple updates to a new cell
+        updates = [
+            ('r3', 'c3', 100),
+            ('r3', 'c3', 200),
+            ('r3', 'c3', 300),  # This should be the final value
+        ]
+        nmat3 = nmat.batch_update(updates, normalize_values=False)
+        assert nmat3.matrix.loc['r3', 'c3'] == 300, \
+            f"Expected last value 300, got {nmat3.matrix.loc['r3', 'c3']}"
+
+        # Test 3: Multiple updates mixed with other updates
+        updates = [
+            ('r1', 'c1', 10),
+            ('r1', 'c2', 50),
+            ('r1', 'c1', 20),  # Second update to r1,c1
+            ('r2', 'c1', 60),
+            ('r1', 'c1', 30),  # Third update to r1,c1 (should win)
+        ]
+        nmat4 = nmat.batch_update(updates, normalize_values=False)
+        assert nmat4.matrix.loc['r1', 'c1'] == 30, \
+            f"Expected last value 30 at r1,c1, got {nmat4.matrix.loc['r1', 'c1']}"
+        assert nmat4.matrix.loc['r1', 'c2'] == 50, \
+            f"Expected value 50 at r1,c2, got {nmat4.matrix.loc['r1', 'c2']}"
+        assert nmat4.matrix.loc['r2', 'c1'] == 60, \
+            f"Expected value 60 at r2,c1, got {nmat4.matrix.loc['r2', 'c1']}"
+
+        # Test 4: Multiple updates with normalized values
+        updates = [
+            ('r1', 'c1', 5),    # Would normalize to 1.0
+            ('r1', 'c1', -3),   # Would normalize to -1.0
+            ('r1', 'c1', 0),    # Would normalize to 0.0 (should win)
+        ]
+        nmat5 = nmat.batch_update(updates, normalize_values=True)
+        assert nmat5.matrix.loc['r1', 'c1'] == 0.0, \
+            f"Expected normalized value 0.0, got {nmat5.matrix.loc['r1', 'c1']}"
+
+        # Test 5: Many updates to the same cell (stress test)
+        updates = [(f'r_new', f'c_new', i) for i in range(1000)]
+        nmat6 = nmat.batch_update(updates, normalize_values=False)
+        assert nmat6.matrix.loc['r_new', 'c_new'] == 999, \
+            f"Expected last value 999, got {nmat6.matrix.loc['r_new', 'c_new']}"
+
+        # Verify original data is still unchanged in test 5
+        assert nmat6.matrix.loc['r1', 'c2'] == 2, \
+            f"Expected original value 2 at r1,c2, got {nmat6.matrix.loc['r1', 'c2']}"
+        assert nmat6.matrix.loc['r2', 'c1'] == 3, \
+            f"Expected original value 3 at r2,c1, got {nmat6.matrix.loc['r2', 'c1']}"
+
 
 class TestCreateNamedMatrix:
     """Tests for the create_named_matrix function."""

--- a/delphi/tests/test_named_matrix.py
+++ b/delphi/tests/test_named_matrix.py
@@ -458,35 +458,51 @@ class TestCreateNamedMatrix:
 
 
 class TestNaNHandling:
-    """Tests for NaN handling in NamedMatrix update methods."""
+    """Tests for NaN handling in NamedMatrix update methods.
+    
+    We want here to reproduce the behaviour of NamedMatrix as it was
+    immediately after the Python port. We might want to revisit this eventually
+    for some more logical behaviour...
+    
+    batch_update  with strings:
+        normalize_values = True (default) -> NaN
+        normalize_values = False -> NaN
 
-    def test_batch_update_converts_nan_to_zero_with_normalization(self):
-        """
-        Test that batch_update converts NaN values to 0.0 when normalize_values=True (default).
+    batch_update with NaN:
+        normalize_values = True (default) -> return 0.0 (as per legacy behavior)
+        normalize_values = False -> NaN
+    
+    update with strings:
+        normalize_value = True ->  NaN
+        normalize_value = False (default) ->  NaN
 
-        1. Creates a NamedMatrix
-        2. Prepares an update with a np.nan in the update
-        3. Calls batch_update on the matrix with that update
-        4. Checks that the NaN is now 0.0
+    update with NaN:
+        normalize_values = True ->  0.0
+        normalize_values = False (default) ->  NaN
+    
+    """
+
+    def test_batch_update_with_nan_normalize_true(self):
         """
-        # Step 1: Create a NamedMatrix
+        Test batch_update with NaN when normalize_values=True (default).
+        Expected: NaN values should become 0.0 (as per legacy behavior)
+        """
         matrix = NamedMatrix(
             matrix=np.array([[1.0, -1.0], [0.0, 1.0]]),
             rownames=['row1', 'row2'],
             colnames=['col1', 'col2']
         )
 
-        # Step 2: Prepare an update with a np.nan in the update
         updates = [
-            ('row1', 'col1', np.nan),  # Update existing cell with NaN
-            ('row2', 'col2', np.nan),  # Update another existing cell with NaN
-            ('row3', 'col3', np.nan),  # Add new cell with NaN
+            ('row1', 'col1', np.nan),
+            ('row2', 'col2', np.nan),
+            ('row3', 'col3', np.nan),  # New cell
         ]
 
-        # Step 3: Call batch_update on the matrix with that update (normalize_values=True is default)
+        # normalize_values=True is the default for batch_update
         updated_matrix = matrix.batch_update(updates, normalize_values=True)
 
-        # Step 4: Check that the NaN is now 0.0
+        # Check that NaN values became 0.0
         assert updated_matrix.matrix.loc['row1', 'col1'] == 0.0, \
             f"Expected 0.0 for row1,col1 but got {updated_matrix.matrix.loc['row1', 'col1']}"
         assert updated_matrix.matrix.loc['row2', 'col2'] == 0.0, \
@@ -494,33 +510,48 @@ class TestNaNHandling:
         assert updated_matrix.matrix.loc['row3', 'col3'] == 0.0, \
             f"Expected 0.0 for new cell row3,col3 but got {updated_matrix.matrix.loc['row3', 'col3']}"
 
-        # Verify no NaN values remain in updated cells
-        assert not np.isnan(updated_matrix.matrix.loc['row1', 'col1']), \
-            "NaN found in row1,col1 when it should be 0.0"
-        assert not np.isnan(updated_matrix.matrix.loc['row2', 'col2']), \
-            "NaN found in row2,col2 when it should be 0.0"
-        assert not np.isnan(updated_matrix.matrix.loc['row3', 'col3']), \
-            "NaN found in row3,col3 when it should be 0.0"
-
-    def test_update_preserves_nan_without_normalization(self):
+    def test_batch_update_with_nan_normalize_false(self):
         """
-        Test that update() (not batch) keeps NaN values as NaN when normalize_value=False (default).
-
-        1. Creates a NamedMatrix
-        2. Uses update() with np.nan
-        3. Checks that the NaN is still nan
+        Test batch_update with NaN when normalize_values=False.
+        Expected: NaN values should remain as NaN
         """
-        # Step 1: Create a NamedMatrix
         matrix = NamedMatrix(
             matrix=np.array([[1.0, -1.0], [0.0, 1.0]]),
             rownames=['row1', 'row2'],
             colnames=['col1', 'col2']
         )
 
-        # Step 2: Use update() with np.nan (normalize_value=False is the default for update())
+        updates = [
+            ('row1', 'col1', np.nan),
+            ('row2', 'col2', np.nan),
+            ('row3', 'col3', np.nan),  # New cell
+        ]
+
+        updated_matrix = matrix.batch_update(updates, normalize_values=False)
+
+        # Check that NaN values remain as NaN
+        assert np.isnan(updated_matrix.matrix.loc['row1', 'col1']), \
+            f"Expected NaN for row1,col1 but got {updated_matrix.matrix.loc['row1', 'col1']}"
+        assert np.isnan(updated_matrix.matrix.loc['row2', 'col2']), \
+            f"Expected NaN for row2,col2 but got {updated_matrix.matrix.loc['row2', 'col2']}"
+        assert np.isnan(updated_matrix.matrix.loc['row3', 'col3']), \
+            f"Expected NaN for new cell row3,col3 but got {updated_matrix.matrix.loc['row3', 'col3']}"
+
+    def test_update_with_nan_normalize_false(self):
+        """
+        Test update with NaN when normalize_value=False (default).
+        Expected: NaN values should remain as NaN
+        """
+        matrix = NamedMatrix(
+            matrix=np.array([[1.0, -1.0], [0.0, 1.0]]),
+            rownames=['row1', 'row2'],
+            colnames=['col1', 'col2']
+        )
+
+        # normalize_value=False is the default for update()
         updated_matrix = matrix.update('row1', 'col1', np.nan, normalize_value=False)
 
-        # Step 3: Check that the NaN is still NaN
+        # Check that NaN remains as NaN
         assert np.isnan(updated_matrix.matrix.loc['row1', 'col1']), \
             f"Expected NaN for row1,col1 but got {updated_matrix.matrix.loc['row1', 'col1']}"
 
@@ -528,3 +559,129 @@ class TestNaNHandling:
         updated_matrix2 = matrix.update('row3', 'col3', np.nan, normalize_value=False)
         assert np.isnan(updated_matrix2.matrix.loc['row3', 'col3']), \
             f"Expected NaN for new cell row3,col3 but got {updated_matrix2.matrix.loc['row3', 'col3']}"
+
+    def test_update_with_nan_normalize_true(self):
+        """
+        Test update with NaN when normalize_value=True.
+        Expected: NaN values should become 0.0
+        """
+        matrix = NamedMatrix(
+            matrix=np.array([[1.0, -1.0], [0.0, 1.0]]),
+            rownames=['row1', 'row2'],
+            colnames=['col1', 'col2']
+        )
+
+        updated_matrix = matrix.update('row1', 'col1', np.nan, normalize_value=True)
+
+        # Check that NaN became 0.0
+        assert updated_matrix.matrix.loc['row1', 'col1'] == 0.0, \
+            f"Expected 0.0 for row1,col1 but got {updated_matrix.matrix.loc['row1', 'col1']}"
+
+        # Also test adding a new cell with NaN
+        updated_matrix2 = matrix.update('row3', 'col3', np.nan, normalize_value=True)
+        assert updated_matrix2.matrix.loc['row3', 'col3'] == 0.0, \
+            f"Expected 0.0 for new cell row3,col3 but got {updated_matrix2.matrix.loc['row3', 'col3']}"
+
+    def test_batch_update_with_strings_normalize_true(self):
+        """
+        Test batch_update with string values when normalize_values=True (default).
+        Expected: String values should become NaN
+        """
+        matrix = NamedMatrix(
+            matrix=np.array([[1.0, -1.0], [0.0, 1.0]]),
+            rownames=['row1', 'row2'],
+            colnames=['col1', 'col2']
+        )
+
+        updates_with_strings = [
+            ('row1', 'col1', 'invalid_string'),
+            ('row2', 'col2', 'another_string'),
+            ('row3', 'col3', 'not_a_number'),  # New cell
+        ]
+
+        # normalize_values=True is the default for batch_update
+        updated_matrix = matrix.batch_update(updates_with_strings, normalize_values=True)
+
+        # Check that string values became NaN
+        assert np.isnan(updated_matrix.matrix.loc['row1', 'col1']), \
+            f"Expected NaN for string at row1,col1 but got {updated_matrix.matrix.loc['row1', 'col1']}"
+        assert np.isnan(updated_matrix.matrix.loc['row2', 'col2']), \
+            f"Expected NaN for string at row2,col2 but got {updated_matrix.matrix.loc['row2', 'col2']}"
+        assert np.isnan(updated_matrix.matrix.loc['row3', 'col3']), \
+            f"Expected NaN for string at new cell row3,col3 but got {updated_matrix.matrix.loc['row3', 'col3']}"
+
+    def test_batch_update_with_strings_normalize_false(self):
+        """
+        Test batch_update with string values when normalize_values=False.
+        Expected: String values should become NaN
+        """
+        matrix = NamedMatrix(
+            matrix=np.array([[1.0, -1.0], [0.0, 1.0]]),
+            rownames=['row1', 'row2'],
+            colnames=['col1', 'col2']
+        )
+
+        updates_with_strings = [
+            ('row1', 'col1', 'invalid_string'),
+            ('row2', 'col2', 'another_string'),
+            ('row3', 'col3', 'not_a_number'),  # New cell
+        ]
+
+        updated_matrix = matrix.batch_update(updates_with_strings, normalize_values=False)
+
+        # Check that string values became NaN
+        assert np.isnan(updated_matrix.matrix.loc['row1', 'col1']), \
+            f"Expected NaN for string at row1,col1 but got {updated_matrix.matrix.loc['row1', 'col1']}"
+        assert np.isnan(updated_matrix.matrix.loc['row2', 'col2']), \
+            f"Expected NaN for string at row2,col2 but got {updated_matrix.matrix.loc['row2', 'col2']}"
+        assert np.isnan(updated_matrix.matrix.loc['row3', 'col3']), \
+            f"Expected NaN for string at new cell row3,col3 but got {updated_matrix.matrix.loc['row3', 'col3']}"
+
+    def test_update_with_strings_normalize_false(self):
+        """
+        Test update with string values when normalize_value=False (default).
+        Expected: String values should become NaN
+        """
+        matrix = NamedMatrix(
+            matrix=np.array([[1.0, -1.0], [0.0, 1.0]]),
+            rownames=['row1', 'row2'],
+            colnames=['col1', 'col2']
+        )
+
+        # normalize_value=False is the default for update()
+        updated_matrix = matrix.update('row1', 'col1', 'invalid_string', normalize_value=False)
+
+        # Check that string value became NaN
+        assert np.isnan(updated_matrix.matrix.loc['row1', 'col1']), \
+            f"Expected NaN for string at row1,col1 but got {updated_matrix.matrix.loc['row1', 'col1']}"
+
+        # Test adding a new cell with string
+        updated_matrix2 = matrix.update('row3', 'col3', 'bad_value', normalize_value=False)
+        assert np.isnan(updated_matrix2.matrix.loc['row3', 'col3']), \
+            f"Expected NaN for string at new cell row3,col3 but got {updated_matrix2.matrix.loc['row3', 'col3']}"
+
+        # Verify original matrix is unchanged
+        assert matrix.matrix.loc['row1', 'col1'] == 1.0, \
+            "Original matrix should remain unchanged"
+
+    def test_update_with_strings_normalize_true(self):
+        """
+        Test update with string values when normalize_value=True.
+        Expected: String values should become NaN
+        """
+        matrix = NamedMatrix(
+            matrix=np.array([[1.0, -1.0], [0.0, 1.0]]),
+            rownames=['row1', 'row2'],
+            colnames=['col1', 'col2']
+        )
+
+        updated_matrix = matrix.update('row1', 'col1', 'not_a_number', normalize_value=True)
+
+        # Check that string value became NaN
+        assert np.isnan(updated_matrix.matrix.loc['row1', 'col1']), \
+            f"Expected NaN for string at row1,col1 but got {updated_matrix.matrix.loc['row1', 'col1']}"
+
+        # Test adding a new cell with string
+        updated_matrix2 = matrix.update('row3', 'col3', 'another_string', normalize_value=True)
+        assert np.isnan(updated_matrix2.matrix.loc['row3', 'col3']), \
+            f"Expected NaN for string at new cell row3,col3 but got {updated_matrix2.matrix.loc['row3', 'col3']}"


### PR DESCRIPTION
Adds a few checks and tests to the math pipeline, which were all used to detect a duplication bug in the prodclone data I was analyzing:

One logic change:
- vectorize the collection of updates (new votes) and their application to the vote matrix, which is more inline with data analysis practice and produces a minor speedup (more visible the more updates there are)

And extra logging/testing that served for investigation:
- add unit test on NamedMatrix to make sure that new votes by same participant on same comment override older votes.
- display memory size of vote matrix and update list, to check our understanding and show we can increase batch size.
- display when no new votes are detected
- add extra statistics about duplicate votes in a utility script

