### PR TITLE
Fix run_math_pipeline test import to use proper package path

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -98,9 +98,19 @@ jobs:
       run: |
         echo "Copying coverage-comment.md from delphi container..."
         docker compose -f docker-compose.test.yml cp delphi:/app/coverage-comment.md .
+        echo "=== Coverage Report ==="
+        cat coverage-comment.md
 
-    - name: 8. Post Coverage Comment
+    - name: 8. Upload Coverage Report
+      if: success()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage-comment.md
+
+    - name: 9. Post Coverage Comment
       if: success() && github.event_name == 'pull_request'
+      continue-on-error: true
       uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -115,7 +125,7 @@ jobs:
             body: "## Coverage Report\n\n" + commentBody
           });
 
-    - name: 9. Show service logs on failure
+    - name: 10. Show service logs on failure
       if: failure()
       run: |
         echo "=== Delphi service logs ==="
@@ -125,7 +135,7 @@ jobs:
         echo "=== DynamoDB service logs ==="
         docker compose -f docker-compose.test.yml logs dynamodb || true
 
-    - name: 10. Clean up services
+    - name: 11. Clean up services
       if: always()
       run: |
         echo "Cleaning up services..."

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -68,8 +68,6 @@ jobs:
         docker compose -f docker-compose.test.yml cp delphi/real_data delphi:/app/real_data
         echo "Copying coverage script into container..."
         docker compose -f docker-compose.test.yml cp delphi/generate_coverage_md.py delphi:/app/generate_coverage_md.py
-        echo "Copying script to be tested into container..."
-        docker compose -f docker-compose.test.yml cp delphi/polismath/run_math_pipeline.py delphi:/app/run_math_pipeline.py
 
         echo "Running tests and generating coverage report..."
         docker compose \
@@ -90,7 +88,7 @@ jobs:
             python create_dynamodb_tables.py --region us-east-1; \
             echo '--- Running Pytest ---'; \
             export PYTHONPATH=\$PYTHONPATH:/app; \
-            pytest --cov=polismath --cov=run_math_pipeline --cov-report=xml:/app/coverage.xml /app/tests --ignore=/app/tests/test_pakistan_conversation.py
+            pytest --cov=polismath --cov-report=xml:/app/coverage.xml /app/tests --ignore=/app/tests/test_pakistan_conversation.py
             echo '--- Generating Coverage Comment Text ---'; \
             python /app/generate_coverage_md.py > /app/coverage-comment.md \
           "

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -110,20 +110,30 @@ jobs:
 
     - name: 9. Post Coverage Comment
       if: success() && github.event_name == 'pull_request'
-      continue-on-error: true
       uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const fs = require('fs');
           const commentBody = fs.readFileSync('coverage-comment.md', 'utf8');
-          
-          await github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: "## Coverage Report\n\n" + commentBody
-          });
+
+          try {
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "## Coverage Report\n\n" + commentBody
+            });
+            console.log('Coverage comment posted successfully.');
+          } catch (error) {
+            if (error.status === 403) {
+              console.log('Note: Could not post coverage comment to PR.');
+              console.log('This is expected for PRs from forks due to GitHub token permissions.');
+              console.log('Coverage report is available in the workflow logs (step 7) and as a downloadable artifact (step 8).');
+            } else {
+              console.log(`Unexpected error posting comment: ${error.message}`);
+            }
+          }
 
     - name: 10. Show service logs on failure
       if: failure()

--- a/delphi/tests/run_math_pipeline_test.py
+++ b/delphi/tests/run_math_pipeline_test.py
@@ -16,7 +16,7 @@ if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
 # Import the main function from the script we want to test
-from run_math_pipeline import main as run_math_pipeline_main
+from polismath.run_math_pipeline import main as run_math_pipeline_main
 
 # --- Define Mock Data Paths ---
 # FIX: Corrected path inside the container. The 'delphi' part is removed
@@ -221,8 +221,8 @@ def test_run_math_pipeline_e2e(mock_connect, dynamodb_resource, mock_comments_da
 
     # --- Mock the helper functions ---
     # The script uses these *before* the batching logic
-    with mock.patch('run_math_pipeline.fetch_comments', return_value=mock_comments_data), \
-         mock.patch('run_math_pipeline.fetch_moderation', return_value=mock_moderation_data):
+    with mock.patch('polismath.run_math_pipeline.fetch_comments', return_value=mock_comments_data), \
+         mock.patch('polismath.run_math_pipeline.fetch_moderation', return_value=mock_moderation_data):
         
         # 1. Mock command-line arguments
         test_args = [


### PR DESCRIPTION
The test file was importing `from run_math_pipeline import main` which failed locally because `run_math_pipeline.py` lives inside the `polismath` package at `delphi/polismath/run_math_pipeline.py`.

CI was working around this by copying the file to a flat location:
  docker cp delphi/polismath/run_math_pipeline.py delphi:/app/run_math_pipeline.py

This created a discrepancy between local and CI environments.

The fix:
1. Update test imports to use the correct package path: `from polismath.run_math_pipeline import main`
2. Update mock.patch paths to match: `mock.patch('polismath.run_math_pipeline.fetch_comments', ...)`
3. Remove the CI workaround that copied the file to /app flat
4. Simplify coverage to `--cov=polismath` (run_math_pipeline is inside it)

The Docker image already has `polismath/` at `/app/polismath/` and the package is installed via `pip install --no-deps .`, so the proper import path works in both local and CI environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)