### PR TITLE
Test infrastructure: parallel execution and dataset filtering

### DIFF
--- a/delphi/docs/regression_testing.md
+++ b/delphi/docs/regression_testing.md
@@ -1,0 +1,550 @@
+# Regression Testing System for Delphi
+
+This document describes the regression testing system for the Polis `delphi/` Python codebase. It captures and compares outputs from key Conversation operations to ensure refactoring doesn't change computational behavior.
+
+**Note**: The Clojure comparison tests (test_legacy_*.py files) are legacy code and will be removed once the Clojure implementation is fully replaced.
+
+## Overview
+
+The regression testing system works by:
+1. **Recording** golden snapshots of Conversation outputs at key lifecycle stages
+2. **Comparing** current implementation outputs against these golden snapshots
+3. **Detecting** any unintended changes in computational results
+
+This provides confidence during refactoring that the mathematical/computational behavior remains unchanged, even if the underlying implementation changes.
+
+## Dataset Organization
+
+Datasets are organized into two locations:
+
+### Committed Datasets (`real_data/`)
+Public datasets that are version-controlled and always available:
+- **`vw`** - VW Conversation (small, ~30K votes)
+- **`biodiversity`** - NZ Biodiversity Strategy (medium, ~30K votes)
+
+### Local Datasets (`real_data/.local/`)
+Datasets that are git-ignored for confidentiality or size reasons:
+- Confidential conversations
+- Large public datasets that would bloat the repo
+- Experimental/temporary test data
+
+**Directory structure:**
+```
+real_data/
+├── r6vbnhffkxbd7ifmfbdrd-vw/           # Committed
+├── r4tykwac8thvzv35jrn53-biodiversity/ # Committed
+└── .local/                              # Git-ignored
+    ├── rexample1234-myconvo/
+    ├── rexample5678-otherconvo/
+    └── ...
+```
+
+### Auto-Discovery
+
+Datasets are automatically discovered based on:
+1. Directory naming pattern: `<report_id>-<name>/`
+2. Required files present:
+   - `*-votes.csv` - Vote data
+   - `*-comments.csv` - Comment data
+   - `golden_snapshot.json` - For regression testing
+3. Optional files:
+   - `{report_id}_math_blob.json` - Clojure math output (for Clojure comparison)
+
+No manual registration needed - just drop data in the right location.
+
+**Note:** The math blob is optional. Without it, regression tests still work but cannot compare against the Clojure implementation. This allows testing without database access.
+
+## Components
+
+### Core Files
+
+- **`polismath/regression/`** - Core regression testing library
+  - `datasets.py` - Auto-discovery and dataset management
+  - `recorder.py` - Golden snapshot recorder
+  - `comparer.py` - Output comparison
+- **`scripts/regression_recorder.py`** - CLI script to record golden snapshots
+- **`scripts/regression_comparer.py`** - CLI script to compare outputs with golden snapshots
+- **`real_data/{dataset}/golden_snapshot.json`** - Golden snapshots stored with their dataset
+
+### Integration
+
+- **`tests/test_regression.py`** - Pytest wrapper for running as part of test suite
+- **`tests/conftest.py`** - Pytest hooks for `--include-local` flag
+
+## Key Features
+
+### 1. Minimal Configuration
+- No config files required
+- Reuses existing test infrastructure from `tests/dataset_config.py` and `tests/common_utils.py`
+- Hardcoded reasonable defaults for tolerances
+
+### 2. Native Serialization
+- Uses `Conversation.to_dict()` and `Conversation.get_full_data()` methods
+- Uses pandas DataFrame for vote matrices
+- JSON-serializable outputs only
+
+### 3. Data Integrity
+- MD5 checksums validate that dataset CSV files haven't changed
+- Fixed timestamps ensure reproducible results
+- Automatically ignores non-deterministic fields (e.g., `math_tick`)
+
+### 4. Tolerance-Based Comparison
+- Absolute tolerance: `1e-6` (for small values)
+- Relative tolerance: `1%` (for large values)
+- Exact matching for integer counts
+- Special handling for NaN and infinity values
+
+### 5. Statistical Performance Benchmarking
+- **Multiple runs**: Each computation stage runs 3 times to collect statistically meaningful timing data
+- **Statistical metrics**: Records mean, standard deviation, and raw timing values
+- **T-test analysis**: Performs independent two-sample t-tests to determine if performance differences are statistically significant
+- **P-value reporting**: Shows p-values with interpretation (significant if p < 0.05)
+- **Visual indicators**: Displays emoji symbols for quick interpretation:
+  - **🚀**: Significantly faster (p < 0.05) - real performance improvement
+  - **⚠️**: Significantly slower (p < 0.05) - real performance regression
+  - **No emoji**: No significant difference (p ≥ 0.05) - normal variation
+- **Compact format**: Single-line display per stage showing:
+  - Status (✅/❌), stage name, current vs golden timing, performance result, and p-value
+  - Example: `✅ after_pca: 101ms ± 4ms vs 94ms ± 8ms │ 1.08x slower, p=0.2461`
+  - Times automatically formatted in appropriate units (µs, ms, or s)
+- **Interpretation**: Small p-values (< 0.05) indicate real performance changes, while large p-values suggest natural variation
+- Helps distinguish real performance regressions from measurement noise
+
+### 6. Comprehensive Stage Coverage
+
+The system captures 6 stages of the Conversation lifecycle:
+
+1. **Empty** - Initial conversation state
+2. **After load (no compute)** - Votes loaded but no analysis performed
+3. **After PCA** - Principal Component Analysis computed
+4. **After clustering** - K-means clustering computed
+5. **After full recompute** - Complete pipeline including repness and participant info
+6. **Full data export** - Output from `get_full_data()` method
+
+## Usage
+
+### Command-Line Interface
+
+```bash
+cd delphi
+
+# Record golden snapshots for all datasets
+python scripts/regression_recorder.py biodiversity vw
+
+# Record for a single dataset
+python scripts/regression_recorder.py biodiversity
+
+# Compare current implementation with golden
+python scripts/regression_comparer.py biodiversity vw
+
+# Update golden snapshots after verified changes
+python scripts/regression_recorder.py biodiversity --force
+
+# Adjust comparison tolerances
+python scripts/regression_comparer.py biodiversity \
+    --tolerance-abs 1e-8 --tolerance-rel 0.001
+```
+
+### Pytest Integration
+
+```bash
+cd delphi
+
+# Run regression tests with committed datasets only (default)
+pytest tests/test_regression.py -v
+
+# Include local datasets from real_data/.local/
+pytest tests/test_regression.py --include-local -v
+
+# Run with coverage
+pytest tests/test_regression.py -v --cov=polismath
+
+# Run specific dataset test
+pytest tests/test_regression.py::test_conversation_regression[biodiversity] -v
+```
+
+### Parallel Test Execution
+
+The test suite supports parallel execution using `pytest-xdist`. Tests are grouped by dataset using `xdist_group` markers, ensuring that fixtures (expensive Conversation computations) are shared within each worker.
+
+```bash
+# Run tests in parallel (auto-detect CPU count)
+pytest tests/test_regression.py -n auto -v
+
+# Run with a specific number of workers
+pytest tests/test_regression.py -n 4 -v
+
+# Run sequentially (useful for debugging)
+pytest tests/test_regression.py -n 0 -v
+```
+
+**How it works:**
+- `--dist=loadgroup` (configured in `pyproject.toml`) groups tests by their `xdist_group` marker
+- Each dataset's tests run on the same worker, so the `conversation_data` fixture is computed once per dataset per worker
+- Workers process dataset groups in parallel
+
+**When NOT to use parallel execution:**
+- Tests that access shared databases (`test_postgres_real_data.py`) may have race conditions
+- When debugging test failures (interleaved output is harder to read)
+- On memory-constrained systems (each worker loads datasets independently)
+
+The test header shows discovered datasets:
+```
+Datasets discovered: 2 total (2 committed, 0 local)
+Valid for regression: 2 (biodiversity, vw)
+Use --include-local to include datasets from real_data/.local/
+```
+
+### Typical Workflow
+
+1. **Initial Setup** - Record golden snapshots before refactoring:
+   ```bash
+   python scripts/regression_recorder.py biodiversity vw
+   ```
+
+2. **During Refactoring** - Run comparison frequently:
+   ```bash
+   python scripts/regression_comparer.py biodiversity
+   ```
+
+3. **After Verification** - Update golden if changes are intentional:
+   ```bash
+   python scripts/regression_recorder.py biodiversity --force
+   ```
+
+### Example Output
+
+When recording, the system runs 3 iterations for statistical benchmarking:
+
+```
+Recording golden snapshot for biodiversity...
+  Computing all stages with benchmarking...
+  Running 3 iterations for benchmarking...
+    Iteration 1/3 complete
+    Iteration 2/3 complete
+    Iteration 3/3 complete
+  Saving golden snapshot to .../biodiversity_golden.json
+Successfully recorded golden snapshot for biodiversity
+```
+
+When comparing, you'll see timing information with statistical significance:
+
+```
+Comparing biodiversity with golden snapshot...
+  Running 3 iterations for benchmarking...
+    Iteration 1/3 complete
+    Iteration 2/3 complete
+    Iteration 3/3 complete
+✅ biodiversity: All stages match!
+
+============================================================
+REGRESSION TEST REPORT
+============================================================
+Dataset: biodiversity
+Overall Result: ✅ PASS
+
+Metadata:
+  dataset_name: biodiversity
+  report_id: r4tykwac8thvzv35jrn53
+  votes_csv_md5: cf32750948416aa7741832f16d004aea
+  comments_csv_md5: 6b961ecb3dd6b5a277139b0f39f83861
+  n_votes_in_csv: 29802
+  n_comments_in_csv: 316
+  n_participants_in_csv: 536
+  fixed_timestamp: 1700000000000
+  recorded_at: 2025-11-12T13:52:26.966074
+
+Numerical comparison:
+  (Tolerances: abs=1e-06, rel=1.0%)
+  ✅ Match      empty                      (= 1.02x slower, p=0.8388)
+  ✅ Match      after_load_no_compute      (= 1.02x faster, p=0.0710)
+  ✅ Match      after_pca                  (= 1.08x slower, p=0.2461)
+  ✅ Match      after_clustering           (= 1.00x faster, p=0.9855)
+  ✅ Match      after_full_recompute       (- 1.07x slower, p=0.0018)
+  ✅ Match      full_data_export           (= 1.03x slower, p=0.8889)
+
+Speed comparison:
+  Status Stage                     Current (mean ± std)  Golden (mean ± std)     Performance
+  ✅ empty                      300µs ± 10µs         vs 300µs ± 10µs          │ 1.02x slower, p=0.8388
+  ✅ after_load_no_compute      605ms ± 7ms          vs 614ms ± 1ms           │ 1.02x faster, p=0.0710
+  ✅ after_pca                  101ms ± 4ms          vs 94ms ± 8ms            │ 1.08x slower, p=0.2461
+  ✅ after_clustering           131ms ± 21ms         vs 132ms ± 0ms           │ 1.00x faster, p=0.9855
+  ✅ after_full_recompute       954ms ± 11ms         vs 891ms ± 10ms          │ ⚠️1.07x slower, p=0.0018
+  ✅ full_data_export           300µs ± 100µs        vs 300µs ± 100µs         │ 1.03x slower, p=0.8889
+============================================================
+```
+
+**Interpreting the Output:**
+
+The report is organized into two sections:
+
+**1. Numerical comparison:**
+Shows the result of comparing numerical values within tolerances:
+- **First line**: Shows the tolerance values used (absolute and relative)
+- **One line per stage**: Compact format showing status, stage name, and optional performance summary
+- **✅ Match / ❌ Mismatch**: Shows whether the numerical values match within tolerances
+- **Performance symbols** (in parentheses):
+  - **"="**: No significant difference (p ≥ 0.05)
+  - **"+"**: Significantly faster (p < 0.05)
+  - **"-"**: Significantly slower (p < 0.05)
+
+**2. Speed comparison:**
+Shows aligned, formatted timing metrics with a header row:
+- **Header line**: Clarifies which column is Current vs Golden timing
+- **Status emoji**: ✅ for passing stages, ❌ for failing stages
+- **Stage name**: Left-aligned with fixed width for visual alignment
+- **Current timing**: Shows mean ± std dev for new implementation
+- **Golden timing**: Shows mean ± std dev for golden snapshot
+- **Performance emoji indicators**:
+  - **🚀**: Significantly faster (p < 0.05) - real performance improvement detected
+  - **⚠️**: Significantly slower (p < 0.05) - real performance regression detected
+  - **No emoji**: No significant difference (p ≥ 0.05) - normal variation
+- **Performance metrics**: Speedup/slowdown ratio with p-value
+- **Time units**: Automatically formatted (µs for < 1ms, ms for < 1s, s otherwise)
+
+In the example above:
+- The Numerical comparison shows all stages match with tolerance abs=1e-06, rel=1.0%
+- Most stages show **"="** (no significant performance difference)
+- `after_full_recompute` shows **"-"** with p=0.0018 and ⚠️ emoji, indicating a real performance regression worth investigating
+
+## Design Decisions
+
+### Fixed Timestamps
+
+The system uses a fixed timestamp (`1700000000000` milliseconds) to ensure reproducibility:
+
+```python
+fixed_timestamp = 1700000000000
+conv = Conversation(dataset_name, last_updated=fixed_timestamp)
+```
+
+This prevents timestamp-based fields from causing false positives in comparisons.
+
+### Ignored Fields
+
+Certain fields are automatically ignored during comparison:
+- `math_tick` - A timestamp-derived metadata field not part of computational results
+
+To add more ignored fields, modify `comparer.py`:
+
+```python
+def _compare_dicts(self, golden: Any, current: Any, path: str = "") -> Dict:
+    # Add new ignored fields here
+    if path.endswith(".your_field") or path == "your_field":
+        return {"match": True, "path": path, "note": "Ignored field"}
+    # ... rest of comparison logic
+```
+
+### Reused Infrastructure
+
+The system leverages existing test code to avoid duplication:
+
+- **Dataset management**: Uses `tests/dataset_config.py` for file discovery
+- **Vote loading**: Follows the same pattern as `tests/common_utils.py`
+- **Test data**: Uses existing test datasets in `real_data/`
+
+## File Format
+
+Golden snapshot files are JSON with this structure:
+
+```json
+{
+  "metadata": {
+    "dataset_name": "biodiversity",
+    "report_id": "r4tykwac8thvzv35jrn53",
+    "recorded_at": "2025-11-11T12:36:01.652000",
+    "votes_csv_md5": "abc123...",
+    "comments_csv_md5": "def456...",
+    "n_votes_in_csv": 29802,
+    "n_comments_in_csv": 316,
+    "n_participants_in_csv": 536
+  },
+  "stages": {
+    "empty": { /* to_dict() output */ },
+    "after_load_no_compute": { /* to_dict() output */ },
+    "after_pca": { /* to_dict() output */ },
+    "after_clustering": { /* to_dict() output */ },
+    "after_full_recompute": { /* to_dict() output */ },
+    "full_data_export": { /* get_full_data() output */ }
+  },
+  "timing_stats": {
+    "empty": {
+      "mean": 0.0006514590349979699,
+      "std": 0.00001234,
+      "raw": [0.00065, 0.00066, 0.00065]
+    },
+    "after_load_no_compute": {
+      "mean": 0.606867374968715,
+      "std": 0.0012345,
+      "raw": [0.6056, 0.6069, 0.6081]
+    },
+    "after_pca": {
+      "mean": 0.08539487503003329,
+      "std": 0.0083456,
+      "raw": [0.0854, 0.0930, 0.0777]
+    },
+    "after_clustering": {
+      "mean": 0.13137866597389802,
+      "std": 0.0213245,
+      "raw": [0.1121, 0.1500, 0.1320]
+    },
+    "after_full_recompute": {
+      "mean": 0.9307277500047348,
+      "std": 0.0103456,
+      "raw": [0.9307, 0.9200, 0.9415]
+    },
+    "full_data_export": {
+      "mean": 0.00022733298828825355,
+      "std": 0.00001000,
+      "raw": [0.00023, 0.00022, 0.00023]
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### Dataset Files Changed
+
+**Error:**
+```
+Dataset files have changed! MD5 mismatch.
+```
+
+**Solution:**
+If the CSV files were intentionally updated, re-record the golden snapshot:
+```bash
+python scripts/regression_recorder.py biodiversity --force
+```
+
+### Numeric Mismatches
+
+**Error:**
+```
+Numeric mismatch: golden=1.234567, current=1.234568, abs_diff=1e-6
+```
+
+**Solutions:**
+1. If the difference is acceptable, adjust tolerances:
+   ```bash
+   python scripts/regression_comparer.py --tolerance-abs 1e-5
+   ```
+
+2. If this represents a genuine regression, investigate the code changes.
+
+### Missing Golden Snapshot
+
+**Error:**
+```
+No golden snapshot found for dataset. Run recorder first.
+```
+
+**Solution:**
+```bash
+python scripts/regression_recorder.py biodiversity
+```
+
+### Non-Deterministic Results
+
+If you encounter random variations in output (e.g., clustering order changes):
+
+1. Check if fields should be ignored (like `math_tick`)
+2. Ensure random seeds are fixed in the code
+3. Verify timestamps are using the fixed value
+
+## Extending the System
+
+### Adding New Datasets
+
+**Option A: Download from running Polis instance**
+```bash
+cd delphi
+
+# Download to .local/ (git-ignored, for confidential/large data)
+python scripts/regression_download.py rexample1234 myconvo
+
+# Download to real_data/ (for public datasets to commit)
+python scripts/regression_download.py rexample1234 myconvo --commit
+```
+
+**Option B: Manual setup**
+1. Create directory: `real_data/.local/<report_id>-<name>/`
+2. Add required files:
+   - `<timestamp>-<report_id>-votes.csv`
+   - `<timestamp>-<report_id>-comments.csv`
+   - `<report_id>_math_blob.json`
+
+**Then record a golden snapshot:**
+```bash
+python scripts/regression_recorder.py your_dataset
+```
+
+The dataset will be auto-discovered based on its directory name.
+
+### Adding New Stages
+
+To capture additional computation stages, modify `recorder.py` and `comparer.py`:
+
+```python
+# In recorder.py
+print("  Computing your stage...")
+conv.your_method()
+snapshot["stages"]["your_stage"] = conv.to_dict()
+
+# In comparer.py
+elif stage_name == "your_stage":
+    current_conv = Conversation(dataset_name, last_updated=fixed_timestamp)
+    # ... setup
+    current_conv.your_method()
+    current_dict = current_conv.to_dict()
+```
+
+### Custom Comparison Logic
+
+For special comparison needs, modify `_compare_dicts()` in `comparer.py`:
+
+```python
+# Example: Special handling for cluster member sets
+if "cluster" in path and "members" in path:
+    # Custom comparison logic for unordered sets
+    return self._compare_sets(golden, current, path)
+```
+
+## Performance Notes
+
+- Recording a golden snapshot: ~2-3 seconds per dataset
+- Comparison run: ~3-4 seconds per dataset
+- Golden snapshot file size: ~500KB - 2MB per dataset
+
+## Limitations
+
+1. **No internal state checking** - Only compares serialized outputs, not internal DataFrame state
+2. **Limited to test datasets** - Only works with datasets that have CSV files available
+3. **No partial updates** - Must record/update entire stage sets
+4. **Fixed tolerance values** - Same tolerances apply to all numeric fields
+
+## When to Use This System
+
+**Use regression tests when:**
+- Refactoring computational code
+- Optimizing algorithms while preserving behavior
+- Restructuring data flow
+- Changing internal representations
+
+**Don't rely solely on regression tests for:**
+- Verifying correctness against requirements (use unit tests)
+- Testing edge cases (use property-based tests)
+- Validating against the Clojure implementation (use comparison tests)
+
+## Related Testing
+
+This regression system complements other test types:
+
+- **Unit tests** (`tests/test_*.py`) - Verify individual component behavior
+- **Smoke tests** (`tests/test_conversation_smoke.py`) - Verify code runs without crashing
+- **Comparison tests** - Validate against Clojure reference implementation
+- **Integration tests** - Test end-to-end workflows
+
+## License
+
+Part of the Polis project. See repository root for license information.

--- a/delphi/polismath/pca_kmeans_rep/pca.py
+++ b/delphi/polismath/pca_kmeans_rep/pca.py
@@ -509,7 +509,10 @@ def pca_project_dataframe(df: pd.DataFrame,
     # Why column mean instead of 0? Using 0 biases covariance estimates for sparse data.
     # Column mean is imperfect (pulls participants toward center, assumes Gaussian data
     # while votes are ternary) but matches Clojure and is better than 0.
-    col_means = np.nanmean(matrix_data, axis=0)
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)  # suppress "Mean of empty slice"
+        col_means = np.nanmean(matrix_data, axis=0)
     # Handle columns that are entirely NaN (e.g., statements with zero votes):
     # nanmean returns NaN for these, which would leave NaNs in the matrix.
     col_means = np.where(np.isnan(col_means), 0.0, col_means)

--- a/delphi/pyproject.toml
+++ b/delphi/pyproject.toml
@@ -122,8 +122,8 @@ include = [
 
 # Pytest configuration
 [tool.pytest.ini_options]
-# When using pytest-xdist (-n), group tests by class/module for efficient fixture sharing
-addopts = "--dist=loadscope"
+# When using pytest-xdist (-n), group tests by xdist_group marker for efficient fixture sharing
+addopts = "--dist=loadgroup"
 filterwarnings = [
     # Ignore python_multipart deprecation warning from ddtrace (third-party)
     "ignore:Please use `import python_multipart`:PendingDeprecationWarning:ddtrace.internal.module",

--- a/delphi/pyproject.toml
+++ b/delphi/pyproject.toml
@@ -122,6 +122,8 @@ include = [
 
 # Pytest configuration
 [tool.pytest.ini_options]
+# When using pytest-xdist (-n), group tests by class/module for efficient fixture sharing
+addopts = "--dist=loadscope"
 filterwarnings = [
     # Ignore python_multipart deprecation warning from ddtrace (third-party)
     "ignore:Please use `import python_multipart`:PendingDeprecationWarning:ddtrace.internal.module",

--- a/delphi/tests/README.md
+++ b/delphi/tests/README.md
@@ -97,14 +97,43 @@ real_data/
 **Optional files:**
 - `{report_id}_math_blob.json` - Clojure math output (for Clojure comparison, requires database access)
 
-### Running Tests with Local Datasets
+### Pytest Command Line Options
 
+**Dataset selection:**
 ```bash
 # Default: committed datasets only
 pytest tests/test_regression.py
 
