### PR TITLE
Fix D2: in-conv participant threshold + D2c vote count source

### DIFF
--- a/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
+++ b/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
@@ -104,16 +104,121 @@ After rebase onto updated `origin/kmeans_analysis_docs`:
 
 ---
 
-## What's Next: PR 1 — Fix D2 (In-Conv Participant Threshold)
+## PR 1: Fix D2 — In-Conv Participant Threshold (blocked on Clojure blob regeneration)
 
-- Change `threshold = 7 + sqrt(n_cmts) * 0.1` to `threshold = min(7, n_cmts)` in `conversation.py:1238`
-- Use `self.raw_rating_mat` instead of `self.rating_mat` for counting
-- Add greedy fallback (top-15 voters if <15 qualify)
-- Add monotonic persistence (once in, always in)
-- Remove xfail from `TestD2InConvThreshold`
-- Check cluster count impact (may change from 3→2 for biodiversity, matching Clojure)
-- Re-record golden snapshots if needed
-- Document new baseline
+### TDD steps
+1. **Baseline (public only)**: 3 failed (2 D2 + 1 DynamoDB), 205 passed, 4 skipped, 20 xfailed, 3 xpassed
+2. **Red**: Removed xfail from `TestD2InConvThreshold` — biodiversity fails (Python=428, Clojure=441, threshold 8.8 vs 7)
+3. **Fix**: Changed `threshold = 7 + sqrt(n_cmts) * 0.1` → `threshold = min(7, n_cmts)` in `conversation.py:1270`
+4. **Green (public only)**: All 4 D2 tests pass (vw + biodiversity × 2 tests each)
+5. **Full suite (public only)**: 1 failed (DynamoDB only), 207 passed — but golden snapshots were re-recorded for biodiversity without proper verification
+6. **Full suite (with private datasets)**: 15 failed, 6 errors — regression tests fail for private datasets (golden snapshots stale), `engage` dataset has duplicate vote files
+7. Investigated regression failures — all caused by expected threshold change. Re-recorded after verification.
+8. **Blocker**: 3 private datasets have incomplete Clojure blobs (no in-conv data). D2 tests fail on those — not a code issue. Delegated blob regeneration to separate session.
+
+### Investigation of regression failures
+- Private dataset golden snapshots were never committed (unstaged in .local repo) — reverted automatically
+- biodiversity: re-recorded after verifying D2 in-conv set matches Clojure exactly (428→441 participants)
+- Private datasets: threshold dropped significantly for large conversations:
+  - bg2050 (7753 comments): old threshold ≈ 15.8, new threshold = 7 → 6609/7890 qualify (was fewer)
+  - This is the expected and correct effect of the D2 fix
+- **Gotcha**: `--datasets <name>` alone won't find private datasets — must also pass `--include-local`!
+  Without it, private datasets are silently skipped (shown as `[NOTSET]`).
+- Golden snapshots re-recorded for FLI, bg2018, pakistan, bg2050 after verifying all regression
+  failures are downstream of the expected threshold change. Committed in `.local` repo on
+  branch `series-of-fixes`.
+
+### Incomplete Clojure blobs (RESOLVED)
+
+3 private datasets have incomplete Clojure cold-start blobs (4 keys instead of 23):
+- Missing `in-conv`, `repness`, `consensus`, `comment-priorities`, etc.
+- Root cause: the Clojure math worker relies on incremental processing and cannot
+  analyse these large conversations in a single cold-start pass.
+- The 4 remaining datasets (vw, biodiversity, FLI, bg2018) have complete cold-start blobs (23 keys)
+
+**Resolution (session 4)**: Instead of regenerating blobs, we now test against both
+incremental and cold-start blob types. `get_blob_variants()` discovers which blob types
+have meaningful content per dataset (via `_is_blob_filled()`). Tests on datasets with
+empty cold-start blobs only run against the incremental blob. D2 in-conv tests on
+incremental blobs are xfailed (see session 4 notes). No blob regeneration needed.
+
+### What was NOT needed (revised — see D2c/D2d below)
+- ~~`raw_rating_mat` vs `rating_mat` — not needed~~ **WRONG**: See D2c below, this IS needed.
+- Greedy fallback / monotonic persistence — not needed for cold-start parity, but monotonicity tests needed for future-proofing (see D2d).
+
+### D2c: Vote count source — raw vs filtered matrix (discovered in session 3)
+
+Deep investigation of Clojure vs Python revealed a **structural discrepancy** in how
+votes are counted for the in-conv threshold, independent of delta vs full processing:
+
+| Aspect | Clojure | Python (current) |
+|--------|---------|-----------------|
+| Vote counts per participant | From `raw-rating-mat` (conversation.clj:217-225) — includes votes on moderated-out comments | From `self.rating_mat` (conversation.py:1226/1244) — excludes moderated-out columns |
+| `n_cmts` (threshold cap) | From `rating-mat` (conversation.clj:214-215) — columns zeroed but still present, so count includes moderated-out | From `self.rating_mat` (conversation.py:1268) — moderated-out columns removed entirely |
+
+Key insight: Clojure's `zero-out-columns` (named_matrix.clj:214-228) sets moderated-out
+column values to 0 but **keeps the columns** in `rating-mat`. Python's `_apply_moderation`
+(conversation.py:308) **removes columns entirely**. This means both `user-vote-counts`
+and `n-cmts` differ between implementations.
+
+**Fix**: Both `_compute_user_vote_counts` and `n_cmts` must use `self.raw_rating_mat`.
+Two xfail unit tests planned (vote count source + n_cmts threshold).
+
+### D2d: In-conv monotonicity — full recompute vs persistence (discovered in session 3)
+
+Investigated whether Python needs to persist in-conv to DynamoDB (like Clojure persists to
+`math_main`). Finding: **no, full recompute is better**.
+
+Clojure persists in-conv (conv_man.clj:55) because it uses delta vote processing. Python
+rebuilds `raw_rating_mat` from all votes every time. Since votes are immutable in PostgreSQL
+(can be updated, never deleted), a participant's vote count never decreases → monotonicity
+is a free consequence of full recompute from `raw_rating_mat`.
+
+**Decision**: No DynamoDB persistence. Instead, 6 tests (T1-T6) guard the monotonicity
+invariant, each documenting that switching to delta processing would require adding
+persistence. See plan PR 1bis for test details. Ref: compdemocracy/polis#2358.
+
+### D2b: Base-cluster sort order (added from Copilot review)
+
+Copilot flagged that Python sorts base clusters by size (descending) and reassigns IDs,
+while Clojure uses `(sort-by :id ...)` which preserves k-means' original cluster IDs.
+The size-sort changes the encounter order of base-cluster centers fed into group-level
+k-means (which uses first-k-distinct initialization), potentially diverging from Clojure.
+
+**Fix**: Removed size-sort and ID reassignment; now sort by k-means ID (ascending),
+matching Clojure's `sort-by :id`.
+
+### Test results for PR 1
+
+```
+17 passed, 16 skipped, 31 xfailed, 7 xpassed, 4 errors (with --include-local, 7 datasets)
+```
+
+- **17 passed**: D2 tests pass on 4 datasets with complete blobs (8 tests) + formula sanity checks + blob consistency
+- **16 skipped**: D2 skipped on 3 datasets with incomplete Clojure blobs + D15 moderation + engage errors
+- **31 xfailed**: Remaining discrepancy tests (D4-D12)
+- **7 xpassed** (all `strict=False`, so green):
+  - D6 two_prop_test × 1 — pseudocount difference too small for this test case
+  - D9 repness_not_empty × 6 — test too weak (checks non-empty, not correct count)
+- **4 errors**: engage dataset has duplicate vote files (pre-existing data issue)
+
+### Golden snapshot re-recording (BLOCKED)
+
+After D2b fix, regression tests fail on all datasets except vw (as expected — sort order
+change cascades to different cluster assignments). biodiversity was re-recorded and verified.
+Private datasets (FLI, bg2018, bg2050, pakistan) need re-recording but the recorder crashes
+on `engage` (pre-existing duplicate vote files) before reaching the others. Need to record
+them individually, but **blocked on fixes to PRs earlier in the stack** (#2393, #2397).
+Will re-record after those are resolved and rebased.
+
+### What's Next
+
+1. **PR 1 (D2c)**: Implement the vote count source fix — switch `_compute_user_vote_counts`
+   and `n_cmts` to use `self.raw_rating_mat`. Write xfail tests first, then fix, then verify.
+2. **PR 1bis (D2d)**: Write the 6 monotonicity tests (T1-T6). These should pass immediately
+   after D2c is fixed (full recompute + raw_rating_mat = monotonicity for free). Add the
+   code comment block and PR description documenting the design decision.
+3. **PR 2 — Fix D4 (Pseudocount)**: Next in pipeline order after D2 is fully resolved.
 
 ---
 
@@ -140,12 +245,162 @@ After rebase onto updated `origin/kmeans_analysis_docs`:
   - `CLJ-PARITY-FIXES-JOURNAL.md` in `series-of-fixes` (amended tip)
   - Force-pushed all three branches, rebased the chain
 - Tests unchanged: 5 passed, 2 skipped, 18 xfailed, 5 xpassed
+- Renamed journal and plan to `CLJ-PARITY-FIXES-*.md`, amended introducing commits, rebased chain
+- Set up private data repo infrastructure:
+  - Pushed data to bare repo at `~/polis/github/real_data_private`
+  - Created `link-to-polis-worktree.sh` for per-worktree clones with post-checkout branch sync
+  - Linked `.local` to this worktree, created `series-of-fixes` branch in private repo
+- Created `CLAUDE.local.md` (via stow) and `CLAUDE.md` in private data repo
+- D2 fix (TDD):
+  - Baseline (public only): 205 passed, 3 failed (2 D2 + 1 DynamoDB)
+  - Red: removed xfail from D2 tests, biodiversity fails (Python=428, Clojure=441)
+  - Fix: `threshold = min(7, n_cmts)` in `conversation.py:1270`
+  - Green: D2 tests pass on vw + biodiversity
+  - Full suite with private datasets (14 min): regression failures on all private datasets (expected — threshold change cascades to clustering)
+  - Investigated: all failures are downstream of threshold change, verified correct
+  - Re-recorded golden snapshots for biodiversity + 4 private datasets after verification
+  - Discovered 3 private datasets have incomplete Clojure blobs (4 keys instead of 23) — delegated regeneration to separate session
+  - Committed and pushed D2 fix (`df2d013ec`)
+
+### Session 3 (2026-03-04)
+
+- Deep investigation of in-conv vote counting: compared Clojure `user-vote-counts`
+  (conversation.clj:217-225, uses `raw-rating-mat`) vs Python `_compute_user_vote_counts`
+  (conversation.py:1226, uses `self.rating_mat`)
+- Discovered D2c: structural discrepancy in both vote count source AND `n_cmts` — Clojure's
+  `zero-out-columns` keeps moderated-out columns (zeroed), Python's `_apply_moderation`
+  removes them entirely. Both vote counts and threshold cap differ.
+- Investigated whether to persist in-conv to DynamoDB (like Clojure does to `math_main`).
+  Found: Clojure persists because it uses delta vote processing. Python does full recompute
+  → monotonicity is free. No persistence needed.
+- Verified Clojure persistence path: `prep-main` (conv_man.clj:55) writes `:in-conv`,
+  `restructure-json-conv` (conv_man.clj:182) restores it on restart.
+- Updated plan: added D2c (vote count source, 2 xfail tests) and D2d (monotonicity, 6 tests
+  guarding against future delta-processing refactor). Ref: compdemocracy/polis#2358.
+- Corrected earlier journal entry that said `raw_rating_mat` was "not needed" — it IS needed.
+- Added terminology rule to CLAUDE.local.md: always say "moderated-out" or "moderated-in",
+  never just "moderated".
+- Committed plan update (`f2bf77c38`)
+
+### Session 4 (2026-03-10)
+
+- **Dual-blob test infrastructure** (committed on `jc/series-of-fixes`, #2420):
+  - Extended `get_dataset_files()` with `blob_type` parameter (explicit `'incremental'` or `'cold_start'`)
+  - Added `get_blob_variants()` to discover which blob types are available per dataset,
+    filtering out empty/unfilled blobs via `_is_blob_filled()` (checks for PCA data or
+    non-empty base-clusters)
+  - Extended `@pytest.mark.use_discovered_datasets` with optional `use_blobs=True` parameter
+    to parametrize tests with composite `dataset-blob_type` IDs (e.g., `biodiversity-incremental`)
+  - Added `parse_dataset_blob_id()` in conftest for splitting composite IDs
+  - Applied to `test_legacy_clojure_regression.py`, `test_discrepancy_fixes.py`, and
+    `test_legacy_repness_comparison.py`
+  - Conversation computation shared across blob variants via `_CONV_CACHE` (keyed by dataset
+    name) to avoid redundant recomputation
+
+- **D2 incremental xfail with rationale** (committed on `jc/clj-parity-d2-fix`, #2421):
+  - D2 in-conv tests on incremental blobs are xfailed with inline comments explaining why:
+    incremental blobs were built progressively as votes trickled in, so the threshold
+    `min(7, n_cmts)` was evaluated at each iteration with a smaller `n_cmts`, admitting
+    a few extra participants (1–2) during earlier iterations. Very large conversations
+    have empty cold-start blobs because the Clojure math worker relies on incremental
+    processing — it cannot analyse the whole conversation in a single cold-start pass.
+  - Matching incremental exactly would require simulating the progressive threshold — tracked
+    as future work under Replay Infrastructure (PRs A/B/C in the plan)
+
+- **Golden snapshots re-recorded** for all public + private datasets, 5 stale xfail markers removed
+- **Final test results**: 245 passed, 5 skipped, 36 xfailed, 0 failures, 0 xpassed
+- Updated PR #2421 description with incremental vs cold-start explanation
+- Local handoff file created at `delphi/docs/HANDOFF_D2_INCREMENTAL_IN_CONV.md` (untracked)
+  for future investigation of how much in-conv sets differ between blob types
+
+### Session 5 (2026-03-11)
+
+- **D2c fix**: Switched `_compute_user_vote_counts` and `_get_in_conv_participants` to use
+  `self.raw_rating_mat` instead of `self.rating_mat`. Both vote counts and `n_cmts` now
+  include votes on moderated-out comments, matching Clojure's `user-vote-counts`
+  (conversation.clj:217-225) and `n-cmts` (conversation.clj:214-215).
+- **D2c tests** (3 in `TestD2cVoteCountSource`):
+  - `test_vote_count_includes_moderated_out_votes`: 10 comments, 3 moderated-out, count=10
+  - `test_n_cmts_includes_moderated_out_comments`: verifies threshold uses raw column count,
+    not filtered; also tests that a participant with 6 raw votes is correctly excluded
+  - `test_participant_stays_in_conv_after_moderation`: the critical scenario — participant
+    with 8 votes stays in-conv when 3 comments moderated-out (filtered count drops to 5)
+- **D2d monotonicity tests** (5 in `TestD2dInConvMonotonicity`):
+  - T1: basic monotonicity across batch updates
+  - T2: survives moderation-out
+  - T3: worker restart + moderation (key delta-processing guard)
+  - T4: worker restart, moderation, no new votes
+  - T5: mixed participants with moderation
+  - All pass for free with D2c fix (full recompute from `raw_rating_mat`)
+- **TDD discipline**: wrote tests first (D2c xfail, D2d no xfail), confirmed D2c red (3
+  xfailed) and D2d red (T2-T5 failed, T1 passed), applied fix, confirmed all green.
+- **Full test suite**: 253 passed, 5 skipped, 36 xfailed, 0 failures (+8 from session 4)
+- **No regressions** on public datasets
+- Added code comments on `_get_in_conv_participants` documenting the monotonicity design
+  decision and delta-processing caveat (ref: #2358)
+- Updated plan: D2, D2b, D2c, D2d all marked DONE; PR 1bis merged into PR 1
+- Updated PR #2421 description with D2c/D2d sections
+
+### What's Next
+
+1. **PR 2 — Fix D4 (Pseudocount)**: `PSEUDO_COUNT = 1.5` → `2.0` to match Clojure's Beta(2,2) prior.
+2. **PR 3 — Fix D9 (Z-score thresholds)**: Switch from two-tailed to one-tailed z-scores.
+
+---
+
+## TDD Discipline
+
+**CRITICAL: For every fix, ALWAYS follow this order:**
+1. **Run the full test suite** (all datasets, including private) to establish the baseline
+2. **Remove xfail** from the target test(s)
+3. **Run tests and confirm they FAIL** (red) — this validates the test actually catches the discrepancy
+4. **Apply the fix**
+5. **Run tests and confirm they PASS** (green)
+6. **Run the full test suite** to check for regressions vs the baseline from step 1
+7. **If regression tests fail**: INVESTIGATE before re-recording golden snapshots (see below)
+
+Never skip step 3. A test that passes before the fix is applied is not testing anything useful.
+
+### Golden snapshots are precious
+
+**NEVER blindly re-record golden snapshots.** They are the regression safety net.
+When a fix causes regression test failures:
+
+1. **Investigate** what changed: compare old vs new output, check which fields differ
+2. **Verify** the new output is closer to Clojure (e.g., in-conv set now matches exactly)
+3. **Only then** re-record, one dataset at a time, after confirming correctness
+4. **Commit** the updated snapshots with a clear message explaining why they changed
+
+### Per-dataset testing for faster feedback
+
+Run each dataset as a **separate background task** instead of one big pytest invocation.
+Smallest datasets finish first, giving early signal without waiting for the 1M-vote ones.
+
+**IMPORTANT**: Always pass `--include-local` when testing private datasets.
+Without it, `--datasets <name>` silently skips private datasets (shown as `[NOTSET]`).
+
+### Pipelined worktree workflow
+
+Full test suite takes ~14 minutes. To avoid idle time:
+- When tests start running on the current worktree, create the next worktree and start coding the next fix
+- Each worktree = one fix, one branch, one PR — stacked like the PR chain
+- Number of worktrees in flight depends on test duration vs coding speed
+- If a lower fix needs amending, rebase the chain of worktrees above it
+- Each worktree gets its own `.local` private data clone (via `link-to-polis-worktree.sh`)
+
+**When starting a new Claude session for the next fix**, ask the user whether they want
+to create a new worktree. If yes, provide a prompt they can use to start that session:
+
+> Start working on [Clj parity] fix DN (<description>). This is a new worktree
+> stacked on `<previous-branch>`. Read `delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md`
+> and `delphi/docs/CLJ-PARITY-FIXES-PLAN.md` for context. Follow the TDD discipline
+> documented in the journal.
 
 ---
 
 ## Notes for Future Sessions
 
-- Private datasets not available in this worktree. Need prodclone DB + `generate_cold_start_clojure.py`.
+- Private datasets are in `delphi/real_data/.local/` (separate git repo, linked via `link-to-polis-worktree.sh`)
 - `test_discrepancy_fixes.py` uses same parametrization pattern as `test_legacy_clojure_regression.py` (own `pytest_generate_tests` hook, `dataset_name` fixture).
 - 11 pre-existing test failures are from the stacked branch, not from our work. They should be fixed in their respective PRs before merging to main.
 - `strict=False` on xfail means xpass (unexpected pass) is reported but not a failure. Used when some datasets pass by coincidence.

--- a/delphi/docs/PLAN_DISCREPANCY_FIXES.md
+++ b/delphi/docs/PLAN_DISCREPANCY_FIXES.md
@@ -103,22 +103,56 @@ Fixes are ordered by **pipeline execution order**: participant filtering → pro
 
 **File**: `delphi/polismath/conversation/conversation.py`
 
-**Current**: `threshold = 7 + sqrt(n_cmts) * 0.1` → biodiversity (314 comments): threshold=8.8, keeps 428/536.
-**Target**: `threshold = min(7, n_cmts)` → threshold=7, more participants qualify.
+**Current**: ~~`threshold = 7 + sqrt(n_cmts) * 0.1`~~ → **DONE**: `threshold = min(7, n_cmts)`.
+**D2c**: ~~Vote counts and `n_cmts` from `rating_mat`~~ → **DONE**: Both use `raw_rating_mat` (includes moderated-out comments). Matches Clojure's `user-vote-counts` (conversation.clj:217-225).
+**D2b**: ~~Base clusters sorted by size~~ → **DONE**: Sort by k-means ID (matches Clojure's `sort-by :id`).
 
-**Additional changes**:
-- Use `self.raw_rating_mat` instead of `self.rating_mat` (count on unmoderated matrix)
-- Add greedy fallback (top-15 voters if <15 qualify)
-- Add monotonic persistence (once in, always in)
+**Remaining (deferred)**:
+- Greedy fallback (top-15 voters if <15 qualify) — not needed for current datasets
+- Cluster comparison test at participant level — deferred to after repness fixes
 
-**Test-first approach**:
-1. Add test comparing in-conv participant count/set between Python and Clojure for ALL datasets
-2. Add synthetic edge-case tests: tiny conversation (fewer comments than threshold), conversation where greedy fallback triggers
-3. Run tests → expect failure
-4. Apply fix
-5. Re-run ALL tests — cluster count may change (possibly 3→2 for biodiversity, matching Clojure)
-6. **Cluster comparison test (CRITICAL)**: After fixing D2, add a test that compares Python and Clojure cluster assignments at the participant level — number of clusters AND which participants are in which cluster (using Jaccard similarity or exact match). The Python clustering calls sklearn K-means; Clojure uses a two-level approach. If clusters still don't match after the threshold fix, investigate why and potentially create an additional PR (PR 1b) to fix the remaining clustering discrepancy before moving on to repness fixes.
-7. Document new baseline in journal
+---
+
+### PR 1bis: Fix D2d — In-Conv Monotonicity — **DONE** (merged into PR 1)
+
+**Related upstream issue**: [compdemocracy/polis#2358](https://github.com/compdemocracy/polis/issues/2358) — "Non-Deterministic K-Means Clustering Due to Worker Restart". That issue focuses on `group-clusterings` not being persisted. In-conv IS persisted in Clojure (see below), but we take a different — and better — approach.
+
+**Clojure behavior (verified)**:
+- **Monotonic**: `(as-> (or (:in-conv conv) #{}) in-conv (into in-conv ...))` (conversation.clj:244) — starts from previous set, only adds, never removes.
+- **Persisted to DB**: `:in-conv` is included in `prep-main` (conv_man.clj:55) and written to `math_main`. On restart, `load-or-init` (conv_man.clj:196) calls `restructure-json-conv` which restores it as a set (conv_man.clj:182). So in-conv **survives worker restarts** in Clojure.
+- **Why Clojure needs persistence**: Clojure uses **delta vote processing** — during normal operation, only new votes since last timestamp are fed via `keep-votes` (conversation.clj:189-190) into `raw-rating-mat`. After a restart, `load-or-init` rebuilds `raw-rating-mat` from scratch (conv_man.clj:200-203, `conv-poll` with offset 0), but during incremental updates, old votes are not re-scanned. Without persisting in-conv, a restart + moderation could drop participants whose qualifying votes are on now-moderated-out comments, because those votes might not be re-counted in delta mode.
+
+**Why Python doesn't need persistence — full recompute is better**:
+
+Python rebuilds `raw_rating_mat` from **all** votes every time (no delta processing). Since:
+1. **Votes are immutable** in PostgreSQL — they can be updated (agree→disagree) but never deleted. A participant's count of "comments voted on" never decreases.
+2. **`raw_rating_mat` includes votes on moderated-out comments** — moderation only affects `rating_mat` (columns removed), not `raw_rating_mat`.
+3. **Therefore monotonicity is a free consequence**: if a participant had ≥7 votes at time T1, they still have ≥7 votes at time T2. No persistence needed — the DB is the persistence.
+4. **Worker restart changes nothing**: on restart, `raw_rating_mat` is rebuilt from all votes → same counts → same in-conv set. No DynamoDB schema change needed.
+
+This is **strictly better** than Clojure's approach: simpler code, no persistence to maintain, no risk of stale/corrupt persisted state, and deterministic regardless of restart history. Clojure only needs persistence because it uses delta updates.
+
+**CRITICAL: future-proofing for delta vote processing**:
+
+If the code is ever refactored to process only delta votes (for performance), in-conv **must** be persisted to DynamoDB at that point. Without full recompute, the guarantees above break: after a restart, `raw_rating_mat` would only contain new votes, and participants whose qualifying votes are all in the past would be lost.
+
+This must be documented:
+1. **In code**: a prominent comment block on `_get_in_conv_participants()` explaining WHY full recompute makes persistence unnecessary, and that switching to delta processing REQUIRES adding persistence (with a reference to how Clojure does it: conv_man.clj:55, conversation.clj:244).
+2. **In the PR description**: a dedicated section explaining the design decision, referencing issue #2358 and the Clojure persistence code.
+
+**File**: `delphi/polismath/conversation/conversation.py`
+
+**DONE**: `_get_in_conv_participants()` uses `self.raw_rating_mat` (D2c fix). Monotonicity is a free consequence. Code comment on the function documents the design decision and the delta-processing caveat.
+
+**Tests implemented** (T1-T5 in `TestD2dInConvMonotonicity`):
+- T1: Basic monotonicity across batch updates
+- T2: Survives moderation-out of voted comments
+- T3: Worker restart + moderation (key delta-processing guard)
+- T4: Worker restart, moderation, no new votes
+- T5: Mixed participants with moderation
+- T6 (greedy fallback): deferred — greedy fallback not yet implemented
+
+All test docstrings explain what would break under delta processing.
 
 ---
 
@@ -370,7 +404,10 @@ By this point, we should have good test coverage from all the per-discrepancy te
 |----|-------------|-----|--------|
 | D1 | PCA sign flips | PR 13 | Fix (sign consistency) |
 | D1b | Projection input | PR 13 | Fix with D1 |
-| D2 | In-conv threshold | **PR 1** | Fix |
+| D2 | In-conv threshold | **PR 1** | **DONE** ✓ |
+| D2b | Base-cluster sort order | **PR 1** | **DONE** ✓ |
+| D2c | Vote count source (raw vs filtered matrix) | **PR 1** | **DONE** ✓ |
+| D2d | In-conv monotonicity (once in, always in) | **PR 1** | **DONE** ✓ (5 guard tests, T1-T5) |
 | D3 | K-smoother buffer | PR 10 | Fix |
 | D4 | Pseudocount formula | **PR 2** | Fix |
 | D5 | Proportion test | PR 4 | Fix |
@@ -422,6 +459,11 @@ Three separate PRs for temporal/incremental testing:
 **Replay PR B**: Use replay infrastructure for tests
 - Test D3 (k-smoother stability) with real incremental data
 - Test D1 (PCA sign consistency) with real incremental data
+- Test D2 (in-conv threshold) on incremental blobs: currently xfailed because early
+  participants (low PIDs) were admitted when `n_cmts` was still < 7 during early
+  iterations, making the threshold equal to `n_cmts` rather than 7. All four datasets
+  with both blob types exhibit this (1–2 extra participants each). Matching incremental
+  behaviour requires simulating the progressive threshold evaluation.
 - Compare Python's incremental behavior to Clojure's
 
 **Replay PR C**: Visualization movie generation

--- a/delphi/polismath/conversation/conversation.py
+++ b/delphi/polismath/conversation/conversation.py
@@ -589,11 +589,10 @@ class Conversation:
                 'members': member_pids
             })
 
-        # Sort base clusters by size (descending) for consistency
-        base_clusters.sort(key=lambda c: len(c['members']), reverse=True)
-        # Reassign IDs based on sorted order
-        for i, cluster in enumerate(base_clusters):
-            cluster['id'] = i
+        # Keep base clusters in k-means ID order (matching Clojure's sort-by :id)
+        # Do NOT sort by size or reassign IDs — that would change the encounter
+        # order of centers used in group clustering's first-k-distinct initialization.
+        base_clusters.sort(key=lambda c: c['id'])
 
         logger.info(f"Created {len(base_clusters)} base clusters")
 
@@ -1211,25 +1210,31 @@ class Conversation:
         """
         Compute the number of votes per participant.
 
+        Uses raw_rating_mat (not rating_mat) so that votes on moderated-out
+        comments are still counted. This matches Clojure's user-vote-counts
+        (conversation.clj:217-225) which reads from raw-rating-mat.
+        Fix D2c: see PLAN_DISCREPANCY_FIXES.md.
+
         Returns:
             Dictionary mapping participant IDs to vote counts
         """
         import time
         start_time = time.time()
-        logger.info(f"Starting _compute_user_vote_counts for {self.rating_mat.shape[0]} participants")
+        mat = self.raw_rating_mat
+        logger.info(f"Starting _compute_user_vote_counts for {mat.shape[0]} participants")
 
         vote_counts = {}
 
         # Use more efficient approach for large datasets
-        if self.rating_mat.shape[0] > 1000:
+        if mat.shape[0] > 1000:
             # Create a mask of non-nan values across the entire matrix
-            non_nan_mask = ~np.isnan(self.rating_mat.values)
+            non_nan_mask = ~np.isnan(mat.values)
 
             # Sum across rows using vectorized operation
             row_sums = np.sum(non_nan_mask, axis=1)
 
             # Convert to dictionary
-            for i, pid in enumerate(self.rating_mat.index):
+            for i, pid in enumerate(mat.index):
                 if i < len(row_sums):
                     vote_counts[pid] = int(row_sums[i])
                 else:
@@ -1239,9 +1244,9 @@ class Conversation:
             logger.info(f"Computed vote counts for {len(vote_counts)} participants using vectorized approach in {time.time() - start_time:.4f}s")
         else:
             # Original approach for smaller datasets
-            for i, pid in enumerate(self.rating_mat.index):
+            for i, pid in enumerate(mat.index):
                 # Get row of votes for this participant
-                row = self.rating_mat.values[i, :]
+                row = mat.values[i, :]
 
                 # Count non-nan values
                 count = np.sum(~np.isnan(row))
@@ -1259,14 +1264,24 @@ class Conversation:
 
         Matches Clojure's in-conv logic from conversation.clj lines 239-266.
 
-        Threshold: participant must have voted on at least:
-            7 + sqrt(n_comments) * 0.1 comments
+        Threshold: participant must have voted on at least min(7, n_comments)
+        comments (Clojure parity fix D2).
+
+        Both vote counts and n_cmts use raw_rating_mat (fix D2c), which includes
+        votes on moderated-out comments. This matches Clojure, where
+        zero-out-columns keeps moderated-out columns in the matrix (zeroed but
+        present). Since raw_rating_mat contains all historical votes and votes
+        are immutable in PostgreSQL, monotonicity is guaranteed without explicit
+        persistence — a participant who once qualified can never lose votes.
+        If the code is ever refactored to use delta vote processing, in-conv
+        MUST be persisted to DynamoDB. See compdemocracy/polis#2358 and
+        Clojure's approach in conv_man.clj:55, conversation.clj:244.
 
         Returns:
             Set of participant IDs that meet the threshold
         """
-        n_cmts = len(self.rating_mat.columns) if hasattr(self.rating_mat, 'columns') else 0
-        threshold = 7 + np.sqrt(n_cmts) * 0.1
+        n_cmts = len(self.raw_rating_mat.columns) if hasattr(self.raw_rating_mat, 'columns') else 0
+        threshold = min(7, n_cmts)
 
         # Get vote counts for all participants
         vote_counts = self._compute_user_vote_counts()

--- a/delphi/tests/test_conversation.py
+++ b/delphi/tests/test_conversation.py
@@ -427,7 +427,7 @@ class TestConversation:
         }
         
         # Create two distinct opinion groups with enough votes per participant
-        # to meet the vote threshold (7 + sqrt(n_comments) * 0.1)
+        # to meet the vote threshold (min(7, n_comments))
         for i in range(20):
             pid = f'p{i}'
 

--- a/delphi/tests/test_discrepancy_fixes.py
+++ b/delphi/tests/test_discrepancy_fixes.py
@@ -154,16 +154,23 @@ def _clojure_in_conv_set(blob: dict) -> set[int]:
 @pytest.mark.clojure_comparison
 class TestD2InConvThreshold:
     """
-    D2: Python uses threshold = 7 + sqrt(n_cmts) * 0.1
-        Clojure uses threshold = min(7, n_cmts)
-
-    This causes Python to require more votes for larger conversations,
-    filtering out participants that Clojure would keep.
+    D2: Clojure uses threshold = min(7, n_cmts) for in-conv filtering.
+    Python now matches (fixed from 7 + sqrt(n_cmts) * 0.1).
     """
 
-    @pytest.mark.xfail(reason="D2: Python threshold = 7+sqrt(n)*0.1 vs Clojure min(7, n)", strict=False)
     def test_in_conv_count_matches(self, conv, clojure_blob, dataset_name):
         """Number of in-conv participants should match Clojure."""
+        if 'in-conv' not in clojure_blob:
+            pytest.skip(f"[{dataset_name}] Clojure blob has no in-conv data")
+        if dataset_name.endswith('-incremental'):
+            # Incremental blobs were built progressively as votes trickled in,
+            # so the threshold min(7, n_cmts) was evaluated at each iteration
+            # with a smaller n_cmts than the final value. This admits a few
+            # extra participants to in-conv during earlier iterations.
+            # The difference is tiny (1-2 participants) when a cold-start blob
+            # is available. Very large conversations have empty cold-start blobs
+            # because Clojure can't process them in one pass.
+            pytest.xfail("D2: behaviour matches on cold-start, incremental deferred to future PR")
         clojure_in_conv = _clojure_in_conv_set(clojure_blob)
         python_in_conv_count = len(conv._get_in_conv_participants())
 
@@ -171,9 +178,19 @@ class TestD2InConvThreshold:
         check.equal(python_in_conv_count, len(clojure_in_conv),
                      f"In-conv count mismatch: Python={python_in_conv_count}, Clojure={len(clojure_in_conv)}")
 
-    @pytest.mark.xfail(reason="D2: Python threshold = 7+sqrt(n)*0.1 vs Clojure min(7, n)", strict=False)
     def test_in_conv_set_matches(self, conv, clojure_blob, dataset_name):
         """The actual set of in-conv participants should match Clojure."""
+        if 'in-conv' not in clojure_blob:
+            pytest.skip(f"[{dataset_name}] Clojure blob has no in-conv data")
+        if dataset_name.endswith('-incremental'):
+            # Incremental blobs were built progressively as votes trickled in,
+            # so the threshold min(7, n_cmts) was evaluated at each iteration
+            # with a smaller n_cmts than the final value. This admits a few
+            # extra participants to in-conv during earlier iterations.
+            # The difference is tiny (1-2 participants) when a cold-start blob
+            # is available. Very large conversations have empty cold-start blobs
+            # because Clojure can't process them in one pass.
+            pytest.xfail("D2: behaviour matches on cold-start, incremental deferred to future PR")
         clojure_in_conv = _clojure_in_conv_set(clojure_blob)
         python_in_conv = conv._get_in_conv_participants()
         # Convert python pids to int for comparison
@@ -191,6 +208,284 @@ class TestD2InConvThreshold:
 
         check.equal(only_python, set(), f"Participants in Python but not Clojure: {len(only_python)}")
         check.equal(only_clojure, set(), f"Participants in Clojure but not Python: {len(only_clojure)}")
+
+
+# ============================================================================
+# D2c — Vote Count Source (raw vs filtered matrix)
+# ============================================================================
+
+def _build_conv_with_moderation(
+    n_comments: int = 10,
+    mod_out_tids: list | None = None,
+    participant_votes: dict | None = None,
+) -> Conversation:
+    """Build a synthetic Conversation with moderation applied.
+
+    Args:
+        n_comments: Total number of comments (tids 0..n_comments-1).
+        mod_out_tids: List of tids to moderate-out.
+        participant_votes: Dict mapping pid → list of tids they voted on.
+            If None, a single participant votes on all comments.
+
+    Returns:
+        A Conversation with votes ingested and moderation applied (no recompute).
+    """
+    if participant_votes is None:
+        participant_votes = {0: list(range(n_comments))}
+
+    votes_list = []
+    for pid, tids in participant_votes.items():
+        for tid in tids:
+            votes_list.append({'pid': pid, 'tid': tid, 'vote': 1})
+
+    conv = Conversation('test-d2c')
+    conv = conv.update_votes({'votes': votes_list}, recompute=False)
+
+    if mod_out_tids:
+        conv = conv.update_moderation(
+            {'mod_out_tids': mod_out_tids}, recompute=False
+        )
+
+    return conv
+
+
+class TestD2cVoteCountSource:
+    """
+    D2c: Vote counts for in-conv threshold must come from raw_rating_mat
+    (includes votes on moderated-out comments), not rating_mat (filtered).
+
+    Clojure's user-vote-counts (conversation.clj:217-225) uses raw-rating-mat.
+    Python currently uses self.rating_mat, undercounting when comments are
+    moderated-out.
+    """
+
+    def test_vote_count_includes_moderated_out_votes(self):
+        """Participant who voted on 10 comments (3 moderated-out) should have count=10."""
+        conv = _build_conv_with_moderation(
+            n_comments=10,
+            mod_out_tids=[0, 1, 2],
+            participant_votes={0: list(range(10))},
+        )
+
+        vote_counts = conv._compute_user_vote_counts()
+        assert vote_counts[0] == 10, (
+            f"Vote count should be 10 (from raw_rating_mat), got {vote_counts[0]} "
+            f"(rating_mat has {len(conv.rating_mat.columns)} columns)"
+        )
+
+    def test_n_cmts_includes_moderated_out_comments(self):
+        """n_cmts in threshold should count all comments including moderated-out.
+
+        With 10 total comments and 5 moderated-out, n_cmts should be 10.
+        This matters when non-moderated-out count < 7: the threshold would be
+        artificially low in Python (min(7,5)=5 vs correct min(7,10)=7).
+        """
+        conv = _build_conv_with_moderation(
+            n_comments=10,
+            mod_out_tids=[0, 1, 2, 3, 4],
+            participant_votes={0: list(range(10))},
+        )
+
+        # raw_rating_mat has all columns; rating_mat has only non-moderated-out
+        n_cmts_raw = len(conv.raw_rating_mat.columns)
+        n_cmts_filtered = len(conv.rating_mat.columns)
+
+        assert n_cmts_raw == 10, f"raw_rating_mat should have 10 columns, got {n_cmts_raw}"
+        assert n_cmts_filtered == 5, f"rating_mat should have 5 columns, got {n_cmts_filtered}"
+
+        # The threshold used by _get_in_conv_participants should be min(7, 10) = 7,
+        # not min(7, 5) = 5. Verify indirectly: participant with exactly 6 votes
+        # should NOT be in-conv (threshold=7), but would be if n_cmts=5 (threshold=5).
+        conv2 = _build_conv_with_moderation(
+            n_comments=10,
+            mod_out_tids=[0, 1, 2, 3, 4],
+            participant_votes={
+                0: list(range(10)),    # 10 raw votes → in-conv
+                1: list(range(5, 11)), # 6 raw votes (only 1 moderated-out) → NOT in-conv
+            },
+        )
+        in_conv = conv2._get_in_conv_participants()
+        assert 0 in in_conv, "P0 (10 raw votes) should be in-conv"
+        assert 1 not in in_conv, (
+            "P1 (6 raw votes) should NOT be in-conv with threshold=7, "
+            "but would be if n_cmts wrongly used filtered count (5)"
+        )
+
+    def test_participant_stays_in_conv_after_moderation(self):
+        """Participant with 8 votes stays in-conv even when 3 comments moderated-out.
+
+        This is the critical scenario: participant votes above threshold (8 >= 7),
+        comments get moderated-out between update_votes calls reducing filtered
+        count to 5, but raw count is still 8 so they should remain in-conv.
+        """
+        # Participant 0: votes on 8 comments (above threshold of 7)
+        # Participant 1: votes on 7 comments (borderline)
+        conv = _build_conv_with_moderation(
+            n_comments=10,
+            mod_out_tids=[0, 1, 2],  # 3 moderated-out
+            participant_votes={
+                0: list(range(8)),   # votes on c0-c7; after mod, only c3-c7 visible (5)
+                1: list(range(7)),   # votes on c0-c6; after mod, only c3-c6 visible (4)
+            },
+        )
+
+        in_conv = conv._get_in_conv_participants()
+
+        # Both should be in-conv: raw counts are 8 and 7, threshold is min(7, 10) = 7
+        assert 0 in in_conv, (
+            f"Participant 0 (8 raw votes) should be in-conv, "
+            f"but filtered count is {np.sum(~np.isnan(conv.rating_mat.loc[0].values))}"
+        )
+        assert 1 in in_conv, (
+            f"Participant 1 (7 raw votes) should be in-conv, "
+            f"but filtered count is {np.sum(~np.isnan(conv.rating_mat.loc[1].values))}"
+        )
+
+
+# ============================================================================
+# D2d — In-Conv Monotonicity
+# ============================================================================
+
+class TestD2dInConvMonotonicity:
+    """
+    D2d: Once a participant qualifies for in-conv, they must never be removed.
+
+    These tests pass today because Python does full recompute from raw_rating_mat
+    (which includes all historical votes, even on moderated-out comments).
+    If the code is ever refactored to use delta vote processing, in-conv MUST be
+    persisted to DynamoDB — see compdemocracy/polis#2358 and the Clojure approach
+    in conv_man.clj:55, conversation.clj:244.
+    """
+
+    def test_t1_basic_monotonicity_across_updates(self):
+        """Participant who qualified in batch 1 stays in-conv after batch 2.
+
+        P votes on 7 comments in batch 1 → qualifies. Batch 2 adds new comments
+        but P doesn't vote on them. P's count stays 7 → still in-conv.
+
+        Would FAIL under delta processing without persistence if batch 2 only
+        contained new votes and P's old votes weren't re-scanned.
+        """
+        conv = Conversation('test-d2d-t1')
+
+        # Batch 1: P0 votes on 7 comments, P1 votes on all 10
+        batch1 = {'votes': [
+            *[{'pid': 0, 'tid': tid, 'vote': 1} for tid in range(7)],
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(10)],
+        ]}
+        conv = conv.update_votes(batch1, recompute=False)
+        in_conv_after_b1 = conv._get_in_conv_participants()
+        assert 0 in in_conv_after_b1, "P0 should be in-conv after batch 1 (7 votes)"
+
+        # Batch 2: new comments c10-c14, only P1 votes on them
+        batch2 = {'votes': [
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(10, 15)],
+        ]}
+        conv = conv.update_votes(batch2, recompute=False)
+        in_conv_after_b2 = conv._get_in_conv_participants()
+        assert 0 in in_conv_after_b2, (
+            "P0 should still be in-conv after batch 2 (7 votes unchanged)"
+        )
+
+    def test_t2_monotonicity_survives_moderation(self):
+        """Participant stays in-conv after their voted comments are moderated-out.
+
+        P votes on 7 comments → qualifies. 3 comments moderated-out. P's raw
+        count is still 7 → still in-conv (because raw_rating_mat is used).
+
+        Would FAIL under delta processing without persistence if moderation
+        caused a recount from only the filtered matrix.
+        """
+        conv = Conversation('test-d2d-t2')
+        votes = {'votes': [
+            *[{'pid': 0, 'tid': tid, 'vote': 1} for tid in range(7)],
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(10)],
+        ]}
+        conv = conv.update_votes(votes, recompute=False)
+
+        in_conv_before = conv._get_in_conv_participants()
+        assert 0 in in_conv_before, "P0 should be in-conv before moderation"
+
+        # Moderate out 3 of P0's comments
+        conv = conv.update_moderation({'mod_out_tids': [0, 1, 2]}, recompute=False)
+
+        in_conv_after = conv._get_in_conv_participants()
+        assert 0 in in_conv_after, (
+            "P0 should still be in-conv after moderation "
+            "(7 raw votes, only 4 on filtered matrix)"
+        )
+
+    def test_t3_worker_restart_with_moderation(self):
+        """Participant survives worker restart + moderation.
+
+        P votes on 7 comments → qualifies. Worker dies. 3 comments moderated-out.
+        New worker rebuilds from all votes. P still has 7 raw votes → in-conv.
+
+        This is the KEY test that would FAIL under delta processing without
+        persistence: after restart, only new votes would be scanned.
+        """
+        # Original worker
+        conv1 = Conversation('test-d2d-t3')
+        votes = {'votes': [
+            *[{'pid': 0, 'tid': tid, 'vote': 1} for tid in range(7)],
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(10)],
+        ]}
+        conv1 = conv1.update_votes(votes, recompute=False)
+        assert 0 in conv1._get_in_conv_participants()
+
+        # Simulate worker restart: new Conversation object, replay ALL votes
+        conv2 = Conversation('test-d2d-t3')
+        conv2 = conv2.update_votes(votes, recompute=False)
+
+        # Apply moderation that happened while worker was dead
+        conv2 = conv2.update_moderation({'mod_out_tids': [0, 1, 2]}, recompute=False)
+
+        in_conv = conv2._get_in_conv_participants()
+        assert 0 in in_conv, (
+            "P0 should be in-conv after restart+moderation "
+            "(full recompute from all votes)"
+        )
+
+    def test_t4_worker_restart_moderation_no_new_votes(self):
+        """Rebuild from existing votes after moderation, no new votes needed.
+
+        Same as T3 but verifies that recompute alone is sufficient — no "trigger"
+        of new votes is needed to re-evaluate in-conv.
+        """
+        votes = {'votes': [
+            *[{'pid': 0, 'tid': tid, 'vote': 1} for tid in range(7)],
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(10)],
+        ]}
+
+        # Build from scratch with moderation already applied
+        conv = Conversation('test-d2d-t4')
+        conv = conv.update_votes(votes, recompute=False)
+        conv = conv.update_moderation({'mod_out_tids': [0, 1, 2]}, recompute=False)
+
+        in_conv = conv._get_in_conv_participants()
+        assert 0 in in_conv, (
+            "P0 should be in-conv with just existing votes + moderation"
+        )
+
+    def test_t5_mixed_participants_moderation(self):
+        """Both old and new participants correct after moderation.
+
+        P0 votes on c0-c6. c0-c2 moderated-out. New participant Q votes on c3-c9.
+        Rebuild from all votes. Both should be in-conv:
+        - P0: 7 raw votes (c0-c6), threshold min(7,10)=7 → qualifies
+        - Q: 7 votes on non-moderated-out comments → qualifies
+        """
+        conv = Conversation('test-d2d-t5')
+        votes = {'votes': [
+            *[{'pid': 0, 'tid': tid, 'vote': 1} for tid in range(7)],   # c0-c6
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(3, 10)],  # c3-c9
+        ]}
+        conv = conv.update_votes(votes, recompute=False)
+        conv = conv.update_moderation({'mod_out_tids': [0, 1, 2]}, recompute=False)
+
+        in_conv = conv._get_in_conv_participants()
+        assert 0 in in_conv, "P0 (7 raw votes) should be in-conv"
+        assert 1 in in_conv, "P1 (7 votes on non-moderated-out comments) should be in-conv"
 
 
 # ============================================================================
@@ -264,7 +559,6 @@ class TestD9ZScoreThresholds:
         check.almost_equal(Z_95, 1.6449, abs=0.001,
                             msg=f"Z_95 should be 1.6449 (one-tailed), got {Z_95}")
 
-    @pytest.mark.xfail(reason="D9: Two-tailed thresholds produce empty repness")
     def test_repness_not_empty(self, conv, dataset_name):
         """Repness should produce non-empty comment_repness with correct thresholds."""
         repness = conv.repness
@@ -347,7 +641,6 @@ class TestD6TwoPropTest:
         Clojure adds +1 pseudocount to all 4 inputs (succ1, n1, succ2, n2).
     """
 
-    @pytest.mark.xfail(reason="D6: Python two_prop_test lacks pseudocounts")
     def test_two_prop_test_with_pseudocounts(self):
         """two_prop_test should add +1 pseudocounts matching Clojure."""
         # With pseudocounts: (succ+1)/(n+2) for both groups

--- a/delphi/tests/test_discrepancy_fixes.py
+++ b/delphi/tests/test_discrepancy_fixes.py
@@ -155,16 +155,23 @@ def _clojure_in_conv_set(blob: dict) -> set[int]:
 @pytest.mark.clojure_comparison
 class TestD2InConvThreshold:
     """
-    D2: Python uses threshold = 7 + sqrt(n_cmts) * 0.1
-        Clojure uses threshold = min(7, n_cmts)
-
-    This causes Python to require more votes for larger conversations,
-    filtering out participants that Clojure would keep.
+    D2: Clojure uses threshold = min(7, n_cmts) for in-conv filtering.
+    Python now matches (fixed from 7 + sqrt(n_cmts) * 0.1).
     """
 
-    @pytest.mark.xfail(reason="D2: Python threshold = 7+sqrt(n)*0.1 vs Clojure min(7, n)", strict=False)
     def test_in_conv_count_matches(self, conv, clojure_blob, dataset_name):
         """Number of in-conv participants should match Clojure."""
+        if 'in-conv' not in clojure_blob:
+            pytest.skip(f"[{dataset_name}] Clojure blob has no in-conv data")
+        if dataset_name.endswith('-incremental'):
+            # Incremental blobs were built progressively as votes trickled in,
+            # so the threshold min(7, n_cmts) was evaluated at each iteration
+            # with a smaller n_cmts than the final value. This admits a few
+            # extra participants to in-conv during earlier iterations.
+            # The difference is tiny (1-2 participants) when a cold-start blob
+            # is available. Very large conversations have empty cold-start blobs
+            # because Clojure can't process them in one pass.
+            pytest.xfail("D2: behaviour matches on cold-start, incremental deferred to future PR")
         clojure_in_conv = _clojure_in_conv_set(clojure_blob)
         python_in_conv_count = len(conv._get_in_conv_participants())
 
@@ -172,9 +179,19 @@ class TestD2InConvThreshold:
         check.equal(python_in_conv_count, len(clojure_in_conv),
                      f"In-conv count mismatch: Python={python_in_conv_count}, Clojure={len(clojure_in_conv)}")
 
-    @pytest.mark.xfail(reason="D2: Python threshold = 7+sqrt(n)*0.1 vs Clojure min(7, n)", strict=False)
     def test_in_conv_set_matches(self, conv, clojure_blob, dataset_name):
         """The actual set of in-conv participants should match Clojure."""
+        if 'in-conv' not in clojure_blob:
+            pytest.skip(f"[{dataset_name}] Clojure blob has no in-conv data")
+        if dataset_name.endswith('-incremental'):
+            # Incremental blobs were built progressively as votes trickled in,
+            # so the threshold min(7, n_cmts) was evaluated at each iteration
+            # with a smaller n_cmts than the final value. This admits a few
+            # extra participants to in-conv during earlier iterations.
+            # The difference is tiny (1-2 participants) when a cold-start blob
+            # is available. Very large conversations have empty cold-start blobs
+            # because Clojure can't process them in one pass.
+            pytest.xfail("D2: behaviour matches on cold-start, incremental deferred to future PR")
         clojure_in_conv = _clojure_in_conv_set(clojure_blob)
         python_in_conv = conv._get_in_conv_participants()
         # Convert python pids to int for comparison
@@ -192,6 +209,284 @@ class TestD2InConvThreshold:
 
         check.equal(only_python, set(), f"Participants in Python but not Clojure: {len(only_python)}")
         check.equal(only_clojure, set(), f"Participants in Clojure but not Python: {len(only_clojure)}")
+
+
+# ============================================================================
+# D2c — Vote Count Source (raw vs filtered matrix)
+# ============================================================================
+
+def _build_conv_with_moderation(
+    n_comments: int = 10,
+    mod_out_tids: list | None = None,
+    participant_votes: dict | None = None,
+) -> Conversation:
+    """Build a synthetic Conversation with moderation applied.
+
+    Args:
+        n_comments: Total number of comments (tids 0..n_comments-1).
+        mod_out_tids: List of tids to moderate-out.
+        participant_votes: Dict mapping pid → list of tids they voted on.
+            If None, a single participant votes on all comments.
+
+    Returns:
+        A Conversation with votes ingested and moderation applied (no recompute).
+    """
+    if participant_votes is None:
+        participant_votes = {0: list(range(n_comments))}
+
+    votes_list = []
+    for pid, tids in participant_votes.items():
+        for tid in tids:
+            votes_list.append({'pid': pid, 'tid': tid, 'vote': 1})
+
+    conv = Conversation('test-d2c')
+    conv = conv.update_votes({'votes': votes_list}, recompute=False)
+
+    if mod_out_tids:
+        conv = conv.update_moderation(
+            {'mod_out_tids': mod_out_tids}, recompute=False
+        )
+
+    return conv
+
+
+class TestD2cVoteCountSource:
+    """
+    D2c: Vote counts for in-conv threshold must come from raw_rating_mat
+    (includes votes on moderated-out comments), not rating_mat (filtered).
+
+    Clojure's user-vote-counts (conversation.clj:217-225) uses raw-rating-mat.
+    Python currently uses self.rating_mat, undercounting when comments are
+    moderated-out.
+    """
+
+    def test_vote_count_includes_moderated_out_votes(self):
+        """Participant who voted on 10 comments (3 moderated-out) should have count=10."""
+        conv = _build_conv_with_moderation(
+            n_comments=10,
+            mod_out_tids=[0, 1, 2],
+            participant_votes={0: list(range(10))},
+        )
+
+        vote_counts = conv._compute_user_vote_counts()
+        assert vote_counts[0] == 10, (
+            f"Vote count should be 10 (from raw_rating_mat), got {vote_counts[0]} "
+            f"(rating_mat has {len(conv.rating_mat.columns)} columns)"
+        )
+
+    def test_n_cmts_includes_moderated_out_comments(self):
+        """n_cmts in threshold should count all comments including moderated-out.
+
+        With 10 total comments and 5 moderated-out, n_cmts should be 10.
+        This matters when non-moderated-out count < 7: the threshold would be
+        artificially low in Python (min(7,5)=5 vs correct min(7,10)=7).
+        """
+        conv = _build_conv_with_moderation(
+            n_comments=10,
+            mod_out_tids=[0, 1, 2, 3, 4],
+            participant_votes={0: list(range(10))},
+        )
+
+        # raw_rating_mat has all columns; rating_mat has only non-moderated-out
+        n_cmts_raw = len(conv.raw_rating_mat.columns)
+        n_cmts_filtered = len(conv.rating_mat.columns)
+
+        assert n_cmts_raw == 10, f"raw_rating_mat should have 10 columns, got {n_cmts_raw}"
+        assert n_cmts_filtered == 5, f"rating_mat should have 5 columns, got {n_cmts_filtered}"
+
+        # The threshold used by _get_in_conv_participants should be min(7, 10) = 7,
+        # not min(7, 5) = 5. Verify indirectly: participant with exactly 6 votes
+        # should NOT be in-conv (threshold=7), but would be if n_cmts=5 (threshold=5).
+        conv2 = _build_conv_with_moderation(
+            n_comments=10,
+            mod_out_tids=[0, 1, 2, 3, 4],
+            participant_votes={
+                0: list(range(10)),    # 10 raw votes → in-conv
+                1: list(range(4, 10)), # 6 raw votes (tids 4..9; tid=4 moderated-out) → NOT in-conv
+            },
+        )
+        in_conv = conv2._get_in_conv_participants()
+        assert 0 in in_conv, "P0 (10 raw votes) should be in-conv"
+        assert 1 not in in_conv, (
+            "P1 (6 raw votes) should NOT be in-conv with threshold=7, "
+            "but would be if n_cmts wrongly used filtered count (5)"
+        )
+
+    def test_participant_stays_in_conv_after_moderation(self):
+        """Participant with 8 votes stays in-conv even when 3 comments moderated-out.
+
+        This is the critical scenario: participant votes above threshold (8 >= 7),
+        comments get moderated-out between update_votes calls reducing filtered
+        count to 5, but raw count is still 8 so they should remain in-conv.
+        """
+        # Participant 0: votes on 8 comments (above threshold of 7)
+        # Participant 1: votes on 7 comments (borderline)
+        conv = _build_conv_with_moderation(
+            n_comments=10,
+            mod_out_tids=[0, 1, 2],  # 3 moderated-out
+            participant_votes={
+                0: list(range(8)),   # votes on c0-c7; after mod, only c3-c7 visible (5)
+                1: list(range(7)),   # votes on c0-c6; after mod, only c3-c6 visible (4)
+            },
+        )
+
+        in_conv = conv._get_in_conv_participants()
+
+        # Both should be in-conv: raw counts are 8 and 7, threshold is min(7, 10) = 7
+        assert 0 in in_conv, (
+            f"Participant 0 (8 raw votes) should be in-conv, "
+            f"but filtered count is {np.sum(~np.isnan(conv.rating_mat.loc[0].values))}"
+        )
+        assert 1 in in_conv, (
+            f"Participant 1 (7 raw votes) should be in-conv, "
+            f"but filtered count is {np.sum(~np.isnan(conv.rating_mat.loc[1].values))}"
+        )
+
+
+# ============================================================================
+# D2d — In-Conv Monotonicity
+# ============================================================================
+
+class TestD2dInConvMonotonicity:
+    """
+    D2d: Once a participant qualifies for in-conv, they must never be removed.
+
+    These tests pass today because Python does full recompute from raw_rating_mat
+    (which includes all historical votes, even on moderated-out comments).
+    If the code is ever refactored to use delta vote processing, in-conv MUST be
+    persisted to DynamoDB — see compdemocracy/polis#2358 and the Clojure approach
+    in conv_man.clj:55, conversation.clj:244.
+    """
+
+    def test_t1_basic_monotonicity_across_updates(self):
+        """Participant who qualified in batch 1 stays in-conv after batch 2.
+
+        P votes on 7 comments in batch 1 → qualifies. Batch 2 adds new comments
+        but P doesn't vote on them. P's count stays 7 → still in-conv.
+
+        Would FAIL under delta processing without persistence if batch 2 only
+        contained new votes and P's old votes weren't re-scanned.
+        """
+        conv = Conversation('test-d2d-t1')
+
+        # Batch 1: P0 votes on 7 comments, P1 votes on all 10
+        batch1 = {'votes': [
+            *[{'pid': 0, 'tid': tid, 'vote': 1} for tid in range(7)],
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(10)],
+        ]}
+        conv = conv.update_votes(batch1, recompute=False)
+        in_conv_after_b1 = conv._get_in_conv_participants()
+        assert 0 in in_conv_after_b1, "P0 should be in-conv after batch 1 (7 votes)"
+
+        # Batch 2: new comments c10-c14, only P1 votes on them
+        batch2 = {'votes': [
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(10, 15)],
+        ]}
+        conv = conv.update_votes(batch2, recompute=False)
+        in_conv_after_b2 = conv._get_in_conv_participants()
+        assert 0 in in_conv_after_b2, (
+            "P0 should still be in-conv after batch 2 (7 votes unchanged)"
+        )
+
+    def test_t2_monotonicity_survives_moderation(self):
+        """Participant stays in-conv after their voted comments are moderated-out.
+
+        P votes on 7 comments → qualifies. 3 comments moderated-out. P's raw
+        count is still 7 → still in-conv (because raw_rating_mat is used).
+
+        Would FAIL under delta processing without persistence if moderation
+        caused a recount from only the filtered matrix.
+        """
+        conv = Conversation('test-d2d-t2')
+        votes = {'votes': [
+            *[{'pid': 0, 'tid': tid, 'vote': 1} for tid in range(7)],
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(10)],
+        ]}
+        conv = conv.update_votes(votes, recompute=False)
+
+        in_conv_before = conv._get_in_conv_participants()
+        assert 0 in in_conv_before, "P0 should be in-conv before moderation"
+
+        # Moderate out 3 of P0's comments
+        conv = conv.update_moderation({'mod_out_tids': [0, 1, 2]}, recompute=False)
+
+        in_conv_after = conv._get_in_conv_participants()
+        assert 0 in in_conv_after, (
+            "P0 should still be in-conv after moderation "
+            "(7 raw votes, only 4 on filtered matrix)"
+        )
+
+    def test_t3_worker_restart_with_moderation(self):
+        """Participant survives worker restart + moderation.
+
+        P votes on 7 comments → qualifies. Worker dies. 3 comments moderated-out.
+        New worker rebuilds from all votes. P still has 7 raw votes → in-conv.
+
+        This is the KEY test that would FAIL under delta processing without
+        persistence: after restart, only new votes would be scanned.
+        """
+        # Original worker
+        conv1 = Conversation('test-d2d-t3')
+        votes = {'votes': [
+            *[{'pid': 0, 'tid': tid, 'vote': 1} for tid in range(7)],
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(10)],
+        ]}
+        conv1 = conv1.update_votes(votes, recompute=False)
+        assert 0 in conv1._get_in_conv_participants()
+
+        # Simulate worker restart: new Conversation object, replay ALL votes
+        conv2 = Conversation('test-d2d-t3')
+        conv2 = conv2.update_votes(votes, recompute=False)
+
+        # Apply moderation that happened while worker was dead
+        conv2 = conv2.update_moderation({'mod_out_tids': [0, 1, 2]}, recompute=False)
+
+        in_conv = conv2._get_in_conv_participants()
+        assert 0 in in_conv, (
+            "P0 should be in-conv after restart+moderation "
+            "(full recompute from all votes)"
+        )
+
+    def test_t4_worker_restart_moderation_no_new_votes(self):
+        """Rebuild from existing votes after moderation, no new votes needed.
+
+        Same as T3 but verifies that recompute alone is sufficient — no "trigger"
+        of new votes is needed to re-evaluate in-conv.
+        """
+        votes = {'votes': [
+            *[{'pid': 0, 'tid': tid, 'vote': 1} for tid in range(7)],
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(10)],
+        ]}
+
+        # Build from scratch with moderation already applied
+        conv = Conversation('test-d2d-t4')
+        conv = conv.update_votes(votes, recompute=False)
+        conv = conv.update_moderation({'mod_out_tids': [0, 1, 2]}, recompute=False)
+
+        in_conv = conv._get_in_conv_participants()
+        assert 0 in in_conv, (
+            "P0 should be in-conv with just existing votes + moderation"
+        )
+
+    def test_t5_mixed_participants_moderation(self):
+        """Both old and new participants correct after moderation.
+
+        P0 votes on c0-c6. c0-c2 moderated-out. New participant Q votes on c3-c9.
+        Rebuild from all votes. Both should be in-conv:
+        - P0: 7 raw votes (c0-c6), threshold min(7,10)=7 → qualifies
+        - Q: 7 votes on non-moderated-out comments → qualifies
+        """
+        conv = Conversation('test-d2d-t5')
+        votes = {'votes': [
+            *[{'pid': 0, 'tid': tid, 'vote': 1} for tid in range(7)],   # c0-c6
+            *[{'pid': 1, 'tid': tid, 'vote': 1} for tid in range(3, 10)],  # c3-c9
+        ]}
+        conv = conv.update_votes(votes, recompute=False)
+        conv = conv.update_moderation({'mod_out_tids': [0, 1, 2]}, recompute=False)
+
+        in_conv = conv._get_in_conv_participants()
+        assert 0 in in_conv, "P0 (7 raw votes) should be in-conv"
+        assert 1 in in_conv, "P1 (7 votes on non-moderated-out comments) should be in-conv"
 
 
 # ============================================================================
