### PR TITLE
Fix flaky treevite test: accept both invite-used error codes

### DIFF
--- a/.spr.yml
+++ b/.spr.yml
@@ -1,0 +1,17 @@
+githubRepoOwner: compdemocracy
+githubRepoName: polis
+githubHost: github.com
+githubRemote: origin
+githubBranch: main
+requireChecks: true
+requireApproval: true
+defaultReviewers: []
+mergeMethod: rebase
+mergeQueue: false
+prTemplateType: stack
+forceFetchTags: false
+multiCommitPRs: false
+concatCommitMessages: true
+showPrTitlesInStack: false
+showStackNumberInTitle: false
+branchPushIndividually: false

--- a/server/__tests__/integration/treevite.test.ts
+++ b/server/__tests__/integration/treevite.test.ts
@@ -961,11 +961,17 @@ describe("Treevite API endpoints", () => {
           invite_code: inviteCode1, // Using same code as agent1
         });
 
-      // Should fail with already used error
+      // Should fail because the invite is already used. Two error codes are
+      // possible depending on timing:
+      // - "invalid_or_used_invite": the SELECT finds status=1 (already committed)
+      // - "invite_race_condition": the SELECT finds status=0 but the UPDATE
+      //   returns no rows (concurrent commit between SELECT and UPDATE)
+      // See #2489 for the underlying orphaned-user bug in the race_condition path.
       expect(response2.status).toBe(400);
       if (response2.body && response2.body.error) {
         expect(response2.body.error).toMatch(
-          /polis_err_treevite_invalid_or_used_invite/
+          /polis_err_treevite_invalid_or_used_invite|polis_err_treevite_invite_race_condition/
+        );
         );
       }
 

--- a/server/__tests__/integration/treevite.test.ts
+++ b/server/__tests__/integration/treevite.test.ts
@@ -972,6 +972,9 @@ describe("Treevite API endpoints", () => {
         expect(response2.body.error).toMatch(
           /polis_err_treevite_invalid_or_used_invite|polis_err_treevite_invite_race_condition/
         );
+      } else {
+        expect(response2.text).toMatch(
+          /polis_err_treevite_invalid_or_used_invite|polis_err_treevite_invite_race_condition/
         );
       }
 


### PR DESCRIPTION
## Summary

Fix flaky treevite test "should handle multiple participants trying to use same invite".

The test expects `polis_err_treevite_invalid_or_used_invite` when a second request tries to use an already-accepted invite. But depending on timing, the server can return `polis_err_treevite_invite_race_condition` instead — both are valid 400 responses meaning "invite already used."

### Root cause

The server has two code paths for rejecting a reused invite (`treevites.ts`):
- **SELECT finds `status=1`** (invite already committed as used) → `invalid_or_used_invite`
- **SELECT finds `status=0` but UPDATE returns no rows** (concurrent commit between SELECT and UPDATE) → `invite_race_condition`

Which path fires depends on whether the first request's COMMIT is visible by the time the second request's SELECT runs.

### Fix

Widen the test assertion to accept either error code.

### Related

See #2489 for the underlying bug: the `invite_race_condition` path creates orphaned user/participant records that are never cleaned up.

## Test plan

- [x] `treevite.test.ts` passes locally
- [ ] CI passes
