### PR TITLE
Regression comparer: sign flip detection and projection metrics

### DIFF
--- a/delphi/polismath/regression/comparer.py
+++ b/delphi/polismath/regression/comparer.py
@@ -436,18 +436,18 @@ class ConversationComparer:
             logger.info("")
 
         # Compute and display projection comparison metrics if we have PCA data
-        # This determines the overall pass/fail result based on meaningful metrics
+        # Treat as an additional signal, not an override of earlier stage results
         projection_metrics_pass = self._log_projection_metrics(golden["stages"], current_stages)
         if projection_metrics_pass is not None:
-            results["overall_match"] = projection_metrics_pass
             results["projection_metrics_pass"] = projection_metrics_pass
+            results["overall_match"] = results["overall_match"] and projection_metrics_pass
 
         # Now show the Overall Result (after projection metrics have been computed)
         logger.info(f"Overall Result: {'✅ PASS' if results['overall_match'] else '❌ FAIL'}")
 
-        # Add explanation if stages failed but projection metrics passed
+        # Add explanation if projection metrics passed but element-wise differences exist
         if projection_metrics_pass and self.all_differences:
-            logger.info("  (Element-wise differences exist but projection metrics confirm match)")
+            logger.info("  (Element-wise differences exist but projection metrics confirm PCA match)")
         logger.info("")
 
         # Only print speed comparison if benchmarking is enabled
@@ -918,7 +918,8 @@ class ConversationComparer:
 
         # Check for cluster centers (derived from PCA projections, so inherit sign ambiguity)
         # Examples: "after_clustering.group_clusters[0].center", "after_clustering.base-clusters[1].center"
-        if ".center" in path:
+        # Exclude ".pca.center" which is the PCA mean vector (not sign-ambiguous)
+        if ".center" in path and ".pca.center" not in path:
             return True
 
         return False
@@ -1443,7 +1444,7 @@ class ConversationComparer:
         return (np.array(all_golden) if len(all_golden) > 0 else np.array([]),
                 np.array(all_current) if len(all_current) > 0 else np.array([]))
 
-    def _log_projection_metrics(self, golden_stages: dict, current_stages: dict) -> None:
+    def _log_projection_metrics(self, golden_stages: dict, current_stages: dict) -> bool | None:
         """
         Compute and log projection comparison metrics for PCA stages.
 
@@ -1453,6 +1454,10 @@ class ConversationComparer:
         Args:
             golden_stages: Full golden stage data
             current_stages: Full current stage data
+
+        Returns:
+            True if projection metrics pass, False if they fail,
+            None if no projection data is available.
         """
         import numpy as np
         from scipy.spatial import procrustes
@@ -1508,8 +1513,21 @@ class ConversationComparer:
         abs_err = np.abs(g_flat - c_flat)
         data_range = np.max(np.abs(g_flat))
 
-        max_err_pct = np.max(abs_err) / data_range * 100
-        mean_err_pct = np.mean(abs_err) / data_range * 100
+        if data_range == 0:
+            # Degenerate golden projection (all points at origin).
+            if np.all(abs_err == 0):
+                max_err_pct = 0.0
+                mean_err_pct = 0.0
+            else:
+                logger.error(
+                    "Golden projection data_range is zero but absolute error is non-zero; "
+                    "cannot compute relative projection error metrics."
+                )
+                max_err_pct = float("inf")
+                mean_err_pct = float("inf")
+        else:
+            max_err_pct = np.max(abs_err) / data_range * 100
+            mean_err_pct = np.mean(abs_err) / data_range * 100
 
         # R² (coefficient of determination)
         ss_res = np.sum((g_flat - c_flat)**2)

--- a/delphi/polismath/regression/comparer.py
+++ b/delphi/polismath/regression/comparer.py
@@ -546,18 +546,25 @@ class ConversationComparer:
                 min_len = len(golden)
 
             # For PCA-related paths, check for sign flips and scaling before element-by-element comparison
+            # Track if we need to use flipped values for comparison
+            use_flipped_current = False
             if min_len == len(golden) and len(golden) > 0 and self._is_pca_related_path(path):
                 # Check for sign flip (if enabled)
                 if self.ignore_pca_sign_flip:
-                    sign_flip_detected = self._check_sign_flip(golden, current, path, stage_name)
-                    if sign_flip_detected:
-                        return {"match": True, "path": path, "note": "Sign flip detected but ignored"}
+                    sign_flip_result = self._check_sign_flip(golden, current, path, stage_name)
+                    if sign_flip_result["detected"]:
+                        use_flipped_current = True
+                        # Continue to element-by-element comparison with flipped values
 
                 # Check for scaling factor (always check for PCA paths to provide better error messages)
-                scaling_factor = self._detect_scaling_factor(golden, current)
+                # Use flipped current if sign flip was detected
+                check_current = [-c for c in current] if use_flipped_current else current
+                scaling_factor = self._detect_scaling_factor(golden, check_current)
                 if scaling_factor is not None and abs(scaling_factor - 1.0) > 0.01:
                     # Scaling factor detected and it's not approximately 1.0
                     reason = f"PCA scaling mismatch: values differ by constant factor {scaling_factor:.6f}"
