### PR TITLE
excludes flagged comments from server csv exports

### DIFF
--- a/server/__tests__/integration/data-export.test.ts
+++ b/server/__tests__/integration/data-export.test.ts
@@ -615,6 +615,7 @@ describe("Data Export API with Excluded Comments", () => {
     });
 
     // Wait for math computation
+    let pcaAvailable = false;
     for (let attempt = 0; attempt < 10; attempt++) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
       try {
@@ -622,11 +623,16 @@ describe("Data Export API with Excluded Comments", () => {
           `/api/v3/math/pca2?conversation_id=${conversationId}`
         );
         if (pcaResponse.status === 200 && pcaResponse.body) {
+          pcaAvailable = true;
           break;
         }
       } catch (error) {
         // Continue trying
       }
+    }
+
+    if (!pcaAvailable) {
+      throw new Error("PCA data not available after waiting 10 seconds");
     }
 
     // Create a report

--- a/server/__tests__/integration/data-export.test.ts
+++ b/server/__tests__/integration/data-export.test.ts
@@ -524,3 +524,200 @@ describe("Data Export API with Importance Enabled", () => {
     });
   });
 });
+
+describe("Data Export API with Excluded Comments", () => {
+  let agent: Agent;
+  let testAgent: Agent;
+  let conversationId: string;
+  let reportId: string;
+  let comments: number[];
+  let excludedTid: number;
+  let includedTids: number[];
+
+  const numParticipants = 3;
+  const numComments = 3;
+  const testTopic = "Test Excluded Comments Conversation";
+  const testDescription = "Testing comment exclusion in data exports";
+
+  beforeAll(async () => {
+    // Use pooled user for JWT authentication
+    const pooledUser = getPooledTestUser(3); // Use a different user pool
+    const testUser = {
+      email: pooledUser.email,
+      hname: pooledUser.name,
+      password: pooledUser.password,
+    };
+
+    // Get JWT authenticated agent
+    const { agent: jwtAgent, token } = await getJwtAuthenticatedAgent(testUser);
+    agent = jwtAgent;
+
+    // Get agent for endpoints and authenticate it
+    testAgent = await getTestAgent();
+    testAgent.set("Authorization", `Bearer ${token}`);
+    testAgent.set("x-forwarded-proto", "http");
+
+    // Create a conversation (returns zinvite string, not zid)
+    const zinvite = await createConversation(agent, {
+      topic: testTopic,
+      description: testDescription,
+    });
+    conversationId = zinvite;
+
+    // Get the actual zid from the zinvite
+    const { pool } = await import("../setup/db-test-helpers");
+    const zidResult = await pool.query(
+      "SELECT zid FROM zinvites WHERE zinvite = $1",
+      [zinvite]
+    );
+    const zid = zidResult.rows[0].zid;
+
+    // Create comments
+    comments = [];
+    for (let i = 1; i <= numComments; i++) {
+      const response = await agent.post("/api/v3/comments").send({
+        conversation_id: conversationId,
+        txt: `Export test comment ${i}`,
+      });
+      if (response.status === 200) {
+        comments.push(response.body.tid);
+      }
+    }
+
+    // The second comment will be excluded
+    excludedTid = comments[1];
+    includedTids = [comments[0], comments[2]];
+
+    // Create participants and have them vote
+    const participants: Awaited<ReturnType<typeof initializeParticipant>>[] = [];
+    for (let i = 0; i < numParticipants; i++) {
+      const participantData = await initializeParticipant(conversationId);
+      participants.push(participantData);
+    }
+
+    // Submit votes from each participant
+    for (let i = 0; i < participants.length; i++) {
+      const participantData = participants[i];
+      for (let j = 0; j < comments.length; j++) {
+        const vote = [-1, 1, 0][j % 3] as -1 | 0 | 1;
+        await submitVote(participantData.agent, {
+          conversation_id: conversationId,
+          tid: comments[j],
+          vote,
+        });
+      }
+    }
+
+    // Trigger math computation
+    await agent.post("/api/v3/mathUpdate").send({
+      conversation_id: conversationId,
+      math_update_type: "update",
+    });
+
+    // Wait for math computation
+    for (let attempt = 0; attempt < 10; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      try {
+        const pcaResponse = await agent.get(
+          `/api/v3/math/pca2?conversation_id=${conversationId}`
+        );
+        if (pcaResponse.status === 200 && pcaResponse.body) {
+          break;
+        }
+      } catch (error) {
+        // Continue trying
+      }
+    }
+
+    // Create a report
+    await agent.post("/api/v3/reports").send({
+      conversation_id: conversationId,
+    });
+    await wait(2000);
+
+    // Get the report ID
+    const getReportsResponse: Response = await agent.get(
+      `/api/v3/reports?conversation_id=${conversationId}`
+    );
+    reportId = getReportsResponse.body[0].report_id;
+
+    // Get the rid from the report_id
+    const ridResult = await pool.query(
+      "SELECT rid FROM reports WHERE report_id = $1",
+      [reportId]
+    );
+    const rid = ridResult.rows[0].rid;
+
+    // Insert a report_comment_selections row to exclude the second comment
+    await pool.query(
+      `INSERT INTO report_comment_selections (zid, rid, tid, selection, modified)
+       VALUES ($1, $2, $3, -1, $4)`,
+      [zid, rid, excludedTid, Date.now()]
+    );
+  });
+
+  test("comments.csv should not contain excluded comment", async () => {
+    const response: Response = await testAgent.get(
+      `/api/v3/reportExport/${reportId}/comments.csv`
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/csv");
+
+    // Included comments should be present
+    for (const tid of includedTids) {
+      expect(response.text).toContain(`Export test comment ${comments.indexOf(tid) + 1}`);
+    }
+
+    // Excluded comment should be absent
+    expect(response.text).not.toContain("Export test comment 2");
+  });
+
+  test("votes.csv should not contain votes for excluded comment", async () => {
+    const response: Response = await testAgent.get(
+      `/api/v3/reportExport/${reportId}/votes.csv`
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/csv");
+
+    // Parse CSV rows (skip header)
+    const dataLines = response.text
+      .split("\n")
+      .slice(1)
+      .filter((line) => line.trim().length > 0);
+
+    // No row should have the excluded tid as comment-id
+    for (const line of dataLines) {
+      const cols = line.split(",");
+      const commentId = parseInt(cols[2]); // comment-id is the 3rd column
+      expect(commentId).not.toBe(excludedTid);
+    }
+
+    // Rows for included tids should exist
+    const tidsInExport = dataLines.map((line) => parseInt(line.split(",")[2]));
+    for (const tid of includedTids) {
+      expect(tidsInExport).toContain(tid);
+    }
+  });
+
+  test("participant-votes.csv should not contain column for excluded comment", async () => {
+    const response: Response = await testAgent.get(
+      `/api/v3/reportExport/${reportId}/participant-votes.csv`
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/csv");
+
+    const headerLine = response.text.split("\n")[0];
+    const headers = headerLine.split(",");
+
+    // Excluded tid should not appear as a column header
+    expect(headers).not.toContain(String(excludedTid));
+
+    // Included tids should appear as column headers
+    for (const tid of includedTids) {
+      expect(headers).toContain(String(tid));
+    }
+  });
+});

--- a/server/__tests__/unit/exportRoutes.test.ts
+++ b/server/__tests__/unit/exportRoutes.test.ts
@@ -2,7 +2,9 @@ import {
   formatCSVHeaders,
   formatCSVRow,
   formatCSV,
+  getExcludedTids,
   loadConversationSummary,
+  sendCommentSummary,
   sendVotesSummary,
   sendParticipantVotesSummary,
   sendParticipantXidsSummary,
@@ -744,6 +746,200 @@ describe("handle_GET_reportExport", () => {
       expect(mockRes.write).toHaveBeenCalledWith("3,,1,1,0,,0\n");
 
       expect(mockRes.end).toHaveBeenCalled();
+    });
+  });
+
+  describe("getExcludedTids", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should return an empty set when no report_comment_selections exist", async () => {
+      (pg.queryP_readOnly as jest.Mock).mockResolvedValueOnce([] as never);
+
+      const result = await getExcludedTids(123);
+
+      expect(result).toEqual(new Set());
+    });
+
+    it("should return tids with negative selection values", async () => {
+      (pg.queryP_readOnly as jest.Mock).mockResolvedValueOnce([
+        { tid: 5 },
+        { tid: 12 },
+      ] as never);
+
+      const result = await getExcludedTids(123);
+
+      expect(result).toEqual(new Set([5, 12]));
+    });
+
+    it("should pass the zid parameter to the query", async () => {
+      (pg.queryP_readOnly as jest.Mock).mockResolvedValueOnce([] as never);
+
+      await getExcludedTids(456);
+
+      expect(pg.queryP_readOnly).toHaveBeenCalledWith(
+        expect.stringContaining("report_comment_selections"),
+        [456]
+      );
+    });
+  });
+
+  describe("Excluded tids filtering", () => {
+    let mockRes: MockResponse;
+    const zid = 123;
+    const excludedTids = new Set([2]);
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRes = createMockResponse();
+    });
+
+    it("sendVotesSummary should skip rows with excluded tids", async () => {
+      const formatDatetimeSpy = jest.spyOn(
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require("../../src/report"),
+        "formatDatetime"
+      );
+      formatDatetimeSpy.mockReturnValue("2024-01-01T00:00:00Z");
+
+      (pg.queryP_readOnly as jest.Mock).mockResolvedValueOnce([
+        { importance_enabled: false },
+      ] as never);
+
+      mockStreamWithRows([
+        { timestamp: 1000000, tid: 1, pid: 1, vote: -1 },
+        { timestamp: 2000000, tid: 2, pid: 1, vote: 1 }, // excluded
+        { timestamp: 3000000, tid: 3, pid: 1, vote: -1 },
+      ]);
+
+      await sendVotesSummary(zid, mockRes as any, excludedTids);
+
+      // Should write header + two data rows (tid 2 excluded)
+      const writeArgs = mockRes.write.mock.calls.map(
+        (call: any[]) => call[0] as string
+      );
+      const dataRows = writeArgs.filter(
+        (s: string) => !s.startsWith("timestamp")
+      );
+      expect(dataRows).toHaveLength(2);
+      // Verify excluded tid is absent
+      expect(writeArgs.join("")).not.toContain(",2,"); // tid 2 should not appear as comment-id
+    });
+
+    it("sendCommentSummary should exclude comments with excluded tids", async () => {
+      // Mock conversations query (importance_enabled)
+      (pg.queryP_readOnly as jest.Mock).mockResolvedValueOnce([
+        { importance_enabled: false },
+      ] as never);
+
+      // Mock comments query
+      (pg.queryP_readOnly as jest.Mock).mockResolvedValueOnce([
+        { tid: 1, pid: 1, created: "1000000", txt: "Comment 1", mod: 0, velocity: 1, active: true },
+        { tid: 2, pid: 1, created: "2000000", txt: "Excluded comment", mod: 0, velocity: 1, active: true },
+        { tid: 3, pid: 2, created: "3000000", txt: "Comment 3", mod: 0, velocity: 1, active: true },
+      ] as never);
+
+      // Mock votes stream (for aggregation)
+      mockStreamWithRows([
+        { tid: 1, vote: -1, high_priority: false },
+        { tid: 3, vote: 1, high_priority: false },
+      ]);
+
+      await sendCommentSummary(zid, mockRes as any, excludedTids);
+
+      // The response should be sent via res.send with CSV text
+      expect(mockRes.send).toHaveBeenCalled();
+      const csvText = mockRes.send.mock.calls[0][0] as string;
+      expect(csvText).toContain("Comment 1");
+      expect(csvText).toContain("Comment 3");
+      expect(csvText).not.toContain("Excluded comment");
+    });
+
+    it("sendParticipantVotesSummary should exclude columns and votes for excluded tids", async () => {
+      // Mock comment data - loadParticipantExportContext filters these
+      (pg.queryP_readOnly as jest.Mock).mockResolvedValueOnce([
+        { tid: 1, pid: 1 },
+        { tid: 2, pid: 1 }, // excluded tid
+        { tid: 3, pid: 2 },
+      ] as never);
+
+      const basePcaData = {
+        "in-conv": [1, 2],
+        "base-clusters": {
+          members: [[1], [2]],
+          x: [0, 1],
+          y: [0, 1],
+          id: [0, 1],
+          count: [1, 1],
+        },
+        "group-clusters": [
+          { id: 1, center: [0, 0], members: [0] },
+          { id: 2, center: [1, 1], members: [1] },
+        ],
+        "user-vote-counts": { 1: 2, 2: 1 },
+      };
+
+      (getPca as jest.Mock).mockResolvedValue({
+        asPOJO: basePcaData,
+      } as never);
+
+      mockStreamWithRows([
+        { pid: 1, tid: 1, vote: -1 },
+        { pid: 1, tid: 2, vote: 1 }, // excluded
+        { pid: 2, tid: 3, vote: -1 },
+      ]);
+
+      await sendParticipantVotesSummary(zid, mockRes as any, excludedTids);
+
+      // Header should NOT include tid 2
+      const headerCall = mockRes.write.mock.calls[0][0] as string;
+      expect(headerCall).toContain(",1,3\n");
+      expect(headerCall).not.toContain(",2,");
+      expect(headerCall).not.toContain(",2\n");
+    });
+
+    it("sendParticipantImportance should exclude columns and votes for excluded tids", async () => {
+      // Mock comment data
+      (pg.queryP_readOnly as jest.Mock).mockResolvedValueOnce([
+        { tid: 1, pid: 1 },
+        { tid: 2, pid: 1 }, // excluded tid
+        { tid: 3, pid: 2 },
+      ] as never);
+
+      const basePcaData = {
+        "in-conv": [1, 2],
+        "base-clusters": {
+          members: [[1], [2]],
+          x: [0, 1],
+          y: [0, 1],
+          id: [0, 1],
+          count: [1, 1],
+        },
+        "group-clusters": [
+          { id: 1, center: [0, 0], members: [0] },
+          { id: 2, center: [1, 1], members: [1] },
+        ],
+        "user-vote-counts": { 1: 2, 2: 1 },
+      };
+
+      (getPca as jest.Mock).mockResolvedValue({
+        asPOJO: basePcaData,
+      } as never);
+
+      mockStreamWithRows([
+        { pid: 1, tid: 1, vote: -1, high_priority: true },
+        { pid: 1, tid: 2, vote: 1, high_priority: true }, // excluded
+        { pid: 2, tid: 3, vote: -1, high_priority: false },
+      ]);
+
+      await sendParticipantImportance(zid, mockRes as any, excludedTids);
+
+      // Header should NOT include tid 2
+      const headerCall = mockRes.write.mock.calls[0][0] as string;
+      expect(headerCall).toContain(",1,3\n");
+      expect(headerCall).not.toContain(",2,");
+      expect(headerCall).not.toContain(",2\n");
     });
   });
 });

