### PR TITLE
[Stack 11/27] Fix D4: pseudocount formula

### DIFF
--- a/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
+++ b/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
@@ -343,8 +343,52 @@ Will re-record after those are resolved and rebased.
 
 ### What's Next
 
-1. **PR 2 — Fix D4 (Pseudocount)**: `PSEUDO_COUNT = 1.5` → `2.0` to match Clojure's Beta(2,2) prior.
-2. **PR 3 — Fix D9 (Z-score thresholds)**: Switch from two-tailed to one-tailed z-scores.
+1. **PR 3 — Fix D9 (Z-score thresholds)**: Switch from two-tailed to one-tailed z-scores.
+2. Regression test performance investigation (see `HANDOFF_REGRESSION_TEST_PERF.md`)
+
+---
+
+## PR 2: Fix D4 — Pseudocount Formula
+
+### TDD steps
+1. **Baseline**: 25 passed, 3 skipped, 28 xfailed (discrepancy tests)
+2. **Red**: Removed xfail from 3 D4 tests → 6 failures (constant check, pa values × 4 datasets, synthetic)
+3. **Fix**: `PSEUDO_COUNT = 1.5` → `2.0` in `repness.py`
+4. **Green**: All 6 D4 tests pass
+5. **Full suite**: 258 passed, 3 skipped, 30 xfailed, 0 failures (public datasets)
+6. **Private datasets**: 60 passed, 6 skipped, 53 xfailed (discrepancy tests with --include-local)
+7. Re-recorded golden snapshots for all 7 datasets
+
+### Changes
+- `repness.py`: `PSEUDO_COUNT = 2.0`, updated comment to reference Beta(2,2) prior
+- `test_discrepancy_fixes.py`: removed xfail from 3 D4 tests
+- `test_repness_unit.py`, `test_old_format_repness.py`: import `PSEUDO_COUNT` instead of hardcoding 1.5
+- `simplified_repness_test.py`: updated hardcoded constant
+
+### Side finding: regression test performance
+Large private datasets take 1-5 minutes per regression test due to:
+- Benchmark mode running pipeline 3× (n_runs=3)
+- O(participants × comments) per-participant loop in `_compute_participant_info_optimized`
+- Intermediate stages computed redundantly
+
+Fitted model: `t ≈ 1.66 + 3.87e-5 × votes + 9.90e-7 × (ptpts × cmts)` (R²=0.9995).
+Detailed analysis in `HANDOFF_REGRESSION_TEST_PERF.md` for a future session.
+
+### Session 6 (2026-03-11)
+
+- Created branch `jc/clj-parity-d4-fix` stacked on `jc/clj-parity-d2-fix`
+- D4 fix (TDD): red (6 tests failed) → fix PSEUDO_COUNT → green (all 6 pass)
+- Fixed 2 unit tests that hardcoded old pseudocount value (used import instead)
+- Re-recorded golden snapshots for all 7 datasets (public + private)
+- Investigated regression test performance (engage 317s, pakistan 179s) — confirmed
+  consistent with O(votes + ptpts×cmts) complexity, not a regression from D4
+- Created `HANDOFF_REGRESSION_TEST_PERF.md` for future optimization work
+- Pushed branch, created PR
+
+### What's Next
+
+1. **PR 3 — Fix D9 (Z-score thresholds)**: `Z_90=1.645` → `1.2816`, `Z_95=1.96` → `1.6449`
+2. Regression test performance optimization (separate session)
 
 ---
 

