### PR TITLE
delphi data inversion fix

### DIFF
--- a/delphi/Dockerfile
+++ b/delphi/Dockerfile
@@ -123,6 +123,15 @@ CMD ["bash", "-c", "\
 # Extends final stage with dev dependencies for CI/testing
 FROM final AS test
 
+# Install build tools needed for dev dependencies (e.g., line-profiler)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        gcc \
+        g++ \
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy pyproject.toml to install dev dependencies
 COPY pyproject.toml .
 

--- a/delphi/docs/NARRATIVE_INVERSION_INVESTIGATION.md
+++ b/delphi/docs/NARRATIVE_INVERSION_INVESTIGATION.md
@@ -1,0 +1,381 @@
+# Narrative Report Vote Inversion Investigation
+
+## Executive Summary
+
+**CRITICAL BUG CONFIRMED**: The Delphi Python codebase uses a "natural" sign convention (AGREE=+1, DISAGREE=-1) **by design**, but the sign flip at the PostgreSQL boundary is **missing**. This causes the LLM narrative reports to interpret agreement as disagreement and vice versa.
+
+## Design Intent
+
+The Delphi codebase was **intentionally designed** to use "natural" signs:
+
+- **AGREE = +1** (positive = agreement, intuitive for humans and LLMs)
+- **DISAGREE = -1** (negative = disagreement, intuitive for humans and LLMs)
+- **PASS = 0**
+
+This design choice was made because:
+
+1. It allows Delphi code maintainers to reason about votes naturally
+2. LLMs were getting confused when positive numbers indicated DISAGREEMENT
+
+**The architecture requires sign flipping at data boundaries:**
+
+- Data coming INTO Delphi (from PostgreSQL) should be flipped
+- Data going OUT to DynamoDB stays in Delphi's natural convention
+- DynamoDB is considered "within Delphi's realm"
+
+## The Root Cause
+
+**The sign flip at the PostgreSQL boundary is MISSING.**
+
+### Vote Conventions by System
+
+| System | AGREE | DISAGREE | PASS |
+|--------|-------|----------|------|
+| **PostgreSQL/Server/Client** | **-1** | **+1** | 0 |
+| **Delphi Internal** | **+1** | **-1** | 0 |
+
+### Evidence: PostgreSQL/Server Convention
+
+**Evidence from authoritative sources:**
+
+1. **Client UI** (`client-participation-alpha/src/components/Statement.jsx:62-65`):
+
+   ```jsx
+   <button className="vote-button agree" onClick={() => handleVoteClick(-1)} disabled={isVoting}>
+   ...
+   <button className="vote-button disagree" onClick={() => handleVoteClick(1)} disabled={isVoting}>
+   ```
+
+2. **Client Constants** (`client-participation/js/util/constants.js:11-15`):
+
+   ```javascript
+   REACTIONS: {
+       AGREE: -1,
+       PASS: 0,
+       DISAGREE: 1
+   }
+   ```
+
+3. **Server Report Generation** (`server/src/report.ts:327-330`):
+
+   ```typescript
+   // note that -1 means agree and 1 means disagree
+   if (row.vote === -1) comment.agrees += 1;
+   else if (row.vote === 1) comment.disagrees += 1;
+   ```
+
+4. **Server Integration Tests** (`server/__tests__/integration/vote.test.ts`):
+
+   ```typescript
+   vote: -1, // -1 = AGREE in this system
+   vote: 1,  // 1 = DISAGREE in this system
+   ```
+
+### Delphi Internal Convention (BY DESIGN)
+
+The Delphi Python code uses the **natural/intuitive** convention (this is CORRECT for internal use):
+
+1. **Constants Definition** (`delphi/polismath/utils/general.py:15-17`):
+
+   ```python
+   AGREE = 1       # CORRECT for Delphi internal use
+   DISAGREE = -1   # CORRECT for Delphi internal use
+   PASS = 0
+   ```
+
+2. **Vote Processing Logic** (`delphi/umap_narrative/polismath_commentgraph/utils/group_data.py:158-163`):
+
+   ```python
+   if vote_val == 1:
+       voting_patterns[pid]['agree'] += 1    # CORRECT if vote_val has been flipped at boundary
+   elif vote_val == -1:
+       voting_patterns[pid]['disagree'] += 1  # CORRECT if vote_val has been flipped at boundary
+   ```
+
+   **PROBLEM**: This code expects Delphi-convention data, but receives PostgreSQL-convention data (no flip).
+
+3. **Same pattern** (`group_data.py:373-381`):
+
+   ```python
+   if vote_val == 1:
+       vote_data[tid]['total_agrees'] += 1
+       vote_data[tid]['groups'][group_id]['agrees'] += 1
+   elif vote_val == -1:
+       vote_data[tid]['total_disagrees'] += 1
+       vote_data[tid]['groups'][group_id]['disagrees'] += 1
+   ```
+
+   **PROBLEM**: Same issue - expects flipped data, receives raw PostgreSQL data.
+
+4. **Documentation** (`delphi/docs/QUICK_START.md:157`):
+   > Votes: columns `voter-id`, `comment-id`, and `vote` (values: 1=agree, -1=disagree, 0=pass)
+
+   **CORRECT** for Delphi's internal convention.
+
+5. **Documentation** (`delphi/docs/usage_examples.md:185`):
+
+   ```python
+   # Randomly determine vote (1=agree, -1=disagree, None=pass)
+   ```
+
+   **CORRECT** for Delphi's internal convention.
+
+6. **Test Code Comments** (`delphi/tests/test_repness_unit.py:601`):
+
+   ```python
+   'vote': [1, 1, 1, 1, -1, -1, -1, -1]  # AGREE=1, DISAGREE=-1
+   ```
+
+   **CORRECT** for Delphi's internal convention.
+
+## Data Flow to Narrative Report
+
+The bug affects the narrative report through this path:
+
+```text
+PostgreSQL (votes table)
+    │
+    │ vote values: AGREE=-1, DISAGREE=+1
+    ▼
+PostgresClient.get_votes_by_conversation()  ← ❌ MISSING SIGN FLIP HERE
+    │
+    │ Raw vote values passed through (PostgreSQL convention)
+    │ Should be: vote = vote * -1  (flip to Delphi convention)
+    ▼
+GroupDataProcessor.get_vote_data_by_groups()
+    │
+    │ Code expects Delphi convention (AGREE=+1)
+    │ But receives PostgreSQL convention (AGREE=-1)
+    │ Result: vote_val=1 (actually DISAGREE) counted as agree
+    ▼
+GroupDataProcessor.get_export_data()
+    │
+    │ Returns inverted agree/disagree counts
+    ▼
+BatchReportGenerator.get_conversation_data()
+    │
+    │ Inverted data stored in processed_comments
+    ▼
+PolisConverter.convert_to_xml()
+    │
+    │ XML attributes have inverted agrees/disagrees
+    ▼
+LLM Prompt (topics.xml, groups.xml, etc.)
+    │
+    │ LLM receives data where "agrees" actually means "disagrees"
+    ▼
+❌ INVERTED NARRATIVE OUTPUT
+```
+
+## PostgreSQL Ingress Points (Boundaries Requiring Sign Flip)
+
+These are the locations where Delphi reads vote data from PostgreSQL. Each needs a sign flip:
+
+### 1. `delphi/umap_narrative/polismath_commentgraph/utils/storage.py`
+
+**Function:** `PostgresClient.get_votes_by_conversation()` (lines 294-316)
+
+```python
+def get_votes_by_conversation(self, zid: int) -> List[Dict[str, Any]]:
+    sql = """
+    SELECT v.zid, v.pid, v.tid, v.vote
+    FROM votes_latest_unique v
+    WHERE v.zid = :zid
+    """
+    return self.query(sql, {"zid": zid})  # ❌ No sign flip!
+```
+
+### 2. `delphi/polismath/database/postgres.py`
+
+**Function:** `poll_votes()` (around line 456-464)
+
+```python
+return [
+    {
+        "pid": str(v["pid"]),
+        "tid": str(v["tid"]),
+        "vote": int(v["vote"]),  # ❌ No sign flip!
+        "created": v["created"],
+    }
+    for v in votes
+]
+```
+
+### 3. `delphi/polismath/run_math_pipeline.py`
+
+**Function:** `fetch_votes()` (lines 67-104)
+
+```python
+votes_list.append({
+    'pid': str(vote['voter_id']),
+    'tid': str(vote['comment_id']),
+    'vote': float(vote['vote']),  # ❌ No sign flip!
+    'created': created_time
+})
+```
+
+### 4. `delphi/scripts/job_poller.py`
+
+**Function:** `PostgresClient.get_votes_by_conversation()` (lines 288-310)
+
+```python
+# Similar pattern - raw query with no sign flip
+```
+
+## Impact
+
+Because the boundary flip is missing, PostgreSQL data (AGREE=-1) is passed directly to Delphi code expecting (AGREE=+1):
+
+- Comments with high agreement in PostgreSQL (vote=-1) are counted as disagrees in Delphi
+- Comments with high disagreement in PostgreSQL (vote=+1) are counted as agrees in Delphi
+- All derivative calculations (consensus, extremity, group patterns) are inverted
+- LLM receives inverted data and generates backwards narratives
+
+## Questions to Investigate Further
+
+1. **Does the Clojure math pipeline use PostgreSQL convention or does it flip?**
+   - The `math/src/polismath/math/conversation.clj` has `(s/def ::vote #{-1 0 1 -1.0 1.0 0.0})` but doesn't explicitly document semantics
+   - If Clojure uses PostgreSQL convention (AGREE=-1), then `math_main` table values are in that convention
+   - This would mean Delphi should NOT flip values read from `math_main` (they're already processed)
+
+2. **Are there any write operations back to PostgreSQL?**
+   - If Delphi writes vote data back to PostgreSQL, it would need a reverse flip
+   - Currently unclear if any such writes exist
+
+3. **What about data from `./math` Clojure pipeline?**
+   - Does Delphi read any intermediate results from the Clojure math pipeline?
+   - If so, what convention do those use?
+
+4. **CSV imports in tests**
+   - Do the CSV test fixtures use PostgreSQL convention or Delphi convention?
+   - If PostgreSQL convention, the CSV loading functions need flipping too
+
+## Fix Applied: Centralized Sign Flip at PostgreSQL Boundary
+
+A centralized utility function was added to handle vote sign conversion, and it's applied at each PostgreSQL ingress point.
+
+### Canonical Function: `delphi/polismath/utils/general.py`
+
+```python
+def postgres_vote_to_delphi(pg_vote: Union[int, float]) -> Union[int, float]:
+    """
+    Convert PostgreSQL vote convention to Delphi convention.
+    
+    PostgreSQL/Server/Client use: AGREE=-1, DISAGREE=+1, PASS=0
+    Delphi uses:                  AGREE=+1, DISAGREE=-1, PASS=0
+    
+    This function should be called at every PostgreSQL data ingress boundary
+    to ensure Delphi code receives votes in the expected convention.
+    """
+    return pg_vote * -1
+
+
+def delphi_vote_to_postgres(delphi_vote: Union[int, float]) -> Union[int, float]:
+    """
+    Convert Delphi vote convention to PostgreSQL convention.
+    (For future use if Delphi writes vote data back to PostgreSQL)
+    """
+    return delphi_vote * -1
+```
+
+### Fix 1: `delphi/umap_narrative/polismath_commentgraph/utils/storage.py` ✅ APPLIED
+
+- Added local `_postgres_vote_to_delphi()` function (same logic, local to avoid cross-package dependency)
+- Updated `get_votes_by_conversation()` to apply the flip
+
+### Fix 2: `delphi/polismath/database/postgres.py` ✅ APPLIED
+
+- Added import: `from polismath.utils.general import postgres_vote_to_delphi`
+- Updated `poll_votes()` to apply the flip
+
+### Fix 3: `delphi/polismath/run_math_pipeline.py` ✅ APPLIED
+
+- Added import: `from polismath.utils.general import postgres_vote_to_delphi`
+- Updated `fetch_votes()` to apply the flip
+
+### Fix 4: `delphi/scripts/job_poller.py` ✅ APPLIED
+
+- Added local `_postgres_vote_to_delphi()` function (same logic, local to avoid import dependencies in standalone script)
+- Updated `get_votes_by_conversation()` to apply the flip
+- Note: This method may be unused, but updated for consistency
+
+### Testing the Fix
+
+After adding the boundary flips, validate by:
+
+1. **Compare with server CSV export**: The server's report endpoint produces CSVs with correct agree/disagree counts. Delphi's counts should now match.
+
+2. **Existing test suite**: Tests using Delphi convention should still pass (they don't go through PostgreSQL boundary).
+
+3. **Integration test**: Run a narrative report and verify:
+   - A comment known to have high agreement in the Polis UI should be described as having high agreement in the narrative
+   - Group characterizations should match manual inspection of the Polis report visualization
+
+4. **Spot check math**: For a known comment, manually verify:
+   - PostgreSQL: `SELECT vote, COUNT(*) FROM votes WHERE tid=X GROUP BY vote`
+   - Delphi output should show the same counts but with flipped signs
+
+## Files Changed
+
+### PostgreSQL Boundary Files (SIGN FLIP APPLIED ✅)
+
+1. **`delphi/umap_narrative/polismath_commentgraph/utils/storage.py`** ✅
+   - Added: `_postgres_vote_to_delphi()` local function
+   - Updated: `PostgresClient.get_votes_by_conversation()` now flips signs
+
+2. **`delphi/polismath/database/postgres.py`** ✅
+   - Added: `from polismath.utils.general import postgres_vote_to_delphi`
+   - Updated: `poll_votes()` now flips signs
+
+3. **`delphi/polismath/run_math_pipeline.py`** ✅
+   - Added: `from polismath.utils.general import postgres_vote_to_delphi`
+   - Updated: `fetch_votes()` now flips signs
+
+4. **`delphi/scripts/job_poller.py`** ✅
+   - Added: `_postgres_vote_to_delphi()` local function
+   - Updated: `PostgresClient.get_votes_by_conversation()` now flips signs
+
+### Utility Function Added ✅
+
+- **`delphi/polismath/utils/general.py`**
+  - Added: `postgres_vote_to_delphi()` - canonical implementation
+  - Added: `delphi_vote_to_postgres()` - inverse for potential future writes
+
+### Files That Are CORRECT (No Changes Needed)
+
+These use Delphi's internal convention correctly:
+
+- `delphi/polismath/utils/general.py` - Constants are correct for internal use
+- `delphi/umap_narrative/polismath_commentgraph/utils/group_data.py` - Logic is correct for Delphi convention
+- `delphi/polismath/conversation/conversation.py` - Vote masks are correct for Delphi convention
+- `delphi/docs/*.md` - Documentation is correct for Delphi convention
+- `delphi/tests/*.py` - Tests use Delphi convention correctly
+
+### Files to Verify: Other Data Ingress Points
+
+Check if these also read from PostgreSQL without flipping:
+
+- `delphi/tests/test_postgres_real_data.py`
+- `delphi/tests/profile_postgres_data.py`
+- `delphi/scripts/participation_timeline.py`
+
+## Historical Context
+
+The Delphi codebase was designed with "natural" sign conventions from the start:
+
+- AGREE = +1 (positive = good/agreement)
+- DISAGREE = -1 (negative = bad/disagreement)
+
+This was an intentional design choice to make the code more intuitive and to help LLMs reason about the data correctly. The expectation was that sign flipping would happen at data boundaries.
+
+**The bug**: The boundary sign flip was never implemented in the PostgreSQL reading functions.
+
+## Summary
+
+This is a **high-severity bug** where the designed boundary sign flip is missing at PostgreSQL ingress points. The fix is:
+
+1. **Add `vote * -1`** at each PostgreSQL read location (4 files identified)
+2. **Leave all other Delphi code unchanged** - it correctly uses Delphi's internal convention
+3. **Verify DynamoDB operations** - should already use Delphi convention (no flip needed)
+
+The fix is minimal and surgical - only the boundary functions need changes, not the entire codebase.

--- a/delphi/polismath/utils/general.py
+++ b/delphi/polismath/utils/general.py
@@ -16,14 +16,55 @@ AGREE = 1
 DISAGREE = -1
 PASS = 0
 
+
+def postgres_vote_to_delphi(pg_vote: Union[int, float]) -> Union[int, float]:
+    """
+    Convert PostgreSQL vote convention to Delphi convention.
+
+    PostgreSQL/Server/Client use: AGREE=-1, DISAGREE=+1, PASS=0
+    Delphi uses:                  AGREE=+1, DISAGREE=-1, PASS=0
+
+    This function should be called at every PostgreSQL data ingress boundary
+    to ensure Delphi code receives votes in the expected convention.
+
+    The sign flip is: vote * -1
+    - PostgreSQL AGREE (-1) → Delphi AGREE (+1)
+    - PostgreSQL DISAGREE (+1) → Delphi DISAGREE (-1)
+    - PostgreSQL PASS (0) → Delphi PASS (0) [unchanged]
+
+    Args:
+        pg_vote: Vote value from PostgreSQL (-1=agree, +1=disagree, 0=pass)
+
+    Returns:
+        Vote value in Delphi convention (+1=agree, -1=disagree, 0=pass)
+    """
+    return pg_vote * -1
+
+
+def delphi_vote_to_postgres(delphi_vote: Union[int, float]) -> Union[int, float]:
+    """
+    Convert Delphi vote convention to PostgreSQL convention.
+
+    This is the inverse of postgres_vote_to_delphi() and should be used
+    if Delphi ever needs to write vote data back to PostgreSQL.
+
+    Args:
+        delphi_vote: Vote value in Delphi convention (+1=agree, -1=disagree, 0=pass)
+
+    Returns:
+        Vote value for PostgreSQL (-1=agree, +1=disagree, 0=pass)
+    """
+    return delphi_vote * -1
+
+
 def xor(a: bool, b: bool) -> bool:
     """
     Logical exclusive OR.
-    
+
     Args:
         a: First boolean
         b: Second boolean
-        
+
     Returns:
         a XOR b
     """
@@ -33,11 +74,11 @@ def xor(a: bool, b: bool) -> bool:
 def round_to(n: float, digits: int = 0) -> float:
     """
     Round a number to a specific number of decimal places.
-    
+
     Args:
         n: Number to round
         digits: Number of decimal digits to keep
-        
+
     Returns:
         Rounded number
     """
@@ -48,10 +89,10 @@ def zip_collections(*colls: Iterable[T]) -> List[Tuple[T, ...]]:
     """
     Zip multiple collections together.
     Similar to Python's built-in zip, but returns a list.
-    
+
     Args:
         *colls: Collections to zip
-        
+
     Returns:
         List of tuples containing corresponding elements
     """
@@ -61,10 +102,10 @@ def zip_collections(*colls: Iterable[T]) -> List[Tuple[T, ...]]:
 def with_indices(coll: Iterable[T]) -> List[Tuple[int, T]]:
     """
     Combine elements of a collection with their indices.
-    
+
     Args:
         coll: Collection to process
-        
+
     Returns:
         List of (index, item) tuples
     """
@@ -74,11 +115,11 @@ def with_indices(coll: Iterable[T]) -> List[Tuple[int, T]]:
 def filter_by_index(coll: Iterable[T], indices: Iterable[int]) -> List[T]:
     """
     Filter a collection to only include items at specified indices.
-    
+
     Args:
         coll: Collection to filter
         indices: Indices to include
-        
+
     Returns:
         Filtered list
     """
@@ -90,14 +131,14 @@ def filter_by_index(coll: Iterable[T], indices: Iterable[int]) -> List[T]:
 def map_rest(f: Callable[[T, T], U], coll: List[T]) -> List[U]:
     """
     Apply a function to each element and all remaining elements.
-    
-    For each element in coll, apply function f to that element and each 
+
+    For each element in coll, apply function f to that element and each
     element that comes after it.
-    
+
     Args:
         f: Function taking two arguments
         coll: Collection to process
-        
+
     Returns:
         List of results
     """
@@ -112,11 +153,11 @@ def map_rest(f: Callable[[T, T], U], coll: List[T]) -> List[U]:
 def mapv_rest(f: Callable[[T, T], U], coll: List[T]) -> List[U]:
     """
     Same as map_rest but guaranteed to return a list.
-    
+
     Args:
         f: Function taking two arguments
         coll: Collection to process
-        
+
     Returns:
         List of results
     """
@@ -126,11 +167,11 @@ def mapv_rest(f: Callable[[T, T], U], coll: List[T]) -> List[U]:
 def typed_indexof(coll: List[T], item: T) -> int:
     """
     Find the index of an item in a collection.
-    
+
     Args:
         coll: Collection to search
         item: Item to find
-        
+
     Returns:
         Index of the item, or -1 if not found
     """
@@ -143,11 +184,11 @@ def typed_indexof(coll: List[T], item: T) -> int:
 def hash_map_subset(m: Dict[T, U], keys: Iterable[T]) -> Dict[T, U]:
     """
     Create a subset of a dictionary containing only specified keys.
-    
+
     Args:
         m: Dictionary to subset
         keys: Keys to include
-        
+
     Returns:
         Dictionary subset
     """
@@ -157,10 +198,10 @@ def hash_map_subset(m: Dict[T, U], keys: Iterable[T]) -> Dict[T, U]:
 def distinct(coll: Iterable[T]) -> List[T]:
     """
     Return a list with duplicates removed, preserving order.
-    
+
     Args:
         coll: Collection to process
-        
+
     Returns:
         List with duplicates removed
     """
@@ -176,16 +217,16 @@ def distinct(coll: Iterable[T]) -> List[T]:
 def weighted_mean(values: List[float], weights: Optional[List[float]] = None) -> float:
     """
     Calculate the weighted mean of a list of values.
-    
+
     Args:
         values: Values to average
         weights: Weights for each value (defaults to equal weights)
-        
+
     Returns:
         Weighted mean
     """
     values_array = np.array(values)
-    
+
     if weights is None:
         return np.mean(values_array)
     else:
@@ -197,25 +238,25 @@ def weighted_means(values_matrix: List[List[float]],
                   weights: Optional[List[float]] = None) -> List[float]:
     """
     Calculate the weighted means of each column in a matrix.
-    
+
     Args:
         values_matrix: Matrix of values (rows are observations, columns are variables)
         weights: Weights for each row (defaults to equal weights)
-        
+
     Returns:
         List of weighted means for each column
     """
     values_array = np.array(values_matrix)
-    
+
     if weights is None:
         return np.mean(values_array, axis=0).tolist()
     else:
         weights_array = np.array(weights)
         # Reshape weights for broadcasting
-        weights_array = weights_array.reshape(-1, 1) 
-        
+        weights_array = weights_array.reshape(-1, 1)
+
         # Calculate weighted sum and sum of weights for each column
         weighted_sum = np.sum(values_array * weights_array, axis=0)
         sum_weights = np.sum(weights_array)
-        
+
         return (weighted_sum / sum_weights).tolist()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,7 @@ services:
     image: 050917022930.dkr.ecr.us-east-1.amazonaws.com/polis/delphi:latest
     build:
       context: ./delphi
+      target: final
     labels:
       polis_tag: ${TAG:-dev}
       com.datadoghq.ad.logs: '[{"source": "python", "service": "delphi"}]'

--- a/example.env
+++ b/example.env
@@ -127,6 +127,7 @@ AWS_SECRET_ACCESS_KEY=
 GOOGLE_APPLICATION_CREDENTIALS=
 # Optional API keys for other services:
 ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=
 GEMINI_API_KEY=
 OPENAI_API_KEY=
 # A value in miliseconds for caching AI responses for narrativeReport


### PR DESCRIPTION
This PR attempts to invert any vote data at data ingress boundaries into delphi.
Delphi uses "natural" vote signage:
AGREE = +1 ; DISAGREE = -1
Whereas Postgres uses "upside-down" vote signage:
AGREE = -1 ; DISAGREE = +1

If we invert the signage wherever delphi imports vote data from postgres (this PR), then Delphi can continue to use "natural" signage throughout.

Testing indicates that this branch is correctly handling vote data when generating reports.

See this markdown description of the problem and solution:
https://github.com/compdemocracy/polis/blob/84e4f174c31e333c0369da1eb73c080b2b975724/delphi/docs/NARRATIVE_INVERSION_INVESTIGATION.md