@@ -265,7 +560,6 @@ class TestD9ZScoreThresholds:
         check.almost_equal(Z_95, 1.6449, abs=0.001,
                             msg=f"Z_95 should be 1.6449 (one-tailed), got {Z_95}")
 
-    @pytest.mark.xfail(reason="D9: Two-tailed thresholds produce empty repness")
     def test_repness_not_empty(self, conv, dataset_name):
         """Repness should produce non-empty comment_repness with correct thresholds."""
         repness = conv.repness
@@ -348,7 +642,6 @@ class TestD6TwoPropTest:
         Clojure adds +1 pseudocount to all 4 inputs (succ1, n1, succ2, n2).
     """
 
-    @pytest.mark.xfail(reason="D6: Python two_prop_test lacks pseudocounts")
     def test_two_prop_test_with_pseudocounts(self):
         """two_prop_test should add +1 pseudocounts matching Clojure."""
         # With pseudocounts: (succ+1)/(n+2) for both groups


### PR DESCRIPTION
## Summary


Fixes the in-conv participant threshold (D2), vote count source (D2c), and base-cluster sort order (D2b) to match Clojure. Adds monotonicity guard tests (D2d).

### D2: In-conv threshold

- **Before**: `threshold = 7 + sqrt(n_cmts) * 0.1` — increasingly restrictive for larger conversations (e.g., 8.8 for biodiversity's 314 comments)
- **After**: `threshold = min(7, n_cmts)` — matches Clojure exactly

### D2b: Base-cluster sort order (from Copilot review)

- **Before**: Base clusters sorted by size (descending) with IDs reassigned — changes encounter order of centers fed into group-level k-means
- **After**: Keep k-means ID order, matching Clojure's `(sort-by :id ...)`

### D2c: Vote count source (raw vs filtered matrix)

- **Before**: `_compute_user_vote_counts` and `n_cmts` used `self.rating_mat` (filtered — moderated-out comment columns removed). A participant who voted on 8 comments could drop to 5 visible votes after 3 comments were moderated-out, falling below threshold.
- **After**: Both use `self.raw_rating_mat` (includes all votes, even on moderated-out comments), matching Clojure's `user-vote-counts` (conversation.clj:217-225) which reads from `raw-rating-mat`.

### D2d: In-conv monotonicity (design decision)

Python does full recompute from `raw_rating_mat` every time, so monotonicity ("once in, always in") is guaranteed without persistence — votes are immutable in PostgreSQL, so a participant's count never decreases. This is **strictly better** than Clojure's approach (which persists in-conv to `math_main` because it uses delta vote processing).

5 guard tests (T1-T5) document this invariant and warn that switching to delta processing would require persisting in-conv to DynamoDB (ref: #2358).

### Impact

- biodiversity: 428 → 441 in-conv participants (now matches Clojure)
- Verified on 4 datasets with complete Clojure cold-start blobs

### Incremental vs cold-start blob testing

D2 tests run against both **cold-start** and **incremental** Clojure blobs (infrastructure from #2420):

- **Cold-start blobs** are computed in one pass on the full dataset. The in-conv threshold `min(7, n_cmts)` is evaluated once with the final `n_cmts`. Python matches these exactly.
- **Incremental blobs** were built progressively as votes trickled in over the conversation's lifetime. The threshold was evaluated at each iteration with a smaller `n_cmts`, admitting a few extra participants during earlier iterations. The difference is tiny (1–2 participants).

D2 tests on incremental blobs are currently **xfailed** with an explanatory comment. Matching incremental behaviour exactly would require simulating the progressive threshold — tracked as future work under Replay Infrastructure.

### Test results

```
253 passed, 5 skipped, 36 xfailed (0 failures)
```

## Test plan

- [x] D2 tests pass on all datasets with complete Clojure cold-start blobs
- [x] D2c: 3 synthetic tests verify vote counts include moderated-out votes, n_cmts includes moderated-out comments, participants stay in-conv after moderation
- [x] D2d: 5 monotonicity tests (basic across updates, survives moderation, worker restart + moderation, restart without new votes, mixed participants)
- [x] D2 tests xfail on incremental blobs (with explanatory comments)
- [x] Full test suite: 253 passed, 0 failures
- [x] Golden snapshots re-recorded for affected datasets

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Squashed commits

- Fix D2: in-conv threshold min(7, n_cmts) to match Clojure
- Skip D2 tests on datasets with incomplete Clojure blobs
- Address Copilot review: fix base-cluster sort order (D2b) and stale comment
- Add PR 1 test results to journal
- Plan: add D2c (vote count source) and D2d (in-conv monotonicity) to fix plan
- Journal: add session 3 findings (D2c vote count source, D2d monotonicity)
- Re-record golden snapshots and remove passing xfail markers
- xfail D2 in-conv tests on incremental blobs
- Journal: add session 4, update plan with D2 incremental in Replay PR B
- Fix D2c: use raw_rating_mat for vote counts and n_cmts threshold

commit-id:c0a682ec

---
**Stack**:
- #2524
- #2523
- #2522
- #2521
- #2520
- #2519
- #2518
- #2517
- #2516
- #2515
- #2514
- #2513 ⬅
- #2512
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*