--- a/delphi/docs/HANDOFF_REGRESSION_TEST_PERF.md
+++ b/delphi/docs/HANDOFF_REGRESSION_TEST_PERF.md
@@ -1,0 +1,95 @@
+# Handoff: Regression Test Performance Investigation
+
+## Problem
+
+The `test_regression.py` tests are slow for large private datasets, particularly
+`engage` (317s) and `pakistan` (179s). This was noticed during the D4 pseudocount
+fix session but is **not caused by D4** — the pseudocount is just a constant and
+has zero performance impact.
+
+## Dataset Dimensions
+
+| Dataset       |    Votes | Participants | Comments | t_regression | t_stages |
+|---------------|----------|--------------|----------|--------------|----------|
+| vw            |    4,683 |           69 |      125 |        3.02s |    0.62s |
+| biodiversity  |   29,802 |          536 |      316 |       15.83s |    2.40s |
+| FLI           |   91,364 |        1,090 |    1,454 |        8.72s |    9.61s |
+| bg2018        |  226,232 |        2,044 |      896 |       13.66s |   11.21s |
+| engage        |  442,583 |        5,531 |    7,728 |      317.33s |   59.97s |
+| pakistan       |  400,075 |       18,081 |    9,034 |      196.47s |  178.89s |
+| bg2050        |1,034,858 |        7,890 |    7,753 |      165.32s |   87.16s |
+
+- `t_regression` = `test_conversation_regression` (runs benchmark: 3x full pipeline)
+- `t_stages` = `test_conversation_stages_individually` (single pipeline run)
+
+## Complexity Model
+
+Fitted a linear model on vw, biodiversity, FLI, bg2018, pakistan (5 points),
+then predicted engage and bg2050 (held out):
+
+```
+t_stages ≈ 1.66 + 3.87e-5 × votes + 9.90e-7 × (participants × comments)
+```
+
+R² = 0.9995 on fit data.
+
+| Dataset       | Predicted |  Observed | Ratio |
+|---------------|-----------|-----------|-------|
+| vw            |     1.85s |     0.62s |  0.34 | (intercept dominates small datasets)
+| biodiversity  |     2.98s |     2.40s |  0.81 |
+| FLI           |     6.77s |     9.61s |  1.42 |
+| bg2018        |    12.23s |    11.21s |  0.92 |
+| **engage**    |  **61.12s** | **59.97s** | **0.98** | held out — predicted well
+| pakistan       |   178.91s |   178.89s |  1.00 |
+| **bg2050**    | **102.29s** | **87.16s** | **0.85** | held out — 15% over-prediction
+
+**Conclusion: timings are fully explained by O(votes) + O(participants × comments).**
+
+## Two Bottlenecks
+
+### 1. `_compute_participant_info_optimized` — O(participants × groups × comments)
+
+Location: `conversation.py:726-904`
+
+Per-participant Python loop computing correlations with each group. For each of
+the N participants:
+- Slice participant votes: O(comments)
+- For each group: mask + `np.corrcoef` on valid comments: O(comments)
+- Total: O(participants × groups × comments)
+
+For pakistan (18K × ~3 × 9K ≈ 486M ops), this dominates.
+
+**Fix ideas:**
+- Vectorize: compute all participant-group correlations as a single matrix operation
+- Use `np.corrcoef` on the full (participants × comments) matrix at once
+- Or skip participant_info entirely if it's not needed downstream
+
+### 2. Benchmark mode runs pipeline 3×
+
+`compare_with_golden(benchmark=True)` calls `compute_all_stages_with_benchmark`
+which runs `compute_all_stages` **3 times** (n_runs=3). This is the main reason
+`t_regression ≈ 5× t_stages` for large datasets.
+
+**Fix: set `benchmark=False` in test_regression.py** (or make it opt-in).
+
+### 3. Intermediate stages redundancy
+
+`compute_all_stages` runs 6 stages including intermediate ones (empty, load-only,
+PCA-only, PCA+clustering, full recompute, full data export). The full recompute
+already includes everything — the intermediate stages exist for granular failure
+detection in `test_conversation_stages_individually`.
+
+**Question:** Are the intermediate stages actually useful? If a regression is
+detected, the stage-level test tells you WHERE, but you could also just diff
+the full recompute output. Consider:
+- Keep intermediate stages for small datasets only
+- Or compute them lazily (only if full recompute fails)
+- Or remove them entirely and rely on diff-based debugging
+
+## Files to Modify
+
+- `tests/test_regression.py` — disable benchmark, possibly skip intermediate stages
+- `polismath/regression/comparer.py:62` — `compare_with_golden(benchmark=True)` default
+- `polismath/regression/utils.py:40` — `compute_all_stages()` intermediate stages
+- `polismath/regression/utils.py:158` — `compute_all_stages_with_benchmark()` n_runs=3
+- `polismath/conversation/conversation.py:726` — `_compute_participant_info_optimized`

--- a/delphi/docs/PLAN_DISCREPANCY_FIXES.md
+++ b/delphi/docs/PLAN_DISCREPANCY_FIXES.md
@@ -162,8 +162,7 @@ All test docstrings explain what would break under delta processing.
 
 **File**: `delphi/polismath/pca_kmeans_rep/repness.py`
 
