### PR TITLE
Add s/d/f vote hotkeys and shortcut hints in vote view

### DIFF
--- a/client-participation/js/templates/vote-view.handlebars
+++ b/client-participation/js/templates/vote-view.handlebars
@@ -276,7 +276,7 @@
           width: 22px;
           fill: #2ecc71;
           ">{{> iconFaCircleCheck}}</i>
-        {{s.agree}} <span style="opacity:0.7; font-size: 0.9em;">({{voteShortcuts.agree}})</span>
+        {{s.agree}} ({{voteShortcuts.agree}})
       </button>
       <button
         id="disagreeButton"
@@ -290,13 +290,13 @@
           width: 22px;
           fill: #e74c3c;
           ">{{> iconFaBan}}</i>
-        {{s.disagree}} <span style="opacity:0.7; font-size: 0.9em;">({{voteShortcuts.disagree}})</span>
+        {{s.disagree}} ({{voteShortcuts.disagree}})
       </button>
       <button
         id="passButton"
         class="reactionButton"
         >
-        {{s.pass}} <span style="opacity:0.7; font-size: 0.9em;">({{voteShortcuts.pass}})</span>
+        {{s.pass}} ({{voteShortcuts.pass}})
       </button>
     </div>
 

--- a/client-participation/js/templates/vote-view.handlebars
+++ b/client-participation/js/templates/vote-view.handlebars
@@ -276,7 +276,7 @@
           width: 22px;
           fill: #2ecc71;
           ">{{> iconFaCircleCheck}}</i>
-        {{s.agree}}
+        {{s.agree}} <span style="opacity:0.7; font-size: 0.9em;">(s)</span>
       </button>
       <button
         id="disagreeButton"
@@ -290,13 +290,13 @@
           width: 22px;
           fill: #e74c3c;
           ">{{> iconFaBan}}</i>
-        {{s.disagree}}
+        {{s.disagree}} <span style="opacity:0.7; font-size: 0.9em;">(d)</span>
       </button>
       <button
         id="passButton"
         class="reactionButton"
         >
-        {{s.pass}}
+        {{s.pass}} <span style="opacity:0.7; font-size: 0.9em;">(f)</span>
       </button>
     </div>
 

--- a/client-participation/js/templates/vote-view.handlebars
+++ b/client-participation/js/templates/vote-view.handlebars
@@ -276,7 +276,7 @@
           width: 22px;
           fill: #2ecc71;
           ">{{> iconFaCircleCheck}}</i>
-        {{s.agree}} <span style="opacity:0.7; font-size: 0.9em;">(s)</span>
+        {{s.agree}} <span style="opacity:0.7; font-size: 0.9em;">({{voteShortcuts.agree}})</span>
       </button>
       <button
         id="disagreeButton"
@@ -290,13 +290,13 @@
           width: 22px;
           fill: #e74c3c;
           ">{{> iconFaBan}}</i>
-        {{s.disagree}} <span style="opacity:0.7; font-size: 0.9em;">(d)</span>
+        {{s.disagree}} <span style="opacity:0.7; font-size: 0.9em;">({{voteShortcuts.disagree}})</span>
       </button>
       <button
         id="passButton"
         class="reactionButton"
         >
-        {{s.pass}} <span style="opacity:0.7; font-size: 0.9em;">(f)</span>
+        {{s.pass}} <span style="opacity:0.7; font-size: 0.9em;">({{voteShortcuts.pass}})</span>
       </button>
     </div>
 

--- a/client-participation/js/util/preloadHelper.js
+++ b/client-participation/js/util/preloadHelper.js
@@ -6,9 +6,6 @@ var $ = require("jquery");
 // bootstrap initial bulk ajax call.
 // we don't have promises until main bundle loads, so this is going to be crappy.
 var p = window.preload;
