### PR TITLE
Add auto-discovery for regression test datasets with --include-local flag

### DIFF
--- a/delphi/.gitignore
+++ b/delphi/.gitignore
@@ -216,6 +216,7 @@ bandit-report.json
 
 # Local datasets (confidential or too large to commit)
 real_data/.local/
+!real_data/.local/.gitkeep
 
 # Generated dependency files (can be recreated from pyproject.toml)
 requirements-prod.txt

--- a/delphi/.gitignore
+++ b/delphi/.gitignore
@@ -214,6 +214,9 @@ bandit-report.json
 # Test outputs (hidden directory for all test-generated files)
 .test_outputs/
 
+# Local datasets (confidential or too large to commit)
+real_data/.local/
+
 # Generated dependency files (can be recreated from pyproject.toml)
 requirements-prod.txt
 requirements-dev.txt

--- a/delphi/polismath/regression/__init__.py
+++ b/delphi/polismath/regression/__init__.py
@@ -8,17 +8,23 @@ outputs to ensure consistency across code changes.
 from .recorder import ConversationRecorder
 from .comparer import ConversationComparer
 from .datasets import (
+    DatasetInfo,
+    discover_datasets,
+    list_regression_datasets,
+    list_available_datasets,
+    get_dataset_info,
     get_dataset_files,
     get_dataset_report_id,
-    list_available_datasets,
-    DATASETS
 )
 
 __all__ = [
     'ConversationRecorder',
     'ConversationComparer',
+    'DatasetInfo',
+    'discover_datasets',
+    'list_regression_datasets',
+    'list_available_datasets',
+    'get_dataset_info',
     'get_dataset_files',
     'get_dataset_report_id',
-    'list_available_datasets',
-    'DATASETS',
 ]

--- a/delphi/polismath/regression/datasets.py
+++ b/delphi/polismath/regression/datasets.py
@@ -1,245 +1,172 @@
 """
-Dataset configuration for regression testing.
+Dataset auto-discovery for regression testing.
 
-This module provides centralized configuration for test datasets, including
-paths to data files and golden snapshots.
+Datasets are auto-discovered from real_data/ and real_data/.local/ based on
+directory naming: <report_id>-<name>/
+
+Required files for regression testing:
+- *-votes.csv, *-comments.csv, {report_id}_math_blob.json, golden_snapshot.json
 """
 
-import os
 import glob