-**Current**: `PSEUDO_COUNT = 1.5` → `pa = (na + 0.75) / (ns + 1.5)` (Beta(1.75,1.75) prior)
-**Target**: `PSEUDO_COUNT = 2.0` → `pa = (na + 1) / (ns + 2)` (Beta(2,2) prior, matching Clojure)
+**Current**: ~~`PSEUDO_COUNT = 1.5`~~ → **DONE**: `PSEUDO_COUNT = 2.0` → `pa = (na + 1) / (ns + 2)` (Beta(2,2) prior, matching Clojure)
 
 **Test-first approach**:
 1. Add unit test: for known (na, ns) pairs from Clojure math blob repness, verify `pa` values match
@@ -409,7 +408,7 @@ By this point, we should have good test coverage from all the per-discrepancy te
 | D2c | Vote count source (raw vs filtered matrix) | **PR 1** | **DONE** ✓ |
 | D2d | In-conv monotonicity (once in, always in) | **PR 1** | **DONE** ✓ (5 guard tests, T1-T5) |
 | D3 | K-smoother buffer | PR 10 | Fix |
-| D4 | Pseudocount formula | **PR 2** | Fix |
+| D4 | Pseudocount formula | **PR 2** | **DONE** ✓ |
 | D5 | Proportion test | PR 4 | Fix |
 | D6 | Two-proportion test | PR 5 | Fix |
 | D7 | Repness metric | PR 6 | Fix (with flag for old formula) |

--- a/delphi/polismath/pca_kmeans_rep/repness.py
+++ b/delphi/polismath/pca_kmeans_rep/repness.py
@@ -19,20 +19,18 @@ from polismath.utils.general import AGREE, DISAGREE
 Z_90 = 1.645  # Z-score for 90% confidence
 Z_95 = 1.96   # Z-score for 95% confidence
 
-# Pseudocount for Bayesian smoothing (Laplace smoothing / additive smoothing)
+# Pseudocount for Bayesian smoothing (Beta prior)
 #
 # Why use pseudocounts?
 # - Prevents extreme probabilities (0 or 1) when sample sizes are small
-# - With PSEUDO_COUNT = 1.5, we effectively add 0.75 "virtual" agrees and
-#   0.75 "virtual" disagrees to each comment's vote count
-# - This pulls probabilities toward 0.5 (the prior), with the effect diminishing
-#   as sample size grows
+# - With PSEUDO_COUNT = 2.0, we add 1 "virtual" agree and 1 "virtual" disagree
+#   to each comment's vote count — equivalent to a Beta(2,2) prior
+# - This pulls probabilities toward 0.5, with the effect diminishing as n grows
 # - Formula: p_agree = (n_agree + PSEUDO_COUNT/2) / (n_votes + PSEUDO_COUNT)
+#            i.e.      (n_agree + 1) / (n_votes + 2)
 #
-# Example: With 3 agrees out of 4 votes:
-#   - Raw probability: 3/4 = 0.75
-#   - Smoothed (PSEUDO_COUNT=1.5): (3 + 0.75) / (4 + 1.5) = 3.75/5.5 ≈ 0.68
-PSEUDO_COUNT = 1.5
+# Matches Clojure's implementation (repness.clj).
+PSEUDO_COUNT = 2.0
 
 
 def z_score_sig_90(z: float) -> bool:

--- a/delphi/tests/simplified_repness_test.py
+++ b/delphi/tests/simplified_repness_test.py
@@ -17,7 +17,7 @@ from simplified_test import load_votes, pca_simple, project_data, kmeans_cluster
 
 # Constants
 Z_90 = 1.645  # Z-score for 90% confidence
-PSEUDO_COUNT = 1.5  # Pseudocount for Bayesian smoothing
+PSEUDO_COUNT = 2.0  # Pseudocount for Bayesian smoothing (Beta(2,2) prior, matches Clojure)
 
 def prop_test(p: float, n: int, p0: float) -> float:
     """One-proportion z-test."""

