### PR TITLE
Fix users_uid_seq not reset after prodclone restore

### DIFF
--- a/server/init-db.sh
+++ b/server/init-db.sh
@@ -11,3 +11,6 @@ fi
 
 echo "Restoring database from dump..."
 pg_restore -j4 --no-owner --no-privileges -U "$POSTGRES_USER" -d "$POSTGRES_DB" "$DUMP_FILE"
+
+echo "Resetting user sequences to match restored data..."
+psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT setval('users_uid_seq', (SELECT COALESCE(MAX(uid), 1) FROM users));"


### PR DESCRIPTION
## Summary
- Fix sequence not being reset after pg_restore from prodclone.dump
- Prevents "duplicate key value violates unique constraint" errors when new users register via OIDC
- Explicitly calls setval() to ensure sequence starts after highest existing uid

## Test plan
- [ ] Run `make refresh-prodclone` to restore from dump
- [ ] Verify new OIDC users can be created without constraint violations (login with admin@polis.test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)