### PR TITLE
Add "exclude_comment_selections" arg to Delphi reports

### DIFF
--- a/delphi/polismath/database/postgres.py
+++ b/delphi/polismath/database/postgres.py
@@ -469,6 +469,45 @@ class PostgresClient:
             for v in votes
         ]
 
+    def get_report_comment_selections(
+        self, zid: int, rid: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Get report comment selections for a conversation.
+
+        This retrieves records from report_comment_selections table which tracks
+        which comments should be included or excluded from reports:
+        - selection = 1: comment should be included in the report
+        - selection = -1: comment should be excluded from the report
+
+        Args:
+            zid: Conversation ID (required)
+            rid: Report ID (optional, if not provided returns selections for all reports)
+
+        Returns:
+            List of dictionaries with keys: rid, tid, selection, zid, modified
+        """
+        params = {"zid": zid}
+
+        sql = """
+        SELECT
+            rid,
+            tid,
+            selection,
+            zid,
+            modified
+        FROM
+            report_comment_selections
+        WHERE
+            zid = :zid
+        """
+
+        if rid is not None:
+            sql += " AND rid = :rid"
+            params["rid"] = rid
+
+        return self.query(sql, params)
+
     def poll_moderation(
         self, zid: int, since: Optional[datetime] = None
     ) -> Dict[str, Any]:

--- a/delphi/run_delphi.py
+++ b/delphi/run_delphi.py
@@ -34,6 +34,7 @@ def main():
     parser.add_argument("--validate", action="store_true", help="Run extra validation checks")
     parser.add_argument("--help", action="store_true", help="Show this help message")
     parser.add_argument('--include_moderation', type=bool, default=False, help='Whether or not to include moderated comments in reports. If false, moderated comments will appear.')
+    parser.add_argument('--exclude_comment_selections', type=bool, default=True, help='Whether to exclude comments with selection=-1 in report_comment_selections table.')
     parser.add_argument('--region', type=str, default='us-east-1', help='AWS region')
 
     args = parser.parse_args()
@@ -118,6 +119,7 @@ def main():
         "python", f"{app_path}/umap_narrative/run_pipeline.py",
         f"--zid={zid}",
         f"--include_moderation={args.include_moderation}",
+        f"--exclude_comment_selections={args.exclude_comment_selections}",
         "--use-ollama"
     ]
     if verbose_arg:
@@ -131,7 +133,8 @@ def main():
     extremity_command = [
         "python", f"{app_path}/umap_narrative/501_calculate_comment_extremity.py",
         f"--zid={zid}",
-        f"--include_moderation={args.include_moderation}"
+        f"--include_moderation={args.include_moderation}",
+        f"--exclude_comment_selections={args.exclude_comment_selections}"
     ]
     if verbose_arg:
         extremity_command.append(verbose_arg)

--- a/delphi/scripts/job_poller.py
+++ b/delphi/scripts/job_poller.py
@@ -700,19 +700,20 @@ class JobProcessor:
             # 1. Build the command
             job_config = json.loads(job.get('job_config', '{}'))
             include_moderation = job_config.get('include_moderation', False)
+            exclude_comment_selections = job_config.get('exclude_comment_selections', True)
             app_path = os.environ.get('DELPHI_APP_PATH', '/app')
             if job_type == 'CREATE_NARRATIVE_BATCH':
                 model = os.environ.get("ANTHROPIC_MODEL")
                 if not model: raise ValueError("ANTHROPIC_MODEL must be set")
                 max_batch_size = job_config.get('max_batch_size', 20)
-                cmd = ['python', f'{app_path}/umap_narrative/801_narrative_report_batch.py', f'--conversation_id={conversation_id}', f'--model={model}', f'--include_moderation={include_moderation}', f'--max-batch-size={str(max_batch_size)}']
+                cmd = ['python', f'{app_path}/umap_narrative/801_narrative_report_batch.py', f'--conversation_id={conversation_id}', f'--model={model}', f'--include_moderation={include_moderation}', f'--exclude_comment_selections={exclude_comment_selections}', f'--max-batch-size={str(max_batch_size)}']
                 if job_config.get('no_cache'): cmd.append('--no-cache')
             elif job_type == 'AWAITING_NARRATIVE_BATCH':
                 cmd_job_id = job.get('batch_job_id', job_id)
                 cmd = ['python', f'{app_path}/umap_narrative/803_check_batch_status.py', f'--job-id={cmd_job_id}']
             else: # FULL_PIPELINE
                 # Base command
-                cmd = ['python', f'{app_path}/run_delphi.py', f'--zid={conversation_id}', f'--include_moderation={include_moderation}',]
+                cmd = ['python', f'{app_path}/run_delphi.py', f'--zid={conversation_id}', f'--include_moderation={include_moderation}', f'--exclude_comment_selections={exclude_comment_selections}',]
                 # Check for report_id and append if it exists
                 report_id = job.get('report_id')
                 if report_id:

--- a/delphi/umap_narrative/501_calculate_comment_extremity.py
+++ b/delphi/umap_narrative/501_calculate_comment_extremity.py
@@ -30,7 +30,7 @@ from polismath_commentgraph.utils.group_data import GroupDataProcessor
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
-def calculate_and_store_extremity(conversation_id: int, force_recalculation: bool = False, include_moderation: bool = False, exclude_comment_selections: bool = False) -> Dict[int, float]:
+def calculate_and_store_extremity(conversation_id: int, force_recalculation: bool = False, include_moderation: bool = False, exclude_comment_selections: bool = True) -> Dict[int, float]:
     """
     Calculate and store extremity values for all comments in a conversation.
     

--- a/delphi/umap_narrative/501_calculate_comment_extremity.py
+++ b/delphi/umap_narrative/501_calculate_comment_extremity.py
@@ -30,13 +30,15 @@ from polismath_commentgraph.utils.group_data import GroupDataProcessor
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
-def calculate_and_store_extremity(conversation_id: int, force_recalculation: bool = False, include_moderation: bool = False) -> Dict[int, float]:
+def calculate_and_store_extremity(conversation_id: int, force_recalculation: bool = False, include_moderation: bool = False, exclude_comment_selections: bool = False) -> Dict[int, float]:
     """
     Calculate and store extremity values for all comments in a conversation.
     
     Args:
         conversation_id: Conversation ID
         force_recalculation: Whether to force recalculation of values
+        include_moderation: Whether to filter out moderated comments (mod == -1)
+        exclude_comment_selections: Whether to exclude comments with selection=-1 in report_comment_selections table
         
     Returns:
         Dictionary mapping comment IDs to extremity values
@@ -46,6 +48,24 @@ def calculate_and_store_extremity(conversation_id: int, force_recalculation: boo
     # Initialize PostgreSQL client and GroupDataProcessor
     postgres_client = PostgresClient()
     group_processor = GroupDataProcessor(postgres_client)
+    
+    # If exclude_comment_selections is enabled, get excluded tids
+    excluded_tids = set()
+    if exclude_comment_selections:
+        logger.info(f"exclude_comment_selections is enabled, fetching report comment selections for conversation {conversation_id}")
+        try:
+            postgres_client.initialize()
+            selections = postgres_client.get_report_comment_selections(conversation_id)
+            excluded_tids = {
+                sel["tid"] for sel in selections if sel.get("selection") == -1
+            }
+            if excluded_tids:
+                logger.info(f"Will exclude {len(excluded_tids)} comments based on report_comment_selections (tids: {excluded_tids})")
+            else:
+                logger.info("No excluded comment selections found for this conversation")
+        except Exception as e:
+            logger.error(f"Error fetching report comment selections: {e}")
+            # Continue without filtering if there's an error
     
     try:
         # Check if we already have extremity values in DynamoDB
@@ -65,6 +85,9 @@ def calculate_and_store_extremity(conversation_id: int, force_recalculation: boo
         for comment in export_data.get('comments', []):
             tid = comment.get('comment_id')
             if tid is not None:
+                # Skip comments that are in the excluded set
+                if tid in excluded_tids:
+                    continue
                 extremity_value = comment.get('comment_extremity', 0)
                 extremity_values[tid] = extremity_value
                 
@@ -167,7 +190,7 @@ def main():
     parser.add_argument('--force', action='store_true', help='Force recalculation of values')
     parser.add_argument('--verbose', action='store_true', help='Show detailed output')
     parser.add_argument('--include_moderation', type=bool, default=False, help='Whether or not to include moderated comments in reports. If false, moderated comments will appear.')
-    args = parser.parse_args()
+    parser.add_argument('--exclude_comment_selections', type=bool, default=True, help='Whether to exclude comments with selection=-1 in report_comment_selections table.')
     args = parser.parse_args()
     
     # Set log level based on verbosity
@@ -175,7 +198,7 @@ def main():
         logging.getLogger().setLevel(logging.DEBUG)
     
     # Calculate and store extremity values
-    extremity_values = calculate_and_store_extremity(args.zid, args.force, args.include_moderation)
+    extremity_values = calculate_and_store_extremity(args.zid, args.force, args.include_moderation, args.exclude_comment_selections)
     
     # Print report
     print_extremity_report(extremity_values)

--- a/delphi/umap_narrative/801_narrative_report_batch.py
+++ b/delphi/umap_narrative/801_narrative_report_batch.py
@@ -202,7 +202,7 @@ class PolisConverter:
 class BatchReportGenerator:
     """Generate batch reports for Polis conversations."""
 
-    def __init__(self, conversation_id, model=None, no_cache=False, max_batch_size=20, job_id=None, layers=None, include_moderation=False):
+    def __init__(self, conversation_id, model=None, no_cache=False, max_batch_size=20, job_id=None, layers=None, include_moderation=False, exclude_comment_selections=False):
         """Initialize the batch report generator."""
         self.conversation_id = str(conversation_id)
         if not model:
@@ -217,8 +217,10 @@ class BatchReportGenerator:
         self.report_id = os.environ.get('DELPHI_REPORT_ID')
         self.postgres_client = PostgresClient()
         self.include_moderation = include_moderation
+        self.exclude_comment_selections = exclude_comment_selections
 
         logger.info(f"include_moderation: {include_moderation}")
+        logger.info(f"exclude_comment_selections: {exclude_comment_selections}")
 
         endpoint_url = os.environ.get('DYNAMODB_ENDPOINT') or None
         self.dynamodb = boto3.resource(
@@ -297,6 +299,20 @@ class BatchReportGenerator:
 
             if self.include_moderation:
                 comments = [comment for comment in comments if comment['mod'] > -1]
+            
+            # Filter out comments based on report_comment_selections if enabled
+            if self.exclude_comment_selections:
+                logger.info("exclude_comment_selections is enabled, fetching report comment selections")
+                selections = self.postgres_client.get_report_comment_selections(int(self.conversation_id))
+                excluded_tids = {
+                    sel["tid"] for sel in selections if sel.get("selection") == -1
+                }
+                if excluded_tids:
+                    original_count = len(comments)
+                    comments = [comment for comment in comments if comment["tid"] not in excluded_tids]
+                    logger.info(f"Excluded {original_count - len(comments)} comments based on report_comment_selections (tids: {excluded_tids})")
+                else:
+                    logger.info("No excluded comment selections found for this conversation")
             
             # Get math data from the Clojure math pipeline (stored in math_main table)
             math_data = self._get_math_main_data(int(self.conversation_id))
@@ -1504,6 +1520,7 @@ async def main():
     parser.add_argument('--layers', type=int, nargs='+', default=None,
                         help='Specific layer numbers to process (e.g., --layers 0 1 2). If not specified, all layers will be processed.')
     parser.add_argument('--include_moderation', type=bool, default=False, help='Whether or not to include moderated comments in reports. If false, moderated comments will appear.')
+    parser.add_argument('--exclude_comment_selections', type=bool, default=True, help='Whether to exclude comments with selection=-1 in report_comment_selections table.')
     args = parser.parse_args()
 
     # Get environment variables for job
@@ -1547,7 +1564,8 @@ async def main():
         max_batch_size=args.max_batch_size,
         job_id=job_id,
         layers=args.layers,
-        include_moderation=args.include_moderation
+        include_moderation=args.include_moderation,
+        exclude_comment_selections=args.exclude_comment_selections
     )
 
     # Process reports

--- a/delphi/umap_narrative/801_narrative_report_batch.py
+++ b/delphi/umap_narrative/801_narrative_report_batch.py
@@ -202,7 +202,7 @@ class PolisConverter:
 class BatchReportGenerator:
     """Generate batch reports for Polis conversations."""
 
-    def __init__(self, conversation_id, model=None, no_cache=False, max_batch_size=20, job_id=None, layers=None, include_moderation=False, exclude_comment_selections=False):
+    def __init__(self, conversation_id, model=None, no_cache=False, max_batch_size=20, job_id=None, layers=None, include_moderation=False, exclude_comment_selections=True):
         """Initialize the batch report generator."""
         self.conversation_id = str(conversation_id)
         if not model:

--- a/delphi/umap_narrative/polismath_commentgraph/utils/storage.py
+++ b/delphi/umap_narrative/polismath_commentgraph/utils/storage.py
@@ -387,6 +387,45 @@ class PostgresClient:
         results = self.query(sql, {"zinvite": conversation_slug})
         return results[0]['zid'] if results else None
 
+    def get_report_comment_selections(
+        self, zid: int, rid: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Get report comment selections for a conversation.
+
+        This retrieves records from report_comment_selections table which tracks
+        which comments should be included or excluded from reports:
+        - selection = 1: comment should be included in the report
+        - selection = -1: comment should be excluded from the report
+
+        Args:
+            zid: Conversation ID (required)
+            rid: Report ID (optional, if not provided returns selections for all reports)
+
+        Returns:
+            List of dictionaries with keys: rid, tid, selection, zid, modified
+        """
+        params = {"zid": zid}
+
+        sql = """
+        SELECT
+            rid,
+            tid,
+            selection,
+            zid,
+            modified
+        FROM
+            report_comment_selections
+        WHERE
+            zid = :zid
+        """
+
+        if rid is not None:
+            sql += " AND rid = :rid"
+            params["rid"] = rid
+
+        return self.query(sql, params)
+
 
 class DynamoDBStorage:
     """

--- a/delphi/umap_narrative/run_pipeline.py
+++ b/delphi/umap_narrative/run_pipeline.py
@@ -1324,7 +1324,7 @@ def create_enhanced_multilayer_index(
 
 
 def process_conversation(
-    zid, export_dynamo=True, use_ollama=False, include_moderation=False
+    zid, export_dynamo=True, use_ollama=False, include_moderation=False, exclude_comment_selections=False
 ):
     """
     Main function to process a conversation and generate visualizations.
@@ -1333,6 +1333,9 @@ def process_conversation(
         zid: Conversation ID
         export_dynamo: Whether to export results to DynamoDB
         use_ollama: Whether to use Ollama for topic naming
+        include_moderation: Whether to filter out moderated comments (mod == -1)
+        exclude_comment_selections: Whether to exclude comments that have selection == -1
+            in report_comment_selections table (for any report in this conversation)
     """
     # Create conversation directory
     output_dir = os.path.join(
@@ -1350,6 +1353,25 @@ def process_conversation(
 
     if include_moderation:
         comments = [comment for comment in comments if comment["mod"] > -1]
+
+    if exclude_comment_selections:
+        logger.info(f"exclude_comment_selections is enabled, fetching report comment selections for zid {zid}")
+        postgres_client = PostgresClient()
+        try:
+            postgres_client.initialize()
+            selections = postgres_client.get_report_comment_selections(zid)
+            # Build a set of tids that should be excluded (selection == -1 in any report)
+            excluded_tids = {
+                sel["tid"] for sel in selections if sel.get("selection") == -1
+            }
+            if excluded_tids:
+                original_count = len(comments)
+                comments = [comment for comment in comments if comment["tid"] not in excluded_tids]
+                logger.info(f"Excluded {original_count - len(comments)} comments based on report_comment_selections (tids: {excluded_tids})")
+            else:
+                logger.info("No excluded comment selections found for this conversation")
+        finally:
+            postgres_client.shutdown()
 
     # Generate a job_id for this pipeline run
     # If DELPHI_JOB_ID is set (e.g., by a calling script like run_delphi.py), use that.
@@ -1495,6 +1517,12 @@ def main():
         default=False,
         help="Whether or not to include moderated comments in reports. If false, moderated comments will appear.",
     )
+    parser.add_argument(
+        "--exclude_comment_selections",
+        type=bool,
+        default=True,
+        help="Whether to exclude comments with selection=-1 in report_comment_selections table.",
+    )
 
     args = parser.parse_args()
 
@@ -1567,6 +1595,7 @@ def main():
             export_dynamo=not args.no_dynamo,
             use_ollama=args.use_ollama,
             include_moderation=args.include_moderation,
+            exclude_comment_selections=args.exclude_comment_selections,
         )
 
 

--- a/delphi/umap_narrative/run_pipeline.py
+++ b/delphi/umap_narrative/run_pipeline.py
@@ -1324,7 +1324,7 @@ def create_enhanced_multilayer_index(
 
 
 def process_conversation(
-    zid, export_dynamo=True, use_ollama=False, include_moderation=False, exclude_comment_selections=False
+    zid, export_dynamo=True, use_ollama=False, include_moderation=False, exclude_comment_selections=True
 ):
     """
     Main function to process a conversation and generate visualizations.


### PR DESCRIPTION
Delphi report runs now support "--exclude-comment-selections" arg (default True).
This tells Delphi to read from the postgres table `report_comment_selections` for instances of matching tids where selection == -1 (exclude).
These tids will be excluded from reporting.
This enables "custom" exclude lists, independent of moderation status.

Note: in prod there are no records in `report_comment_selections` since 2020, so there should be no impact on existing reports. Also `math` used this feature by default, so it *is* the legacy behavior (more or less).