-# Include local datasets
+# Include local datasets from real_data/.local/
 pytest tests/test_regression.py --include-local
+
+# Run tests on specific datasets only
+pytest tests/ --datasets=biodiversity
+pytest tests/ --datasets=biodiversity,vw
+
+# Combine options
+pytest tests/ --include-local --datasets=myconvo
+```
+
+**Parallel execution:**
+```bash
+# Run tests in parallel across 4 workers
+pytest tests/ -n4
+
+# Tests are grouped by dataset (via xdist_group markers)
+# so each dataset's fixtures are computed once per worker
+```
+
+**Common combinations:**
+```bash
+# Fast smoke test on one dataset
+pytest tests/test_legacy_clojure_regression.py --datasets=vw -v
+
+# Full parallel run with local datasets
+pytest tests/ --include-local -n4
+
+# Quick check that all tests pass
+pytest tests/ --datasets=biodiversity -q
 ```
 
 ### Downloading Test Data

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -66,6 +66,20 @@ def pytest_addoption(parser):
         default=False,
         help="Include datasets from real_data/.local/ in tests"
     )
+    parser.addoption(
+        "--datasets",
+        action="store",
+        default=None,
+        help="Comma-separated list of datasets to run (e.g., --datasets=biodiversity,vw)"
+    )
+
+
+def _get_requested_datasets(config) -> set[str] | None:
+    """Get the set of datasets requested via --datasets, or None for all."""
+    datasets_opt = config.getoption("--datasets")
+    if datasets_opt:
+        return {d.strip() for d in datasets_opt.split(",")}
+    return None
 
 
 def pytest_configure(config):
@@ -99,35 +113,70 @@ def pytest_generate_tests(metafunc):
 
     Tests that have a 'dataset' parameter will be parametrized with all
     valid regression datasets. Use --include-local to include datasets
-    from real_data/.local/.
+    from real_data/.local/. Use --datasets to limit to specific datasets.
 
     Uses xdist_group markers for efficient parallel execution with pytest-xdist.
     """
     if "dataset" in metafunc.fixturenames:
-        # Check if this test uses the regression dataset parametrization
-        # by looking for the marker or checking the test module
         include_local = metafunc.config.getoption("--include-local")
+        requested = _get_requested_datasets(metafunc.config)
 
         # Get datasets valid for regression testing
         datasets = list_regression_datasets(include_local=include_local)
+
+        # Filter to requested datasets if specified
+        if requested:
+            datasets = [d for d in datasets if d in requested]
 
         # Parametrize with xdist_group markers for parallel execution
         params = make_dataset_params(datasets)
         metafunc.parametrize("dataset", params)
 
 
+def _extract_dataset_from_test(item) -> str | None:
+    """Extract dataset name from test item's parameter, if present."""
+    # Check for parametrized marker with dataset/dataset_name parameter
+    for marker in item.iter_markers("parametrize"):
+        argnames = marker.args[0] if marker.args else ""
+        if "dataset" in argnames:
+            # Get the parameter value from callspec
+            if hasattr(item, 'callspec'):
+                for param_name in ['dataset', 'dataset_name']:
+                    if param_name in item.callspec.params:
+                        return item.callspec.params[param_name]
+    return None
+
+
 def pytest_collection_modifyitems(config, items):
     """
     Modify test collection:
     1. Skip local_dataset tests unless --include-local is passed
-    2. Add xdist_group marker for parallel execution by dataset
+    2. Deselect tests for datasets not in --datasets list
     """
     include_local = config.getoption("--include-local")
+    requested = _get_requested_datasets(config)
+
+    selected = []
+    deselected = []
 
     for item in items:
         # Skip local dataset tests unless --include-local
         if not include_local and "local_dataset" in item.keywords:
             item.add_marker(pytest.mark.skip(reason="need --include-local option to run"))
+
+        # Filter by --datasets if specified
+        if requested:
+            dataset = _extract_dataset_from_test(item)
+            if dataset is not None and dataset not in requested:
+                deselected.append(item)
+                continue
+
+        selected.append(item)
+
+    # Apply deselection
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = selected
 
 
 
@@ -135,6 +184,7 @@ def pytest_collection_modifyitems(config, items):
 def pytest_report_header(config):
     """Add dataset discovery info to pytest header."""
     include_local = config.getoption("--include-local")
+    requested = _get_requested_datasets(config)
     datasets = discover_datasets(include_local=include_local)
     regression_valid = [
         name for name, info in datasets.items()
@@ -148,6 +198,9 @@ def pytest_report_header(config):
         f"Datasets discovered: {len(datasets)} total ({committed_count} committed, {local_count} local)",
         f"Valid for regression: {len(regression_valid)} ({', '.join(sorted(regression_valid)) or 'none'})",
     ]
+
+    if requested:
+        lines.append(f"Filtered to: {', '.join(sorted(requested))}")
 
     if not include_local:
         lines.append("Use --include-local to include datasets from real_data/.local/")

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -71,19 +71,17 @@ def pytest_generate_tests(metafunc):
 
 def pytest_collection_modifyitems(config, items):
     """
-    Modify test collection based on --include-local flag.
-
-    Tests marked with @pytest.mark.local_dataset will be skipped unless
-    --include-local is passed.
+    Modify test collection:
+    1. Skip local_dataset tests unless --include-local is passed
+    2. Add xdist_group marker for parallel execution by dataset
     """
-    if config.getoption("--include-local"):
-        # --include-local passed, don't skip any local dataset tests
-        return
+    include_local = config.getoption("--include-local")
 
-    skip_local = pytest.mark.skip(reason="need --include-local option to run")
     for item in items:
-        if "local_dataset" in item.keywords:
-            item.add_marker(skip_local)
+        # Skip local dataset tests unless --include-local
+        if not include_local and "local_dataset" in item.keywords:
+            item.add_marker(pytest.mark.skip(reason="need --include-local option to run"))
+
 
 
 # Provide summary of discovered datasets at start of test run

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -5,13 +5,57 @@ This module provides:
 - Command line option --include-local for including local datasets in tests
 - Fixtures for accessing dataset information
 - Dynamic test parametrization based on discovered datasets
+- Helper functions for parallel test execution with xdist_group markers
 """
 
 import pytest
 from polismath.regression.datasets import (
     discover_datasets,
     list_regression_datasets,
+    list_available_datasets,
 )
+
+
+# =============================================================================
+# Parallel Execution Helpers
+# =============================================================================
+
+def make_dataset_params(datasets: list[str]) -> list:
+    """
+    Create pytest.param objects with xdist_group markers for parallel execution.
+
+    When using pytest-xdist with --dist=loadgroup, tests with the same
+    xdist_group marker will run on the same worker. This ensures fixtures
+    are computed only once per dataset per worker.
+
+    Args:
+        datasets: List of dataset names
+
+    Returns:
+        List of pytest.param objects with xdist_group markers
+
+    Example:
+        @pytest.mark.parametrize("dataset_name", make_dataset_params(["biodiversity", "vw"]))
+        def test_something(dataset_name):
+            ...
+    """
+    return [
+        pytest.param(ds, marks=pytest.mark.xdist_group(ds))
+        for ds in datasets
+    ]
+
+
+def get_available_dataset_params() -> list:
+    """
+    Get all available datasets as pytest.param objects with xdist_group markers.
+
+    NOTE: This is evaluated at import time, so it does NOT respect --include-local.
+    For tests that need --include-local support, use pytest_generate_tests hook instead.
+
+    Returns:
+        List of pytest.param objects for all available (committed) datasets
+    """
+    return make_dataset_params(list(list_available_datasets().keys()))
 
 
 def pytest_addoption(parser):
@@ -56,6 +100,8 @@ def pytest_generate_tests(metafunc):
     Tests that have a 'dataset' parameter will be parametrized with all
     valid regression datasets. Use --include-local to include datasets
     from real_data/.local/.
+
+    Uses xdist_group markers for efficient parallel execution with pytest-xdist.
     """
     if "dataset" in metafunc.fixturenames:
         # Check if this test uses the regression dataset parametrization
@@ -65,8 +111,9 @@ def pytest_generate_tests(metafunc):
         # Get datasets valid for regression testing
         datasets = list_regression_datasets(include_local=include_local)
 
-        # Parametrize with discovered datasets (empty list = no test instances)
-        metafunc.parametrize("dataset", datasets)
+        # Parametrize with xdist_group markers for parallel execution
+        params = make_dataset_params(datasets)
+        metafunc.parametrize("dataset", params)
 
 
 def pytest_collection_modifyitems(config, items):

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -2,9 +2,9 @@
 Pytest configuration and fixtures for delphi tests.
 
 This module provides:
-- Command line option --include-local for including local datasets in tests
+- Command line options --include-local and --datasets for dataset selection
 - Fixtures for accessing dataset information
-- Dynamic test parametrization based on discovered datasets
+- @pytest.mark.use_discovered_datasets for dynamic dataset parametrization
 - Helper functions for parallel test execution with xdist_group markers
 """
 
@@ -12,7 +12,6 @@ import pytest
 from polismath.regression.datasets import (
     discover_datasets,
     list_regression_datasets,
-    list_available_datasets,
 )
 
 
@@ -43,19 +42,6 @@ def make_dataset_params(datasets: list[str]) -> list:
         pytest.param(ds, marks=pytest.mark.xdist_group(ds))
         for ds in datasets
     ]
-
-
-def get_available_dataset_params() -> list:
-    """
-    Get all available datasets as pytest.param objects with xdist_group markers.
-
-    NOTE: This is evaluated at import time, so it does NOT respect --include-local.
-    For tests that need --include-local support, use pytest_generate_tests hook instead.
-
-    Returns:
-        List of pytest.param objects for all available (committed) datasets
-    """
-    return make_dataset_params(list(list_available_datasets().keys()))
 
 
 def pytest_addoption(parser):
@@ -96,7 +82,9 @@ def _get_requested_datasets(config) -> set[str] | None:
 def pytest_configure(config):
     """Register custom markers."""
     config.addinivalue_line(
-        "markers", "local_dataset: mark test as using local (non-committed) datasets"
+        "markers",
+        "use_discovered_datasets: dynamically parametrize with discovered "
+        "datasets, respecting --include-local and --datasets CLI options"
     )
 
 
@@ -120,75 +108,24 @@ def regression_datasets(include_local):
 
 def pytest_generate_tests(metafunc):
     """
-    Dynamically parametrize tests based on discovered datasets.
+    Dynamically parametrize tests marked with @pytest.mark.use_discovered_datasets.
 
-    Tests that have a 'dataset' parameter will be parametrized with all
-    valid regression datasets. Use --include-local to include datasets
-    from real_data/.local/. Use --datasets to limit to specific datasets.
+    These tests must declare a 'dataset_name' parameter. They will be parametrized
+    with all regression datasets, filtered by --include-local and --datasets.
 
     Uses xdist_group markers for efficient parallel execution with pytest-xdist.
     """
-    if "dataset" in metafunc.fixturenames:
-        include_local = metafunc.config.getoption("--include-local")
-        requested = _get_requested_datasets(metafunc.config)
+    if not list(metafunc.definition.iter_markers("use_discovered_datasets")):
+        return
 
-        # Get datasets valid for regression testing
-        datasets = list_regression_datasets(include_local=include_local)
+    include_local = metafunc.config.getoption("--include-local")
+    requested = _get_requested_datasets(metafunc.config)
 
-        # Filter to requested datasets if specified
-        if requested:
-            datasets = [d for d in datasets if d in requested]
+    datasets = list_regression_datasets(include_local=include_local)
+    if requested:
+        datasets = [d for d in datasets if d in requested]
 
-        # Parametrize with xdist_group markers for parallel execution
-        params = make_dataset_params(datasets)
-        metafunc.parametrize("dataset", params)
-
-
-def _extract_dataset_from_test(item) -> str | None:
-    """Extract dataset name from test item's parameter, if present."""
-    # Check for parametrized marker with dataset/dataset_name parameter
-    for marker in item.iter_markers("parametrize"):
-        argnames = marker.args[0] if marker.args else ""
-        if "dataset" in argnames:
-            # Get the parameter value from callspec
-            if hasattr(item, 'callspec'):
-                for param_name in ['dataset', 'dataset_name']:
-                    if param_name in item.callspec.params:
-                        return item.callspec.params[param_name]
-    return None
-
-
-def pytest_collection_modifyitems(config, items):
-    """
-    Modify test collection:
-    1. Skip local_dataset tests unless --include-local is passed
-    2. Deselect tests for datasets not in --datasets list
-    """
-    include_local = config.getoption("--include-local")
-    requested = _get_requested_datasets(config)
-
-    selected = []
-    deselected = []
-
-    for item in items:
-        # Skip local dataset tests unless --include-local
-        if not include_local and "local_dataset" in item.keywords:
-            item.add_marker(pytest.mark.skip(reason="need --include-local option to run"))
-
-        # Filter by --datasets if specified
-        if requested:
-            dataset = _extract_dataset_from_test(item)
-            if dataset is not None and dataset not in requested:
-                deselected.append(item)
-                continue
-
-        selected.append(item)
-
-    # Apply deselection
-    if deselected:
-        config.hook.pytest_deselected(items=deselected)
-        items[:] = selected
-
+    metafunc.parametrize("dataset_name", make_dataset_params(datasets))
 
 
 # Provide summary of discovered datasets at start of test run

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -77,9 +77,20 @@ def pytest_addoption(parser):
 def _get_requested_datasets(config) -> set[str] | None:
     """Get the set of datasets requested via --datasets, or None for all."""
     datasets_opt = config.getoption("--datasets")
-    if datasets_opt:
-        return {d.strip() for d in datasets_opt.split(",")}
-    return None
+    if not datasets_opt:
+        return None
+
+    # Split on commas, strip whitespace, and drop empty entries to avoid
+    # treating trailing/repeated commas as empty dataset names.
+    requested = {d.strip() for d in datasets_opt.split(",") if d.strip()}
+
+    if not requested:
+        raise pytest.UsageError(
+            "No valid dataset names specified in --datasets option. "
+            "Provide a comma-separated list, e.g. --datasets=biodiversity,vw."
+        )
+
+    return requested
 
 
 def pytest_configure(config):

--- a/delphi/tests/test_conversation_smoke.py
+++ b/delphi/tests/test_conversation_smoke.py
@@ -15,8 +15,6 @@ import os
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from common_utils import create_test_conversation
-from conftest import get_available_dataset_params
-
 logger = logging.getLogger(__name__)
 
 
@@ -32,7 +30,7 @@ class TestConversationWithRealData:
             "For comparison tests, run test_real_data_comparison.py manually."
         )
 
-    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
+    @pytest.mark.use_discovered_datasets
     def test_conversation_recompute(self, dataset_name: str):
         """
         Test that Conversation.recompute() runs successfully on real data.

--- a/delphi/tests/test_conversation_smoke.py
+++ b/delphi/tests/test_conversation_smoke.py
@@ -15,7 +15,7 @@ import os
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from common_utils import create_test_conversation
-from polismath.regression import list_available_datasets
+from conftest import get_available_dataset_params
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class TestConversationWithRealData:
             "For comparison tests, run test_real_data_comparison.py manually."
         )
 
-    @pytest.mark.parametrize("dataset_name", list(list_available_datasets().keys()))
+    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
     def test_conversation_recompute(self, dataset_name: str):
         """
         Test that Conversation.recompute() runs successfully on real data.

--- a/delphi/tests/test_dataset_selection.py
+++ b/delphi/tests/test_dataset_selection.py
@@ -1,0 +1,216 @@
+"""
+Tests for the dataset selection logic in conftest.py.
+
+Verifies that:
+- @pytest.mark.use_discovered_datasets tests are filtered by --datasets
+- Hardcoded @pytest.mark.parametrize tests are NOT filtered by --datasets
+- --include-local correctly includes/excludes local datasets
+- _get_requested_datasets parses --datasets correctly
+"""
+
+import pytest
+from conftest import _get_requested_datasets, make_dataset_params
+
+
+# =============================================================================
+# Unit tests for _get_requested_datasets
+# =============================================================================
+
+
+class TestGetRequestedDatasets:
+    """Test the --datasets CLI option parsing."""
+
+    def test_no_option_returns_none(self):
+        """No --datasets flag means 'run all datasets'."""
+        config = type("Config", (), {"getoption": lambda self, x: None})()
+        assert _get_requested_datasets(config) is None
+
+    def test_empty_string_returns_none(self):
+        """Empty string means 'run all datasets'."""
+        config = type("Config", (), {"getoption": lambda self, x: ""})()
+        assert _get_requested_datasets(config) is None
+
+    def test_single_dataset(self):
+        config = type("Config", (), {"getoption": lambda self, x: "vw"})()
+        assert _get_requested_datasets(config) == {"vw"}
+
+    def test_multiple_datasets(self):
+        config = type("Config", (), {
+            "getoption": lambda self, x: "vw,biodiversity"
+        })()
+        assert _get_requested_datasets(config) == {"vw", "biodiversity"}
+
+    def test_strips_whitespace(self):
+        config = type("Config", (), {
+            "getoption": lambda self, x: " vw , biodiversity "
+        })()
+        assert _get_requested_datasets(config) == {"vw", "biodiversity"}
+
+    def test_ignores_empty_entries(self):
+        config = type("Config", (), {
+            "getoption": lambda self, x: "vw,,biodiversity,"
+        })()
+        assert _get_requested_datasets(config) == {"vw", "biodiversity"}
+
+    def test_only_commas_raises(self):
+        config = type("Config", (), {"getoption": lambda self, x: ",,"})()
+        with pytest.raises(pytest.UsageError, match="No valid dataset names"):
+            _get_requested_datasets(config)
+
+
+# =============================================================================
+# Unit tests for make_dataset_params
+# =============================================================================
+
+
+class TestMakeDatasetParams:
+    """Test the xdist_group param creation."""
+
+    def test_creates_params_with_xdist_group(self):
+        params = make_dataset_params(["vw", "biodiversity"])
+        assert len(params) == 2
+        # Each param's value is the dataset name
+        assert params[0].values == ("vw",)
+        assert params[1].values == ("biodiversity",)
+
+    def test_empty_list(self):
+        assert make_dataset_params([]) == []
+
+
+# =============================================================================
+# Integration tests using pytester
+# =============================================================================
+
+pytest_plugins = ["pytester"]
+
+_SHARED_CONFTEST = """
+import pytest
+
+COMMITTED_DATASETS = ["alpha", "beta", "gamma"]
+LOCAL_DATASETS = ["local_one"]
+
+def make_dataset_params(datasets):
+    return [pytest.param(ds, marks=pytest.mark.xdist_group(ds)) for ds in datasets]
+
+def pytest_addoption(parser):
+    parser.addoption("--include-local", action="store_true", default=False)
+    parser.addoption("--datasets", action="store", default=None)
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "use_discovered_datasets: test marker")
+
+def pytest_generate_tests(metafunc):
+    if not list(metafunc.definition.iter_markers("use_discovered_datasets")):
+        return
+    include_local = metafunc.config.getoption("--include-local")
+    datasets_opt = metafunc.config.getoption("--datasets")
+    requested = {d.strip() for d in datasets_opt.split(",") if d.strip()} if datasets_opt else None
+    datasets = list(COMMITTED_DATASETS)
+    if include_local:
+        datasets += LOCAL_DATASETS
+    if requested:
+        datasets = [d for d in datasets if d in requested]
+    metafunc.parametrize("dataset_name", make_dataset_params(datasets))
+"""
+
+_SHARED_TESTFILE = """
+import pytest
+from conftest import make_dataset_params
+
+@pytest.mark.use_discovered_datasets
+def test_discovered(dataset_name):
+    pass
+
+@pytest.mark.parametrize("dataset_name", make_dataset_params(["alpha", "beta"]))
+def test_hardcoded(dataset_name):
+    pass
+
+def test_plain():
+    pass
+"""
+
+
+def _collected_test_ids(pytester_result) -> list[str]:
+    """Extract test IDs from pytester --co -q output."""
+    return [
+        line.strip()
+        for line in pytester_result.stdout.lines
+        if "::test_" in line
+    ]
+
+
+def _dataset_names_for(test_ids: list[str], test_func: str) -> set[str]:
+    """Extract dataset names from test IDs for a given test function.
+
+    Test IDs look like: 'test_file.py::test_discovered[alpha]'
+    """
+    return {
+        tid.split("[")[1].rstrip("]")
+        for tid in test_ids
+        if f"::{test_func}[" in tid
+    }
+
+
+class TestDiscoveredDatasetsFiltering:
+    """Tests that @pytest.mark.use_discovered_datasets respects --datasets."""
+
+    def test_default_discovers_committed_not_local(self, pytester):
+        """Without any flags, discovered tests get exactly the committed datasets."""
+        pytester.makeconftest(_SHARED_CONFTEST)
+        pytester.makepyfile(_SHARED_TESTFILE)
+        result = pytester.runpytest("--co", "-q")
+        ids = _collected_test_ids(result)
+
+        discovered = _dataset_names_for(ids, "test_discovered")
+        assert discovered == {"alpha", "beta", "gamma"}, (
+            "Without flags, discovered tests should get all committed datasets"
+        )
+        assert "local_one" not in discovered, (
+            "Local datasets should NOT appear without --include-local"
+        )
+
+    def test_include_local_adds_local_datasets(self, pytester):
+        """--include-local should add local datasets on top of committed ones."""
+        pytester.makeconftest(_SHARED_CONFTEST)
+        pytester.makepyfile(_SHARED_TESTFILE)
+        result = pytester.runpytest("--co", "-q", "--include-local")
+        ids = _collected_test_ids(result)
+
+        discovered = _dataset_names_for(ids, "test_discovered")
+        assert discovered == {"alpha", "beta", "gamma", "local_one"}, (
+            "With --include-local, discovered tests should include both committed and local"
+        )
+
+    def test_datasets_flag_filters_discovered_only(self, pytester):
+        """--datasets should filter discovered tests but leave hardcoded ones untouched."""
+        pytester.makeconftest(_SHARED_CONFTEST)
+        pytester.makepyfile(_SHARED_TESTFILE)
+        result = pytester.runpytest("--co", "-q", "--datasets=alpha")
+        ids = _collected_test_ids(result)
+
+        discovered = _dataset_names_for(ids, "test_discovered")
+        assert discovered == {"alpha"}, (
+            "--datasets=alpha should limit discovered tests to alpha only"
+        )
+
+        hardcoded = _dataset_names_for(ids, "test_hardcoded")
+        assert hardcoded == {"alpha", "beta"}, (
+            "--datasets should NOT filter hardcoded parametrize tests"
+        )
+
+        assert any("::test_plain" in tid for tid in ids), (
+            "Plain tests should always be collected"
+        )
+
+    def test_plain_tests_unaffected_by_datasets(self, pytester):
+        """Non-parametrized tests always run regardless of --datasets."""
+        pytester.makeconftest(_SHARED_CONFTEST)
+        pytester.makepyfile("""
+def test_plain_one():
+    pass
+
+def test_plain_two():
+    pass
+""")
+        result = pytester.runpytest("--co", "-q", "--datasets=nonexistent")
+        result.stdout.fnmatch_lines(["2 tests collected*"])

--- a/delphi/tests/test_golden_data.py
+++ b/delphi/tests/test_golden_data.py
@@ -10,9 +10,10 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from polismath.conversation.conversation import Conversation
 from common_utils import create_test_conversation
 from tests.dataset_config import get_dataset_files
+from conftest import make_dataset_params
 
 @pytest.mark.xfail(reason="Discrepancies between Python and Clojure implementations")
-@pytest.mark.parametrize("dataset_name", ["biodiversity", "vw"])
+@pytest.mark.parametrize("dataset_name", make_dataset_params(["biodiversity", "vw"]))
 def test_compare_to_golden_data(dataset_name):
     """
     Runs the full pipeline and compares the output to the 'golden' Clojure data.

--- a/delphi/tests/test_legacy_clojure_regression.py
+++ b/delphi/tests/test_legacy_clojure_regression.py
@@ -36,32 +36,45 @@ def _get_clojure_datasets(include_local: bool) -> list[str]:
     ]
 
 
-def pytest_generate_tests(metafunc):
-    """Parametrize tests with clojure datasets at collection time.
+# Module-level cache for conversation data - survives across fixture calls
+_CONVERSATION_CACHE: dict = {}
 
-    Using indirect=True ensures the fixture is only instantiated once per
-    parameter value when combined with scope="class".
-    """
-    if "clojure_dataset" in metafunc.fixturenames:
+
+def pytest_generate_tests(metafunc):
+    """Parametrize tests with clojure datasets at collection time."""
+    if "dataset_name" in metafunc.fixturenames:
         include_local = metafunc.config.getoption("--include-local", default=False)
         datasets = _get_clojure_datasets(include_local)
-        metafunc.parametrize("clojure_dataset", datasets, indirect=True, scope="class")
+        metafunc.parametrize("dataset_name", datasets, scope="class")
+
+
+def _cleanup_previous_datasets(current_dataset: str):
+    """Clear cached datasets except the current one to manage memory."""
+    global _CONVERSATION_CACHE
+    for ds in list(_CONVERSATION_CACHE.keys()):
+        if ds != current_dataset:
+            print(f"[{ds}] Cleaning up previous dataset...")
+            _CONVERSATION_CACHE.pop(ds, None)
+            Conversation._reset_conversion_cache()
+            gc.collect()
 
 
 @pytest.fixture(scope="class")
-def clojure_dataset(request):
-    """Fixture that receives the dataset name via indirect parametrization."""
-    return request.param
-
-
-@pytest.fixture(scope="class")
-def conversation_data(clojure_dataset):
+def conversation_data(dataset_name):
     """
     Class-scoped fixture computed once per dataset.
-    Returns dict with all data needed by tests.
-    Teardown clears cache and forces garbage collection.
+    Uses module-level cache to avoid recomputation.
     """
-    dataset_name = clojure_dataset
+    global _CONVERSATION_CACHE
+
+    # Clean up previous datasets to manage memory
+    _cleanup_previous_datasets(dataset_name)
+
+    # Return cached data if available
+    if dataset_name in _CONVERSATION_CACHE:
+        return _CONVERSATION_CACHE[dataset_name]
+
+    # Compute the data
 
     # Get dataset files using central configuration
     dataset_files = get_dataset_files(dataset_name)
@@ -118,23 +131,22 @@ def conversation_data(clojure_dataset):
 
     print(f"[{dataset_name}] Saved results to {output_path}")
 
-    yield {
+    # Cache for sharing across test methods
+    data = {
         'conv': conv,
         'clojure_output': clojure_output,
         'dataset_name': dataset_name,
         'comments': comments,
     }
+    _CONVERSATION_CACHE[dataset_name] = data
 
-    # TEARDOWN: Clear cache and force garbage collection
-    print(f"[{dataset_name}] Cleaning up...")
-    Conversation._reset_conversion_cache()
-    gc.collect()
+    return data
 
 
 class TestClojureRegression:
     """
     Test class for Clojure regression comparisons.
-    Parametrized per-dataset, with class-scoped fixture for efficiency.
+    Parametrized per-dataset, with module-level cache for efficiency.
     """
 
     def test_basic_outputs(self, conversation_data):

--- a/delphi/tests/test_legacy_clojure_regression.py
+++ b/delphi/tests/test_legacy_clojure_regression.py
@@ -45,7 +45,12 @@ def pytest_generate_tests(metafunc):
     if "dataset_name" in metafunc.fixturenames:
         include_local = metafunc.config.getoption("--include-local", default=False)
         datasets = _get_clojure_datasets(include_local)
-        metafunc.parametrize("dataset_name", datasets, scope="class")
+        # Add xdist_group marker to each parameter for parallel execution
+        params = [
+            pytest.param(ds, marks=pytest.mark.xdist_group(ds))
+            for ds in datasets
+        ]
+        metafunc.parametrize("dataset_name", params, scope="class")
 
 
 def _cleanup_previous_datasets(current_dataset: str):

--- a/delphi/tests/test_legacy_clojure_regression.py
+++ b/delphi/tests/test_legacy_clojure_regression.py
@@ -22,18 +22,24 @@ from polismath.conversation.conversation import Conversation
 from polismath.regression import get_dataset_files
 from polismath.regression.datasets import discover_datasets
 from tests.common_utils import load_votes, load_comments, load_clojure_output
+from conftest import _get_requested_datasets, make_dataset_params
 
 
-def _get_clojure_datasets(include_local: bool) -> list[str]:
+def _get_clojure_datasets(include_local: bool, requested: set[str] | None = None) -> list[str]:
     """Get datasets that have Clojure math_blob for comparison.
 
     Only requires votes, comments, and math_blob - does NOT require golden_snapshot.
+    Filters by requested datasets if specified.
     """
     datasets = discover_datasets(include_local=include_local)
-    return [
+    result = [
         name for name, info in datasets.items()
         if info.has_votes and info.has_comments and info.has_clojure_reference
     ]
+    # Filter by --datasets if specified
+    if requested:
+        result = [d for d in result if d in requested]
+    return result
 
 
 # Module-level cache for conversation data - survives across fixture calls
@@ -44,12 +50,10 @@ def pytest_generate_tests(metafunc):
     """Parametrize tests with clojure datasets at collection time."""
     if "dataset_name" in metafunc.fixturenames:
         include_local = metafunc.config.getoption("--include-local", default=False)
-        datasets = _get_clojure_datasets(include_local)
+        requested = _get_requested_datasets(metafunc.config)
+        datasets = _get_clojure_datasets(include_local, requested)
         # Add xdist_group marker to each parameter for parallel execution
-        params = [
-            pytest.param(ds, marks=pytest.mark.xdist_group(ds))
-            for ds in datasets
-        ]
+        params = make_dataset_params(datasets)
         metafunc.parametrize("dataset_name", params, scope="class")
 
 

--- a/delphi/tests/test_legacy_clojure_regression.py
+++ b/delphi/tests/test_legacy_clojure_regression.py
@@ -9,16 +9,14 @@ Datasets are auto-discovered from:
 - real_data/.local/ (local datasets, included with --include-local flag)
 
 Only datasets with math_blob (has_clojure_reference=True) are included.
+
+Performance note: Uses scope="class" with parametrization to ensure only ONE
+Conversation object is in memory at a time (teardown between datasets).
 """
 
 import pytest
 import pytest_check as check
-import os
-import sys
-import json
-
-# Add the parent directory to the path to import the module
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import gc
 
 from polismath.conversation.conversation import Conversation
 from polismath.regression import get_dataset_files
@@ -39,45 +37,46 @@ def _get_clojure_datasets(include_local: bool) -> list[str]:
 
 
 def pytest_generate_tests(metafunc):
-    """Parametrize fixtures that need clojure datasets."""
+    """Parametrize tests with clojure datasets at collection time.
+
+    Using indirect=True ensures the fixture is only instantiated once per
+    parameter value when combined with scope="class".
+    """
     if "clojure_dataset" in metafunc.fixturenames:
         include_local = metafunc.config.getoption("--include-local", default=False)
         datasets = _get_clojure_datasets(include_local)
-        metafunc.parametrize("clojure_dataset", datasets, scope="module")
+        metafunc.parametrize("clojure_dataset", datasets, indirect=True, scope="class")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="class")
+def clojure_dataset(request):
+    """Fixture that receives the dataset name via indirect parametrization."""
+    return request.param
+
+
+@pytest.fixture(scope="class")
 def conversation_data(clojure_dataset):
     """
-    Module-scoped fixture that loads and computes conversation once per dataset.
-    This avoids redundant computation when running multiple comparison tests.
+    Class-scoped fixture computed once per dataset.
+    Returns dict with all data needed by tests.
+    Teardown clears cache and forces garbage collection.
     """
     dataset_name = clojure_dataset
 
     # Get dataset files using central configuration
     dataset_files = get_dataset_files(dataset_name)
-    votes_path = dataset_files['votes']
-    comments_path = dataset_files['comments']
-    clojure_output_path = dataset_files['math_blob']
-    data_dir = dataset_files['data_dir']
 
     # Load the Clojure output for comparison
-    clojure_output = load_clojure_output(clojure_output_path)
+    clojure_output = load_clojure_output(dataset_files['math_blob'])
 
-    # Create a new conversation
-    conv = Conversation(dataset_name)
+    # Create and compute conversation
+    votes = load_votes(dataset_files['votes'])
+    comments = load_comments(dataset_files['comments'])
 
-    # Load votes
-    votes = load_votes(votes_path)
-
-    # Load comments
-    comments = load_comments(comments_path)
-
-    # Update conversation with votes and comments
     print(f"\n[{dataset_name}] Processing conversation with {len(votes['votes'])} votes and {len(comments['comments'])} comments")
+    conv = Conversation(dataset_name)
     conv = conv.update_votes(votes)
 
-    # Recompute to generate clustering, PCA, and representativeness
     print(f"[{dataset_name}] Recomputing conversation analysis...")
     conv = conv.recompute()
 
@@ -107,253 +106,262 @@ def conversation_data(clojure_dataset):
                 print(f"  {i+1}. Comment {comment_id} (Repness: {rep_item['repness']:.4f}): {comment_txt[:50]}...")
 
     # Save the Python conversion results for manual inspection
+    import os
+    import json
+    data_dir = dataset_files['data_dir']
     output_dir = os.path.join(os.path.dirname(data_dir), '.test_outputs', 'python_output', dataset_name)
     os.makedirs(output_dir, exist_ok=True)
 
-    # Save the conversation data
     output_path = os.path.join(output_dir, 'conversation_result.json')
     with open(output_path, 'w') as f:
         json.dump(conv.to_dict(), f, indent=2)
 
     print(f"[{dataset_name}] Saved results to {output_path}")
 
-    # Return all data needed for comparison tests
-    return {
+    yield {
         'conv': conv,
         'clojure_output': clojure_output,
         'dataset_name': dataset_name,
-        'comments': comments
+        'comments': comments,
     }
 
+    # TEARDOWN: Clear cache and force garbage collection
+    print(f"[{dataset_name}] Cleaning up...")
+    Conversation._reset_conversion_cache()
+    gc.collect()
 
-def test_basic_outputs(conversation_data):
+
+class TestClojureRegression:
     """
-    Test that basic pipeline outputs are calculated correctly.
-    This test checks that the pipeline runs successfully and produces
-    representativeness calculations.
+    Test class for Clojure regression comparisons.
+    Parametrized per-dataset, with class-scoped fixture for efficiency.
     """
-    dataset_name = conversation_data['dataset_name']
-    conv = conversation_data['conv']
 
-    print(f"\n[{dataset_name}] Testing basic outputs...")
+    def test_basic_outputs(self, conversation_data):
+        """
+        Test that basic pipeline outputs are calculated correctly.
+        This test checks that the pipeline runs successfully and produces
+        representativeness calculations.
+        """
+        conv = conversation_data['conv']
+        dataset_name = conversation_data['dataset_name']
 
-    # Compare basic pipeline outputs like representativeness
-    check.is_not_none(conv.repness, "Representativeness should be calculated")
-    check.is_in('comment_repness', conv.repness or {}, "Comment representativeness should exist")
-    if conv.repness and 'comment_repness' in conv.repness:
-        check.greater(len(conv.repness['comment_repness']), 0, "Should have representative comments")
+        print(f"\n[{dataset_name}] Testing basic outputs...")
 
+        # Compare basic pipeline outputs like representativeness
+        check.is_not_none(conv.repness, "Representativeness should be calculated")
+        check.is_in('comment_repness', conv.repness or {}, "Comment representativeness should exist")
+        if conv.repness and 'comment_repness' in conv.repness:
+            check.greater(len(conv.repness['comment_repness']), 0, "Should have representative comments")
 
-@pytest.mark.skip(reason="Clojure regression tests not yet fully implemented - clustering algorithms may differ")
-def test_group_clustering(conversation_data):
-    """
-    Test that group clustering matches the Clojure implementation.
-    This test compares the number of groups, group sizes, and membership
-    overlap between Python and Clojure implementations.
-    
-    NOTE: Currently skipped as there are known differences between Python and Clojure
-    clustering implementations that need to be resolved.
-    """
-    dataset_name = conversation_data['dataset_name']
-    conv = conversation_data['conv']
-    clojure_output = conversation_data['clojure_output']
+    def test_pca_components_match_clojure(self, conversation_data):
+        """
+        Test that PCA components match the Clojure implementation.
 
-    print(f"\n[{dataset_name}] Testing group clustering...")
+        This test compares the principal components computed by Python against
+        the Clojure implementation. PCA eigenvectors are only defined up to sign,
+        so we check correlation (should be ±1) and angle (should be 0°).
 
-    # Compare group clustering results between Python and Clojure implementations
-    if 'group-clusters' not in clojure_output:
-        check.is_in('group-clusters', clojure_output, "Clojure output should contain group-clusters")
-        return
+        Note: The centers will be negated due to vote sign convention difference
+        (Python: agree=+1, Clojure: agree=-1), but the eigenvectors should match.
+        """
+        import numpy as np
 
-    print(f"[{dataset_name}] Comparing group clustering:")
-    clojure_clusters = clojure_output['group-clusters']
-    python_clusters = conv.group_clusters
+        conv = conversation_data['conv']
+        clojure_output = conversation_data['clojure_output']
+        dataset_name = conversation_data['dataset_name']
 
-    # 1. Compare number of groups
-    clojure_n_groups = len(clojure_clusters)
-    python_n_groups = len(python_clusters)
-    print(f"  Number of groups - Python: {python_n_groups}, Clojure: {clojure_n_groups}")
-    check.equal(python_n_groups, clojure_n_groups,
-               f"Number of groups should match (Python: {python_n_groups}, Clojure: {clojure_n_groups})")
+        print(f"\n[{dataset_name}] Testing PCA components match Clojure...")
 
-    if python_n_groups != clojure_n_groups:
-        return
+        # Get PCA components
+        if 'pca' not in clojure_output or 'comps' not in clojure_output['pca']:
+            check.is_in('pca', clojure_output, "Clojure output should contain pca")
+            return
 
-    # 2. Match groups by best overlap (groups may be numbered differently)
-    python_to_clojure_mapping = {}
-    used_clojure_groups = set()
+        py_comps = np.array(conv.pca['comps'])
+        clj_comps = np.array(clojure_output['pca']['comps'])
 
-    print("\n  Finding best group mappings:")
-    for py_idx in range(python_n_groups):
-        python_members = set(python_clusters[py_idx]['members'])
-        best_clj_idx = None
-        best_jaccard = -1.0
+        # Check dimensions match
+        check.equal(py_comps.shape, clj_comps.shape,
+                    f"PCA component dimensions should match: Python {py_comps.shape} vs Clojure {clj_comps.shape}")
 
-        for clj_idx in range(clojure_n_groups):
-            if clj_idx in used_clojure_groups:
-                continue
+        if py_comps.shape != clj_comps.shape:
+            return
+
+        # Compare each component
+        for i in range(min(2, len(py_comps))):
+            py_pc = py_comps[i]
+            clj_pc = clj_comps[i]
+
+            # Correlation should be ±1 (components match up to sign)
+            correlation = np.corrcoef(py_pc, clj_pc)[0, 1]
+            print(f"  PC{i+1} correlation: {correlation:.6f}")
+
+            # Angle between vectors (should be 0° or 180°, we take min with 180-angle)
+            # NOTE: This assumes both vectors are unit-normalized. If not, the angle will be wrong.
+            dot_product = np.clip(np.abs(np.dot(py_pc, clj_pc)), -1, 1)
+            angle_deg = np.arccos(dot_product) * 180 / np.pi
+            print(f"  PC{i+1} angle difference: {angle_deg:.2f}°")
+
+            # Normalized angle (correct even if vectors have different norms)
+            py_norm = np.linalg.norm(py_pc)
+            clj_norm = np.linalg.norm(clj_pc)
+            cos_sim = np.dot(py_pc, clj_pc) / (py_norm * clj_norm) if py_norm > 0 and clj_norm > 0 else 0
+            # Clip for numerical stability: arccos domain is [-1, 1], but floating-point
+            # errors can produce values slightly outside this range (e.g., 1.0000000002).
+            # Assert we're only clipping by a tiny amount - large deviations indicate a bug.
+            abs_cos_sim = np.abs(cos_sim)
+            assert abs_cos_sim < 1.0 + 1e-6, f"cos_sim={cos_sim} is too far outside [-1, 1]"
+            norm_angle_deg = np.arccos(np.clip(abs_cos_sim, -1, 1)) * 180 / np.pi
+            print(f"  PC{i+1} angle after normalization: {norm_angle_deg:.2f}°")
+            print(f"  PC{i+1} norms: Python={py_norm:.4f}, Clojure={clj_norm:.4f}")
+
+            # Assert correlation is close to ±1 (allow 2% tolerance for numerical differences)
+            check.almost_equal(abs(correlation), 1.0, rel=0.02,
+                              msg=f"PC{i+1} correlation should be ±1 (got {correlation:.4f})")
+
+            # Assert angle is small (allow 10° for power iteration numerical differences)
+            # 10° ≈ 98.5% correlation - catches major regressions while allowing numerical variance
+            check.less_equal(norm_angle_deg, 10.0,
+                            f"PC{i+1} angle difference should be ≤10° (got {norm_angle_deg:.2f}°)")
+
+    @pytest.mark.skip(reason="Clojure regression tests not yet fully implemented - clustering algorithms may differ")
+    def test_group_clustering(self, conversation_data):
+        """
+        Test that group clustering matches the Clojure implementation.
+        This test compares the number of groups, group sizes, and membership
+        overlap between Python and Clojure implementations.
+
+        NOTE: Currently skipped as there are known differences between Python and Clojure
+        clustering implementations that need to be resolved.
+        """
+        conv = conversation_data['conv']
+        clojure_output = conversation_data['clojure_output']
+        dataset_name = conversation_data['dataset_name']
+
+        print(f"\n[{dataset_name}] Testing group clustering...")
+
+        # Compare group clustering results between Python and Clojure implementations
+        if 'group-clusters' not in clojure_output:
+            check.is_in('group-clusters', clojure_output, "Clojure output should contain group-clusters")
+            return
+
+        print(f"[{dataset_name}] Comparing group clustering:")
+        clojure_clusters = clojure_output['group-clusters']
+        python_clusters = conv.group_clusters
+
+        # 1. Compare number of groups
+        clojure_n_groups = len(clojure_clusters)
+        python_n_groups = len(python_clusters)
+        print(f"  Number of groups - Python: {python_n_groups}, Clojure: {clojure_n_groups}")
+        check.equal(python_n_groups, clojure_n_groups,
+                   f"Number of groups should match (Python: {python_n_groups}, Clojure: {clojure_n_groups})")
+
+        if python_n_groups != clojure_n_groups:
+            return
+
+        # 2. Match groups by best overlap (groups may be numbered differently)
+        python_to_clojure_mapping = {}
+        used_clojure_groups = set()
+
+        print("\n  Finding best group mappings:")
+        for py_idx in range(python_n_groups):
+            python_members = set(python_clusters[py_idx]['members'])
+            best_clj_idx = None
+            best_jaccard = -1.0
+
+            for clj_idx in range(clojure_n_groups):
+                if clj_idx in used_clojure_groups:
+                    continue
+                clojure_members = set(clojure_clusters[clj_idx]['members'])
+                intersection = len(python_members & clojure_members)
+                union = len(python_members | clojure_members)
+                jaccard = (intersection / union) if union > 0 else 0
+
+                if best_clj_idx is None or jaccard > best_jaccard:
+                    best_jaccard = jaccard
+                    best_clj_idx = clj_idx
+
+            if best_clj_idx is not None:
+                python_to_clojure_mapping[py_idx] = best_clj_idx
+                used_clojure_groups.add(best_clj_idx)
+                print(f"    Python group {py_idx} -> Clojure group {best_clj_idx} (Jaccard: {best_jaccard*100:.1f}%)")
+            else:
+                print(f"    Python group {py_idx} -> No matching Clojure group found")
+
+        # 3. Compare group sizes with matched groups
+        print("\n  Comparing matched group sizes:")
+        for py_idx, clj_idx in python_to_clojure_mapping.items():
+            clojure_size = len(clojure_clusters[clj_idx]['members'])
+            python_size = len(python_clusters[py_idx]['members'])
+            print(f"    Python group {py_idx} ({python_size} members) <-> Clojure group {clj_idx} ({clojure_size} members)")
+
+            size_diff_pct = abs(python_size - clojure_size) / max(clojure_size, 1) * 100
+            check.less_equal(size_diff_pct, 15.0,
+                           f"Matched groups (Py:{py_idx}/Clj:{clj_idx}) size difference should be ≤15% (Python: {python_size}, Clojure: {clojure_size}, diff: {size_diff_pct:.1f}%)")
+
+        # 4. Compare group membership overlap with matched groups
+        print("\n  Comparing matched group membership:")
+        for py_idx, clj_idx in python_to_clojure_mapping.items():
             clojure_members = set(clojure_clusters[clj_idx]['members'])
-            intersection = len(python_members & clojure_members)
-            union = len(python_members | clojure_members)
-            jaccard = (intersection / union) if union > 0 else 0
+            python_members = set(python_clusters[py_idx]['members'])
 
-            if best_clj_idx is None or jaccard > best_jaccard:
-                best_jaccard = jaccard
-                best_clj_idx = clj_idx
+            intersection = len(clojure_members & python_members)
+            union = len(clojure_members | python_members)
+            jaccard_similarity = (intersection / union * 100) if union > 0 else 0
+            symmetric_diff = len(clojure_members ^ python_members)
 
-        if best_clj_idx is not None:
-            python_to_clojure_mapping[py_idx] = best_clj_idx
-            used_clojure_groups.add(best_clj_idx)
-            print(f"    Python group {py_idx} -> Clojure group {best_clj_idx} (Jaccard: {best_jaccard*100:.1f}%)")
-        else:
-            print(f"    Python group {py_idx} -> No matching Clojure group found")
+            print(f"    Python group {py_idx} <-> Clojure group {clj_idx}:")
+            print(f"      Jaccard similarity: {jaccard_similarity:.1f}%")
+            print(f"      Symmetric difference: {symmetric_diff} members")
+            print(f"      Intersection: {intersection}/{union} members")
 
-    # 3. Compare group sizes with matched groups
-    print("\n  Comparing matched group sizes:")
-    for py_idx, clj_idx in python_to_clojure_mapping.items():
-        clojure_size = len(clojure_clusters[clj_idx]['members'])
-        python_size = len(python_clusters[py_idx]['members'])
-        print(f"    Python group {py_idx} ({python_size} members) <-> Clojure group {clj_idx} ({clojure_size} members)")
+            check.greater_equal(jaccard_similarity, 70.0,
+                              f"Matched groups (Py:{py_idx}/Clj:{clj_idx}) should have ≥70% Jaccard similarity (got {jaccard_similarity:.1f}%)")
 
-        size_diff_pct = abs(python_size - clojure_size) / max(clojure_size, 1) * 100
-        check.less_equal(size_diff_pct, 15.0,
-                       f"Matched groups (Py:{py_idx}/Clj:{clj_idx}) size difference should be ≤15% (Python: {python_size}, Clojure: {clojure_size}, diff: {size_diff_pct:.1f}%)")
+    @pytest.mark.skip(reason="Clojure regression tests not yet fully implemented - comment priorities may differ")
+    def test_comment_priorities(self, conversation_data):
+        """
+        Test that comment priorities match the Clojure implementation.
+        This test compares the priority values assigned to comments between
+        Python and Clojure implementations.
+        """
+        conv = conversation_data['conv']
+        clojure_output = conversation_data['clojure_output']
+        dataset_name = conversation_data['dataset_name']
 
-    # 4. Compare group membership overlap with matched groups
-    print("\n  Comparing matched group membership:")
-    for py_idx, clj_idx in python_to_clojure_mapping.items():
-        clojure_members = set(clojure_clusters[clj_idx]['members'])
-        python_members = set(python_clusters[py_idx]['members'])
+        print(f"\n[{dataset_name}] Testing comment priorities...")
 
-        intersection = len(clojure_members & python_members)
-        union = len(clojure_members | python_members)
-        jaccard_similarity = (intersection / union * 100) if union > 0 else 0
-        symmetric_diff = len(clojure_members ^ python_members)
+        # Compare comment priorities between Python and Clojure implementations
+        print(f"[{dataset_name}] Comparing comment priorities:")
+        has_python_priorities = hasattr(conv, 'comment_priorities')
+        has_clojure_priorities = 'comment-priorities' in clojure_output
 
-        print(f"    Python group {py_idx} <-> Clojure group {clj_idx}:")
-        print(f"      Jaccard similarity: {jaccard_similarity:.1f}%")
-        print(f"      Symmetric difference: {symmetric_diff} members")
-        print(f"      Intersection: {intersection}/{union} members")
+        check.is_true(has_python_priorities, "Python output should have comment_priorities attribute")
+        check.is_true(has_clojure_priorities, "Clojure output should have comment-priorities")
 
-        check.greater_equal(jaccard_similarity, 70.0,
-                          f"Matched groups (Py:{py_idx}/Clj:{clj_idx}) should have ≥70% Jaccard similarity (got {jaccard_similarity:.1f}%)")
+        if not (has_python_priorities and has_clojure_priorities):
+            return
 
+        python_priorities = conv.comment_priorities
+        clojure_priorities = clojure_output['comment-priorities']
 
-@pytest.mark.skip(reason="Clojure regression tests not yet fully implemented - comment priorities may differ")
-def test_comment_priorities(conversation_data):
-    """
-    Test that comment priorities match the Clojure implementation.
-    This test compares the priority values assigned to comments between
-    Python and Clojure implementations.
-    """
-    dataset_name = conversation_data['dataset_name']
-    conv = conversation_data['conv']
-    clojure_output = conversation_data['clojure_output']
+        # Count matching priorities (approximately)
+        matches = 0
+        total = 0
 
-    print(f"\n[{dataset_name}] Testing comment priorities...")
+        for comment_id, priority in python_priorities.items():
+            if comment_id in clojure_priorities:
+                clojure_priority = float(clojure_priorities[comment_id])
+                # Allow for some numerical differences
+                if abs(priority - clojure_priority) / max(1, clojure_priority) < 0.2:  # 20% tolerance
+                    matches += 1
+                total += 1
 
-    # Compare comment priorities between Python and Clojure implementations
-    print(f"[{dataset_name}] Comparing comment priorities:")
-    has_python_priorities = hasattr(conv, 'comment_priorities')
-    has_clojure_priorities = 'comment-priorities' in clojure_output
+        match_percentage = (matches / total * 100) if total > 0 else 0
+        print(f"  Priority matches: {matches}/{total} ({match_percentage:.1f}%)")
 
-    check.is_true(has_python_priorities, "Python output should have comment_priorities attribute")
-    check.is_true(has_clojure_priorities, "Clojure output should have comment-priorities")
-
-    if not (has_python_priorities and has_clojure_priorities):
-        return
-
-    python_priorities = conv.comment_priorities
-    clojure_priorities = clojure_output['comment-priorities']
-
-    # Count matching priorities (approximately)
-    matches = 0
-    total = 0
-
-    for comment_id, priority in python_priorities.items():
-        if comment_id in clojure_priorities:
-            clojure_priority = float(clojure_priorities[comment_id])
-            # Allow for some numerical differences
-            if abs(priority - clojure_priority) / max(1, clojure_priority) < 0.2:  # 20% tolerance
-                matches += 1
-            total += 1
-
-    match_percentage = (matches / total * 100) if total > 0 else 0
-    print(f"  Priority matches: {matches}/{total} ({match_percentage:.1f}%)")
-
-    # Soft assertions for Clojure comparison
-    check.greater(total, 0, "Should have comment priorities to compare with Clojure")
-    check.greater_equal(match_percentage, 70.0,
-                      f"Priority match rate with Clojure should be ≥70% (got {match_percentage:.1f}%)")
-
-
-def test_pca_components_match_clojure(conversation_data):
-    """
-    Test that PCA components match the Clojure implementation.
-
-    This test compares the principal components computed by Python against
-    the Clojure implementation. PCA eigenvectors are only defined up to sign,
-    so we check correlation (should be ±1) and angle (should be 0°).
-
-    Note: The centers will be negated due to vote sign convention difference
-    (Python: agree=+1, Clojure: agree=-1), but the eigenvectors should match.
-    """
-    import numpy as np
-
-    dataset_name = conversation_data['dataset_name']
-    conv = conversation_data['conv']
-    clojure_output = conversation_data['clojure_output']
-
-    print(f"\n[{dataset_name}] Testing PCA components match Clojure...")
-
-    # Get PCA components
-    if 'pca' not in clojure_output or 'comps' not in clojure_output['pca']:
-        check.is_in('pca', clojure_output, "Clojure output should contain pca")
-        return
-
-    py_comps = np.array(conv.pca['comps'])
-    clj_comps = np.array(clojure_output['pca']['comps'])
-
-    # Check dimensions match
-    check.equal(py_comps.shape, clj_comps.shape,
-                f"PCA component dimensions should match: Python {py_comps.shape} vs Clojure {clj_comps.shape}")
-
-    if py_comps.shape != clj_comps.shape:
-        return
-
-    # Compare each component
-    for i in range(min(2, len(py_comps))):
-        py_pc = py_comps[i]
-        clj_pc = clj_comps[i]
-
-        # Correlation should be ±1 (components match up to sign)
-        correlation = np.corrcoef(py_pc, clj_pc)[0, 1]
-        print(f"  PC{i+1} correlation: {correlation:.6f}")
-
-        # Angle between vectors (should be 0° or 180°, we take min with 180-angle)
-        # NOTE: This assumes both vectors are unit-normalized. If not, the angle will be wrong.
-        dot_product = np.clip(np.abs(np.dot(py_pc, clj_pc)), -1, 1)
-        angle_deg = np.arccos(dot_product) * 180 / np.pi
-        print(f"  PC{i+1} angle difference: {angle_deg:.2f}°")
-
-        # Normalized angle (correct even if vectors have different norms)
-        py_norm = np.linalg.norm(py_pc)
-        clj_norm = np.linalg.norm(clj_pc)
-        cos_sim = np.dot(py_pc, clj_pc) / (py_norm * clj_norm) if py_norm > 0 and clj_norm > 0 else 0
-        # Clip for numerical stability: arccos domain is [-1, 1], but floating-point
-        # errors can produce values slightly outside this range (e.g., 1.0000000002).
-        # Assert we're only clipping by a tiny amount - large deviations indicate a bug.
-        abs_cos_sim = np.abs(cos_sim)
-        assert abs_cos_sim < 1.0 + 1e-6, f"cos_sim={cos_sim} is too far outside [-1, 1]"
-        norm_angle_deg = np.arccos(np.clip(abs_cos_sim, -1, 1)) * 180 / np.pi
-        print(f"  PC{i+1} angle after normalization: {norm_angle_deg:.2f}°")
-        print(f"  PC{i+1} norms: Python={py_norm:.4f}, Clojure={clj_norm:.4f}")
-
-        # Assert correlation is close to ±1 (allow 2% tolerance for numerical differences)
-        check.almost_equal(abs(correlation), 1.0, rel=0.02,
-                          msg=f"PC{i+1} correlation should be ±1 (got {correlation:.4f})")
-
-        # Assert angle is small (allow 10° for power iteration numerical differences)
-        # 10° ≈ 98.5% correlation - catches major regressions while allowing numerical variance
-        check.less_equal(norm_angle_deg, 10.0,
-                        f"PC{i+1} angle difference should be ≤10° (got {norm_angle_deg:.2f}°)")
+        # Soft assertions for Clojure comparison
+        check.greater(total, 0, "Should have comment priorities to compare with Clojure")
+        check.greater_equal(match_percentage, 70.0,
+                          f"Priority match rate with Clojure should be ≥70% (got {match_percentage:.1f}%)")

--- a/delphi/tests/test_legacy_repness_comparison.py
+++ b/delphi/tests/test_legacy_repness_comparison.py
@@ -21,7 +21,8 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from polismath.pca_kmeans_rep.repness import conv_repness, participant_stats
 from common_utils import create_test_conversation
-from polismath.regression import get_dataset_files, list_available_datasets
+from polismath.regression import get_dataset_files
+from conftest import get_available_dataset_params
 import json
 
 logger = logging.getLogger(__name__)
@@ -210,7 +211,7 @@ class TestRepnessComparison:
 
         return overall_match_rate, stats
 
-    @pytest.mark.parametrize("dataset_name", list(list_available_datasets().keys()))
+    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
     def test_structural_compatibility(self, dataset_name: str, python_results, clojure_results):
         """Test that Python and Clojure results have compatible structure."""
         logger.info(f"Testing structural compatibility for {dataset_name} dataset")
@@ -227,7 +228,7 @@ class TestRepnessComparison:
         else:
             logger.warning(f"No Clojure results available for {dataset_name}")
 
-    @pytest.mark.parametrize("dataset_name", list(list_available_datasets().keys()))
+    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
     def test_comparison_visibility(self, dataset_name: str, python_results, clojure_results):
         """
         Compare Python and Clojure results for visibility into differences.

--- a/delphi/tests/test_legacy_repness_comparison.py
+++ b/delphi/tests/test_legacy_repness_comparison.py
@@ -22,7 +22,6 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from polismath.pca_kmeans_rep.repness import conv_repness, participant_stats
 from common_utils import create_test_conversation
 from polismath.regression import get_dataset_files
-from conftest import get_available_dataset_params
 import json
 
 logger = logging.getLogger(__name__)
@@ -211,7 +210,7 @@ class TestRepnessComparison:
 
         return overall_match_rate, stats
 
-    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
+    @pytest.mark.use_discovered_datasets
     def test_structural_compatibility(self, dataset_name: str, python_results, clojure_results):
         """Test that Python and Clojure results have compatible structure."""
         logger.info(f"Testing structural compatibility for {dataset_name} dataset")
@@ -228,7 +227,7 @@ class TestRepnessComparison:
         else:
             logger.warning(f"No Clojure results available for {dataset_name}")
 
-    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
+    @pytest.mark.use_discovered_datasets
     def test_comparison_visibility(self, dataset_name: str, python_results, clojure_results):
         """
         Compare Python and Clojure results for visibility into differences.

--- a/delphi/tests/test_pca_smoke.py
+++ b/delphi/tests/test_pca_smoke.py
@@ -21,7 +21,8 @@ from typing import Dict
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from polismath.pca_kmeans_rep.pca import pca_project_dataframe
-from polismath.regression import get_dataset_files, list_available_datasets
+from polismath.regression import get_dataset_files
+from conftest import get_available_dataset_params
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +90,7 @@ class TestPCAImplementation:
         )
         return df_matrix.apply(pd.to_numeric, errors='coerce')
 
-    @pytest.mark.parametrize("dataset_name", list(list_available_datasets().keys()))
+    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
     def test_pca_runs_without_error(self, dataset_name: str, vote_matrix):
         """Test PCA functions run successfully on real data (smoke test)."""
         logger.info(f"Testing PCA on {dataset_name} dataset")
@@ -113,7 +114,7 @@ class TestPCAImplementation:
 
         logger.info(f"✓ PCA runs without error for {dataset_name}")
 
-    @pytest.mark.parametrize("dataset_name", list(list_available_datasets().keys()))
+    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
     def test_pca_projection_statistics(self, dataset_name: str, vote_matrix):
         """Test PCA projections have reasonable statistical properties."""
         logger.debug(f"Testing projection statistics for {dataset_name}")
@@ -138,7 +139,7 @@ class TestPCAImplementation:
 
         logger.debug(f"✓ Projection statistics validated")
 
-    @pytest.mark.parametrize("dataset_name", list(list_available_datasets().keys()))
+    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
     def test_pca_with_clustering(self, dataset_name: str, vote_matrix):
         """Test PCA projections can be used for clustering."""
         logger.debug(f"Testing clustering for {dataset_name}")

--- a/delphi/tests/test_pca_smoke.py
+++ b/delphi/tests/test_pca_smoke.py
@@ -22,8 +22,6 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from polismath.pca_kmeans_rep.pca import pca_project_dataframe
 from polismath.regression import get_dataset_files
-from conftest import get_available_dataset_params
-
 logger = logging.getLogger(__name__)
 
 
@@ -90,7 +88,7 @@ class TestPCAImplementation:
         )
         return df_matrix.apply(pd.to_numeric, errors='coerce')
 
-    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
+    @pytest.mark.use_discovered_datasets
     def test_pca_runs_without_error(self, dataset_name: str, vote_matrix):
         """Test PCA functions run successfully on real data (smoke test)."""
         logger.info(f"Testing PCA on {dataset_name} dataset")
@@ -114,7 +112,7 @@ class TestPCAImplementation:
 
         logger.info(f"✓ PCA runs without error for {dataset_name}")
 
-    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
+    @pytest.mark.use_discovered_datasets
     def test_pca_projection_statistics(self, dataset_name: str, vote_matrix):
         """Test PCA projections have reasonable statistical properties."""
         logger.debug(f"Testing projection statistics for {dataset_name}")
@@ -139,7 +137,7 @@ class TestPCAImplementation:
 
         logger.debug(f"✓ Projection statistics validated")
 
-    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
+    @pytest.mark.use_discovered_datasets
     def test_pca_with_clustering(self, dataset_name: str, vote_matrix):
         """Test PCA projections can be used for clustering."""
         logger.debug(f"Testing clustering for {dataset_name}")

--- a/delphi/tests/test_pipeline_integrity.py
+++ b/delphi/tests/test_pipeline_integrity.py
@@ -34,6 +34,7 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from polismath.conversation.conversation import Conversation
 from tests.common_utils import create_test_conversation
 from polismath.regression import get_dataset_files
+from conftest import make_dataset_params
 
 
 def save_results(dataset_name: str, conversation: Conversation) -> None:
@@ -121,7 +122,7 @@ def save_results(dataset_name: str, conversation: Conversation) -> None:
 
     print(f"Pipeline diagnostics saved to {file_path}")
 
-@pytest.mark.parametrize("dataset_name", ["biodiversity", "vw"])
+@pytest.mark.parametrize("dataset_name", make_dataset_params(["biodiversity", "vw"]))
 def test_full_pipeline(dataset_name: str) -> None:
     """
     Run the full pipeline integrity test for a dataset.

--- a/delphi/tests/test_regression.py
+++ b/delphi/tests/test_regression.py
@@ -20,7 +20,7 @@ from polismath.regression import ConversationRecorder, ConversationComparer
 from polismath.regression.utils import load_golden_snapshot
 
 
-def _check_golden_exists(dataset: str):
+def _check_golden_exists(dataset_name: str):
     """
     Check if golden snapshot exists for a specific dataset.
 
@@ -28,23 +28,24 @@ def _check_golden_exists(dataset: str):
     if it's missing. This allows tests for other datasets to run independently.
 
     Args:
-        dataset: Dataset name to check
+        dataset_name: Dataset name to check
 
     Raises:
         pytest.fail: If golden snapshot is missing for this dataset
     """
-    golden, golden_path = load_golden_snapshot(dataset)
+    golden, golden_path = load_golden_snapshot(dataset_name)
 
     if golden is None:
         pytest.fail(
-            f"Missing golden snapshot for dataset: {dataset}\n"
+            f"Missing golden snapshot for dataset: {dataset_name}\n"
             f"Golden snapshots must be created explicitly using regression_recorder.py:\n"
             f"  cd delphi\n"
-            f"  python scripts/regression_recorder.py {dataset}\n"
+            f"  python scripts/regression_recorder.py {dataset_name}\n"
         )
 
 
-def test_conversation_regression(dataset):
+@pytest.mark.use_discovered_datasets
+def test_conversation_regression(dataset_name):
     """
     Test that current implementation matches golden snapshot.
 
@@ -53,44 +54,45 @@ def test_conversation_regression(dataset):
     unintended changes in behavior.
 
     Args:
-        dataset: Dataset name to test
+        dataset_name: Name of the dataset to test
     """
     # Check that golden file exists for THIS specific dataset
-    _check_golden_exists(dataset)
+    _check_golden_exists(dataset_name)
 
     # Use ignore_pca_sign_flip=True because PCA eigenvectors are only defined up to sign,
     # and different implementations may produce equivalent results with opposite signs
     comparer = ConversationComparer(ignore_pca_sign_flip=True)
 
     # Run comparison
-    result = comparer.compare_with_golden(dataset)
+    result = comparer.compare_with_golden(dataset_name)
 
     # Check for errors
     if "error" in result:
         # Special handling for MD5 mismatch - this might mean test data was updated
         if "MD5 mismatch" in result.get("error", ""):
             pytest.fail(
-                f"Dataset files have changed for {dataset}!\n"
+                f"Dataset files have changed for {dataset_name}!\n"
                 f"Golden votes MD5: {result.get('golden_votes_md5', 'N/A')}\n"
                 f"Current votes MD5: {result.get('current_votes_md5', 'N/A')}\n"
                 f"Golden comments MD5: {result.get('golden_comments_md5', 'N/A')}\n"
                 f"Current comments MD5: {result.get('current_comments_md5', 'N/A')}\n"
                 f"\nIf this is expected, update golden snapshots with:\n"
-                f"  python regression_tests/regression_test.py update --datasets {dataset} --force"
+                f"  python regression_tests/regression_test.py update --datasets {dataset_name} --force"
             )
         else:
             pytest.fail(f"Error in comparison: {result.get('error')}")
 
     # Check comparison results
     assert result["overall_match"], (
-        f"Regression detected in {dataset}!\n"
+        f"Regression detected in {dataset_name}!\n"
         f"{comparer.generate_report(result)}\n"
         f"\nTo update golden snapshots after verified changes:\n"
-        f"  python regression_tests/regression_test.py update --datasets {dataset} --force"
+        f"  python regression_tests/regression_test.py update --datasets {dataset_name} --force"
     )
 
 
-def test_conversation_stages_individually(dataset):
+@pytest.mark.use_discovered_datasets
+def test_conversation_stages_individually(dataset_name):
     """
     Test each computation stage individually for more granular failure detection.
 
@@ -98,16 +100,16 @@ def test_conversation_stages_individually(dataset):
     making it easier to identify exactly where a regression occurs.
 
     Args:
-        dataset: Dataset name to test
+        dataset_name: Name of the dataset to test
     """
     # Check that golden file exists for THIS specific dataset
-    _check_golden_exists(dataset)
+    _check_golden_exists(dataset_name)
 
     # Use ignore_pca_sign_flip=True because PCA eigenvectors are only defined up to sign
     comparer = ConversationComparer(ignore_pca_sign_flip=True)
 
     # Run comparison
-    result = comparer.compare_with_golden(dataset)
+    result = comparer.compare_with_golden(dataset_name)
 
     # Skip if there's an error (this is tested in the main test)
     if "error" in result:
@@ -127,7 +129,7 @@ def test_conversation_stages_individually(dataset):
         if stage_name in result.get("stages_compared", {}):
             stage_result = result["stages_compared"][stage_name]
             assert stage_result["match"], (
-                f"Stage '{stage_description}' failed for {dataset}\n"
+                f"Stage '{stage_description}' failed for {dataset_name}\n"
                 f"Path: {stage_result.get('path', 'unknown')}\n"
                 f"Reason: {stage_result.get('reason', 'unknown')}"
             )

--- a/delphi/tests/test_repness_smoke.py
+++ b/delphi/tests/test_repness_smoke.py
@@ -20,8 +20,6 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from polismath.pca_kmeans_rep.repness import conv_repness, participant_stats
 from common_utils import create_test_conversation
-from conftest import get_available_dataset_params
-
 logger = logging.getLogger(__name__)
 
 
@@ -59,7 +57,7 @@ class TestRepnessImplementation:
 
         return conv
 
-    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
+    @pytest.mark.use_discovered_datasets
     def test_repness_runs_without_error(self, dataset_name: str, conversation):
         """Test representativeness calculation runs successfully on real data (smoke test)."""
         logger.info(f"Testing representativeness on {dataset_name} dataset")
@@ -83,7 +81,7 @@ class TestRepnessImplementation:
 
         logger.info(f"✓ Representativeness runs without error for {dataset_name}")
 
-    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
+    @pytest.mark.use_discovered_datasets
     def test_repness_structure(self, dataset_name: str, conversation):
         """Test representativeness results have expected structure."""
         logger.debug(f"Testing representativeness structure for {dataset_name}")
@@ -113,7 +111,7 @@ class TestRepnessImplementation:
 
         logger.debug("✓ Representativeness structure validated")
 
-    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
+    @pytest.mark.use_discovered_datasets
     def test_participant_stats(self, dataset_name: str, conversation):
         """Test participant statistics calculation."""
         logger.debug(f"Testing participant stats for {dataset_name}")

--- a/delphi/tests/test_repness_smoke.py
+++ b/delphi/tests/test_repness_smoke.py
@@ -20,7 +20,7 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 from polismath.pca_kmeans_rep.repness import conv_repness, participant_stats
 from common_utils import create_test_conversation
-from polismath.regression import list_available_datasets
+from conftest import get_available_dataset_params
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class TestRepnessImplementation:
 
         return conv
 
-    @pytest.mark.parametrize("dataset_name", list(list_available_datasets().keys()))
+    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
     def test_repness_runs_without_error(self, dataset_name: str, conversation):
         """Test representativeness calculation runs successfully on real data (smoke test)."""
         logger.info(f"Testing representativeness on {dataset_name} dataset")
@@ -83,7 +83,7 @@ class TestRepnessImplementation:
 
         logger.info(f"✓ Representativeness runs without error for {dataset_name}")
 
-    @pytest.mark.parametrize("dataset_name", list(list_available_datasets().keys()))
+    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
     def test_repness_structure(self, dataset_name: str, conversation):
         """Test representativeness results have expected structure."""
         logger.debug(f"Testing representativeness structure for {dataset_name}")
@@ -113,7 +113,7 @@ class TestRepnessImplementation:
 
         logger.debug("✓ Representativeness structure validated")
 
-    @pytest.mark.parametrize("dataset_name", list(list_available_datasets().keys()))
+    @pytest.mark.parametrize("dataset_name", get_available_dataset_params())
     def test_participant_stats(self, dataset_name: str, conversation):
         """Test participant statistics calculation."""
         logger.debug(f"Testing participant stats for {dataset_name}")


### PR DESCRIPTION
## Summary

> **Stacked on #2396** (PCA NaN fix). Please review and merge #2396 first.
>
> **To see only the diff added by this PR** (excluding #2396 commits): [compare pca_nan_fix...pca_test_infra](https://github.com/jucor/polis/compare/pca_nan_fix...pca_test_infra)
>
> Stack: #2396 (NaN fix) → **This PR** → #2398 (comparer) → #2399 (sklearn PCA) → #2400 (test cleanup)

- Isolate test state: each test class gets its own Conversation object with memory cleanup
- Add \`pytest-xdist\` for parallel test execution by dataset
- Factorize \`xdist_group\` markers across the test suite
- Add \`--datasets\` CLI option to run tests on specific datasets
- Document parallel test execution in \`docs/regression_testing.md\`

## Test plan

- [x] 215 passed, 7 skipped, 2 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)