+                    if use_flipped_current:
+                        reason += " (after sign flip correction)"
                     # Record this difference
                     self.all_differences.append({
                         "stage_name": stage_name,
@@ -573,9 +580,11 @@ class ConversationComparer:
 
             # Do element-by-element comparison
             for i in range(min_len):
+                # Use flipped current value if sign flip was detected
+                current_val = -current[i] if use_flipped_current else current[i]
                 result = self._compare_dicts(
                     golden[i],
-                    current[i],
+                    current_val,
                     f"{path}[{i}]",
                     stage_name=stage_name
                 )
@@ -734,7 +743,7 @@ class ConversationComparer:
 
         return False
 
-    def _check_sign_flip(self, golden: list, current: list, path: str, stage_name: str) -> bool:
+    def _check_sign_flip(self, golden: list, current: list, path: str, stage_name: str) -> dict:
         """
         Check if two lists are equal up to a sign flip (multiplication by -1).
 
@@ -747,20 +756,25 @@ class ConversationComparer:
             stage_name: Name of the stage being compared (for logging)
 
         Returns:
-            True if sign flip detected, False otherwise
+            Dictionary with:
+                - detected: True if sign flip detected, False otherwise
+                - max_abs_error: Maximum absolute error after flip correction (if detected)
+                - max_rel_error: Maximum relative error after flip correction (if detected)
         """
         import numpy as np
 
+        result = {"detected": False, "max_abs_error": None, "max_rel_error": None}
+
         # Lists must be same length
         if len(golden) != len(current):
-            return False
+            return result
 
         # Check if all elements are numeric
         def is_numeric(val):
             return isinstance(val, (int, float, np.integer, np.floating))
 
         if not all(is_numeric(g) and is_numeric(c) for g, c in zip(golden, current)):
-            return False
+            return result
 
         # Convert to numpy arrays for easier comparison
         golden_array = np.array([float(g) for g in golden])
@@ -769,21 +783,44 @@ class ConversationComparer:
         # Check if arrays are equal (with tolerance)
         if np.allclose(golden_array, current_array, rtol=self.rel_tol, atol=self.abs_tol):
             # Already equal, not a sign flip
-            return False
+            return result
 
-        # Check if arrays are equal when one is negated
-        if np.allclose(golden_array, -current_array, rtol=self.rel_tol, atol=self.abs_tol):
-            # Sign flip detected!
-            warning_msg = f"PCA sign flip detected at {path} in stage {stage_name}"
+        # Check if flipped version matches (with tolerance)
+        flipped_matches = np.allclose(golden_array, -current_array, rtol=self.rel_tol, atol=self.abs_tol)
+
+        # Compute errors for both original and flipped
+        original_abs_errors = np.abs(golden_array - current_array)
+        flipped_abs_errors = np.abs(golden_array - (-current_array))
+
+        # Detect sign flip if: flipped passes tolerance OR flipped is closer than original
+        if flipped_matches or np.max(flipped_abs_errors) < np.max(original_abs_errors):
+            # Flipped version is better - sign flip detected!
+            max_abs_error = float(np.max(flipped_abs_errors))
+
+            # Compute relative error (avoid division by zero)
+            with np.errstate(divide='ignore', invalid='ignore'):
+                rel_errors = flipped_abs_errors / np.abs(golden_array)
+                rel_errors = np.where(np.isfinite(rel_errors), rel_errors, 0)
+            max_rel_error = float(np.max(rel_errors))
+
+            warning_msg = (
+                f"PCA sign flip detected at {path} in stage {stage_name} "
+                f"(max residual after flip: abs={max_abs_error:.2e}, rel={max_rel_error:.2%})"
+            )
             logger.debug(warning_msg)
             self.sign_flip_warnings.append({
                 "stage_name": stage_name,
                 "path": path,
-                "message": warning_msg
+                "message": warning_msg,
+                "max_abs_error": max_abs_error,
+                "max_rel_error": max_rel_error
             })
-            return True
 
-        return False
+            result["detected"] = True
+            result["max_abs_error"] = max_abs_error
+            result["max_rel_error"] = max_rel_error
+
+        return result
 
     def _detect_scaling_factor(self, golden: list, current: list) -> float | None:
         """
@@ -909,11 +946,16 @@ class ConversationComparer:
                 f.write("-" * 80 + "\n")
                 f.write("WARNING: PCA SIGN FLIPS DETECTED\n")
                 f.write(f"Total sign flips: {len(self.sign_flip_warnings)}\n")
-                f.write("(These were ignored due to ignore_pca_sign_flip=True)\n\n")
+                f.write("(These were corrected due to ignore_pca_sign_flip=True)\n\n")
 
                 for i, warning in enumerate(self.sign_flip_warnings):
                     f.write(f"  {i+1}. Stage: {warning['stage_name']}\n")
                     f.write(f"     Path: {warning['path']}\n")
+                    if 'max_abs_error' in warning and warning['max_abs_error'] is not None:
+                        f.write(f"     Residual after flip: abs={warning['max_abs_error']:.2e}")
+                        if 'max_rel_error' in warning and warning['max_rel_error'] is not None:
+                            f.write(f", rel={warning['max_rel_error']:.2%}")
+                        f.write("\n")
 
                 f.write("\n")
 

--- a/delphi/polismath/regression/comparer.py
+++ b/delphi/polismath/regression/comparer.py
@@ -318,12 +318,11 @@ class ConversationComparer:
         logger.debug(f"Computation output saved to: {json_path}")
         logger.debug(f"Latest output symlink: {symlink_path}")
 
-        # Log detailed report
+        # Log detailed report header (result will be shown after projection metrics)
         logger.info("=" * 60)
         logger.info("REGRESSION TEST REPORT")
         logger.info("=" * 60)
         logger.info(f"Dataset: {results['dataset']}")
-        logger.info(f"Overall Result: {'✅ PASS' if results['overall_match'] else '❌ FAIL'}")
         logger.info("")
 
         if "metadata" in results:
@@ -379,6 +378,9 @@ class ConversationComparer:
                               f"Q3={np.percentile(rel_arr, 75):.2f}%, "
                               f"max={np.max(rel_arr):.2f}%")
 
+            # Group differences by PCA component or center, and show top 4 abs/rel errors each
+            self._log_top_errors_per_pca_path(self.all_differences, golden["stages"], current_stages)
+
             # Show a few examples
             n_examples = min(5, len(self.all_differences))
             logger.warning(f"  First {n_examples} examples:")
@@ -432,6 +434,21 @@ class ConversationComparer:
             if len(self.sign_flip_warnings) > n_examples:
                 logger.info(f"    ... and {len(self.sign_flip_warnings) - n_examples} more (see log file)")
             logger.info("")
+
+        # Compute and display projection comparison metrics if we have PCA data
+        # This determines the overall pass/fail result based on meaningful metrics
+        projection_metrics_pass = self._log_projection_metrics(golden["stages"], current_stages)
+        if projection_metrics_pass is not None:
+            results["overall_match"] = projection_metrics_pass
+            results["projection_metrics_pass"] = projection_metrics_pass
+
+        # Now show the Overall Result (after projection metrics have been computed)
+        logger.info(f"Overall Result: {'✅ PASS' if results['overall_match'] else '❌ FAIL'}")
+
+        # Add explanation if stages failed but projection metrics passed
+        if projection_metrics_pass and self.all_differences:
+            logger.info("  (Element-wise differences exist but projection metrics confirm match)")
+        logger.info("")
 
         # Only print speed comparison if benchmarking is enabled
         if benchmark:
@@ -1188,6 +1205,371 @@ class ConversationComparer:
             if not isinstance(item, (int, float, np.integer, np.floating)):
                 return False
         return True
+
+    def _log_top_errors_per_pca_path(
+        self, differences: list, golden_stages: dict, current_stages: dict, top_n: int = 4
+    ) -> None:
+        """
+        Log the top N absolute and relative errors for each PCA component and center.
+
+        Groups differences by their parent path (e.g., "stage.pca.comps[0]" or "stage.center")
+        and shows the worst errors to help identify which elements are causing failures.
+
+        For projections, aggregates across all projections (not per-projection).
+        Shows quantile context computed from ALL values (not just failing ones) to understand
+        if errors are in important (large) or negligible (small) values.
+
+        Args:
+            differences: List of difference dictionaries
+            golden_stages: Full golden stage data for computing proper quantiles
+            current_stages: Full current stage data for computing proper quantiles
+            top_n: Number of top errors to show per group (default: 4)
+        """
+        import numpy as np
+        from collections import defaultdict
+
+        # Group differences by parent path (strip the final [index])
+        groups: dict = defaultdict(list)
+
+        for diff in differences:
+            path = diff.get('path', '')
+            if 'golden_value' not in diff or 'current_value' not in diff:
+                continue
+
+            try:
+                g = float(diff['golden_value'])
+                c = float(diff['current_value'])
+            except (TypeError, ValueError):
+                continue
+
+            abs_err = abs(g - c)
+            rel_err = abs_err / abs(g) if abs(g) > 1e-10 else None
+
+            # Extract parent path and index
+            # Matches paths like "stage.pca.comps[0][42]" -> parent="stage.pca.comps[0]", idx=42
+            # or "stage.proj.123[0]" -> parent="stage.proj.123", idx=0
+            # or "stage.center[1]" -> parent="stage.center", idx=1
+            match = re.match(r'^(.+)\[(\d+)\]$', path)
+            if match:
+                parent_path = match.group(1)
+                idx = int(match.group(2))
+            else:
+                # No trailing index, use the path as-is
+                parent_path = path
+                idx = None
+
+            # Only group PCA-related paths
+            if self._is_pca_related_path(parent_path) or self._is_pca_related_path(path):
+                # For projections, aggregate by stage.proj (not stage.proj.123)
+                # This groups all projections together for top-error analysis
+                if ".proj." in parent_path:
+                    # Extract stage prefix and normalize to "stage.proj.*"
+                    proj_match = re.match(r'^(.+\.proj)\.\d+$', parent_path)
+                    if proj_match:
+                        group_key = proj_match.group(1) + ".*"
+                    else:
+                        group_key = parent_path
+                else:
+                    group_key = parent_path
+
+                groups[group_key].append({
+                    'idx': idx,
+                    'golden': g,
+                    'current': c,
+                    'abs_err': abs_err,
+                    'rel_err': rel_err,
+                    'path': path
+                })
+
+        if not groups:
+            return
+
+        logger.warning("")
+        logger.warning("  Top errors per PCA component/center (quantiles computed from ALL values):")
+
+        for group_key in sorted(groups.keys()):
+            items = groups[group_key]
+            if not items:
+                continue
+
+            # Extract ALL values from the full stage data for proper quantile computation
+            all_golden, all_current = self._extract_all_values_for_group(
+                group_key, golden_stages, current_stages
+            )
+
+            if len(all_golden) == 0:
+                # Fallback to just the failing items if extraction failed
+                all_golden = np.array([abs(x['golden']) for x in items])
+                all_current = np.array([abs(x['current']) for x in items])
+
+            golden_median = np.median(all_golden) if len(all_golden) > 0 else 1.0
+            current_median = np.median(all_current) if len(all_current) > 0 else 1.0
+
+            # Sort by absolute error for top abs
+            by_abs = sorted(items, key=lambda x: x['abs_err'], reverse=True)[:top_n]
+            # Sort by relative error for top rel (filter out None rel_err)
+            with_rel = [x for x in items if x['rel_err'] is not None]
+            by_rel = sorted(with_rel, key=lambda x: x['rel_err'], reverse=True)[:top_n]
+
+            logger.warning(f"    {group_key} ({len(items)} failing of {len(all_golden)} total, median |value|={golden_median:.2e}):")
+
+            # Show top absolute errors with quantile context
+            logger.warning(f"      Top {min(top_n, len(by_abs))} by abs error:")
+            for item in by_abs:
+                # Compute quantiles (what fraction of values are <= this value)
+                g_abs = abs(item['golden'])
+                c_abs = abs(item['current'])
+                g_quantile = np.sum(all_golden <= g_abs) / len(all_golden) * 100
+                c_quantile = np.sum(all_current <= c_abs) / len(all_current) * 100
+                g_ratio = g_abs / golden_median if golden_median > 1e-15 else float('inf')
+                c_ratio = c_abs / current_median if current_median > 1e-15 else float('inf')
+
+                path_short = item['path']
+                # Shorten path for readability
+                if len(path_short) > 35:
+                    path_short = "..." + path_short[-32:]
+
+                logger.warning(
+                    f"        {path_short}: abs_err={item['abs_err']:.2e}"
+                )
+                logger.warning(
+                    f"          golden={item['golden']:+.2e} (Q{g_quantile:.0f}, {g_ratio:.1f}x med), "
+                    f"current={item['current']:+.2e} (Q{c_quantile:.0f}, {c_ratio:.1f}x med)"
+                )
+
+            # Show top relative errors with quantile context
+            if by_rel:
+                logger.warning(f"      Top {min(top_n, len(by_rel))} by rel error:")
+                for item in by_rel:
+                    g_abs = abs(item['golden'])
+                    c_abs = abs(item['current'])
+                    g_quantile = np.sum(all_golden <= g_abs) / len(all_golden) * 100
+                    c_quantile = np.sum(all_current <= c_abs) / len(all_current) * 100
+                    g_ratio = g_abs / golden_median if golden_median > 1e-15 else float('inf')
+                    c_ratio = c_abs / current_median if current_median > 1e-15 else float('inf')
+                    rel_pct = item['rel_err'] * 100 if item['rel_err'] else 0
+
+                    path_short = item['path']
+                    if len(path_short) > 35:
+                        path_short = "..." + path_short[-32:]
+
+                    logger.warning(
+                        f"        {path_short}: rel_err={rel_pct:.1f}%"
+                    )
+                    logger.warning(
+                        f"          golden={item['golden']:+.2e} (Q{g_quantile:.0f}, {g_ratio:.1f}x med), "
+                        f"current={item['current']:+.2e} (Q{c_quantile:.0f}, {c_ratio:.1f}x med)"
+                    )
+
+    def _extract_all_values_for_group(
+        self, group_key: str, golden_stages: dict, current_stages: dict
+    ) -> tuple:
+        """
+        Extract ALL values for a group key from the full stage data.
+
+        This is used to compute proper quantiles against the full distribution,
+        not just the failing items.
+
+        Args:
+            group_key: The group key (e.g., "after_pca.pca.comps[1]" or "after_pca.proj.*")
+            golden_stages: Full golden stage data
+            current_stages: Full current stage data
+
+        Returns:
+            Tuple of (all_golden_abs, all_current_abs) numpy arrays
+        """
+        import numpy as np
+
+        all_golden = []
+        all_current = []
+
+        # Parse the group key to understand what data to extract
+        # Examples:
+        #   "after_pca.pca.comps[1]" -> stage=after_pca, type=pca_comp, idx=1
+        #   "after_pca.proj.*" -> stage=after_pca, type=proj_all
+
+        if ".pca.comps[" in group_key:
+            # Extract PCA component values
+            match = re.match(r'^([^.]+)\.pca\.comps\[(\d+)\]$', group_key)
+            if match:
+                stage_name = match.group(1)
+                comp_idx = int(match.group(2))
+                if stage_name in golden_stages and stage_name in current_stages:
+                    g_comps = golden_stages[stage_name].get('pca', {}).get('comps', [])
+                    c_comps = current_stages[stage_name].get('pca', {}).get('comps', [])
+                    if comp_idx < len(g_comps) and comp_idx < len(c_comps):
+                        all_golden = np.abs(g_comps[comp_idx])
+                        all_current = np.abs(c_comps[comp_idx])
+
+        elif ".proj.*" in group_key:
+            # Extract ALL projection values (aggregated across all participants)
+            match = re.match(r'^([^.]+)\.proj\.\*$', group_key)
+            if match:
+                stage_name = match.group(1)
+                if stage_name in golden_stages and stage_name in current_stages:
+                    g_proj = golden_stages[stage_name].get('proj', {})
+                    c_proj = current_stages[stage_name].get('proj', {})
+                    # Collect all projection coordinates (flattened)
+                    for pid in g_proj:
+                        if pid in c_proj:
+                            all_golden.extend([abs(v) for v in g_proj[pid]])
+                            all_current.extend([abs(v) for v in c_proj[pid]])
+                    all_golden = np.array(all_golden)
+                    all_current = np.array(all_current)
+
+        elif ".center" in group_key:
+            # Extract center values
+            match = re.match(r'^([^.]+)\.(.+)\.center$', group_key)
+            if not match:
+                match = re.match(r'^([^.]+)\.center$', group_key)
+            if match:
+                stage_name = match.group(1)
+                # Try to find centers in various places
+                if stage_name in golden_stages and stage_name in current_stages:
+                    g_stage = golden_stages[stage_name]
+                    c_stage = current_stages[stage_name]
+                    # Look for centers in group_clusters or base-clusters
+                    for cluster_key in ['group_clusters', 'base-clusters']:
+                        if cluster_key in g_stage and cluster_key in c_stage:
+                            for cluster in g_stage[cluster_key]:
+                                if 'center' in cluster:
+                                    all_golden.extend([abs(v) for v in cluster['center']])
+                            for cluster in c_stage[cluster_key]:
+                                if 'center' in cluster:
+                                    all_current.extend([abs(v) for v in cluster['center']])
+                    all_golden = np.array(all_golden)
+                    all_current = np.array(all_current)
+
+        return (np.array(all_golden) if len(all_golden) > 0 else np.array([]),
+                np.array(all_current) if len(all_current) > 0 else np.array([]))
+
+    def _log_projection_metrics(self, golden_stages: dict, current_stages: dict) -> None:
+        """
+        Compute and log projection comparison metrics for PCA stages.
+
+        Displays metrics that properly handle the case where relative errors
+        blow up on small values but the overall match is excellent.
+
+        Args:
+            golden_stages: Full golden stage data
+            current_stages: Full current stage data
+        """
+        import numpy as np
+        from scipy.spatial import procrustes
+
+        # Find stages with projections
+        stages_with_proj = []
+        for stage_name in golden_stages:
+            if stage_name in current_stages:
+                g_stage = golden_stages[stage_name]
+                c_stage = current_stages[stage_name]
+                if 'proj' in g_stage and 'proj' in c_stage:
+                    stages_with_proj.append(stage_name)
+
+        if not stages_with_proj:
+            return
+
+        # Use the first stage with projections (typically after_pca)
+        stage_name = stages_with_proj[0]
+        g_proj = golden_stages[stage_name]['proj']
+        c_proj = current_stages[stage_name]['proj']
+
+        # Collect projections, applying sign flips from stored corrections
+        g_all = []
+        c_all = []
+        sign_flips = self._pca_sign_flips.get(stage_name, {})
+
+        # Build lookup for current projections (handle str/int key differences)
+        c_proj_lookup = {}
+        for k, v in c_proj.items():
+            c_proj_lookup[str(k)] = v
+
+        for pid in g_proj:
+            pid_str = str(pid)
+            if pid_str in c_proj_lookup:
+                g_coords = list(g_proj[pid])
+                c_coords = list(c_proj_lookup[pid_str])
+                # Apply stored sign flips to current
+                for dim_idx, flip in sign_flips.items():
+                    if dim_idx < len(c_coords):
+                        c_coords[dim_idx] *= flip
+                g_all.append(g_coords)
+                c_all.append(c_coords)
+
+        if len(g_all) == 0:
+            return False
+
+        g_all = np.array(g_all)
+        c_all = np.array(c_all)
+        g_flat = g_all.flatten()
+        c_flat = c_all.flatten()
+
+        # Compute metrics
+        abs_err = np.abs(g_flat - c_flat)
+        data_range = np.max(np.abs(g_flat))
+
+        max_err_pct = np.max(abs_err) / data_range * 100
+        mean_err_pct = np.mean(abs_err) / data_range * 100
+
+        # R² (coefficient of determination)
+        ss_res = np.sum((g_flat - c_flat)**2)
+        ss_tot = np.sum((g_flat - np.mean(g_flat))**2)
+        r_squared = 1 - ss_res / ss_tot if ss_tot > 0 else 1.0
+
+        # Procrustes disparity
+        try:
+            _, _, procrustes_disp = procrustes(g_all, c_all)
+        except Exception:
+            procrustes_disp = None
+
+        # Per-dimension R²
+        dim_r2 = []
+        for dim in range(g_all.shape[1]):
+            g_dim = g_all[:, dim]
+            c_dim = c_all[:, dim]
+            ss_res_dim = np.sum((g_dim - c_dim)**2)
+            ss_tot_dim = np.sum((g_dim - np.mean(g_dim))**2)
+            r2_dim = 1 - ss_res_dim / ss_tot_dim if ss_tot_dim > 0 else 1.0
+            dim_r2.append(r2_dim)
+
+        # Define thresholds
+        THRESH_MAX_ERR_PCT = 1.0        # Max error < 1% of range
+        THRESH_MEAN_ERR_PCT = 0.1       # Mean error < 0.1% of range
+        THRESH_R2_ALL = 0.9999          # R² > 99.99%
+        THRESH_R2_DIM = 0.999           # Per-dim R² > 99.9%
+        THRESH_PROCRUSTES = 1e-4        # Procrustes < 0.0001
+
+        # Check thresholds
+        pass_max_err = max_err_pct < THRESH_MAX_ERR_PCT
+        pass_mean_err = mean_err_pct < THRESH_MEAN_ERR_PCT
+        pass_r2_all = r_squared >= THRESH_R2_ALL
+        pass_r2_dims = all(r2 >= THRESH_R2_DIM for r2 in dim_r2)
+        pass_procrustes = procrustes_disp is None or procrustes_disp < THRESH_PROCRUSTES
+
+        all_pass = pass_max_err and pass_mean_err and pass_r2_all and pass_r2_dims and pass_procrustes
+
+        # Helper for emoji
+        def check(passed):
+            return "✅" if passed else "❌"
+
+        # Log the metrics with pass/fail indicators
+        logger.info(f"Projection comparison metrics ({stage_name}, {len(g_all)} points):")
+        logger.info(f"  ┌────┬─────────────────────────┬─────────────────┬───────────┬─────────────────────────────┐")
+        logger.info(f"  │    │ Metric                  │ Value           │ Threshold │ Interpretation              │")
+        logger.info(f"  ├────┼─────────────────────────┼─────────────────┼───────────┼─────────────────────────────┤")
+        logger.info(f"  │ {check(pass_max_err)} │ Max |error| / range     │ {max_err_pct:>13.4f}% │ < {THRESH_MAX_ERR_PCT:>5.1f}%  │ Worst displacement vs scale │")
+        logger.info(f"  │ {check(pass_mean_err)} │ Mean |error| / range    │ {mean_err_pct:>13.4f}% │ < {THRESH_MEAN_ERR_PCT:>5.2f}% │ Avg displacement vs scale   │")
+        logger.info(f"  │ {check(pass_r2_all)} │ R² (all coordinates)    │ {r_squared:>15.10f} │ > {THRESH_R2_ALL:.4f} │ Variance explained          │")
+        for i, r2 in enumerate(dim_r2):
+            pass_dim = r2 >= THRESH_R2_DIM
+            logger.info(f"  │ {check(pass_dim)} │ R² (PC{i+1})               │ {r2:>15.10f} │ > {THRESH_R2_DIM:.3f}  │ Per-dimension fit           │")
+        if procrustes_disp is not None:
+            logger.info(f"  │ {check(pass_procrustes)} │ Procrustes disparity    │ {procrustes_disp:>15.2e} │ < {THRESH_PROCRUSTES:.0e}  │ Shape similarity (0=same)   │")
+        logger.info(f"  └────┴─────────────────────────┴─────────────────┴───────────┴─────────────────────────────┘")
+        logger.info(f"  Overall: {check(all_pass)} {'PASS' if all_pass else 'FAIL'}")
+        logger.info("")
+
+        return all_pass
 
     def _write_comparison_log(self, log_path: Path, dataset_name: str) -> None:
         """

--- a/delphi/polismath/regression/comparer.py
+++ b/delphi/polismath/regression/comparer.py
@@ -5,6 +5,7 @@ Comparer for comparing current Conversation outputs with golden snapshots.
 
 import json
 import logging
+import re
 from pathlib import Path
 from typing import Dict, Any
 from datetime import datetime
@@ -54,6 +55,9 @@ class ConversationComparer:
         self.all_differences = []  # Collect all differences for detailed reporting
         self.sign_flip_warnings = []  # Collect sign flip warnings when ignore_pca_sign_flip is True
         self.outlier_warnings = []  # Collect outlier warnings when values exceed tight but pass loose tolerance
+        # Per-stage PCA sign flip vectors: stage_name -> list of +1/-1 per component
+        # E.g., [1, -1] means PC1 unchanged, PC2 flipped
+        self._pca_sign_flips: Dict[str, list] = {}
 
     def compare_with_golden(self, dataset_name: str, benchmark: bool = True) -> Dict:
         """
@@ -70,6 +74,7 @@ class ConversationComparer:
         self.all_differences = []
         self.sign_flip_warnings = []
         self.outlier_warnings = []
+        self._pca_sign_flips = {}
 
         # Load golden snapshot using shared function
         try:
@@ -629,24 +634,57 @@ class ConversationComparer:
                 min_len = len(golden)
 
             # For PCA-related paths, check for sign flips and scaling before element-by-element comparison
-            # Track if we need to use flipped values for comparison
-            use_flipped_current = False
+            # Track sign correction to apply
+            sign_correction = None  # None = no correction, list = per-element multipliers
             if min_len == len(golden) and len(golden) > 0 and self._is_pca_related_path(path):
                 # Check for sign flip (if enabled)
                 if self.ignore_pca_sign_flip:
-                    sign_flip_result = self._check_sign_flip(golden, current, path, stage_name)
-                    if sign_flip_result["detected"]:
-                        use_flipped_current = True
-                        # Continue to element-by-element comparison with flipped values
+                    # Different handling for PCA components vs projections/centers
+                    if ".pca.comps[" in path:
+                        # For PCA component vectors, detect whole-vector flip and store it
+                        sign_flip_result = self._check_sign_flip(golden, current, path, stage_name)
+                        if sign_flip_result["detected"]:
+                            sign_correction = [-1] * len(current)
+                            # Extract component index and store for later use on projections
+                            match = re.search(r'\.pca\.comps\[(\d+)\]', path)
+                            if match:
+                                comp_idx = int(match.group(1))
+                                if stage_name not in self._pca_sign_flips:
+                                    self._pca_sign_flips[stage_name] = {}
+                                self._pca_sign_flips[stage_name][comp_idx] = -1
+                    elif ".proj." in path or ".center" in path:
+                        # For projections and centers, apply stored per-dimension sign flips
+                        stored_flips = self._pca_sign_flips.get(stage_name, {})
+                        if stored_flips:
+                            # Build per-element sign correction based on stored component flips
+                            sign_correction = [
+                                stored_flips.get(i, 1) for i in range(len(current))
+                            ]
+                            # Only keep if there's actually a flip to apply
+                            if all(s == 1 for s in sign_correction):
+                                sign_correction = None
+                            else:
+                                # Log the per-dimension correction
+                                flipped_dims = [i for i, s in enumerate(sign_correction) if s == -1]
+                                self.sign_flip_warnings.append({
+                                    "stage_name": stage_name,
+                                    "path": path,
+                                    "message": f"Applying per-dimension sign correction for PC{flipped_dims}",
+                                    "max_abs_error": None,
+                                    "max_rel_error": None
+                                })
 
                 # Check for scaling factor (always check for PCA paths to provide better error messages)
-                # Use flipped current if sign flip was detected
-                check_current = [-c for c in current] if use_flipped_current else current
+                # Use corrected current if sign correction was detected
+                if sign_correction:
+                    check_current = [c * s for c, s in zip(current, sign_correction)]
+                else:
+                    check_current = current
                 scaling_factor = self._detect_scaling_factor(golden, check_current)
                 if scaling_factor is not None and abs(scaling_factor - 1.0) > 0.01:
                     # Scaling factor detected and it's not approximately 1.0
                     reason = f"PCA scaling mismatch: values differ by constant factor {scaling_factor:.6f}"
-                    if use_flipped_current:
+                    if sign_correction:
                         reason += " (after sign flip correction)"
                     # Record this difference
                     self.all_differences.append({
@@ -661,8 +699,11 @@ class ConversationComparer:
                         "reason": reason
                     }
 
-            # Prepare the current list (apply sign flip if detected)
-            compare_current = [-c for c in current[:min_len]] if use_flipped_current else current[:min_len]
+            # Prepare the current list (apply sign correction if detected)
+            if sign_correction:
+                compare_current = [c * s for c, s in zip(current[:min_len], sign_correction[:min_len])]
+            else:
+                compare_current = current[:min_len]
             compare_golden = golden[:min_len]
 
             # For numeric lists with outlier allowance enabled, use the specialized method

--- a/delphi/polismath/regression/comparer.py
+++ b/delphi/polismath/regression/comparer.py
@@ -722,8 +722,8 @@ class ConversationComparer:
         Check if a path corresponds to PCA-related data that can have arbitrary sign or scaling.
 
         PCA components can be flipped by -1 and scaled by a constant factor and still
-        be mathematically valid. This checks if we're comparing PCA component vectors
-        or projections.
+        be mathematically valid. This checks if we're comparing PCA component vectors,
+        projections, or cluster centers (which are derived from projections).
 
         Args:
             path: The path in the data structure (e.g., "after_pca.pca.comps[0]", "after_pca.proj.1")
@@ -739,6 +739,11 @@ class ConversationComparer:
         # Check for projections
         # Examples: "after_pca.proj.1", "after_clustering.proj.2[0]"
         if ".proj." in path:
+            return True
+
+        # Check for cluster centers (derived from PCA projections, so inherit sign ambiguity)
+        # Examples: "after_clustering.group_clusters[0].center", "after_clustering.base-clusters[1].center"
+        if ".center" in path:
             return True
 
         return False

--- a/delphi/polismath/regression/comparer.py
+++ b/delphi/polismath/regression/comparer.py
@@ -24,20 +24,36 @@ logger = logging.getLogger(__name__)
 class ConversationComparer:
     """Compares current Conversation outputs with golden snapshots."""
 
-    def __init__(self, abs_tolerance: float = 1e-6, rel_tolerance: float = 0.01, ignore_pca_sign_flip: bool = False):
+    def __init__(
+        self,
+        abs_tolerance: float = 1e-6,
+        rel_tolerance: float = 0.01,
+        ignore_pca_sign_flip: bool = False,
+        outlier_fraction: float = 0.01,
+        loose_abs_tolerance: float | None = None,
+        loose_rel_tolerance: float | None = None,
+    ):
         """
         Initialize the comparer with numeric tolerances.
 
         Args:
-            abs_tolerance: Absolute tolerance for numeric comparisons
-            rel_tolerance: Relative tolerance for numeric comparisons
+            abs_tolerance: Absolute tolerance for numeric comparisons (tight)
+            rel_tolerance: Relative tolerance for numeric comparisons (tight)
             ignore_pca_sign_flip: If True, ignore sign flips in PCA components (default: False)
+            outlier_fraction: Fraction of values (0.0-1.0) allowed to exceed tight tolerance
+                             but must still be within loose tolerance. Default 0.01 (1%).
+            loose_abs_tolerance: Absolute tolerance for outliers. If None, uses 1000 * abs_tolerance.
+            loose_rel_tolerance: Relative tolerance for outliers. If None, uses 10 * rel_tolerance.
         """
         self.abs_tol = abs_tolerance
         self.rel_tol = rel_tolerance
         self.ignore_pca_sign_flip = ignore_pca_sign_flip
+        self.outlier_fraction = outlier_fraction
+        self.loose_abs_tol = loose_abs_tolerance if loose_abs_tolerance is not None else 1000 * abs_tolerance
+        self.loose_rel_tol = loose_rel_tolerance if loose_rel_tolerance is not None else 10 * rel_tolerance
         self.all_differences = []  # Collect all differences for detailed reporting
         self.sign_flip_warnings = []  # Collect sign flip warnings when ignore_pca_sign_flip is True
+        self.outlier_warnings = []  # Collect outlier warnings when values exceed tight but pass loose tolerance
 
     def compare_with_golden(self, dataset_name: str, benchmark: bool = True) -> Dict:
         """
@@ -53,6 +69,7 @@ class ConversationComparer:
         # Reset differences collection for this comparison
         self.all_differences = []
         self.sign_flip_warnings = []
+        self.outlier_warnings = []
 
         # Load golden snapshot using shared function
         try:
@@ -322,29 +339,93 @@ class ConversationComparer:
 
         # Log differences summary if there are any
         if self.all_differences:
+            import numpy as np
             logger.warning("Differences found:")
             logger.warning(f"  Total differences: {len(self.all_differences)}")
-            logger.warning(f"  First {min(10, len(self.all_differences))} differences:")
-            for i, diff in enumerate(self.all_differences[:10]):
-                logger.warning(f"    {i+1}. Stage: {diff['stage_name']}")
-                logger.warning(f"       Path: {diff['path']}")
-                logger.warning(f"       Reason: {diff['reason']}")
+
+            # Collect numeric error statistics
+            abs_diffs = []
+            rel_diffs = []
+            for diff in self.all_differences:
                 if 'golden_value' in diff and 'current_value' in diff:
-                    logger.warning(f"       Golden: {diff['golden_value']}")
-                    logger.warning(f"       Current: {diff['current_value']}")
-            if len(self.all_differences) > 10:
-                logger.warning(f"  ... and {len(self.all_differences) - 10} more differences (see log file for details)")
+                    try:
+                        g = float(diff['golden_value'])
+                        c = float(diff['current_value'])
+                        abs_diffs.append(abs(g - c))
+                        if abs(g) > 1e-10:
+                            rel_diffs.append(abs(g - c) / abs(g))
+                    except (TypeError, ValueError):
+                        pass
+
+            if abs_diffs:
+                abs_arr = np.array(abs_diffs)
+                logger.warning(f"  Abs error stats: "
+                              f"min={np.min(abs_arr):.2e}, "
+                              f"Q1={np.percentile(abs_arr, 25):.2e}, "
+                              f"median={np.median(abs_arr):.2e}, "
+                              f"Q3={np.percentile(abs_arr, 75):.2e}, "
+                              f"max={np.max(abs_arr):.2e}")
+            if rel_diffs:
+                rel_arr = np.array(rel_diffs) * 100
+                logger.warning(f"  Rel error stats: "
+                              f"min={np.min(rel_arr):.2f}%, "
+                              f"Q1={np.percentile(rel_arr, 25):.2f}%, "
+                              f"median={np.median(rel_arr):.2f}%, "
+                              f"Q3={np.percentile(rel_arr, 75):.2f}%, "
+                              f"max={np.max(rel_arr):.2f}%")
+
+            # Show a few examples
+            n_examples = min(5, len(self.all_differences))
+            logger.warning(f"  First {n_examples} examples:")
+            for i, diff in enumerate(self.all_differences[:n_examples]):
+                logger.warning(f"    {i+1}. {diff['path']}: {diff['reason']}")
+            if len(self.all_differences) > n_examples:
+                logger.warning(f"  ... and {len(self.all_differences) - n_examples} more (see log file)")
             if diff_log_path:
                 logger.info(f"  Full details: {diff_log_path}")
             logger.info("")
 
-        # Log sign flip warnings if any
+        # Log sign flip warnings summary if any
         if self.sign_flip_warnings:
-            logger.warning("PCA sign flips detected (ignored due to ignore_pca_sign_flip=True):")
-            logger.warning(f"  Total sign flips: {len(self.sign_flip_warnings)}")
-            for i, warning in enumerate(self.sign_flip_warnings):
-                logger.warning(f"    {i+1}. Stage: {warning['stage_name']}")
-                logger.warning(f"       Path: {warning['path']}")
+            import numpy as np
+            logger.info("PCA sign flips detected (corrected due to ignore_pca_sign_flip=True):")
+            logger.info(f"  Total sign flips: {len(self.sign_flip_warnings)}")
+
+            # Collect error statistics
+            abs_errors = [w.get('max_abs_error', 0) for w in self.sign_flip_warnings if w.get('max_abs_error') is not None]
+            rel_errors = [w.get('max_rel_error', 0) for w in self.sign_flip_warnings if w.get('max_rel_error') is not None]
+
+            if abs_errors:
+                abs_arr = np.array(abs_errors)
+                logger.info(f"  Residual abs errors after flip: "
+                           f"min={np.min(abs_arr):.2e}, "
+                           f"Q1={np.percentile(abs_arr, 25):.2e}, "
+                           f"median={np.median(abs_arr):.2e}, "
+                           f"Q3={np.percentile(abs_arr, 75):.2e}, "
+                           f"max={np.max(abs_arr):.2e}")
+            if rel_errors:
+                rel_arr = np.array(rel_errors) * 100  # Convert to percentage
+                logger.info(f"  Residual rel errors after flip: "
+                           f"min={np.min(rel_arr):.2f}%, "
+                           f"Q1={np.percentile(rel_arr, 25):.2f}%, "
+                           f"median={np.median(rel_arr):.2f}%, "
+                           f"Q3={np.percentile(rel_arr, 75):.2f}%, "
+                           f"max={np.max(rel_arr):.2f}%")
+
+            # Show a few examples
+            n_examples = min(3, len(self.sign_flip_warnings))
+            logger.info(f"  First {n_examples} examples:")
+            for i, warning in enumerate(self.sign_flip_warnings[:n_examples]):
+                abs_err = warning.get('max_abs_error')
+                rel_err = warning.get('max_rel_error')
+                err_str = ""
+                if abs_err is not None:
+                    err_str = f"abs={abs_err:.2e}"
+                    if rel_err is not None:
+                        err_str += f", rel={rel_err:.2%}"
+                logger.info(f"    - {warning['path']} ({err_str})")
+            if len(self.sign_flip_warnings) > n_examples:
+                logger.info(f"    ... and {len(self.sign_flip_warnings) - n_examples} more (see log file)")
             logger.info("")
 
         # Only print speed comparison if benchmarking is enabled
@@ -418,7 +499,8 @@ class ConversationComparer:
 
         return results
 
-    def _compare_dicts(self, golden: Any, current: Any, path: str = "", stage_name: str = "") -> Dict:
+    def _compare_dicts(self, golden: Any, current: Any, path: str = "", stage_name: str = "",
+                       use_loose_tolerance: bool = False) -> Dict:
         """
         Recursively compare two dictionaries/values with numeric tolerance.
 
@@ -427,6 +509,7 @@ class ConversationComparer:
             current: Current value/dictionary
             path: Current path in the structure (for error reporting)
             stage_name: Name of the stage being compared (for difference logging)
+            use_loose_tolerance: If True, use loose tolerance for numeric comparisons
 
         Returns:
             Dictionary with comparison results
@@ -578,15 +661,44 @@ class ConversationComparer:
                         "reason": reason
                     }
 
-            # Do element-by-element comparison
+            # Prepare the current list (apply sign flip if detected)
+            compare_current = [-c for c in current[:min_len]] if use_flipped_current else current[:min_len]
+            compare_golden = golden[:min_len]
+
+            # For numeric lists with outlier allowance enabled, use the specialized method
+            # Only apply to lists with enough elements (>=10) to make outlier fraction meaningful
+            min_elements_for_outlier_logic = 10
+            if (self.outlier_fraction > 0 and
+                len(compare_golden) >= min_elements_for_outlier_logic and
+                self._is_numeric_list(compare_golden) and
+                self._is_numeric_list(compare_current)):
+                result = self._compare_numeric_list_with_outliers(
+                    compare_golden, compare_current, path, stage_name
+                )
+                if not result["match"]:
+                    overall_match = False
+                return {"match": overall_match, "path": path}
+
+            # For small numeric lists when outlier mode is enabled, use loose tolerance
+            # This handles cases like 2D projection coordinates where outlier fraction
+            # can't be meaningfully applied at the list level
+            use_loose_tolerance = (
+                self.outlier_fraction > 0 and
+                len(compare_golden) < min_elements_for_outlier_logic and
+                len(compare_golden) > 0 and
+                self._is_numeric_list(compare_golden) and
+                self._is_numeric_list(compare_current)
+            )
+
+            # Standard element-by-element comparison
             for i in range(min_len):
-                # Use flipped current value if sign flip was detected
-                current_val = -current[i] if use_flipped_current else current[i]
+                current_val = compare_current[i]
                 result = self._compare_dicts(
-                    golden[i],
+                    compare_golden[i],
                     current_val,
                     f"{path}[{i}]",
-                    stage_name=stage_name
+                    stage_name=stage_name,
+                    use_loose_tolerance=use_loose_tolerance
                 )
                 if not result["match"]:
                     overall_match = False
@@ -657,12 +769,17 @@ class ConversationComparer:
                     }
 
             # For floats, use tolerance-based comparison
-            if np.allclose([golden_float], [current_float], rtol=self.rel_tol, atol=self.abs_tol):
+            # Use loose tolerance if requested (for small lists in outlier mode)
+            rel_tol = self.loose_rel_tol if use_loose_tolerance else self.rel_tol
+            abs_tol = self.loose_abs_tol if use_loose_tolerance else self.abs_tol
+
+            if np.allclose([golden_float], [current_float], rtol=rel_tol, atol=abs_tol):
                 return {"match": True, "path": path}
             else:
                 diff = abs(golden_float - current_float)
                 rel_diff = diff / max(abs(golden_float), 1e-10)
-                reason = f"Numeric mismatch: golden={golden_float:.6e}, current={current_float:.6e}, abs_diff={diff:.6e}, rel_diff={rel_diff:.6%}"
+                tol_note = " (using loose tolerance)" if use_loose_tolerance else ""
+                reason = f"Numeric mismatch{tol_note}: golden={golden_float:.6e}, current={current_float:.6e}, abs_diff={diff:.6e}, rel_diff={rel_diff:.6%}"
                 self.all_differences.append({
                     "stage_name": stage_name,
                     "path": path,
@@ -887,6 +1004,150 @@ class ConversationComparer:
 
         return None
 
+    def _compare_numeric_list_with_outliers(
+        self,
+        golden: list,
+        current: list,
+        path: str,
+        stage_name: str
+    ) -> Dict:
+        """
+        Compare two numeric lists with outlier allowance.
+
+        This method compares lists element-by-element and allows a fraction
+        of elements to exceed the tight tolerance, as long as they stay within
+        the loose tolerance.
+
+        Args:
+            golden: Golden list of numeric values
+            current: Current list of numeric values
+            path: Current path in the structure (for error reporting)
+            stage_name: Name of the stage being compared
+
+        Returns:
+            Dictionary with comparison results including outlier information
+        """
+        import numpy as np
+
+        if len(golden) != len(current):
+            return {
+                "match": False,
+                "path": path,
+                "reason": f"List length mismatch: {len(golden)} vs {len(current)}"
+            }
+
+        n = len(golden)
+        if n == 0:
+            return {"match": True, "path": path}
+
+        # Convert to arrays
+        golden_arr = np.array([float(g) for g in golden])
+        current_arr = np.array([float(c) for c in current])
+
+        # Check each element against tight and loose tolerances
+        tight_pass = np.zeros(n, dtype=bool)
+        loose_pass = np.zeros(n, dtype=bool)
+
+        for i in range(n):
+            g, c = golden_arr[i], current_arr[i]
+
+            # Handle NaN
+            if np.isnan(g) and np.isnan(c):
+                tight_pass[i] = True
+                loose_pass[i] = True
+                continue
+            if np.isnan(g) or np.isnan(c):
+                tight_pass[i] = False
+                loose_pass[i] = False
+                continue
+
+            # Handle infinity
+            if np.isinf(g) and np.isinf(c) and np.sign(g) == np.sign(c):
+                tight_pass[i] = True
+                loose_pass[i] = True
+                continue
+
+            # Check tight tolerance
+            tight_pass[i] = np.allclose([g], [c], rtol=self.rel_tol, atol=self.abs_tol)
+
+            # Check loose tolerance
+            loose_pass[i] = np.allclose([g], [c], rtol=self.loose_rel_tol, atol=self.loose_abs_tol)
+
+        # Count results
+        n_tight_fail = np.sum(~tight_pass)
+        n_loose_fail = np.sum(~loose_pass)
+        outlier_indices = np.where(~tight_pass & loose_pass)[0]
+        hard_fail_indices = np.where(~loose_pass)[0]
+
+        # Check if any values exceed loose tolerance (hard fail)
+        if n_loose_fail > 0:
+            # Record differences for hard failures
+            for i in hard_fail_indices:
+                g, c = golden_arr[i], current_arr[i]
+                diff = abs(g - c)
+                rel_diff = diff / max(abs(g), 1e-10)
+                self.all_differences.append({
+                    "stage_name": stage_name,
+                    "path": f"{path}[{i}]",
+                    "reason": f"Exceeds loose tolerance: golden={g:.6e}, current={c:.6e}, "
+                              f"abs_diff={diff:.6e}, rel_diff={rel_diff:.6%}",
+                    "golden_value": g,
+                    "current_value": c
+                })
+            return {
+                "match": False,
+                "path": path,
+                "reason": f"{n_loose_fail} values exceed loose tolerance "
+                          f"(rel={self.loose_rel_tol:.1%}, abs={self.loose_abs_tol:.0e})"
+            }
+
+        # Check if outlier fraction is exceeded
+        outlier_frac = n_tight_fail / n if n > 0 else 0.0
+        if outlier_frac > self.outlier_fraction:
+            # Record differences for outliers that caused the failure
+            for i in outlier_indices:
+                g, c = golden_arr[i], current_arr[i]
+                diff = abs(g - c)
+                rel_diff = diff / max(abs(g), 1e-10)
+                self.all_differences.append({
+                    "stage_name": stage_name,
+                    "path": f"{path}[{i}]",
+                    "reason": f"Outlier (exceeds tight tolerance): golden={g:.6e}, current={c:.6e}, "
+                              f"abs_diff={diff:.6e}, rel_diff={rel_diff:.6%}",
+                    "golden_value": g,
+                    "current_value": c
+                })
+            return {
+                "match": False,
+                "path": path,
+                "reason": f"Outlier fraction {outlier_frac:.2%} exceeds allowed {self.outlier_fraction:.2%} "
+                          f"({n_tight_fail}/{n} values exceed tight tolerance)"
+            }
+
+        # Pass, but record outliers as warnings
+        if len(outlier_indices) > 0:
+            for i in outlier_indices:
+                g, c = golden_arr[i], current_arr[i]
+                diff = abs(g - c)
+                rel_diff = diff / max(abs(g), 1e-10)
+                self.outlier_warnings.append({
+                    "stage_name": stage_name,
+                    "path": f"{path}[{i}]",
+                    "message": f"Outlier within allowed fraction: abs_diff={diff:.6e}, rel_diff={rel_diff:.2%}",
+                    "golden_value": g,
+                    "current_value": c
+                })
+
+        return {"match": True, "path": path, "outliers": len(outlier_indices)}
+
+    def _is_numeric_list(self, lst: list) -> bool:
+        """Check if a list contains only numeric values (int, float, or numpy numeric types)."""
+        import numpy as np
+        for item in lst:
+            if not isinstance(item, (int, float, np.integer, np.floating)):
+                return False
+        return True
+
     def _write_comparison_log(self, log_path: Path, dataset_name: str) -> None:
         """
         Write comparison results to a log file.
@@ -907,8 +1168,9 @@ class ConversationComparer:
 
             # Write configuration/tolerances
             f.write("Configuration:\n")
-            f.write(f"  Absolute tolerance: {self.abs_tol:.0e}\n")
-            f.write(f"  Relative tolerance: {self.rel_tol:.1%}\n")
+            f.write(f"  Tight tolerances: abs={self.abs_tol:.0e}, rel={self.rel_tol:.1%}\n")
+            f.write(f"  Loose tolerances: abs={self.loose_abs_tol:.0e}, rel={self.loose_rel_tol:.1%}\n")
+            f.write(f"  Outlier fraction allowed: {self.outlier_fraction:.1%}\n")
             f.write(f"  Ignore PCA sign flips: {self.ignore_pca_sign_flip}\n")
             f.write("\n")
 
@@ -961,6 +1223,22 @@ class ConversationComparer:
                         if 'max_rel_error' in warning and warning['max_rel_error'] is not None:
                             f.write(f", rel={warning['max_rel_error']:.2%}")
                         f.write("\n")
+
+                f.write("\n")
+
+            # Write outlier warnings if any occurred
+            if self.outlier_warnings:
+                f.write("-" * 80 + "\n")
+                f.write("INFO: OUTLIERS WITHIN ALLOWED FRACTION\n")
+                f.write(f"Total outliers: {len(self.outlier_warnings)}\n")
+                f.write(f"(Values exceeded tight tolerance but passed loose tolerance, within {self.outlier_fraction:.1%} limit)\n\n")
+
+                for i, warning in enumerate(self.outlier_warnings):
+                    f.write(f"  {i+1}. Stage: {warning['stage_name']}\n")
+                    f.write(f"     Path: {warning['path']}\n")
+                    f.write(f"     {warning['message']}\n")
+                    if 'golden_value' in warning:
+                        f.write(f"     Golden: {warning['golden_value']:.6e}, Current: {warning['current_value']:.6e}\n")
 
                 f.write("\n")
 

--- a/delphi/polismath/regression/comparer.py
+++ b/delphi/polismath/regression/comparer.py
@@ -230,15 +230,29 @@ class ConversationComparer:
         output_dir = Path(__file__).parent.parent.parent / ".test_outputs" / "regression"
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        if self.all_differences:
-            diff_log_path = output_dir / f"comparer-differences-{timestamp}.log"
-            self._write_differences_log(diff_log_path, dataset_name)
-            results["diff_log_path"] = str(diff_log_path)
+        # Use dataset_name or fall back to report_id for the identifier
+        identifier = dataset_name if dataset_name else golden["metadata"].get("report_id", "unknown")
+
+        # Always create a comparison log file
+        log_filename = f"{identifier}-{timestamp}.log"
+        log_path = output_dir / log_filename
+        self._write_comparison_log(log_path, dataset_name)
+        results["comparison_log_path"] = str(log_path)
+
+        # Create or update symlink to latest comparison log
+        log_symlink_name = f"{identifier}-latest.log"
+        log_symlink_path = output_dir / log_symlink_name
+
+        # Remove existing symlink if it exists
+        if log_symlink_path.exists() or log_symlink_path.is_symlink():
+            log_symlink_path.unlink()
+
+        # Create new symlink pointing to the log file (relative path for portability)
+        log_symlink_path.symlink_to(log_filename)
+        results["comparison_log_latest_symlink_path"] = str(log_symlink_path)
 
         # Save current computation output as JSON (the data being compared, not the comparison results)
-        # Use dataset_name or fall back to report_id for the filename
-        identifier = dataset_name if dataset_name else golden["metadata"].get("report_id", "unknown")
-        json_filename = f"{identifier}-comparer-output-{timestamp}.json"
+        json_filename = f"{identifier}-{timestamp}.json"
         json_path = output_dir / json_filename
 
         # Build output snapshot structure similar to golden format
@@ -831,9 +845,12 @@ class ConversationComparer:
 
         return None
 
-    def _write_differences_log(self, log_path: Path, dataset_name: str) -> None:
+    def _write_comparison_log(self, log_path: Path, dataset_name: str) -> None:
         """
-        Write all collected differences to a log file.
+        Write comparison results to a log file.
+
+        If differences were found, writes detailed difference information.
+        If no differences, writes a success message with configuration details.
 
         Args:
             log_path: Path to the log file
@@ -841,32 +858,62 @@ class ConversationComparer:
         """
         with open(log_path, 'w') as f:
             f.write("=" * 80 + "\n")
-            f.write(f"COMPARISON DIFFERENCES LOG\n")
+            f.write(f"COMPARISON LOG\n")
             f.write(f"Dataset: {dataset_name}\n")
             f.write(f"Generated: {datetime.now().isoformat()}\n")
-            f.write(f"Total differences: {len(self.all_differences)}\n")
             f.write("=" * 80 + "\n\n")
 
-            for i, diff in enumerate(self.all_differences):
-                f.write(f"Difference #{i+1}\n")
+            # Write configuration/tolerances
+            f.write("Configuration:\n")
+            f.write(f"  Absolute tolerance: {self.abs_tol:.0e}\n")
+            f.write(f"  Relative tolerance: {self.rel_tol:.1%}\n")
+            f.write(f"  Ignore PCA sign flips: {self.ignore_pca_sign_flip}\n")
+            f.write("\n")
+
+            if self.all_differences:
+                # Differences found - write detailed information
+                f.write(f"RESULT: DIFFERENCES FOUND\n")
+                f.write(f"Total differences: {len(self.all_differences)}\n")
+                f.write("-" * 80 + "\n\n")
+
+                for i, diff in enumerate(self.all_differences):
+                    f.write(f"Difference #{i+1}\n")
+                    f.write("-" * 80 + "\n")
+                    f.write(f"  Stage: {diff['stage_name']}\n")
+                    f.write(f"  Path: {diff['path']}\n")
+                    f.write(f"  Reason: {diff['reason']}\n")
+
+                    if 'golden_value' in diff:
+                        golden_val = diff['golden_value']
+                        # Truncate long values for readability
+                        if isinstance(golden_val, str) and len(golden_val) > 200:
+                            golden_val = golden_val[:200] + "... (truncated)"
+                        f.write(f"  Golden value: {golden_val}\n")
+
+                    if 'current_value' in diff:
+                        current_val = diff['current_value']
+                        # Truncate long values for readability
+                        if isinstance(current_val, str) and len(current_val) > 200:
+                            current_val = current_val[:200] + "... (truncated)"
+                        f.write(f"  Current value: {current_val}\n")
+
+                    f.write("\n")
+            else:
+                # No differences - success message
+                f.write("RESULT: NO REGRESSION DETECTED\n")
+                f.write("Output matches golden snapshot within tolerance.\n")
+                f.write("\n")
+
+            # Write sign flip warnings if any occurred
+            if self.sign_flip_warnings:
                 f.write("-" * 80 + "\n")
-                f.write(f"  Stage: {diff['stage_name']}\n")
-                f.write(f"  Path: {diff['path']}\n")
-                f.write(f"  Reason: {diff['reason']}\n")
+                f.write("WARNING: PCA SIGN FLIPS DETECTED\n")
+                f.write(f"Total sign flips: {len(self.sign_flip_warnings)}\n")
+                f.write("(These were ignored due to ignore_pca_sign_flip=True)\n\n")
 
-                if 'golden_value' in diff:
-                    golden_val = diff['golden_value']
-                    # Truncate long values for readability
-                    if isinstance(golden_val, str) and len(golden_val) > 200:
-                        golden_val = golden_val[:200] + "... (truncated)"
-                    f.write(f"  Golden value: {golden_val}\n")
-
-                if 'current_value' in diff:
-                    current_val = diff['current_value']
-                    # Truncate long values for readability
-                    if isinstance(current_val, str) and len(current_val) > 200:
-                        current_val = current_val[:200] + "... (truncated)"
-                    f.write(f"  Current value: {current_val}\n")
+                for i, warning in enumerate(self.sign_flip_warnings):
+                    f.write(f"  {i+1}. Stage: {warning['stage_name']}\n")
+                    f.write(f"     Path: {warning['path']}\n")
 
                 f.write("\n")
 

--- a/delphi/scripts/regression_comparer.py
+++ b/delphi/scripts/regression_comparer.py
@@ -24,13 +24,26 @@ def main(datasets: tuple, benchmark: bool, ignore_pca_sign_flip: bool, include_l
     Otherwise, compares only the specified datasets.
 
     Examples:
-        python comparer.py                              # Compare all datasets
-        python comparer.py biodiversity                 # Compare only biodiversity
-        python comparer.py biodiversity vw              # Compare biodiversity and vw
-        python comparer.py --include-local              # Include datasets from real_data/.local/
-        python comparer.py --log-level DEBUG            # Compare with debug logging
-        python comparer.py -i biodiversity              # Compare with PCA sign flip tolerance
-        python comparer.py --ignore-pca-sign-flip vw    # Compare with PCA sign flip tolerance
+        # Compare all datasets:
+        python comparer.py
+        
+        # Compare only biodiversity:
+        python comparer.py biodiversity
+        
+        # Compare biodiversity and vw:
+        python comparer.py biodiversity vw
+        
+        # Include datasets from real_data/.local/:
+        python comparer.py --include-local
+        
+        # Compare with debug logging:
+        python comparer.py --log-level DEBUG
+        
+        # Compare with PCA sign flip tolerance:
+        python comparer.py -i biodiversity
+        
+        # Compare with PCA sign flip tolerance:
+        python comparer.py --ignore-pca-sign-flip vw
     """
     # Configure logging - must be done before imports to prevent conversation module
     # from adding its own handler

--- a/delphi/scripts/regression_comparer.py
+++ b/delphi/scripts/regression_comparer.py
@@ -16,7 +16,14 @@ import click
 @click.option('--include-local', is_flag=True, default=False, help='Include datasets from real_data/.local/')
 @click.option('--log-level', type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], case_sensitive=False),
               default='INFO', help='Set logging level (default: INFO). Use DEBUG to save detailed comparison output.')
-def main(datasets: tuple, benchmark: bool, ignore_pca_sign_flip: bool, include_local: bool, log_level: str):
+@click.option('--outlier-fraction', type=float, default=0.01,
+              help='Fraction of values (0.0-1.0) allowed to exceed tight tolerance. Default 0.01 (1%).')
+@click.option('--loose-rel-tol', type=float, default=None,
+              help='Loose relative tolerance for outliers. Default: 10 * rel_tolerance.')
+@click.option('--loose-abs-tol', type=float, default=None,
+              help='Loose absolute tolerance for outliers. Default: 1000 * abs_tolerance.')
+def main(datasets: tuple, benchmark: bool, ignore_pca_sign_flip: bool, include_local: bool, log_level: str,
+         outlier_fraction: float, loose_rel_tol: float | None, loose_abs_tol: float | None):
     """
     Compare current implementation with golden snapshots.
 
@@ -26,24 +33,24 @@ def main(datasets: tuple, benchmark: bool, ignore_pca_sign_flip: bool, include_l
     Examples:
         # Compare all datasets:
         python comparer.py
-        
+
         # Compare only biodiversity:
         python comparer.py biodiversity
-        
+
         # Compare biodiversity and vw:
         python comparer.py biodiversity vw
-        
+
         # Include datasets from real_data/.local/:
         python comparer.py --include-local
-        
+
         # Compare with debug logging:
         python comparer.py --log-level DEBUG
-        
+
         # Compare with PCA sign flip tolerance:
         python comparer.py -i biodiversity
-        
-        # Compare with PCA sign flip tolerance:
-        python comparer.py --ignore-pca-sign-flip vw
+
+        # Allow 1% of values to be outliers (within 10% loose tolerance):
+        python comparer.py -i --outlier-fraction 0.01 biodiversity
     """
     # Configure logging - must be done before imports to prevent conversation module
     # from adding its own handler
@@ -56,7 +63,12 @@ def main(datasets: tuple, benchmark: bool, ignore_pca_sign_flip: bool, include_l
     # Import after logging is configured to ensure conversation module uses root logger
     from polismath.regression import ConversationComparer, list_available_datasets
 
-    comparer = ConversationComparer(ignore_pca_sign_flip=ignore_pca_sign_flip)
+    comparer = ConversationComparer(
+        ignore_pca_sign_flip=ignore_pca_sign_flip,
+        outlier_fraction=outlier_fraction,
+        loose_rel_tolerance=loose_rel_tol,
+        loose_abs_tolerance=loose_abs_tol,
+    )
 
     # If no datasets specified, use all available datasets
     if not datasets:


### PR DESCRIPTION
## Summary

> **Stacked on #2397** (test infra). Please review and merge #2396 → #2397 first.
>
> **To see only the diff added by this PR** (excluding previous commits): [compare pca_test_infra...pca_comparer](https://github.com/jucor/polis/compare/pca_test_infra...pca_comparer)
>
> Stack: #2396 (NaN fix) → #2397 (test infra) → **This PR** → #2399 (sklearn PCA) → #2400 (test cleanup)

Improvements to the regression comparison tooling (\`comparer.py\`, \`regression_comparer.py\`):

- Save difference log regardless of errors (previously lost on exceptions)
- Account for PCA sign flips in numerical difference reporting
- Extend sign flip detection to cluster centers
- Allow per-component error tolerance for PCA
- Fix per-component PCA sign flip detection (was incorrectly applied globally)
- Add projection-based comparison metrics: R², Procrustes distance, range-normalized error

These improvements are needed to properly validate the sklearn PCA transition (next PR in stack) but are independently useful for any PCA implementation change.

## Test plan

- [x] 215 passed, 7 skipped, 2 xfailed
- [x] No production code changes — only regression testing tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)