+import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
-
-# Dataset configuration mapping dataset names to report IDs
-DATASETS = {
-    'biodiversity': {
-        'report_id': 'r4tykwac8thvzv35jrn53',
-        'description': 'NZ Biodiversity Strategy'
-    },
-    'vw': {
-        'report_id': 'r6vbnhffkxbd7ifmfbdrd',
-        'description': 'VW Conversation'
-    },
+# Optional metadata for known datasets
+DATASET_METADATA = {
+    'biodiversity': 'NZ Biodiversity Strategy',
+    'vw': 'VW Conversation',
 }
+
+# Pattern: <report_id>-<name> where report_id starts with 'r'
+_DIR_PATTERN = re.compile(r'^(r[a-z0-9]+)-(.+)$')
+
+
+@dataclass
+class DatasetInfo:
+    """Auto-discovered dataset information."""
+    name: str
+    report_id: str
+    path: Path
+    is_local: bool
+    has_golden: bool
+    has_math_blob: bool
+    has_votes: bool
+    has_comments: bool
+
+    @property
+    def is_valid(self) -> bool:
+        """Has all files needed for regression testing."""
+        return all([self.has_golden, self.has_math_blob, self.has_votes, self.has_comments])
+
+    @property
+    def description(self) -> str:
+        return DATASET_METADATA.get(self.name, f'Dataset: {self.name}')
 
 
 def get_real_data_dir() -> Path:
-    """
-    Get the absolute path to the real_data directory.
-
-    Returns:
-        Path to the real_data directory (delphi/real_data)
-    """
-    # This file is in delphi/polismath/regression, so go up three levels to delphi, then into real_data
-    module_dir = Path(__file__).parent
-    polismath_dir = module_dir.parent
-    delphi_dir = polismath_dir.parent
-    real_data_dir = delphi_dir / 'real_data'
-
-    return real_data_dir.resolve()
+    """Path to delphi/real_data/"""
+    return (Path(__file__).parent.parent.parent / 'real_data').resolve()
 
 
+def get_local_data_dir() -> Path:
+    """Path to delphi/real_data/.local/"""
+    return get_real_data_dir() / '.local'
+
+
+def _check_files(path: Path, report_id: str) -> dict:
+    """Check which required files exist."""
+    return {
+        'has_votes': bool(list(path.glob(f"*-{report_id}-votes.csv"))),
+        'has_comments': bool(list(path.glob(f"*-{report_id}-comments.csv"))),
+        'has_math_blob': (path / f"{report_id}_math_blob.json").exists(),
+        'has_golden': (path / "golden_snapshot.json").exists(),
+    }
+
+
+def _discover_in_dir(search_dir: Path, is_local: bool) -> Dict[str, DatasetInfo]:
+    """Discover datasets in a directory."""
+    if not search_dir.exists():
+        return {}
+
+    datasets = {}
+    for item in search_dir.iterdir():
+        if not item.is_dir():
+            continue
+        match = _DIR_PATTERN.match(item.name)
+        if match:
+            report_id, name = match.groups()
+            datasets[name] = DatasetInfo(
+                name=name, report_id=report_id, path=item, is_local=is_local,
+                **_check_files(item, report_id)
+            )
+    return datasets
+
+
+def discover_datasets(include_local: bool = False) -> Dict[str, DatasetInfo]:
+    """Auto-discover datasets from real_data/ and optionally .local/"""
+    datasets = _discover_in_dir(get_real_data_dir(), is_local=False)
+    if include_local:
+        datasets.update(_discover_in_dir(get_local_data_dir(), is_local=True))
+    return datasets
+
+
+def list_regression_datasets(include_local: bool = False) -> List[str]:
+    """List dataset names valid for regression testing."""
+    return [n for n, d in discover_datasets(include_local).items() if d.is_valid]
+
+
+def list_available_datasets(include_local: bool = False) -> Dict[str, dict]:
+    """List datasets in legacy dict format for backward compatibility."""
+    return {
+        name: {
+            'report_id': d.report_id,
+            'description': d.description,
+            'is_local': d.is_local,
+            'has_golden': d.has_golden,
+            'has_math_blob': d.has_math_blob,
+        }
+        for name, d in discover_datasets(include_local).items()
+    }
+
+
+def get_dataset_info(name: str) -> DatasetInfo:
+    """Get dataset by name (searches both locations)."""
+    datasets = discover_datasets(include_local=True)
+    if name not in datasets:
+        raise ValueError(f"Unknown dataset: {name}. Available: {', '.join(sorted(datasets))}")
+    return datasets[name]
+
+
+def get_dataset_report_id(name: str) -> str:
+    """Get report_id for a dataset name."""
+    return get_dataset_info(name).report_id
+
+
+def get_dataset_files(name: str) -> Dict[str, str]:
+    """Get file paths for a dataset."""
+    info = get_dataset_info(name)
+    rid = info.report_id
+
+    def find_file(pattern: str) -> str:
+        matches = list(info.path.glob(pattern))
+        if not matches:
+            raise FileNotFoundError(f"No file matching {pattern} in {info.path}")
+        return str(matches[0].resolve())
+
+    return {
+        'report_id': rid,
+        'data_dir': str(info.path),
+        'votes': find_file(f"*-{rid}-votes.csv"),
+        'comments': find_file(f"*-{rid}-comments.csv"),
+        'summary': find_file(f"*-{rid}-summary.csv"),
+        'math_blob': str(info.path / f"{rid}_math_blob.json"),
+    }
+
+
+# Legacy aliases
 def get_dataset_directory(report_id: str, dataset_name: Optional[str] = None) -> Path:
-    """
-    Get the directory path for a dataset, supporting both old and new naming conventions.
-
-    The new convention uses format: <report_id>-<dataset_name>
-    The old convention uses format: <report_id>
-
-    Args:
-        report_id: Report ID (e.g., 'r4tykwac8thvzv35jrn53')
-        dataset_name: Optional dataset name (e.g., 'biodiversity')
-
-    Returns:
-        Path to the dataset directory
-
-    Raises:
-        FileNotFoundError: If no matching directory is found
-    """
-    real_data_dir = get_real_data_dir()
-
-    # Try new format first: <report_id>-<dataset_name>
-    if dataset_name:
-        new_format_dir = real_data_dir / f"{report_id}-{dataset_name}"
-        if new_format_dir.exists():
-            return new_format_dir
-
-    # Fall back to old format: <report_id>
-    old_format_dir = real_data_dir / report_id
-    if old_format_dir.exists():
-        return old_format_dir
-
-    # If neither exists, raise an error with helpful message
-    if dataset_name:
-        raise FileNotFoundError(
-            f"Dataset directory not found. Tried:\n"
-            f"  - {real_data_dir / f'{report_id}-{dataset_name}'}\n"
-            f"  - {real_data_dir / report_id}\n"
-            f"Make sure you have downloaded the test data for {dataset_name} ({report_id})"
-        )
-    else:
-        raise FileNotFoundError(
-            f"Report directory not found: {real_data_dir / report_id}\n"
-            f"Make sure you have downloaded the test data for report {report_id}"
-        )
+    """Find dataset directory by report_id."""
+    for search_dir in [get_real_data_dir(), get_local_data_dir()]:
+        if not search_dir.exists():
+            continue
+        if dataset_name:
+            path = search_dir / f"{report_id}-{dataset_name}"
+            if path.exists():
+                return path
+        path = search_dir / report_id
+        if path.exists():
+            return path
+    raise FileNotFoundError(f"Dataset not found: {report_id}")
 
 
 def find_dataset_file(report_id: str, suffix: str, dataset_name: Optional[str] = None) -> str:
-    """
-    Find a file in the real_data directory by report ID and suffix.
-
-    This function uses glob patterns to find files with timestamped names,
-    allowing tests to work regardless of when the data was downloaded.
-
-    Args:
-        report_id: Report ID (e.g., 'r4tykwac8thvzv35jrn53')
-        suffix: File suffix to search for. Supported suffixes:
-            - 'votes.csv' - Vote data
-            - 'comments.csv' - Comment data
-            - 'summary.csv' - Summary statistics
-            - 'math_blob.json' - Clojure math computation output
-        dataset_name: Optional dataset name for new directory format
-
-    Returns:
-        Absolute path to the file
-
-    Raises:
-        FileNotFoundError: If no matching file is found
-        ValueError: If multiple matching files are found
-
-    Examples:
-        >>> find_dataset_file('r4tykwac8thvzv35jrn53', 'votes.csv', 'biodiversity')
-        '/path/to/real_data/r4tykwac8thvzv35jrn53-biodiversity/2025-11-07-1035-r4tykwac8thvzv35jrn53-votes.csv'
-    """
+    """Find a file by report_id and suffix."""
     report_dir = get_dataset_directory(report_id, dataset_name)
-
-    # Build the search pattern based on suffix
-    if suffix == 'math_blob.json':
-        # Math blob uses format: {report_id}_math_blob.json
-        pattern = f"{report_id}_math_blob.json"
-    else:
-        # CSV files use format: {timestamp}-{report_id}-{suffix}
-        pattern = f"*-{report_id}-{suffix}"
-
-    search_path = report_dir / pattern
-    matches = glob.glob(str(search_path))
-
+    pattern = f"{report_id}_math_blob.json" if suffix == 'math_blob.json' else f"*-{report_id}-{suffix}"
+    matches = glob.glob(str(report_dir / pattern))
     if not matches:
-        raise FileNotFoundError(
-            f"No file found matching pattern: {search_path}\n"
-            f"Available files in {report_dir}:\n" +
-            "\n".join(f"  - {f.name}" for f in sorted(report_dir.glob('*')))
-        )
-
-    if len(matches) > 1:
-        raise ValueError(
-            f"Multiple files found matching pattern: {search_path}\n" +
-            "\n".join(f"  - {m}" for m in matches) +
-            "\nPlease clean up old files or specify a more specific pattern."
-        )
-
-    return os.path.abspath(matches[0])
-
-
-def get_dataset_files(dataset_name: str) -> Dict[str, Path]:
-    """
-    Get file paths for a dataset by name.
-
-    Args:
-        dataset_name: Dataset name (e.g., 'biodiversity', 'vw')
-                     Must be a key in the DATASETS dictionary
-
-    Returns:
-        Dictionary with keys:
-            - 'votes': Path to votes CSV file
-            - 'comments': Path to comments CSV file
-            - 'summary': Path to summary CSV file
-            - 'math_blob': Path to math blob JSON file
-            - 'data_dir': Path to the dataset directory
-            - 'report_id': The report ID for this dataset
-
-    Raises:
-        ValueError: If dataset_name is not recognized
-        FileNotFoundError: If any required files are missing
-
-    Examples:
-        >>> files = get_dataset_files('biodiversity')
-        >>> print(files['votes'])
-        '/path/to/real_data/r4tykwac8thvzv35jrn53-biodiversity/2025-11-07-1035-r4tykwac8thvzv35jrn53-votes.csv'
-    """
-    if dataset_name not in DATASETS:
-        available = ', '.join(DATASETS.keys())
-        raise ValueError(
-            f"Unknown dataset: {dataset_name}\n"
-            f"Available datasets: {available}"
-        )
-
-    report_id = DATASETS[dataset_name]['report_id']
-    data_dir = get_dataset_directory(report_id, dataset_name)
-
-    # Find all required files
-    files = {
-        'report_id': report_id,
-        'data_dir': str(data_dir),
-        'votes': find_dataset_file(report_id, 'votes.csv', dataset_name),
-        'comments': find_dataset_file(report_id, 'comments.csv', dataset_name),
-        'summary': find_dataset_file(report_id, 'summary.csv', dataset_name),
-        'math_blob': find_dataset_file(report_id, 'math_blob.json', dataset_name),
-    }
-
-    return files
-
-
-def get_dataset_report_id(dataset_name: str) -> str:
-    """
-    Get the report ID for a dataset by name.
-
-    Args:
-        dataset_name: Dataset name (e.g., 'biodiversity', 'vw')
-
-    Returns:
-        The report ID string
-
-    Raises:
-        ValueError: If dataset_name is not recognized
-    """
-    if dataset_name not in DATASETS:
-        available = ', '.join(DATASETS.keys())
-        raise ValueError(
-            f"Unknown dataset: {dataset_name}\n"
-            f"Available datasets: {available}"
-        )
-
-    return DATASETS[dataset_name]['report_id']
-
-
-def list_available_datasets() -> Dict[str, Dict[str, str]]:
-    """
-    List all available datasets and their information.
-
-    Returns:
-        Dictionary mapping dataset names to their configuration
-    """
-    return DATASETS.copy()
-
-
-def get_dataset_file_optional(dataset_name: str, suffix: str) -> Optional[str]:
-    """
-    Get a dataset file path, returning None if the file doesn't exist.
-
-    This is useful for files that may not always be present (e.g., math_blob.json
-    when only CSV files were downloaded).
-
-    Args:
-        dataset_name: Dataset name (e.g., 'biodiversity', 'vw')
-        suffix: File suffix (e.g., 'votes.csv', 'math_blob.json')
-
-    Returns:
-        Absolute path to the file, or None if not found
-    """
-    try:
-        report_id = get_dataset_report_id(dataset_name)
-        return find_dataset_file(report_id, suffix, dataset_name)
-    except (FileNotFoundError, ValueError):
-        return None
+        raise FileNotFoundError(f"No {suffix} in {report_dir}")
+    return matches[0]

--- a/delphi/polismath/regression/datasets.py
+++ b/delphi/polismath/regression/datasets.py
@@ -5,7 +5,10 @@ Datasets are auto-discovered from real_data/ and real_data/.local/ based on
 directory naming: <report_id>-<name>/
 
 Required files for regression testing:
-- *-votes.csv, *-comments.csv, {report_id}_math_blob.json, golden_snapshot.json
+- *-votes.csv, *-comments.csv, golden_snapshot.json
+
+Optional files:
+- {report_id}_math_blob.json (for Clojure comparison - requires database access to download)
 """
 
 import glob
@@ -38,8 +41,13 @@ class DatasetInfo:
 
     @property
     def is_valid(self) -> bool:
-        """Has all files needed for regression testing."""
-        return all([self.has_golden, self.has_math_blob, self.has_votes, self.has_comments])
+        """Has all files needed for regression testing (math_blob is optional)."""
+        return all([self.has_golden, self.has_votes, self.has_comments])
+
+    @property
+    def has_clojure_reference(self) -> bool:
+        """Has math_blob for comparison with Clojure implementation."""
+        return self.has_math_blob
 
     @property
     def description(self) -> str:
@@ -117,6 +125,7 @@ def list_available_datasets(include_local: bool = False) -> Dict[str, dict]:
             'is_local': d.is_local,
             'has_golden': d.has_golden,
             'has_math_blob': d.has_math_blob,
+            'has_clojure_reference': d.has_clojure_reference,
         }
         for name, d in discover_datasets(include_local).items()
     }

--- a/delphi/polismath/regression/datasets.py
+++ b/delphi/polismath/regression/datasets.py
@@ -89,7 +89,17 @@ def discover_datasets(include_local: bool = False) -> Dict[str, DatasetInfo]:
     """Auto-discover datasets from real_data/ and optionally .local/"""
     datasets = _discover_in_dir(get_real_data_dir(), is_local=False)
     if include_local:
-        datasets.update(_discover_in_dir(get_local_data_dir(), is_local=True))
+        local_datasets = _discover_in_dir(get_local_data_dir(), is_local=True)
+        # Warn about name collisions (local would shadow committed)
+        collisions = set(datasets.keys()) & set(local_datasets.keys())
+        if collisions:
+            import warnings
+            warnings.warn(
+                f"Local datasets shadow committed datasets with same name: {', '.join(sorted(collisions))}. "
+                f"Local versions will be used.",
+                UserWarning
+            )
+        datasets.update(local_datasets)
     return datasets
 
 

--- a/delphi/polismath/regression/datasets.py
+++ b/delphi/polismath/regression/datasets.py
@@ -59,8 +59,8 @@ def get_local_data_dir() -> Path:
 def _check_files(path: Path, report_id: str) -> dict:
     """Check which required files exist."""
     return {
-        'has_votes': bool(list(path.glob(f"*-{report_id}-votes.csv"))),
-        'has_comments': bool(list(path.glob(f"*-{report_id}-comments.csv"))),
+        'has_votes': any(path.glob(f"*-{report_id}-votes.csv")),
+        'has_comments': any(path.glob(f"*-{report_id}-comments.csv")),
         'has_math_blob': (path / f"{report_id}_math_blob.json").exists(),
         'has_golden': (path / "golden_snapshot.json").exists(),
     }
@@ -134,6 +134,8 @@ def get_dataset_files(name: str) -> Dict[str, str]:
         matches = list(info.path.glob(pattern))
         if not matches:
             raise FileNotFoundError(f"No file matching {pattern} in {info.path}")
+        if len(matches) > 1:
+            raise ValueError(f"Multiple files matching {pattern} in {info.path}: {matches}")
         return str(matches[0].resolve())
 
     return {

--- a/delphi/polismath/regression/utils.py
+++ b/delphi/polismath/regression/utils.py
@@ -289,14 +289,11 @@ def load_golden_snapshot(dataset_name: str, golden_dir: Optional[Path] = None) -
         Tuple of (golden_snapshot_dict, golden_path) or (None, path) if not found
     """
     if golden_dir is None:
-        # Check if dataset is configured
-        from polismath.regression.datasets import get_dataset_files, list_available_datasets
-
-        available_datasets = list_available_datasets()
-        if dataset_name not in available_datasets:
-            raise ValueError(f"Unknown dataset: {dataset_name}. Available datasets: {', '.join(available_datasets.keys())}")
-
         # Get the dataset directory from dataset_config
+        # get_dataset_files() will handle dataset discovery (including local datasets) and raise
+        # a proper error if the dataset doesn't exist
+        from polismath.regression.datasets import get_dataset_files
+
         dataset_files = get_dataset_files(dataset_name)
         dataset_dir = Path(dataset_files['data_dir'])
         golden_dir = dataset_dir

--- a/delphi/pyproject.toml
+++ b/delphi/pyproject.toml
@@ -128,6 +128,9 @@ filterwarnings = [
     # Ignore botocore datetime.utcnow() deprecation warning (third-party)
     "ignore:datetime.datetime.utcnow\\(\\) is deprecated:DeprecationWarning:botocore",
 ]
+markers = [
+    "local_dataset: mark test as using local (non-committed) datasets from real_data/.local/",
+]
 
 [tool.coverage.run]
 relative_files = true

--- a/delphi/scripts/regression_download.py
+++ b/delphi/scripts/regression_download.py
@@ -5,12 +5,18 @@ Script to download real test data from Polis exports for delphi tests.
 This script downloads data from a running Polis instance:
 1. Downloads CSV exports (comments, votes, summary) from the report endpoint
    - Requires: Polis web server running (default: http://localhost)
+   - Use --base-url to specify a different instance (e.g., --base-url https://pol.is for production)
 2. Extracts the math blob JSON from the Postgres database
+   - Requires: DATABASE_URL environment variable set to a valid Postgres connection string
    - Requires: Postgres database with the reports and math_main table populated
    - Note: Math blobs may not be available if the database is not accessible or
      if the Clojure math computation hasn't run for the given report
 3. Saves all files to real_data/.local/<report_id>-<name>/ by default
    (use --commit to save to real_data/ for committed datasets)
+
+Requirements:
+    - DATABASE_URL environment variable must be set (e.g., postgres://user:pass@host:port/dbname)
+    - Polis web server accessible (default: http://localhost, use --base-url for other instances)
 
 Usage:
     # Download a new dataset (saves to .local/ by default)
@@ -18,6 +24,9 @@ Usage:
 
     # Download to committed location (for public datasets)
     python regression_download.py rexample1234 myconvo --commit
+
+    # Download from production (https://pol.is)
+    python regression_download.py rexample1234 myconvo --base-url https://pol.is
 
     # Force re-download all configured datasets
     python regression_download.py --force
@@ -29,6 +38,7 @@ Examples:
     python regression_download.py rexample1234 myconvo          # Downloads to .local/
     python regression_download.py rexample1234 myconvo --commit # Downloads to real_data/
     python regression_download.py --datasets vw                 # Downloads configured dataset
+    python regression_download.py rexample1234 myconvo --base-url https://pol.is  # From production
 """
 
 import json
@@ -36,10 +46,8 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 from dotenv import load_dotenv
-
-load_dotenv(Path(__file__).parent.parent.parent / '.env')
 
 import click
 import psycopg2
@@ -48,12 +56,21 @@ from tqdm import tqdm
 
 from polismath.regression import list_available_datasets, get_dataset_report_id
 
+# Load .env from polis/ parent directory (script is at polis/delphi/scripts/regression_download.py)
+# Need to go up 3 levels: scripts/ -> delphi/ -> polis/
+load_dotenv(Path(__file__).parent.parent.parent / '.env')
+
 
 def get_db_connection():
     """Create a connection to the Postgres database using environment variables."""
     # These will be automatically loaded from .env by pyauto-dotenv when running from delphi directory
     # Try to use DATABASE_URL first (connection string), fall back to individual parameters
     database_url = os.environ.get('DATABASE_URL')
+    if not database_url:
+        raise ValueError(
+            "DATABASE_URL environment variable is not set. "
+            "Please set it to a valid Postgres connection string (e.g., postgres://user:pass@host:port/dbname)"
+        )
     return psycopg2.connect(database_url)
 
     # TODO: Uncomment once sorted the difference between env var names between delphi and rest of polis
@@ -363,10 +380,25 @@ def main(report_id: Optional[str], dataset_name: Optional[str], datasets: tuple,
         python regression_download.py --force
 
         \b
-        # Specify custom base URL
-        python regression_download.py --base-url http://localhost:5000
+        # Download from production Polis instance
+        python regression_download.py rexample1234 myconvo --base-url https://pol.is
+
+        \b
+        # Specify custom base URL (e.g., local dev server on different port)
+        python regression_download.py rexample1234 myconvo --base-url http://localhost:5000
     """
-    # Get the delphi directory (parent of tests directory where this script lives)
+    # Check for required DATABASE_URL environment variable
+    database_url = os.environ.get('DATABASE_URL')
+    if not database_url:
+        click.echo("Error: DATABASE_URL environment variable is required", err=True)
+        click.echo("\nThe DATABASE_URL must be set to a valid Postgres connection string.", err=True)
+        click.echo("Example: postgres://user:password@localhost:5432/dbname", err=True)
+        click.echo("\nYou can set it in your .env file or export it before running:", err=True)
+        click.echo("  export DATABASE_URL='postgres://user:pass@host:port/dbname'", err=True)
+        click.echo("  python scripts/regression_download.py ...", err=True)
+        raise click.Abort()
+
+    # Get the delphi directory (script is at delphi/scripts/regression_download.py)
     delphi_dir = Path(__file__).parent.parent
 
     # Determine base directory: .local/ by default, real_data/ with --commit
@@ -522,6 +554,8 @@ def _offer_golden_snapshot_creation(download_items: list, rid_to_name: dict,
         from polismath.regression import ConversationRecorder
         recorder = ConversationRecorder()
 
+        successful = []
+        failed = []
         for ds_name in missing_golden:
             click.echo(f"\n{'='*60}")
             click.echo(f"Recording golden snapshot for: {ds_name}")
@@ -529,10 +563,17 @@ def _offer_golden_snapshot_creation(download_items: list, rid_to_name: dict,
             try:
                 recorder.record_golden(ds_name, force=False, benchmark=True)
                 click.echo(f"✓ Created golden snapshot for {ds_name}")
+                successful.append(ds_name)
             except Exception as e:
                 click.echo(f"✗ Failed to create golden snapshot for {ds_name}: {e}", err=True)
+                failed.append(ds_name)
 
-        click.echo("\n✓ Golden snapshot creation complete!")
+        if successful and not failed:
+            click.echo("\n✓ Golden snapshot creation complete!")
+        elif successful:
+            click.echo(f"\n⚠️  Golden snapshot creation partially complete: {len(successful)} succeeded, {len(failed)} failed")
+        else:
+            click.echo("\n✗ Golden snapshot creation failed for all datasets", err=True)
 
 
 if __name__ == '__main__':

--- a/delphi/scripts/regression_download.py
+++ b/delphi/scripts/regression_download.py
@@ -14,21 +14,21 @@ This script downloads data from a running Polis instance:
 
 Usage:
     # Download a new dataset (saves to .local/ by default)
-    python download_real_data.py rexample1234 myconvo
+    python regression_download.py rexample1234 myconvo
 
     # Download to committed location (for public datasets)
-    python download_real_data.py rexample1234 myconvo --commit
+    python regression_download.py rexample1234 myconvo --commit
 
     # Force re-download all configured datasets
-    python download_real_data.py --force
+    python regression_download.py --force
 
     # Download specific datasets by name (from config)
-    python download_real_data.py --datasets biodiversity vw
+    python regression_download.py --datasets biodiversity vw
 
 Examples:
-    python download_real_data.py rexample1234 myconvo          # Downloads to .local/
-    python download_real_data.py rexample1234 myconvo --commit # Downloads to real_data/
-    python download_real_data.py --datasets vw                 # Downloads configured dataset
+    python regression_download.py rexample1234 myconvo          # Downloads to .local/
+    python regression_download.py rexample1234 myconvo --commit # Downloads to real_data/
+    python regression_download.py --datasets vw                 # Downloads configured dataset
 """
 
 import json
@@ -348,23 +348,23 @@ def main(report_id: Optional[str], dataset_name: Optional[str], datasets: tuple,
 
         \b
         # Download a new dataset to .local/ (git-ignored)
-        python download_real_data.py rexample1234 myconvo
+        python regression_download.py rexample1234 myconvo
 
         \b
         # Download a dataset for committing to the repo
-        python download_real_data.py rexample1234 myconvo --commit
+        python regression_download.py rexample1234 myconvo --commit
 
         \b
         # Download configured datasets by name
-        python download_real_data.py --datasets biodiversity --datasets vw
+        python regression_download.py --datasets biodiversity --datasets vw
 
         \b
         # Force re-download all configured datasets
-        python download_real_data.py --force
+        python regression_download.py --force
 
         \b
         # Specify custom base URL
-        python download_real_data.py --base-url http://localhost:5000
+        python regression_download.py --base-url http://localhost:5000
     """
     # Get the delphi directory (parent of tests directory where this script lives)
     delphi_dir = Path(__file__).parent.parent

--- a/delphi/scripts/regression_download.py
+++ b/delphi/scripts/regression_download.py
@@ -9,26 +9,26 @@ This script downloads data from a running Polis instance:
    - Requires: Postgres database with the reports and math_main table populated
    - Note: Math blobs may not be available if the database is not accessible or
      if the Clojure math computation hasn't run for the given report
-3. Saves all files to the real_data/<report_id>/ folder
+3. Saves all files to real_data/.local/<report_id>-<name>/ by default
+   (use --commit to save to real_data/ for committed datasets)
 
 Usage:
-    # Download all datasets from config (skip existing)
-    # From environment variable (if TEST_REPORT_IDS set .env)
-    python download_real_data.py
+    # Download a new dataset (saves to .local/ by default)
+    python download_real_data.py rexample1234 myconvo
 
-    # Force re-download all datasets
+    # Download to committed location (for public datasets)
+    python download_real_data.py rexample1234 myconvo --commit
+
+    # Force re-download all configured datasets
     python download_real_data.py --force
 
-    # Download specific datasets by name
+    # Download specific datasets by name (from config)
     python download_real_data.py --datasets biodiversity vw
 
-    # Download specific report IDs
-    python download_real_data.py rabc123xyz456 rdef789uvw012
-
 Examples:
-    python download_real_data.py
-    python download_real_data.py --force
-    python download_real_data.py --datasets vw bg2018
+    python download_real_data.py rexample1234 myconvo          # Downloads to .local/
+    python download_real_data.py rexample1234 myconvo --commit # Downloads to real_data/
+    python download_real_data.py --datasets vw                 # Downloads configured dataset
 """
 
 import json
@@ -308,7 +308,8 @@ def save_test_data(report_id: str, output_dir: Path, base_url: str = "http://loc
 
 
 @click.command()
-@click.argument('report_ids', nargs=-1)
+@click.argument('report_id', required=False)
+@click.argument('dataset_name', required=False)
 @click.option(
     '--datasets',
     multiple=True,
@@ -323,99 +324,123 @@ def save_test_data(report_id: str, output_dir: Path, base_url: str = "http://loc
     '--output-dir',
     type=click.Path(path_type=Path),
     default=None,
-    help='Output directory (default: real_data/<report_id>)'
+    help='Output directory (overrides default location)'
+)
+@click.option(
+    '--commit',
+    is_flag=True,
+    help='Save to real_data/ instead of real_data/.local/ (for public datasets to commit)'
 )
 @click.option(
     '--force',
     is_flag=True,
     help='Force re-download even if files already exist'
 )
-def main(report_ids: tuple, datasets: tuple, base_url: str, output_dir: Optional[Path], force: bool):
+def main(report_id: Optional[str], dataset_name: Optional[str], datasets: tuple,
+         base_url: str, output_dir: Optional[Path], commit: bool, force: bool):
     """
     Download real test data from Polis exports.
 
-    If no arguments are provided, downloads all datasets from config.
-    Otherwise, downloads specified datasets or report IDs.
+    By default, downloads to real_data/.local/ (git-ignored).
+    Use --commit to download to real_data/ for datasets intended to be committed.
 
     Examples:
 
         \b
-        # Download all datasets from config (skip existing)
-        python download_real_data.py
+        # Download a new dataset to .local/ (git-ignored)
+        python download_real_data.py rexample1234 myconvo
 
         \b
-        # Force re-download all datasets from config
-        python download_real_data.py --force
+        # Download a dataset for committing to the repo
+        python download_real_data.py rexample1234 myconvo --commit
 
         \b
-        # Download specific datasets by name
+        # Download configured datasets by name
         python download_real_data.py --datasets biodiversity --datasets vw
 
         \b
-        # Download specific datasets by report ID
-        python download_real_data.py rabc123xyz456 rdef789uvw012
+        # Force re-download all configured datasets
+        python download_real_data.py --force
 
         \b
         # Specify custom base URL
         python download_real_data.py --base-url http://localhost:5000
-
-        \b
-        # Specify custom output directory
-        python download_real_data.py --output-dir /path/to/output
     """
-    # Determine which datasets to download
-    download_report_ids = []
-    env_report_ids = os.getenv('TEST_REPORT_IDS', '').strip()
-
-    # Option 1: Specific dataset names from --datasets flag
-    if datasets:
-        available_datasets = list_available_datasets()
-        for dataset_name in datasets:
-            if dataset_name not in available_datasets:
-                available = ', '.join(available_datasets.keys())
-                click.echo(f"Error: Unknown dataset: {dataset_name}", err=True)
-                click.echo(f"Available datasets: {available}", err=True)
-                raise click.Abort()
-            report_id = get_dataset_report_id(dataset_name)
-            download_report_ids.append(report_id)
-        click.echo(f"Downloading {len(download_report_ids)} dataset(s) from config: {', '.join(datasets)}")
-    # Option 2: Specific report IDs from command line
-    elif report_ids:
-        download_report_ids = list(report_ids)
-        click.echo(f"Downloading {len(download_report_ids)} report ID(s) from command line")
-    # Option 3: environment variable
-    elif env_report_ids:
-        download_report_ids = [rid.strip() for rid in env_report_ids.replace(',', ' ').split() if rid.strip()]
-        click.echo(f"Downloading {len(report_ids)} report IDs from TEST_REPORT_IDS environment variable")
-    # Option 4: Default - all datasets from config
-    else:
-        available_datasets = list_available_datasets()
-        download_report_ids = [dataset['report_id'] for dataset in available_datasets.values()]
-        click.echo(f"No datasets specified. Downloading all {len(download_report_ids)} dataset(s) from config:")
-        for name, info in available_datasets.items():
-            click.echo(f"  - {name}: {info['report_id']} ({info['description']})")
-        click.echo()
-
     # Get the delphi directory (parent of tests directory where this script lives)
     delphi_dir = Path(__file__).parent.parent
 
-    # Process each report ID
+    # Determine base directory: .local/ by default, real_data/ with --commit
+    if commit:
+        base_data_dir = delphi_dir / 'real_data'
+        location_msg = "real_data/ (will be committed)"
+    else:
+        base_data_dir = delphi_dir / 'real_data' / '.local'
+        location_msg = "real_data/.local/ (git-ignored)"
+
+    # Ensure .local directory exists
+    if not commit:
+        base_data_dir.mkdir(parents=True, exist_ok=True)
+
+    # Determine which datasets to download
+    download_items = []  # List of (report_id, name) tuples
+    env_report_ids = os.getenv('TEST_REPORT_IDS', '').strip()
+
+    # Option 1: Positional arguments (report_id and dataset_name)
+    if report_id:
+        if not dataset_name:
+            click.echo("Error: dataset_name is required when specifying report_id", err=True)
+            click.echo("Usage: python download_real_data.py <report_id> <dataset_name>", err=True)
+            raise click.Abort()
+        download_items.append((report_id, dataset_name))
+        click.echo(f"Downloading dataset '{dataset_name}' ({report_id}) to {location_msg}")
+
+    # Option 2: Specific dataset names from --datasets flag
+    elif datasets:
+        available_datasets = list_available_datasets(include_local=True)
+        for ds_name in datasets:
+            if ds_name not in available_datasets:
+                available = ', '.join(available_datasets.keys())
+                click.echo(f"Error: Unknown dataset: {ds_name}", err=True)
+                click.echo(f"Available datasets: {available}", err=True)
+                raise click.Abort()
+            ds_report_id = get_dataset_report_id(ds_name)
+            download_items.append((ds_report_id, ds_name))
+        click.echo(f"Downloading {len(download_items)} dataset(s) from config: {', '.join(datasets)}")
+        click.echo(f"Saving to: {location_msg}")
+
+    # Option 3: Environment variable
+    elif env_report_ids:
+        for rid in env_report_ids.replace(',', ' ').split():
+            rid = rid.strip()
+            if rid:
+                ds_name = get_dataset_name_from_report_id(rid)
+                download_items.append((rid, ds_name or rid))
+        click.echo(f"Downloading {len(download_items)} report IDs from TEST_REPORT_IDS")
+        click.echo(f"Saving to: {location_msg}")
+
+    # Option 4: Default - all configured datasets
+    else:
+        available_datasets = list_available_datasets(include_local=True)
+        for ds_name, info in available_datasets.items():
+            download_items.append((info['report_id'], ds_name))
+        click.echo(f"No datasets specified. Downloading all {len(download_items)} dataset(s) from config:")
+        for ds_name, info in available_datasets.items():
+            click.echo(f"  - {ds_name}: {info['report_id']} ({info['description']})")
+        click.echo(f"Saving to: {location_msg}")
+        click.echo()
+
+    # Process each dataset
     results = {}
-    for report_id in download_report_ids:
+    for rid, ds_name in download_items:
         # Determine output directory
-        # Use format "reportID-name" if name is available from config
-        dataset_name = get_dataset_name_from_report_id(report_id)
-        if dataset_name:
-            dir_name = f"{report_id}-{dataset_name}"
-        else:
-            dir_name = report_id
+        dir_name = f"{rid}-{ds_name}"
 
         if output_dir:
             out_dir = output_dir / dir_name
         else:
-            out_dir = delphi_dir / 'real_data' / dir_name
+            out_dir = base_data_dir / dir_name
 
-        results[report_id] = save_test_data(report_id, out_dir, base_url, force=force)
+        results[rid] = save_test_data(rid, out_dir, base_url, force=force)
 
     # Print summary
     click.echo(f"\n{'='*60}")
@@ -430,21 +455,24 @@ def main(report_ids: tuple, datasets: tuple, base_url: str, output_dir: Optional
     if failed:
         click.echo(f"Failed: {len(failed)}")
 
+    # Build a map of report_id -> dataset_name for display
+    rid_to_name = {rid: ds_name for rid, ds_name in download_items}
+
     if successful:
         click.echo(f"\n✓ Successful:")
         for rid in successful:
-            dataset_name = get_dataset_name_from_report_id(rid)
-            if dataset_name:
-                click.echo(f"  {rid} ({dataset_name})")
+            ds_name = rid_to_name.get(rid) or get_dataset_name_from_report_id(rid)
+            if ds_name:
+                click.echo(f"  {rid} ({ds_name})")
             else:
                 click.echo(f"  {rid}")
 
     if failed:
         click.echo(f"\n✗ Failed:")
         for rid in failed:
-            dataset_name = get_dataset_name_from_report_id(rid)
-            if dataset_name:
-                click.echo(f"  {rid} ({dataset_name})")
+            ds_name = rid_to_name.get(rid) or get_dataset_name_from_report_id(rid)
+            if ds_name:
+                click.echo(f"  {rid} ({ds_name})")
             else:
                 click.echo(f"  {rid}")
         click.echo("\nSome datasets failed to download!", err=True)

--- a/delphi/scripts/regression_download.py
+++ b/delphi/scripts/regression_download.py
@@ -388,8 +388,8 @@ def main(report_id: Optional[str], dataset_name: Optional[str], datasets: tuple,
     # Option 1: Positional arguments (report_id and dataset_name)
     if report_id:
         if not dataset_name:
-            click.echo("Error: dataset_name is required when specifying report_id", err=True)
-            click.echo("Usage: python download_real_data.py <report_id> <dataset_name>", err=True)
+            click.echo("Error: Both report_id and dataset_name are required when downloading a single dataset", err=True)
+            click.echo("Usage: python scripts/regression_download.py <report_id> <dataset_name>", err=True)
             raise click.Abort()
         download_items.append((report_id, dataset_name))
         click.echo(f"Downloading dataset '{dataset_name}' ({report_id}) to {location_msg}")

--- a/delphi/scripts/regression_download.py
+++ b/delphi/scripts/regression_download.py
@@ -480,6 +480,60 @@ def main(report_id: Optional[str], dataset_name: Optional[str], datasets: tuple,
     else:
         click.echo("\n✓ All datasets processed successfully!")
 
+    # Check for missing golden snapshots and offer to create them
+    if successful:
+        _offer_golden_snapshot_creation(download_items, rid_to_name, base_data_dir, output_dir)
+
+
+def _offer_golden_snapshot_creation(download_items: list, rid_to_name: dict,
+                                     base_data_dir: Path, output_dir: Optional[Path]):
+    """Check for missing golden snapshots and offer to create them."""
+    # Find datasets missing golden snapshots
+    missing_golden = []
+    for rid, ds_name in download_items:
+        dir_name = f"{rid}-{ds_name}"
+        if output_dir:
+            ds_dir = output_dir / dir_name
+        else:
+            ds_dir = base_data_dir / dir_name
+
+        golden_path = ds_dir / "golden_snapshot.json"
+        if not golden_path.exists():
+            missing_golden.append(ds_name)
+
+    if not missing_golden:
+        return
+
+    click.echo(f"\n{'='*60}")
+    click.echo("GOLDEN SNAPSHOTS")
+    click.echo(f"{'='*60}\n")
+    click.echo("The following datasets are missing golden snapshots:")
+    for name in missing_golden:
+        click.echo(f"  - {name}")
+
+    click.echo("\n⚠️  Without golden snapshots, these datasets cannot be used for regression testing.")
+    click.echo("   Golden snapshots capture the expected output at a known-good commit.")
+    click.echo("\n   To create golden snapshots later, run:")
+    click.echo(f"     python scripts/regression_recorder.py {' '.join(missing_golden)}")
+
+    if click.confirm("\nWould you like to create golden snapshots now?", default=True):
+        click.echo()
+        # Import here to avoid circular imports and speed up script loading
+        from polismath.regression import ConversationRecorder
+        recorder = ConversationRecorder()
+
+        for ds_name in missing_golden:
+            click.echo(f"\n{'='*60}")
+            click.echo(f"Recording golden snapshot for: {ds_name}")
+            click.echo(f"{'='*60}")
+            try:
+                recorder.record_golden(ds_name, force=False, benchmark=True)
+                click.echo(f"✓ Created golden snapshot for {ds_name}")
+            except Exception as e:
+                click.echo(f"✗ Failed to create golden snapshot for {ds_name}: {e}", err=True)
+
+        click.echo("\n✓ Golden snapshot creation complete!")
+
 
 if __name__ == '__main__':
     main()

--- a/delphi/tests/README.md
+++ b/delphi/tests/README.md
@@ -92,8 +92,10 @@ real_data/
 **Required files per dataset:**
 - `*-votes.csv` - Vote data
 - `*-comments.csv` - Comment data
-- `{report_id}_math_blob.json` - Clojure math output
 - `golden_snapshot.json` - For regression testing
+
+**Optional files:**
+- `{report_id}_math_blob.json` - Clojure math output (for Clojure comparison, requires database access)
 
 ### Running Tests with Local Datasets
 

--- a/delphi/tests/README.md
+++ b/delphi/tests/README.md
@@ -70,66 +70,59 @@ The tests are organized as follows:
 
 ## Test Data
 
-The real data tests use conversation data from the following sources:
+Datasets are **auto-discovered** from two locations:
 
-1. **Biodiversity** - A conversation about biodiversity strategy
-2. **VW** - A conversation related to Volkswagen
+### Committed Datasets (`real_data/`)
+Version-controlled, always available:
+- **biodiversity** - NZ Biodiversity Strategy
+- **vw** - VW Conversation
 
-The test data is located in the `real_data` directory and includes:
-- Votes CSV files
-- Comments CSV files
-- Summary CSV files
-- Math blob JSON (from Clojure math computation)
+### Local Datasets (`real_data/.local/`)
+Git-ignored, for confidential or large datasets. Just drop data here and it's auto-discovered.
 
-### Downloading Real Test Data
+**Directory structure:**
+```
+real_data/
+├── r...-vw/                # Committed
+├── r...-biodiversity/      # Committed
+└── .local/                 # Git-ignored
+    └── r...-myconvo/       # Auto-discovered
+```
 
-**Note:** This script is only needed if you were not provided with a `real_data` folder containing allowed test data. If you already have test data available, you can skip this section.
+**Required files per dataset:**
+- `*-votes.csv` - Vote data
+- `*-comments.csv` - Comment data
+- `{report_id}_math_blob.json` - Clojure math output
+- `golden_snapshot.json` - For regression testing
 
-The `download_real_data.py` script allows you to download real conversation data from a running Polis instance for testing purposes.
+### Running Tests with Local Datasets
+
+```bash
+# Default: committed datasets only
+pytest tests/test_regression.py
+
+# Include local datasets
+pytest tests/test_regression.py --include-local
+```
+
+### Downloading Test Data
+
+```bash
+cd delphi
+
+# Download to .local/ (git-ignored, default)
+python scripts/regression_download.py rexample1234 myconvo
+
+# Download to real_data/ (for committing)
+python scripts/regression_download.py rexample1234 myconvo --commit
+
+# Re-download existing configured datasets
+python scripts/regression_download.py --datasets vw --force
+```
 
 **Requirements:**
-- Polis web server running (default: http://localhost) for CSV exports
-- Postgres database accessible with populated `math_main` table for math blobs
-  - **Important:** The math blob will only be downloaded if you have a local Polis PostgreSQL instance running with data matching the specified report IDs. Without this, only CSV files will be downloaded.
-
-**Usage:**
-
-```bash
-cd delphi/tests
-
-# Download data for specific report IDs
-python download_real_data.py rabc123xyz456 rdef789uvw012
-
-# Load report IDs from TEST_REPORT_IDS environment variable in .env
-python download_real_data.py
-
-# Specify custom base URL
-python download_real_data.py --base-url http://localhost:5000 rabc123xyz456
-```
-
-**Setting up TEST_REPORT_IDS in .env:**
-
-Add the following to your `delphi/.env` file:
-
-```bash
-# Comma or space-separated list of report IDs to download
-TEST_REPORT_IDS="rabc123xyz456 rdef789uvw012 rxyz789abc123"
-```
-
-**What gets downloaded:**
-
-For each report ID, the script downloads:
-1. **comments.csv** - All comments with metadata (timestamp, author, moderation status, etc.)
-2. **votes.csv** - All votes (timestamp, voter ID, comment ID, vote value)
-3. **summary.csv** - Conversation summary statistics
-4. **math_blob.json** - The complete Clojure math computation output from the `math_main` table
-
-Files are saved to `../real_data/<report_id>/` with timestamped filenames.
-
-**Important Notes:**
-- The math blob JSON will only be downloaded if you have a local Polis PostgreSQL instance accessible with math computation results for the given report IDs in the `math_main` table
-- CSV files (comments, votes, summary) only require the Polis web server to be running and will be downloaded regardless of database availability
-- If you don't have a local PostgreSQL instance with the required data, you will only receive CSV files, and tests that depend on the math blob will not be able to run
+- Polis web server running (default: http://localhost)
+- Postgres database for math blobs (optional - CSV files work without it)
 
 ## Expected Output
 

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -1,0 +1,113 @@
+"""
+Pytest configuration and fixtures for delphi tests.
+
+This module provides:
+- Command line option --include-local for including local datasets in tests
+- Fixtures for accessing dataset information
+- Dynamic test parametrization based on discovered datasets
+"""
+
+import pytest
+from polismath.regression.datasets import (
+    discover_datasets,
+    list_regression_datasets,
+)
+
+
+def pytest_addoption(parser):
+    """Add custom command line options to pytest."""
+    parser.addoption(
+        "--include-local",
+        action="store_true",
+        default=False,
+        help="Include datasets from real_data/.local/ in tests"
+    )
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers", "local_dataset: mark test as using local (non-committed) datasets"
+    )
+
+
+@pytest.fixture(scope="session")
+def include_local(request):
+    """Fixture that returns True if --include-local flag was passed."""
+    return request.config.getoption("--include-local")
+
+
+@pytest.fixture(scope="session")
+def all_datasets(include_local):
+    """Fixture that returns all discovered datasets based on --include-local flag."""
+    return discover_datasets(include_local=include_local)
+
+
+@pytest.fixture(scope="session")
+def regression_datasets(include_local):
+    """Fixture that returns datasets valid for regression testing."""
+    return list_regression_datasets(include_local=include_local)
+
+
+def pytest_generate_tests(metafunc):
+    """
+    Dynamically parametrize tests based on discovered datasets.
+
+    Tests that have a 'dataset' parameter will be parametrized with all
+    valid regression datasets. Use --include-local to include datasets
+    from real_data/.local/.
+    """
+    if "dataset" in metafunc.fixturenames:
+        # Check if this test uses the regression dataset parametrization
+        # by looking for the marker or checking the test module
+        include_local = metafunc.config.getoption("--include-local")
+
+        # Get datasets valid for regression testing
+        datasets = list_regression_datasets(include_local=include_local)
+
+        if datasets:
+            metafunc.parametrize("dataset", datasets)
+        else:
+            # If no datasets found, skip with a clear message
+            pytest.skip("No valid regression datasets found")
+
+
+def pytest_collection_modifyitems(config, items):
+    """
+    Modify test collection based on --include-local flag.
+
+    Tests marked with @pytest.mark.local_dataset will be skipped unless
+    --include-local is passed.
+    """
+    if config.getoption("--include-local"):
+        # --include-local passed, don't skip any local dataset tests
+        return
+
+    skip_local = pytest.mark.skip(reason="need --include-local option to run")
+    for item in items:
+        if "local_dataset" in item.keywords:
+            item.add_marker(skip_local)
+
+
+# Provide summary of discovered datasets at start of test run
+def pytest_report_header(config):
+    """Add dataset discovery info to pytest header."""
+    include_local = config.getoption("--include-local")
+    datasets = discover_datasets(include_local=include_local)
+    regression_valid = [
+        name for name, info in datasets.items()
+        if info.is_valid
+    ]
+
+    local_count = sum(1 for info in datasets.values() if info.is_local)
+    committed_count = len(datasets) - local_count
+
+    lines = [
+        f"Datasets discovered: {len(datasets)} total ({committed_count} committed, {local_count} local)",
+        f"Valid for regression: {len(regression_valid)} ({', '.join(sorted(regression_valid)) or 'none'})",
+    ]
+
+    if not include_local:
+        lines.append("Use --include-local to include datasets from real_data/.local/")
+
+    return lines

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -65,11 +65,8 @@ def pytest_generate_tests(metafunc):
         # Get datasets valid for regression testing
         datasets = list_regression_datasets(include_local=include_local)
 
-        if datasets:
-            metafunc.parametrize("dataset", datasets)
-        else:
-            # If no datasets found, skip with a clear message
-            pytest.skip("No valid regression datasets found")
+        # Parametrize with discovered datasets (empty list = no test instances)
+        metafunc.parametrize("dataset", datasets)
 
 
 def pytest_collection_modifyitems(config, items):

--- a/delphi/tests/test_datasets.py
+++ b/delphi/tests/test_datasets.py
@@ -88,6 +88,16 @@ class TestIntegration:
         result = discover_datasets(include_local=False)
         assert len(result) > 0
 
+    def test_discover_with_include_local(self):
+        """Should include local datasets when flag is set."""
+        without_local = discover_datasets(include_local=False)
+        with_local = discover_datasets(include_local=True)
+        # With local should have >= datasets (may have more if .local/ has data)
+        assert len(with_local) >= len(without_local)
+        # All committed datasets should still be present
+        for name in without_local:
+            assert name in with_local
+
     def test_list_regression_datasets(self):
         result = list_regression_datasets()
         assert isinstance(result, list)
@@ -101,3 +111,36 @@ class TestIntegration:
     def test_paths_exist(self):
         assert get_real_data_dir().exists()
         assert get_local_data_dir().parent.exists()
+
+
+class TestNameCollision:
+    def test_warns_on_name_collision(self, tmp_path, monkeypatch):
+        """Should warn when local dataset shadows committed dataset."""
+        import warnings
+        from polismath.regression import datasets
+
+        # Create mock directories
+        real_data = tmp_path / "real_data"
+        local_data = real_data / ".local"
+        real_data.mkdir()
+        local_data.mkdir()
+
+        # Create dataset with same name in both locations
+        (real_data / "rabc123-test").mkdir()
+        (local_data / "rdef456-test").mkdir()  # Same name "test", different report_id
+
+        # Patch the directory functions
+        monkeypatch.setattr(datasets, "get_real_data_dir", lambda: real_data)
+        monkeypatch.setattr(datasets, "get_local_data_dir", lambda: local_data)
+
+        # Should warn about collision
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = datasets.discover_datasets(include_local=True)
+            assert len(w) == 1
+            assert "shadow" in str(w[0].message)
+            assert "test" in str(w[0].message)
+
+        # Local version should win
+        assert result["test"].report_id == "rdef456"
+        assert result["test"].is_local

--- a/delphi/tests/test_datasets.py
+++ b/delphi/tests/test_datasets.py
@@ -16,7 +16,7 @@ from polismath.regression.datasets import (
 )
 
 
-class TestDirPattern:
+class TestDirectoryPattern:
     """Tests for directory naming pattern."""
 
     def test_valid_patterns(self):

--- a/delphi/tests/test_datasets.py
+++ b/delphi/tests/test_datasets.py
@@ -1,0 +1,103 @@
+"""Unit tests for dataset auto-discovery."""
+
+import pytest
+from pathlib import Path
+
+from polismath.regression.datasets import (
+    DatasetInfo,
+    _DIR_PATTERN,
+    _check_files,
+    _discover_in_dir,
+    discover_datasets,
+    list_regression_datasets,
+    list_available_datasets,
+    get_real_data_dir,
+    get_local_data_dir,
+)
+
+
+class TestDirPattern:
+    """Tests for directory naming pattern."""
+
+    def test_valid_patterns(self):
+        for name in ["r6vbnhffkxbd7ifmfbdrd-vw", "rabc123-test", "r1-x"]:
+            assert _DIR_PATTERN.match(name), f"Should match: {name}"
+
+    def test_invalid_patterns(self):
+        for name in ["vw", "6vbnhffkxbd7ifmfbdrd-vw", "r6vbnhffkxbd7ifmfbdrd", ".local"]:
+            assert not _DIR_PATTERN.match(name), f"Should not match: {name}"
+
+    def test_extracts_groups(self):
+        m = _DIR_PATTERN.match("rabc123-mydata")
+        assert m.group(1) == "rabc123"
+        assert m.group(2) == "mydata"
+
+
+class TestDatasetInfo:
+    def test_is_valid_all_files(self):
+        info = DatasetInfo("t", "r1", Path("/x"), False, True, True, True, True)
+        assert info.is_valid
+
+    def test_is_valid_missing_file(self):
+        info = DatasetInfo("t", "r1", Path("/x"), False, False, True, True, True)
+        assert not info.is_valid
+
+
+class TestCheckFiles:
+    def test_all_files_exist(self, tmp_path):
+        rid = "rabc123"
+        (tmp_path / f"2025-01-01-{rid}-votes.csv").touch()
+        (tmp_path / f"2025-01-01-{rid}-comments.csv").touch()
+        (tmp_path / f"{rid}_math_blob.json").touch()
+        (tmp_path / "golden_snapshot.json").touch()
+
+        result = _check_files(tmp_path, rid)
+        assert all(result.values())
+
+    def test_missing_files(self, tmp_path):
+        result = _check_files(tmp_path, "rabc123")
+        assert not any(result.values())
+
+
+class TestDiscovery:
+    def test_empty_dir(self, tmp_path):
+        assert _discover_in_dir(tmp_path, False) == {}
+
+    def test_nonexistent_dir(self, tmp_path):
+        assert _discover_in_dir(tmp_path / "nope", False) == {}
+
+    def test_discovers_valid_dataset(self, tmp_path):
+        ds_dir = tmp_path / "rabc123-test"
+        ds_dir.mkdir()
+        (ds_dir / "2025-01-01-rabc123-votes.csv").touch()
+
+        result = _discover_in_dir(tmp_path, is_local=True)
+        assert "test" in result
+        assert result["test"].report_id == "rabc123"
+        assert result["test"].is_local
+
+    def test_ignores_non_matching(self, tmp_path):
+        (tmp_path / ".local").mkdir()
+        (tmp_path / "random").mkdir()
+        assert _discover_in_dir(tmp_path, False) == {}
+
+
+class TestIntegration:
+    def test_discover_real_data(self):
+        """Should find at least one committed dataset."""
+        result = discover_datasets(include_local=False)
+        assert len(result) > 0
+
+    def test_list_regression_datasets(self):
+        result = list_regression_datasets()
+        assert isinstance(result, list)
+
+    def test_list_available_datasets(self):
+        result = list_available_datasets()
+        for info in result.values():
+            assert "report_id" in info
+            assert "description" in info
+
+    def test_paths_exist(self):
+        assert get_real_data_dir().exists()
+        assert get_local_data_dir().parent.exists()

--- a/delphi/tests/test_datasets.py
+++ b/delphi/tests/test_datasets.py
@@ -38,9 +38,25 @@ class TestDatasetInfo:
         info = DatasetInfo("t", "r1", Path("/x"), False, True, True, True, True)
         assert info.is_valid
 
-    def test_is_valid_missing_file(self):
+    def test_is_valid_without_math_blob(self):
+        """Math blob is optional for regression testing."""
+        # has_golden=True, has_math_blob=False, has_votes=True, has_comments=True
+        info = DatasetInfo("t", "r1", Path("/x"), False, True, False, True, True)
+        assert info.is_valid
+        assert not info.has_clojure_reference
+
+    def test_is_valid_missing_required_file(self):
+        """Missing golden/votes/comments makes dataset invalid."""
+        # Missing golden
         info = DatasetInfo("t", "r1", Path("/x"), False, False, True, True, True)
         assert not info.is_valid
+
+    def test_has_clojure_reference(self):
+        """has_clojure_reference reflects math_blob presence."""
+        with_blob = DatasetInfo("t", "r1", Path("/x"), False, True, True, True, True)
+        without_blob = DatasetInfo("t", "r1", Path("/x"), False, True, False, True, True)
+        assert with_blob.has_clojure_reference
+        assert not without_blob.has_clojure_reference
 
 
 class TestCheckFiles:

--- a/delphi/tests/test_legacy_clojure_regression.py
+++ b/delphi/tests/test_legacy_clojure_regression.py
@@ -3,6 +3,12 @@ Legacy: Comparison with Clojure implementation. Will be removed once Clojure is 
 
 Tests for the conversion with real data from conversations, comparing Python output
 against the old Clojure implementation's math_blob outputs.
+
+Datasets are auto-discovered from:
+- real_data/ (committed datasets, always included)
+- real_data/.local/ (local datasets, included with --include-local flag)
+
+Only datasets with math_blob (has_clojure_reference=True) are included.
 """
 
 import pytest
@@ -16,16 +22,34 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from polismath.conversation.conversation import Conversation
 from polismath.regression import get_dataset_files
+from polismath.regression.datasets import discover_datasets
 from tests.common_utils import load_votes, load_comments, load_clojure_output
 
 
-@pytest.fixture(scope="module", params=["biodiversity", "vw"])
-def conversation_data(request):
+def _get_clojure_datasets(include_local: bool) -> list[str]:
+    """Get datasets that have Clojure math_blob for comparison."""
+    datasets = discover_datasets(include_local=include_local)
+    return [
+        name for name, info in datasets.items()
+        if info.is_valid and info.has_clojure_reference
+    ]
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize fixtures that need clojure datasets."""
+    if "clojure_dataset" in metafunc.fixturenames:
+        include_local = metafunc.config.getoption("--include-local", default=False)
+        datasets = _get_clojure_datasets(include_local)
+        metafunc.parametrize("clojure_dataset", datasets, scope="module")
+
+
+@pytest.fixture(scope="module")
+def conversation_data(clojure_dataset):
     """
     Module-scoped fixture that loads and computes conversation once per dataset.
     This avoids redundant computation when running multiple comparison tests.
     """
-    dataset_name = request.param
+    dataset_name = clojure_dataset
 
     # Get dataset files using central configuration
     dataset_files = get_dataset_files(dataset_name)

--- a/delphi/tests/test_legacy_clojure_regression.py
+++ b/delphi/tests/test_legacy_clojure_regression.py
@@ -27,11 +27,14 @@ from tests.common_utils import load_votes, load_comments, load_clojure_output
 
 
 def _get_clojure_datasets(include_local: bool) -> list[str]:
-    """Get datasets that have Clojure math_blob for comparison."""
+    """Get datasets that have Clojure math_blob for comparison.
+
+    Only requires votes, comments, and math_blob - does NOT require golden_snapshot.
+    """
     datasets = discover_datasets(include_local=include_local)
     return [
         name for name, info in datasets.items()
-        if info.is_valid and info.has_clojure_reference
+        if info.has_votes and info.has_comments and info.has_clojure_reference
     ]
 
 

--- a/delphi/tests/test_regression.py
+++ b/delphi/tests/test_regression.py
@@ -3,23 +3,21 @@ Pytest integration for regression testing system.
 
 This test module integrates the regression testing system with pytest,
 allowing it to be run as part of the regular test suite.
+
+Datasets are auto-discovered from:
+- real_data/ (committed datasets, always included)
+- real_data/.local/ (local datasets, included with --include-local flag)
+
+Usage:
+    pytest tests/test_regression.py              # Run with committed datasets only
+    pytest tests/test_regression.py --include-local  # Include local datasets
 """
 
 import pytest
 import numpy as np
 
-from polismath.regression import ConversationRecorder, ConversationComparer, list_available_datasets
+from polismath.regression import ConversationRecorder, ConversationComparer, list_regression_datasets
 from polismath.regression.utils import load_golden_snapshot
-
-
-# Get all available datasets from central config
-AVAILABLE_DATASETS = list(list_available_datasets().keys())
-
-# Optionally, modify the line below to limit to specific, fast datasets
-TEST_DATASETS = AVAILABLE_DATASETS # e.g., ['vw']
-if not set(TEST_DATASETS).issubset(set(AVAILABLE_DATASETS)):
-    missing = set(TEST_DATASETS) - set(AVAILABLE_DATASETS)
-    raise ValueError(f"Test datasets not found in available datasets: {missing}")
 
 
 def _check_golden_exists(dataset: str):
@@ -46,7 +44,6 @@ def _check_golden_exists(dataset: str):
         )
 
 
-@pytest.mark.parametrize("dataset", TEST_DATASETS)
 def test_conversation_regression(dataset):
     """
     Test that current implementation matches golden snapshot.
@@ -91,7 +88,6 @@ def test_conversation_regression(dataset):
     )
 
 
-@pytest.mark.parametrize("dataset", TEST_DATASETS)
 def test_conversation_stages_individually(dataset):
     """
     Test each computation stage individually for more granular failure detection.

--- a/delphi/tests/test_regression.py
+++ b/delphi/tests/test_regression.py
@@ -8,7 +8,7 @@ Datasets are auto-discovered from:
 - real_data/ (committed datasets, always included)
 - real_data/.local/ (local datasets, included with --include-local flag)
 
-Usage:
+Usage (from delphi/ directory):
     pytest tests/test_regression.py              # Run with committed datasets only
     pytest tests/test_regression.py --include-local  # Include local datasets
 """
@@ -16,7 +16,7 @@ Usage:
 import pytest
 import numpy as np
 
-from polismath.regression import ConversationRecorder, ConversationComparer, list_regression_datasets
+from polismath.regression import ConversationRecorder, ConversationComparer
 from polismath.regression.utils import load_golden_snapshot
 
 


### PR DESCRIPTION
## Summary

This PR adds support for testing with local datasets that are not committed to the repository. This enables:

1. **Confidential data testing** - Run regression tests on private conversations without risking accidental commits
2. **Large dataset testing** - Test with larger conversations that would bloat the repository
3. **Easy dataset addition** - Just drop data in `real_data/.local/` and it's auto-discovered, no config changes needed

### Changes

- Auto-discover datasets from `real_data/` and `real_data/.local/` based on directory naming pattern `<report_id>-<name>/`
- Add `--include-local` pytest flag to include git-ignored local datasets
- Add `.local/` to `.gitignore` for confidential/large datasets
- Simplify `datasets.py` with `DatasetInfo` dataclass and discovery functions
- Add `conftest.py` with pytest hooks for dynamic test parametrization
- Update `download_real_data.py` to default to `.local/` with `--commit` flag
- Add unit tests for dataset discovery in `test_datasets.py`
- Update `tests/README.md` with new documentation

### Usage

```bash
# Default: run with committed datasets only
pytest tests/test_regression.py

# Include local datasets from real_data/.local/
pytest tests/test_regression.py --include-local
```

## Test plan

- [x] Run `pytest delphi/tests/test_datasets.py` to verify dataset discovery
- [x] Run `pytest delphi/tests/test_regression.py` with committed datasets
- [x] Add a dataset to `real_data/.local/` and verify it's discovered with `--include-local`
- [x] Verify `.local/` directory is properly git-ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)