### PR TITLE
[Stack 2/25] CI: run server and E2E tests on PRs targeting jc/** branches

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [ edge, stable ]
   pull_request:
-    branches: [ edge, stable ]
+    branches:
+      - edge
+      - stable
+      - 'jc/**'
 
 jobs:
   cypress-run:

--- a/.github/workflows/jest-server-test.yml
+++ b/.github/workflows/jest-server-test.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [ edge, stable ]
   pull_request:
-    branches: [ edge, stable ]
+    branches:
+      - edge
+      - stable
+      - 'jc/**'
 
 jobs:
   server-integration-tests:


### PR DESCRIPTION
## Summary

> **Next in stack:** #2418 (Clojure comparison test consolidation and cleanup)

- Add `jc/**` to `pull_request.branches` in `jest-server-test.yml` and `cypress-tests.yml`
- Stacked PRs target `jc/*` branches, not `edge`/`stable`, so server integration tests and Cypress E2E tests were not running on them
- `python-ci.yml` already has this from a prior change; this brings the other two heavy CI workflows in line

## Test plan

- [x] Verify workflow YAML is valid
- [ ] Confirm server and E2E tests trigger on next stack PR push

Generated with [Claude Code](https://claude.com/claude-code)