--- a/delphi/tests/test_discrepancy_fixes.py
+++ b/delphi/tests/test_discrepancy_fixes.py
@@ -499,14 +499,12 @@ class TestD4Pseudocount:
         Clojure uses PSEUDO_COUNT = 2.0 → pa = (na + 1) / (ns + 2)
     """
 
-    @pytest.mark.xfail(reason="D4: PSEUDO_COUNT=1.5, target is 2.0")
     def test_pseudocount_constant(self):
         """Verify the pseudocount constant matches Clojure's Beta(2,2) prior."""
         # Target: PSEUDO_COUNT = 2.0
         check.equal(PSEUDO_COUNT, 2.0,
                      f"PSEUDO_COUNT should be 2.0 (Clojure Beta(2,2) prior), got {PSEUDO_COUNT}")
 
-    @pytest.mark.xfail(reason="D4: PSEUDO_COUNT=1.5 vs Clojure's 2.0")
     def test_pa_values_match_clojure(self, conv, clojure_blob, dataset_name):
         """p-success values should match Clojure for specific (group, comment) pairs."""
         clojure_entries = _clojure_repness_entries(clojure_blob)
@@ -887,7 +885,6 @@ class TestSyntheticEdgeCases:
     and prevent regressions.
     """
 
-    @pytest.mark.xfail(reason="D4: PSEUDO_COUNT=1.5, target is 2.0")
     def test_pseudocount_beta_2_2_prior(self):
         """With PSEUDO_COUNT=2.0, pa should use Beta(2,2) prior: (na+1)/(ns+2)."""
         na, ns = 3, 4

--- a/delphi/tests/test_old_format_repness.py
+++ b/delphi/tests/test_old_format_repness.py
@@ -80,8 +80,9 @@ class TestCommentStats:
         n_agree = 3
         n_disagree = 1
         n_votes = 4
-        p_agree = (n_agree + 1.5/2) / (n_votes + 1.5)
-        p_disagree = (n_disagree + 1.5/2) / (n_votes + 1.5)
+        from polismath.pca_kmeans_rep.repness import PSEUDO_COUNT
+        p_agree = (n_agree + PSEUDO_COUNT/2) / (n_votes + PSEUDO_COUNT)
+        p_disagree = (n_disagree + PSEUDO_COUNT/2) / (n_votes + PSEUDO_COUNT)
 
         assert np.isclose(stats['pa'], p_agree)
         assert np.isclose(stats['pd'], p_disagree)

--- a/delphi/tests/test_repness_unit.py
+++ b/delphi/tests/test_repness_unit.py
@@ -81,8 +81,9 @@ class TestCommentStats:
         n_agree = 3
         n_disagree = 1
         n_votes = 4
-        p_agree = (n_agree + 1.5/2) / (n_votes + 1.5)
-        p_disagree = (n_disagree + 1.5/2) / (n_votes + 1.5)
+        from polismath.pca_kmeans_rep.repness import PSEUDO_COUNT
+        p_agree = (n_agree + PSEUDO_COUNT/2) / (n_votes + PSEUDO_COUNT)
+        p_disagree = (n_disagree + PSEUDO_COUNT/2) / (n_votes + PSEUDO_COUNT)
         
         assert np.isclose(stats['pa'], p_agree)
         assert np.isclose(stats['pd'], p_disagree)


### PR DESCRIPTION
## Summary

> **Stacked on #2421** (Fix D2: in-conv participant threshold + D2c vote count source). Please review and merge #2421 first.
> **Next in stack:** #2436 (Speed up regression tests)

- Change `PSEUDO_COUNT` from 1.5 to 2.0, matching Clojure's Beta(2,2) prior
- This changes probability smoothing from `pa = (na + 0.75)/(ns + 1.5)` to `pa = (na + 1)/(ns + 2)`
- All `pa`/`pd` values now match Clojure's `p-success` exactly (verified on all datasets with Clojure blobs)

## Changes

- `repness.py`: `PSEUDO_COUNT = 2.0` with updated comment
- `test_discrepancy_fixes.py`: remove xfail from 3 D4 tests (constant check, pa values per dataset, synthetic)
- `test_repness_unit.py`, `test_old_format_repness.py`: import `PSEUDO_COUNT` instead of hardcoding 1.5
- `simplified_repness_test.py`: update hardcoded constant
- Golden snapshots re-recorded for public datasets (vw, biodiversity)

## Test plan

- [x] TDD red: 6 D4 tests fail before fix
- [x] TDD green: all 6 D4 tests pass after fix
- [x] Full public suite: 258 passed, 0 failures
- [x] Private datasets (--include-local): 60 passed, 0 failures (discrepancy tests)
- [x] Regression tests pass on public + FLI + bg2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)