-var hasPreloadKey = function (key) {
-  return Object.prototype.hasOwnProperty.call(p, key);
-};
 
 function makeListener(dfd) {
   return function (err, data) {
@@ -20,7 +17,7 @@ function makeListener(dfd) {
   };
 }
 
-var firstCommentPromise = hasPreloadKey("firstComment")
+var firstCommentPromise = p.firstComment
   ? $.Deferred().resolve(p.firstComment)
   : (function () {
       var dfd = $.Deferred();
@@ -28,7 +25,7 @@ var firstCommentPromise = hasPreloadKey("firstComment")
       return dfd.promise();
     })();
 
-var firstConvPromise = hasPreloadKey("firstConv")
+var firstConvPromise = p.firstConv
   ? $.Deferred().resolve(p.firstConv)
   : (function () {
       var dfd = $.Deferred();
@@ -37,7 +34,7 @@ var firstConvPromise = hasPreloadKey("firstConv")
     })();
 
 // firstUser may legitimately be null for anonymous participants.
-var firstUserPromise = hasPreloadKey("firstUser")
+var firstUserPromise = Object.prototype.hasOwnProperty.call(p, "firstUser")
   ? $.Deferred().resolve(p.firstUser)
   : (function () {
       var dfd = $.Deferred();
@@ -45,7 +42,7 @@ var firstUserPromise = hasPreloadKey("firstUser")
       return dfd.promise();
     })();
 
-var firstPtptPromise = hasPreloadKey("firstPtpt")
+var firstPtptPromise = p.firstPtpt
   ? $.Deferred().resolve(p.firstPtpt)
   : (function () {
       var dfd = $.Deferred();
@@ -53,7 +50,7 @@ var firstPtptPromise = hasPreloadKey("firstPtpt")
       return dfd.promise();
     })();
 
-var firstVotesByMePromise = hasPreloadKey("firstVotesByMe")
+var firstVotesByMePromise = p.firstVotesByMe
   ? $.Deferred().resolve(p.firstVotesByMe)
   : (function () {
       var dfd = $.Deferred();
@@ -69,7 +66,7 @@ var firstMathPromise = _.isObject(p.firstMath)
       return dfd.promise();
     })();
 
-var firstFamousPromise = hasPreloadKey("firstFamous")
+var firstFamousPromise = p.firstFamous
   ? $.Deferred().resolve(p.firstFamous)
   : (function () {
       var dfd = $.Deferred();
@@ -77,7 +74,7 @@ var firstFamousPromise = hasPreloadKey("firstFamous")
       return dfd.promise();
     })();
 
-var acceptLanguagePromise = hasPreloadKey("acceptLanguage")
+var acceptLanguagePromise = p.acceptLanguage
   ? $.Deferred().resolve(p.acceptLanguage)
   : (function () {
       var dfd = $.Deferred();

--- a/client-participation/js/util/preloadHelper.js
+++ b/client-participation/js/util/preloadHelper.js
@@ -6,6 +6,9 @@ var $ = require("jquery");
 // bootstrap initial bulk ajax call.
 // we don't have promises until main bundle loads, so this is going to be crappy.
 var p = window.preload;
+var hasPreloadKey = function (key) {
+  return Object.prototype.hasOwnProperty.call(p, key);
+};
 
 function makeListener(dfd) {
   return function (err, data) {
@@ -17,7 +20,7 @@ function makeListener(dfd) {
   };
 }
 
-var firstCommentPromise = p.firstComment
+var firstCommentPromise = hasPreloadKey("firstComment")
   ? $.Deferred().resolve(p.firstComment)
   : (function () {
       var dfd = $.Deferred();
@@ -25,7 +28,7 @@ var firstCommentPromise = p.firstComment
       return dfd.promise();
     })();
 
-var firstConvPromise = p.firstConv
+var firstConvPromise = hasPreloadKey("firstConv")
   ? $.Deferred().resolve(p.firstConv)
   : (function () {
       var dfd = $.Deferred();
@@ -33,7 +36,8 @@ var firstConvPromise = p.firstConv
       return dfd.promise();
     })();
 
-var firstUserPromise = p.firstUser
+// firstUser may legitimately be null for anonymous participants.
+var firstUserPromise = hasPreloadKey("firstUser")
   ? $.Deferred().resolve(p.firstUser)
   : (function () {
       var dfd = $.Deferred();
@@ -41,7 +45,7 @@ var firstUserPromise = p.firstUser
       return dfd.promise();
     })();
 
-var firstPtptPromise = p.firstPtpt
+var firstPtptPromise = hasPreloadKey("firstPtpt")
   ? $.Deferred().resolve(p.firstPtpt)
   : (function () {
       var dfd = $.Deferred();
@@ -49,7 +53,7 @@ var firstPtptPromise = p.firstPtpt
       return dfd.promise();
     })();
 
-var firstVotesByMePromise = p.firstVotesByMe
+var firstVotesByMePromise = hasPreloadKey("firstVotesByMe")
   ? $.Deferred().resolve(p.firstVotesByMe)
   : (function () {
       var dfd = $.Deferred();
@@ -65,7 +69,7 @@ var firstMathPromise = _.isObject(p.firstMath)
       return dfd.promise();
     })();
 
-var firstFamousPromise = p.firstFamous
+var firstFamousPromise = hasPreloadKey("firstFamous")
   ? $.Deferred().resolve(p.firstFamous)
   : (function () {
       var dfd = $.Deferred();
@@ -73,7 +77,7 @@ var firstFamousPromise = p.firstFamous
       return dfd.promise();
     })();
 
-var acceptLanguagePromise = p.acceptLanguage
+var acceptLanguagePromise = hasPreloadKey("acceptLanguage")
   ? $.Deferred().resolve(p.acceptLanguage)
   : (function () {
       var dfd = $.Deferred();

--- a/client-participation/js/views/vote-view.js
+++ b/client-participation/js/views/vote-view.js
@@ -215,10 +215,14 @@ module.exports = Handlebones.ModelView.extend({
   },
   initialize: function (options) {
     Handlebones.ModelView.prototype.initialize.apply(this, arguments);
+    var that = this;
     eb.on(eb.exitConv, cleanup);
 
     function cleanup() {
       eb.off(eb.exitConv, cleanup);
+      if (that.onKeyDownVoteShortcuts && that.hotkeyTarget) {
+        that.hotkeyTarget.removeEventListener("keydown", that.onKeyDownVoteShortcuts, true);
+      }
     }
     var serverClient = (this.serverClient = options.serverClient);
     var votesByMe = (this.votesByMe = options.votesByMe);
@@ -234,13 +238,48 @@ module.exports = Handlebones.ModelView.extend({
     var conversation_id = (this.conversation_id = options.conversation_id);
     this.pid = options.pid;
     this.isSubscribed = options.isSubscribed;
+    this.hotkeyTarget = window;
+
+    this.onKeyDownVoteShortcuts = function (e) {
+      if (e.repeat || e.altKey || e.ctrlKey || e.metaKey) {
+        return;
+      }
+
+      var target = e.target || document.activeElement;
+      var tagName = target && target.tagName ? target.tagName.toLowerCase() : "";
+      if (
+        tagName === "input" ||
+        tagName === "textarea" ||
+        tagName === "select" ||
+        (target && target.isContentEditable)
+      ) {
+        return;
+      }
+
+      // Only enable shortcuts when vote buttons are currently visible.
+      if (!that.$("#agreeButton").length || !that.$("#disagreeButton").length || !that.$("#passButton").length) {
+        return;
+      }
+
+      var code = (e.code || "").toLowerCase();
+      var key = (e.key || String.fromCharCode(e.which || e.keyCode || 0)).toLowerCase();
+      if (code === "keys" || key === "s") {
+        e.preventDefault();
+        that.participantAgreed();
+      } else if (code === "keyd" || key === "d") {
+        e.preventDefault();
+        that.participantDisagreed();
+      } else if (code === "keyf" || key === "f") {
+        e.preventDefault();
+        that.participantPassed();
+      }
+    };
+    this.hotkeyTarget.addEventListener("keydown", this.onKeyDownVoteShortcuts, true);
 
     if (Utils.isDemoMode()) {
       votesByMeFetched.resolve();
     }
     votesByMe.on("sync", votesByMeFetched.resolve);
-
-    var that = this;
     var waitingForComments = true;
     var commentPollInterval = 5 * 1000;
 

--- a/client-participation/js/views/vote-view.js
+++ b/client-participation/js/views/vote-view.js
@@ -11,6 +11,16 @@ var $ = require("jquery");
 var _ = require("lodash");
 
 var iOS = Utils.isIos();
+var VOTE_SHORTCUT_KEYS = {
+  agree: "s",
+  disagree: "d",
+  pass: "f"
+};
+var VOTE_SHORTCUT_KEY_BY_CODE = {
+  keys: VOTE_SHORTCUT_KEYS.agree,
+  keyd: VOTE_SHORTCUT_KEYS.disagree,
+  keyf: VOTE_SHORTCUT_KEYS.pass
+};
 
 function getOfficialTranslations(translations) {
   return (translations || []).filter(function (t) {
@@ -56,6 +66,7 @@ module.exports = Handlebones.ModelView.extend({
       ctx.createdString = new Date(ctx.created * 1).toString().match(/(.*?) [0-9]+:/)[1];
     }
     ctx.s = Strings;
+    ctx.voteShortcuts = VOTE_SHORTCUT_KEYS;
 
     var btnBg = preload.conversation.style_btn;
     if (btnBg) {
@@ -256,20 +267,40 @@ module.exports = Handlebones.ModelView.extend({
         return;
       }
 
-      // Only enable shortcuts when vote buttons are currently visible.
-      if (!that.$("#agreeButton").length || !that.$("#disagreeButton").length || !that.$("#passButton").length) {
+      var agreeButton = that.$("#agreeButton");
+      var disagreeButton = that.$("#disagreeButton");
+      var passButton = that.$("#passButton");
+
+      // Enable shortcuts only while the vote screen is actually visible.
+      if (
+        !agreeButton.length ||
+        !disagreeButton.length ||
+        !passButton.length ||
+        !agreeButton.is(":visible") ||
+        !disagreeButton.is(":visible") ||
+        !passButton.is(":visible")
+      ) {
         return;
       }
 
-      var code = (e.code || "").toLowerCase();
-      var key = (e.key || String.fromCharCode(e.which || e.keyCode || 0)).toLowerCase();
-      if (code === "keys" || key === "s") {
+      var key = (e.key || "").toLowerCase();
+      if (!key) {
+        key = String.fromCharCode(e.which || e.keyCode || 0).toLowerCase();
+      }
+
+      // Fallback to physical-key detection only when character key is unavailable.
+      if (!key || key === "unidentified") {
+        var code = (e.code || "").toLowerCase();
+        key = VOTE_SHORTCUT_KEY_BY_CODE[code] || key;
+      }
+
+      if (key === VOTE_SHORTCUT_KEYS.agree) {
         e.preventDefault();
         that.participantAgreed();
-      } else if (code === "keyd" || key === "d") {
+      } else if (key === VOTE_SHORTCUT_KEYS.disagree) {
         e.preventDefault();
         that.participantDisagreed();
-      } else if (code === "keyf" || key === "f") {
+      } else if (key === VOTE_SHORTCUT_KEYS.pass) {
         e.preventDefault();
         that.participantPassed();
       }


### PR DESCRIPTION
 Add keyboard vote shortcuts in the vote view.
 - `s` => agree
 - `d` => disagree
 - `f` => pass