--- a/server/src/report.ts
+++ b/server/src/report.ts
@@ -89,6 +89,25 @@ const sep = "\n";
 
 const formatEscapedText = (s: string) => `"${s.replace(/"/g, '""')}"`;
 
+/**
+ * Returns the set of tids that should be excluded from report exports for a conversation.
+ * When the same tid has conflicting selections across different reports (rids),
+ * the most recent entry (by modified timestamp) wins.
+ */
+export async function getExcludedTids(zid: number): Promise<Set<number>> {
+  const rows = (await pg.queryP_readOnly(
+    `SELECT tid FROM (
+      SELECT DISTINCT ON (tid) tid, selection
+      FROM report_comment_selections
+      WHERE zid = ($1)
+      ORDER BY tid, modified DESC
+    ) AS latest
+    WHERE selection < 0`,
+    [zid]
+  )) as { tid: number }[];
+  return new Set(rows.map((r) => r.tid));
+}
+
 type ParticipantExportContext = {
   commentIds: number[];
   commentIdSet: Set<number>;
@@ -176,7 +195,8 @@ function createGroupIdResolver(
 }
 
 async function loadParticipantExportContext(
-  zid: number
+  zid: number,
+  excludedTids?: Set<number>
 ): Promise<ParticipantExportContext> {
   const [commentRowsRaw, pca] = await Promise.all([
     pg.queryP_readOnly(
@@ -186,7 +206,11 @@ async function loadParticipantExportContext(
     getPca(zid),
   ]);
 
-  const commentRows = (commentRowsRaw as { tid: number; pid: number }[]) || [];
+  const allCommentRows =
+    (commentRowsRaw as { tid: number; pid: number }[]) || [];
+  const commentRows = excludedTids?.size
+    ? allCommentRows.filter((r) => !excludedTids.has(r.tid))
+    : allCommentRows;
 
   const commentIds = commentRows.map((row) => row.tid);
   const commentIdSet = new Set(commentIds);
@@ -290,7 +314,11 @@ export async function sendConversationSummary(
   res.send(rows.join(sep));
 }
 
-export async function sendCommentSummary(zid: number, res: ResponseLike) {
+export async function sendCommentSummary(
+  zid: number,
+  res: ResponseLike,
+  excludedTids?: Set<number>
+) {
   const comments = new Map<number, CommentRow>();
 
   try {
@@ -303,10 +331,13 @@ export async function sendCommentSummary(zid: number, res: ResponseLike) {
       convRows.length > 0 ? convRows[0].importance_enabled : false;
 
     // First query: Load comments metadata
-    const commentRows = (await pg.queryP_readOnly(
+    const allCommentRows = (await pg.queryP_readOnly(
       "SELECT tid, pid, created, txt, mod, velocity, active FROM comments WHERE zid = ($1)",
       [zid]
     )) as CommentRow[];
+    const commentRows = excludedTids?.size
+      ? allCommentRows.filter((c) => !excludedTids.has(c.tid))
+      : allCommentRows;
     for (const comment of commentRows) {
       comment.agrees = 0;
       comment.disagrees = 0;
@@ -333,8 +364,6 @@ export async function sendCommentSummary(zid: number, res: ResponseLike) {
           if (importanceEnabled && row.high_priority) {
             comment.importance = (comment.importance || 0) + 1;
           }
-        } else {
-          logger.warn(`Comment row not found for [zid=${zid}, tid=${row.tid}]`);
         }
       },
       () => {
@@ -374,7 +403,11 @@ export async function sendCommentSummary(zid: number, res: ResponseLike) {
   }
 }
 
-export async function sendVotesSummary(zid: number, res: ResponseLike) {
+export async function sendVotesSummary(
+  zid: number,
+  res: ResponseLike,
+  excludedTids?: Set<number>
+) {
   try {
     // Check if importance is enabled for this conversation
     const convRows = (await pg.queryP_readOnly(
@@ -409,10 +442,12 @@ export async function sendVotesSummary(zid: number, res: ResponseLike) {
     pg.stream_queryP_readOnly(
       selectClause,
       [zid],
-      (row) => res.write(formatCSVRow(row, formatters) + sep),
+      (row) => {
+        if (excludedTids?.has(row.tid)) return;
+        res.write(formatCSVRow(row, formatters) + sep);
+      },
       () => res.end(),
       (error) => {
-        // Handle any errors
         logger.error("polis_err_report_votes_csv", error);
         failJson(res, 500, "polis_err_data_export", error);
       }
@@ -425,10 +460,11 @@ export async function sendVotesSummary(zid: number, res: ResponseLike) {
 
 export async function sendParticipantVotesSummary(
   zid: number,
-  res: ResponseLike
+  res: ResponseLike,
+  excludedTids?: Set<number>
 ) {
   const { commentIds, participantCommentCounts, getGroupId } =
-    await loadParticipantExportContext(zid);
+    await loadParticipantExportContext(zid, excludedTids);
 
   res.setHeader("content-type", "text/csv");
   res.write(
@@ -475,6 +511,7 @@ export async function sendParticipantVotesSummary(
     "SELECT pid, tid, vote FROM votes WHERE zid = ($1) ORDER BY pid, tid",
     [zid],
     (row) => {
+      if (excludedTids?.has(row.tid)) return;
       const pid: number = row.pid;
       if (pid != currentParticipantId) {
         if (currentParticipantId != -1) {
@@ -501,7 +538,8 @@ export async function sendParticipantVotesSummary(
 
 export async function sendParticipantImportance(
   zid: number,
-  res: ResponseLike
+  res: ResponseLike,
+  excludedTids?: Set<number>
 ) {
   // Export participant importance data as CSV matrix
   // Columns: participant, group-id, n-comments, n-votes, n-important, [comment-id...]
@@ -510,7 +548,7 @@ export async function sendParticipantImportance(
   //   "0" - participant voted on this comment with high_priority = false
   //   "" (empty) - participant did not vote on this comment
   const { commentIds, commentIdSet, participantCommentCounts, getGroupId } =
-    await loadParticipantExportContext(zid);
+    await loadParticipantExportContext(zid, excludedTids);
 
   res.setHeader("content-type", "text/csv");
   res.write(
@@ -608,7 +646,8 @@ export async function sendCommentGroupsSummary(
     comment_extremity?: number;
     comment_id: number;
     num_groups: number;
-  }) => boolean
+  }) => boolean,
+  excludedTids?: Set<number>
 ) {
   const csvText = [];
   // Get PCA data to identify groups and get groupVotes
@@ -753,6 +792,8 @@ export async function sendCommentGroupsSummary(
 
   // Write data rows
   for (const stats of commentStats.values()) {
+    if (excludedTids?.has(stats.tid)) continue;
+
     const row = [
       stats.tid,
       formatEscapedText(stats.txt),
@@ -803,13 +844,17 @@ export async function sendCommentGroupsSummary(
 
 export async function sendCommentClustersSummary(
   zid: number,
-  res: ResponseLike
+  res: ResponseLike,
+  excludedTids?: Set<number>
 ) {
   try {
     logger.info(`Generating comment-clusters export for zid ${zid}`);
 
     // Get comments with cluster assignments
-    const comments = await getCommentsWithClusters(zid);
+    const allComments = await getCommentsWithClusters(zid);
+    const comments = excludedTids?.size
+      ? allComments.filter((c) => !excludedTids.has(c.tid))
+      : allComments;
 
     if (comments.length === 0) {
       logger.warn(`No comments found for zid ${zid}`);

--- a/server/src/routes/export.ts
+++ b/server/src/routes/export.ts
@@ -12,6 +12,7 @@ import {
   sendConversationSummary,
   sendParticipantXidsSummary,
   sendCommentSummary,
+  getExcludedTids,
 } from "../report";
 import logger from "../utils/logger";
 
@@ -30,6 +31,8 @@ export async function handle_GET_reportExport(
       return;
     }
 
+    const excludedTids = await getExcludedTids(zid);
+
     switch (report_type) {
       case "summary.csv": {
         const siteUrl = `${req.headers["x-forwarded-proto"]}://${req.headers.host}`;
@@ -38,27 +41,27 @@ export async function handle_GET_reportExport(
       }
 
       case "comments.csv":
-        await sendCommentSummary(zid, res);
+        await sendCommentSummary(zid, res, excludedTids);
         break;
 
       case "votes.csv":
-        await sendVotesSummary(zid, res);
+        await sendVotesSummary(zid, res, excludedTids);
         break;
 
       case "participant-votes.csv":
-        await sendParticipantVotesSummary(zid, res);
+        await sendParticipantVotesSummary(zid, res, excludedTids);
         break;
 
       case "participant-importance.csv":
-        await sendParticipantImportance(zid, res);
+        await sendParticipantImportance(zid, res, excludedTids);
         break;
 
       case "comment-groups.csv":
-        await sendCommentGroupsSummary(zid, res);
+        await sendCommentGroupsSummary(zid, res, true, undefined, excludedTids);
         break;
 
       case "comment-clusters.csv":
-        await sendCommentClustersSummary(zid, res);
+        await sendCommentClustersSummary(zid, res, excludedTids);
         break;
 
       default:


### PR DESCRIPTION
follow-up to https://github.com/compdemocracy/polis/pull/2338

excludes flagged comments from server csv exports, per `report_comment_selections` table

same behavior as we already use in delphi