### PR TITLE
Fix D15: match Clojure moderation handling (zero out columns, don't remove)

### DIFF
--- a/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
+++ b/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
@@ -712,6 +712,65 @@ to create a new worktree. If yes, provide a prompt they can use to start that se
 
 ---
 
+## Session: Fix D15 — Moderation Handling (2026-03-16)
+
+### Branch: `jc/clj-parity-d15-moderation-handling-zeros-vs-removes`
+
+### What was done
+
+Fixed D15: Python now zeros out moderated-out comment columns instead of removing them,
+matching Clojure's `zero-out-columns` behavior (named_matrix.clj:214-230).
+
+**The discrepancy**: Python's `_apply_moderation()` removed moderated-out columns from
+`rating_mat` entirely (`raw_rating_mat.loc[keep_ptpts, keep_comments]`). Clojure zeros
+them out (`matrix/set-column m' i 0`), preserving matrix structure.
+
+**The fix**: Changed `_apply_moderation()` to:
+1. Still remove moderated-out participants (rows) — unchanged
+2. Zero out moderated-out comment columns instead of removing them
+3. `rating_mat` now has the same column count as `raw_rating_mat`
+
+**Impact on downstream**:
+- `tids` output now includes moderated-out tids (matching Clojure)
+- PCA: zeroed columns contribute nothing to variance, so PCA results are effectively identical
+- Repness: zeroed columns get na=0, nd=0, failing significance — effectively excluded
+- Vote counting (`user-vote-counts`, `votes-base`, `_compute_vote_stats`) is routed
+  through `raw_rating_mat` so the moderation-zeroed values in `rating_mat` don't
+  inflate counts. This matches Clojure's `conversation.clj:220-228` (uses
+  `raw-rating-mat` for `:user-vote-counts`) and `:593-600` (uses `raw-rating-mat`
+  for `:votes-base`). See the "Audit + Recovery (2026-06-09)" session at the
+  bottom of this journal for the downstream-fix landing details — the audit
+  caught and resolved the earlier-claimed `rating_mat` routing.
+
+### Tests
+
+**New synthetic tests** (`TestD15SyntheticModeration`, 5 tests):
+- `test_zeroing_preserves_columns` — moderated columns still present
+- `test_zeroed_columns_are_all_zero` — moderated column values are 0.0
+- `test_non_moderated_columns_unchanged` — other columns retain original values
+- `test_empty_moderation_no_change` — no-op when no moderation
+- `test_moderate_nonexistent_tid` — graceful handling of unknown tids
+
+**Enhanced real-data tests** (`TestD15ModerationHandling`, 2 tests):
+- `test_moderated_comments_zeroed_not_removed` — applies mod-out from Clojure blob, checks column count and zeroed values
+- `test_tids_include_moderated` — verifies moderated tids remain in rating_mat columns
+
+**Updated existing tests**:
+- `test_conversation.py::test_moderation` — updated to expect zeroed columns
+- `test_conversation.py::test_update_moderation` — same
+- `test_discrepancy_fixes.py::TestD2cVoteCountSource::test_n_cmts_includes_moderated_out_comments` — updated comment count assertion
+
+### Test results
+
+- Public datasets: **328 passed, 0 failed, 6 skipped, 56 xfailed**
+- Private datasets: 13 failures — all **pre-existing** (golden snapshot staleness from earlier fixes, not D15-related). Verified by running parent branch.
+
+### What's next
+
+- D12 (comment priorities) or D1/D1b (PCA sign flips) — per plan ordering
+
+---
+
 ## Notes for Future Sessions
 
 - Private datasets are in `delphi/real_data/.local/` (separate git repo, linked via `link-to-polis-worktree.sh`)

--- a/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
+++ b/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
@@ -711,6 +711,60 @@ to create a new worktree. If yes, provide a prompt they can use to start that se
 
 ---
 
+## Session: Fix D15 — Moderation Handling (2026-03-16)
+
+### Branch: `jc/clj-parity-d15-moderation-handling-zeros-vs-removes`
+
+### What was done
+
+Fixed D15: Python now zeros out moderated-out comment columns instead of removing them,
+matching Clojure's `zero-out-columns` behavior (named_matrix.clj:214-230).
+
+**The discrepancy**: Python's `_apply_moderation()` removed moderated-out columns from
+`rating_mat` entirely (`raw_rating_mat.loc[keep_ptpts, keep_comments]`). Clojure zeros
+them out (`matrix/set-column m' i 0`), preserving matrix structure.
+
+**The fix**: Changed `_apply_moderation()` to:
+1. Still remove moderated-out participants (rows) — unchanged
+2. Zero out moderated-out comment columns instead of removing them
+3. `rating_mat` now has the same column count as `raw_rating_mat`
+
+**Impact on downstream**:
+- `tids` output now includes moderated-out tids (matching Clojure)
+- PCA: zeroed columns contribute nothing to variance, so PCA results are effectively identical
+- Repness: zeroed columns get na=0, nd=0, failing significance — effectively excluded
+- Vote counting: `user-vote-counts` in `to_math_blob()` uses `rating_mat`, so moderated
+  columns now count as "pass" votes (matching Clojure's behavior with zeroed columns)
+
+### Tests
+
+**New synthetic tests** (`TestD15SyntheticModeration`, 5 tests):
+- `test_zeroing_preserves_columns` — moderated columns still present
+- `test_zeroed_columns_are_all_zero` — moderated column values are 0.0
+- `test_non_moderated_columns_unchanged` — other columns retain original values
+- `test_empty_moderation_no_change` — no-op when no moderation
+- `test_moderate_nonexistent_tid` — graceful handling of unknown tids
+
+**Enhanced real-data tests** (`TestD15ModerationHandling`, 2 tests):
+- `test_moderated_comments_zeroed_not_removed` — applies mod-out from Clojure blob, checks column count and zeroed values
+- `test_tids_include_moderated` — verifies moderated tids remain in rating_mat columns
+
+**Updated existing tests**:
+- `test_conversation.py::test_moderation` — updated to expect zeroed columns
+- `test_conversation.py::test_update_moderation` — same
+- `test_discrepancy_fixes.py::TestD2cVoteCountSource::test_n_cmts_includes_moderated_out_comments` — updated comment count assertion
+
+### Test results
+
+- Public datasets: **328 passed, 0 failed, 6 skipped, 56 xfailed**
+- Private datasets: 13 failures — all **pre-existing** (golden snapshot staleness from earlier fixes, not D15-related). Verified by running parent branch.
+
+### What's next
+
+- D12 (comment priorities) or D1/D1b (PCA sign flips) — per plan ordering
+
+---
+
 ## Notes for Future Sessions
 
 - Private datasets are in `delphi/real_data/.local/` (separate git repo, linked via `link-to-polis-worktree.sh`)

--- a/delphi/docs/PLAN_DISCREPANCY_FIXES.md
+++ b/delphi/docs/PLAN_DISCREPANCY_FIXES.md
@@ -47,6 +47,9 @@ Because this work will span multiple Claude Code sessions, we maintain:
 ### Testing Principles
 
 - **Granular tests per discrepancy**: Not just overall regression — each fix gets its own targeted test checking the specific aspect it addresses. Multiple discrepancies may affect `test_basic_outputs`; we need to see incremental improvement per fix.
+- **Clojure blob comparison is MANDATORY**: Every fix PR must include tests that compare Python output to actual Clojure math blob values — not just formula re-implementation tests (which are tautological: they only verify our code matches our reading of the Clojure, not that it matches Clojure's actual output). The Clojure blob is the ground truth oracle.
+- **Stage isolation via blob injection**: Since upstream stages (PCA, clustering) may not match between Python and Clojure, tests must inject Clojure blob values as inputs to the stage being tested, then compare outputs. For example: to test `prop_test` (D5), extract `n-success` and `n-trials` from the Clojure blob's `repness` entries, feed them to Python's `prop_test()`, and compare the result to the blob's `p-test`. This isolates each stage from upstream divergence.
+- **Blob fields available for injection/comparison**: The Clojure cold-start blob provides per-group repness entries with: `n-success` (=na), `n-trials` (=ns), `p-success` (=pa), `p-test` (=pat), `repness` (=ra), `repness-test` (=rat), `repful-for`, `best-agree`, `tid`. Also: `group-clusters` (memberships), `group-votes` (per-group vote counts), `consensus` (selected consensus comments), `comment-priorities` (per-tid priority values), `in-conv` (participant list).
 - **Targeted pipeline-stage tests**: For D2/D3 (participant filtering, clustering), check in-conv count, cluster count, and cluster memberships against Clojure blob. For D12, check comment-priorities against Clojure blob.
 - **All datasets, not just biodiversity**: Every fix must pass on ALL datasets. biodiversity is just one reference among many.
 - **Synthetic edge-case tests**: Every time we discover an edge case specific to one conversation, extract it into a synthetic unit test with made-up data (never real data from private datasets). These run fast and document the intent clearly.
@@ -441,6 +444,38 @@ By this point, we should have good test coverage from all the per-discrepancy te
 
 ---
 
+### Investigation: Cold-Start K Divergence (after D15, before D12)
+
+**Prerequisite**: All cold-start-relevant upstream fixes complete: D2/D2c/D2b (in-conv,
+vote counts, sort order), D15 (moderation handling). Note: D1 (PCA sign flips) only
+affects incremental updates — on cold start there are no previous components to align to.
+
+After D15, the rating matrix construction, in-conv filtering, and PCA inputs should all
+match Clojure. Both implementations use silhouette for k-selection. Yet on vw, Python
+selects k=4 while Clojure selects k=2.
+
+**Investigation steps**:
+
+1. **PCA component comparison**: Feed the same rating matrix to both sklearn TruncatedSVD
+   and a Python reimplementation of Clojure's power iteration. Quantify divergence
+   (cosine similarity per component, Frobenius norm).
+2. **Projection comparison**: Inject Clojure blob's PCA components into Python's
+   clustering path. Does k now match?
+3. **Base-cluster comparison**: Given the same projections, compare k-means centroids
+   and member assignments. Check initialization (Clojure uses first-k-distinct centers
+   from base clusters — does Python match?).
+4. **Silhouette score comparison**: Given the same base clusters, compare per-k
+   silhouette scores. Are the scores close but the winner differs?
+5. **All datasets**: Run on all datasets with cold-start blobs, not just vw.
+
+**Outcome**: Either (a) identify a fixable discrepancy that makes k match, or
+(b) document the inherent numerical divergence between sklearn SVD and Clojure
+power iteration, and establish tolerance bounds for k agreement in tests.
+
+See `delphi/docs/HANDOFF_K_DIVERGENCE_INVESTIGATION.md` for detailed context.
+
+---
+
 ### Explicitly Deferred
 
 - **D13 — Subgroup Clustering**: Not implemented in Python, never used by TypeScript consumers. No fix needed.
@@ -470,14 +505,15 @@ By this point, we should have good test coverage from all the per-discrepancy te
 | D5 | Proportion test | **PR 4** | — | **DONE** ✓ |
 | D6 | Two-proportion test | **PR 5** | — | **DONE** ✓ |
 | D7 | Repness metric | PR 6 | — | **DONE** ✓ |
-| D8 | Finalize cmt stats | PR 7 | — | Fix |
+| D8 | Finalize cmt stats | PR 7 | — | **DONE** ✓ |
 | D9 | Z-score thresholds | **PR 3** | **#2446** | **DONE** ✓ |
 | D10 | Rep comment selection | PR 8 | — | Fix (with legacy env var) |
 | D11 | Consensus selection | PR 9 | — | Fix (with legacy env var) |
 | D12 | Comment priorities | PR 11 | — | Fix (implement from scratch) |
 | D13 | Subgroup clustering | — | — | **Deferred** (unused) |
 | D14 | Large conv optimization | — | — | **Deferred** (Python fast enough) |
-| D15 | Moderation handling | PR 12 | — | Fix |
+| D15 | Moderation handling | PR 12 | — | **DONE** ✓ |
+| K-inv | Cold-start k divergence | (investigation) | — | Branch off D15 (D2+D15 done, clustering independent of repness) |
 | Replay | Replay infrastructure (A/B/C) | — | — | NOT BUILT — D3/D1 used synthetic tests only. Needed for incremental blob comparison. |
 
 ### Non-discrepancy PRs in the stack

--- a/delphi/polismath/conversation/conversation.py
+++ b/delphi/polismath/conversation/conversation.py
@@ -296,15 +296,23 @@ class Conversation:
     def _apply_moderation(self) -> None:
         """
         Apply moderation settings to create filtered rating matrix.
+
+        Matches Clojure behavior (named_matrix.clj:214-230):
+        - Moderated-out participants are removed (rows dropped)
+        - Moderated-out comments are ZEROED OUT, not removed — the column
+          stays in the matrix with all values set to 0.  This preserves
+          matrix structure so that tids, column indices, and dimensions
+          match between Python and Clojure.
         """
-        # Filter out moderated participants and comments, and keep them sorted!
-        # Note: set operations are unordered, hence the extra sort.
-        # Natural sort: preserves types and sorts numerically when possible
+        # Filter out moderated participants (remove rows)
         keep_ptpts = natsorted(list(set(self.raw_rating_mat.index) - set(self.mod_out_ptpts)))
-        keep_comments = natsorted(list(set(self.raw_rating_mat.columns) - set(self.mod_out_tids)))
-        
-        # Create filtered matrix
-        self.rating_mat = self.raw_rating_mat.loc[keep_ptpts, keep_comments]
+        self.rating_mat = self.raw_rating_mat.loc[keep_ptpts].copy()
+
+        # Zero out moderated-out comments (keep columns, set values to 0)
+        # Clojure: (matrix/set-column m' i 0) — zeroes the column
+        mod_cols = [c for c in self.mod_out_tids if c in self.rating_mat.columns]
+        if mod_cols:
+            self.rating_mat[mod_cols] = 0.0
     
     def _compute_vote_stats(self) -> None:
         """
@@ -323,8 +331,11 @@ class Conversation:
         }
 
         try:
-            # Get clean numeric matrix
-            clean_mat = self._get_clean_matrix()
+            # Use raw_rating_mat (Clojure parity): post-D15 zeroed-moderation columns
+            # in self.rating_mat would otherwise inflate n_votes / per-comment 'S' /
+            # per-participant counts. raw_rating_mat still has NaN for non-votes,
+            # matching Clojure's user-vote-counts and votes-base semantics.
+            clean_mat = self._get_clean_matrix(raw=True)
             values = clean_mat.to_numpy()
 
             # Create boolean masks once for the entire matrix.
@@ -492,15 +503,25 @@ class Conversation:
             self.proj = {pid: np.zeros(2) for pid in self.rating_mat.index}
             logger.info(f"PCA computation completed in {time.time() - start_time:.2f}s (with errors)")
 
-    def _get_clean_matrix(self) -> pd.DataFrame:
+    def _get_clean_matrix(self, raw: bool = False) -> pd.DataFrame:
         """
         Get a clean copy of the rating matrix with proper numeric values.
-        
+
+        Args:
+            raw: If True, sanitize self.raw_rating_mat filtered to
+                 self.rating_mat.index (includes votes on moderated-out comments
+                 but excludes moderated-out participants, matching Clojure's
+                 user-vote-counts / votes-base semantics combined with Polis's
+                 mod_out_ptpts handling). If False (default), sanitize the
+                 moderation-applied self.rating_mat (used for PCA and clustering).
+
         Returns:
             Clean DataFrame with numeric values
         """
+        source = (self.raw_rating_mat.loc[self.rating_mat.index]
+                  if raw else self.rating_mat)
         # Convert all entries to float64, with np.nan for pd.NA and for strings
-        matrix_data = self.rating_mat.to_numpy(copy=True)
+        matrix_data = source.to_numpy(copy=True)
         if not np.issubdtype(matrix_data.dtype, np.floating):
             try:
                 matrix_data = matrix_data.astype(float)
@@ -523,7 +544,7 @@ class Conversation:
                 # Step 5: Convert back to numpy array
                 matrix_data = df_numeric.to_numpy(dtype='float64')
 
-        return pd.DataFrame(matrix_data, index=self.rating_mat.index, columns=self.rating_mat.columns)
+        return pd.DataFrame(matrix_data, index=source.index, columns=source.columns)
     
     def _compute_clusters(self) -> None:
         """
@@ -1074,53 +1095,47 @@ class Conversation:
         logger.info(f"Total get_full_data time: {time.time() - start_time:.4f}s")
         return result
     
-    # TODO(julien): why is that not called anywhere ?
     def _compute_votes_base(self) -> Dict[str, Any]:
         """
-        Compute votes base structure which maps each comment ID to aggregated vote counts.
-        This matches the Clojure conversation.clj votes-base implementation.
-        
+        Compute per-comment vote aggregations, matching Clojure's votes-base.
+
+        Clojure (math/src/polismath/math/conversation.clj:593-600):
+            :votes-base (plmb/fnk [bid-to-pid raw-rating-mat]
+                          (->> raw-rating-mat
+                            nm/colnames
+                            (map ...
+                              {:A (count agree?) :D (count disagree?) :S (count number?)})))
+
+        Reads from raw_rating_mat (not the moderation-zeroed rating_mat) so
+        that moderated-out columns report the actual votes cast, not the
+        post-D15 zeros. 'S' is the total non-NaN count per Clojure semantics
+        (number? predicate), not just pass votes.
+
         Returns:
-            Dictionary mapping comment IDs to vote statistics
+            Dictionary mapping comment IDs to {'A': int, 'D': int, 'S': int}.
         """
-        import numpy as np
-        
-        # Get all comment IDs
-        comment_ids = self.rating_mat.columns
-        
-        # Helper functions to identify vote types (like utils/agree?, utils/disagree? in Clojure)
-        def agree_vote(x):
-            return not np.isnan(x) and abs(x - 1.0) < 0.001
-            
-        def disagree_vote(x):
-            return not np.isnan(x) and abs(x + 1.0) < 0.001
-            
-        def is_number(x):
-            return not np.isnan(x)
-        
-        # Create vote aggregations for each comment
+        # raw_rating_mat for the COLUMN view (D15 parity — un-zeroed values), but
+        # filtered to rating_mat.index for the ROW view so moderated-out participants
+        # don't leak into per-comment counts. See _compute_user_vote_counts for the
+        # same dual-filter rationale.
+        mat = self.raw_rating_mat.loc[self.rating_mat.index]
+        values = mat.values
+        agree_mask = np.abs(values - 1.0) < 0.001
+        disagree_mask = np.abs(values + 1.0) < 0.001
+        valid_mask = ~np.isnan(values)
+
         votes_base = {}
-        for tid in comment_ids:
-            # Get the column for this comment
+        for j, tid in enumerate(mat.columns):
+            entry = {
+                'A': int(np.sum(agree_mask[:, j])),
+                'D': int(np.sum(disagree_mask[:, j])),
+                'S': int(np.sum(valid_mask[:, j])),
+            }
             try:
-                # TODO(julien): how can that even work ?? Should be self.rating_mat[tid]
-                votes = self.rating_mat[:, 'tid'].to_numpy()
-                
-                # Count vote types
-                agree_votes = np.sum(agree_vote(votes))
-                disagree_votes = np.sum(disagree_vote(votes))
-                total_votes = np.sum(is_number(votes))
-                
-                # Store in format matching Clojure
-                votes_base[tid] = {
-                    'A': int(agree_votes),
-                    'D': int(disagree_votes),
-                    'S': int(total_votes)
-                }
-            except (ValueError, IndexError) as e:
-                # If comment not found, use empty counts
-                votes_base[tid] = {'A': 0, 'D': 0, 'S': 0}
-                
+                votes_base[int(tid)] = entry
+            except (ValueError, TypeError):
+                votes_base[tid] = entry
+
         return votes_base
     
     def _compute_group_votes(self) -> Dict[str, Any]:
@@ -1224,7 +1239,12 @@ class Conversation:
         """
         import time
         start_time = time.time()
-        mat = self.raw_rating_mat
+        # raw_rating_mat for the COLUMN view (preserves moderated-out comments — D15
+        # parity), but filtered to rating_mat.index for the ROW view so moderated-out
+        # *participants* (mod_out_ptpts, dropped by _apply_moderation) don't leak
+        # into vote counts. Both filters together give the moderation-applied state
+        # with un-zeroed values, matching what Clojure produces.
+        mat = self.raw_rating_mat.loc[self.rating_mat.index]
         logger.info(f"Starting _compute_user_vote_counts for {mat.shape[0]} participants")
 
         vote_counts = {}
@@ -1522,54 +1542,18 @@ class Conversation:
         result['n'] = self.participant_count
         result['n-cmts'] = self.comment_count
         
-        # Add user vote counts with vectorized operations
+        # Clojure parity (conversation.clj:220-228): user-vote-counts must come from
+        # raw_rating_mat so that post-D15 zeroed columns don't inflate per-participant counts.
+        # _compute_user_vote_counts() already routes through raw_rating_mat correctly.
         vote_counts_start = time.time()
-        
-        # Use more efficient batch processing approach from to_dynamo_dict
-        user_vote_counts = {}
-        if len(self.rating_mat.index) > 0:
-            # Create a mask of non-nan values and sum across rows
-            non_nan_mask = ~np.isnan(self.rating_mat.values)
-            row_sums = np.sum(non_nan_mask, axis=1)
-            
-            # Convert to dictionary with integer keys where possible
-            for i, pid in enumerate(self.rating_mat.index):
-                if i < len(row_sums):
-                    # Try to convert participant ID to integer for Clojure compatibility
-                    try:
-                        user_vote_counts[int(pid)] = int(row_sums[i])
-                    except (ValueError, TypeError):
-                        user_vote_counts[pid] = int(row_sums[i])
-        
-        result['user-vote-counts'] = user_vote_counts
+        result['user-vote-counts'] = self._compute_user_vote_counts()
         logger.info(f"User vote counts: {time.time() - vote_counts_start:.4f}s")
         
-        # Calculate votes-base efficiently with vectorized operations
+        # Clojure parity (conversation.clj:593-600): votes-base must come from
+        # raw_rating_mat so that moderated-out columns report the actual votes cast,
+        # not the post-D15 zeros (which would inflate every column's 'S' count).
         votes_base_start = time.time()
-        
-        # Create pre-calculated masks for agree/disagree votes
-        agree_mask = np.abs(self.rating_mat.values - 1.0) < 0.001
-        disagree_mask = np.abs(self.rating_mat.values + 1.0) < 0.001
-        valid_mask = ~np.isnan(self.rating_mat.values)
-        
-        # Compute votes base with vectorized operations
-        votes_base = {}
-        for j, tid in enumerate(self.rating_mat.columns):
-            if j >= self.rating_mat.values.shape[1]:
-                continue
-                
-            # Calculate vote stats with vectorized operations
-            col_agree = np.sum(agree_mask[:, j])
-            col_disagree = np.sum(disagree_mask[:, j])
-            col_total = np.sum(valid_mask[:, j])
-            
-            # Try to convert tid to int for Clojure compatibility
-            try:
-                votes_base[int(tid)] = {'A': int(col_agree), 'D': int(col_disagree), 'S': int(col_total)}
-            except (ValueError, TypeError):
-                votes_base[tid] = {'A': int(col_agree), 'D': int(col_disagree), 'S': int(col_total)}
-        
-        result['votes-base'] = votes_base
+        result['votes-base'] = self._compute_votes_base()
         logger.info(f"Votes base: {time.time() - votes_base_start:.4f}s")
         
         # Compute group votes with optimized approach
@@ -2090,24 +2074,11 @@ class Conversation:
             except (ValueError, TypeError):
                 result['meta_comments'].append(tid)
         
-        # Add user vote counts (more efficient approach)
+        # Clojure parity (conversation.clj:220-228): user-vote-counts come from
+        # raw_rating_mat. Routed through the same helper used by to_dict so the
+        # two serializers can't drift apart again (audit-discovered 2026-06-09).
         logger.info(f"[{time.time() - start_time:.2f}s] Computing user vote counts...")
-        user_vote_counts = {}
-        for i, pid in enumerate(self.rating_mat.index):
-            # Skip if index is out of bounds
-            if i >= self.rating_mat.values.shape[0]:
-                continue
-                
-            # Count votes with efficient numpy operations
-            row = self.rating_mat.values[i, :]
-            count = int(np.sum(~np.isnan(row)))
-            
-            # Try to convert pid to int for DynamoDB
-            try:
-                user_vote_counts[int(pid)] = count
-            except (ValueError, TypeError):
-                user_vote_counts[pid] = count
-        
+        user_vote_counts = self._compute_user_vote_counts()
         result['user_vote_counts'] = user_vote_counts
         
         # Calculate included participants (meeting vote threshold)
@@ -2121,37 +2092,16 @@ class Conversation:
         
         result['included_participants'] = included_participants
         
-        # Add votes base structure (optimized batch conversion)
+        # Clojure parity (conversation.clj:593-600): votes-base comes from
+        # raw_rating_mat. Routed through the same helper used by to_dict; DynamoDB
+        # uses different key names (agree/disagree/total vs Clojure's A/D/S) so we
+        # rename on the way out. Audit-discovered 2026-06-09.
         logger.info(f"[{time.time() - start_time:.2f}s] Computing votes base structure...")
         votes_base_start = time.time()
-        votes_base = {}
-        
-        # Pre-identify agree, disagree, and voteless masks
-        agree_mask = np.abs(self.rating_mat.values - 1.0) < 0.001
-        disagree_mask = np.abs(self.rating_mat.values + 1.0) < 0.001
-        valid_mask = ~np.isnan(self.rating_mat.values)
-        
-        # Process column by column
-        for j, tid in enumerate(self.rating_mat.columns):
-            if j >= self.rating_mat.values.shape[1]:
-                continue
-                
-            # Get the column
-            try:
-                # Calculate stats with vectorized operations
-                col_agree = np.sum(agree_mask[:, j])
-                col_disagree = np.sum(disagree_mask[:, j])
-                col_total = np.sum(valid_mask[:, j])
-                
-                # Try to convert tid to int for compatibility
-                try:
-                    votes_base[int(tid)] = {'agree': int(col_agree), 'disagree': int(col_disagree), 'total': int(col_total)}
-                except (ValueError, TypeError):
-                    votes_base[tid] = {'agree': int(col_agree), 'disagree': int(col_disagree), 'total': int(col_total)}
-            except (IndexError, ValueError, TypeError):
-                # Handle any errors gracefully
-                continue
-        
+        votes_base = {
+            tid: {'agree': entry['A'], 'disagree': entry['D'], 'total': entry['S']}
+            for tid, entry in self._compute_votes_base().items()
+        }
         logger.info(f"[{time.time() - start_time:.2f}s] votes_base computed in {time.time() - votes_base_start:.2f}s")
         result['votes_base'] = votes_base
         

--- a/delphi/polismath/conversation/conversation.py
+++ b/delphi/polismath/conversation/conversation.py
@@ -296,15 +296,23 @@ class Conversation:
     def _apply_moderation(self) -> None:
         """
         Apply moderation settings to create filtered rating matrix.
+
+        Matches Clojure behavior (named_matrix.clj:214-230):
+        - Moderated-out participants are removed (rows dropped)
+        - Moderated-out comments are ZEROED OUT, not removed — the column
+          stays in the matrix with all values set to 0.  This preserves
+          matrix structure so that tids, column indices, and dimensions
+          match between Python and Clojure.
         """
-        # Filter out moderated participants and comments, and keep them sorted!
-        # Note: set operations are unordered, hence the extra sort.
-        # Natural sort: preserves types and sorts numerically when possible
+        # Filter out moderated participants (remove rows)
         keep_ptpts = natsorted(list(set(self.raw_rating_mat.index) - set(self.mod_out_ptpts)))
-        keep_comments = natsorted(list(set(self.raw_rating_mat.columns) - set(self.mod_out_tids)))
-        
-        # Create filtered matrix
-        self.rating_mat = self.raw_rating_mat.loc[keep_ptpts, keep_comments]
+        self.rating_mat = self.raw_rating_mat.loc[keep_ptpts].copy()
+
+        # Zero out moderated-out comments (keep columns, set values to 0)
+        # Clojure: (matrix/set-column m' i 0) — zeroes the column
+        mod_cols = [c for c in self.mod_out_tids if c in self.rating_mat.columns]
+        if mod_cols:
+            self.rating_mat[mod_cols] = 0.0
     
     def _compute_vote_stats(self) -> None:
         """

--- a/delphi/tests/test_conversation.py
+++ b/delphi/tests/test_conversation.py
@@ -408,10 +408,13 @@ class TestConversation:
         assert 'c2' in moderated_conv.mod_out_tids
         assert 'p3' in moderated_conv.mod_out_ptpts
         
-        # Check filtered rating matrix
-        assert 'c2' not in moderated_conv.rating_mat.columns
-        assert 'p3' not in moderated_conv.rating_mat.index
-        
+        # Check filtered rating matrix:
+        # - Moderated-out comments are ZEROED, not removed (D15 fix)
+        # - Moderated-out participants are still removed (rows dropped)
+        assert 'c2' in moderated_conv.rating_mat.columns  # column kept
+        assert (moderated_conv.rating_mat['c2'] == 0.0).all()  # but zeroed
+        assert 'p3' not in moderated_conv.rating_mat.index  # participant removed
+
         # Raw matrix should still have all data
         assert 'c2' in moderated_conv.raw_rating_mat.columns
         assert 'p3' in moderated_conv.raw_rating_mat.index
@@ -605,9 +608,10 @@ class TestConversationManager:
         
         conv = manager.update_moderation('test_conv', moderation)
         
-        # Check moderation was applied
+        # Check moderation was applied: column kept but zeroed (D15 fix)
         assert 'c2' in conv.mod_out_tids
-        assert 'c2' not in conv.rating_mat.columns
+        assert 'c2' in conv.rating_mat.columns
+        assert (conv.rating_mat['c2'] == 0.0).all()
     
     # Suppress sklearn PCA warning: test uses minimal data (2 participants, 2 comments)
     # which can have zero variance. The test validates that recompute runs, not PCA quality.

--- a/delphi/tests/test_discrepancy_fixes.py
+++ b/delphi/tests/test_discrepancy_fixes.py
@@ -289,12 +289,13 @@ class TestD2cVoteCountSource:
             participant_votes={0: list(range(10))},
         )
 
-        # raw_rating_mat has all columns; rating_mat has only non-moderated-out
+        # Both raw_rating_mat and rating_mat have all columns (D15 fix:
+        # moderated-out columns are zeroed, not removed)
         n_cmts_raw = len(conv.raw_rating_mat.columns)
         n_cmts_filtered = len(conv.rating_mat.columns)
 
         assert n_cmts_raw == 10, f"raw_rating_mat should have 10 columns, got {n_cmts_raw}"
-        assert n_cmts_filtered == 5, f"rating_mat should have 5 columns, got {n_cmts_filtered}"
+        assert n_cmts_filtered == 10, f"rating_mat should keep all 10 columns (zeroed, not removed), got {n_cmts_filtered}"
 
         # The threshold used by _get_in_conv_participants should be min(7, 10) = 7,
         # not min(7, 5) = 5. Verify indirectly: participant with exactly 6 votes
@@ -1223,29 +1224,374 @@ class TestD15ModerationHandling:
     """
     D15: Python removes moderated comments entirely from matrix.
          Clojure zeros them out (keeps structure, sets values to 0).
+
+    Clojure behavior (named_matrix.clj:214-230):
+      zero-out-columns sets all values in moderated columns to 0,
+      preserving the matrix structure (same number of columns).
+
+    Python should match: _apply_moderation() must zero out moderated
+    columns rather than removing them, so that:
+      - rating_mat.columns includes moderated tids (zeroed)
+      - tids output includes moderated tids
+      - Matrix dimensions match Clojure
     """
 
     def test_moderated_comments_zeroed_not_removed(self, conv, clojure_blob, dataset_name):
         """
-        Moderated comments should be zeroed out, not removed, if any exist.
-
-        Note: This test only applies when the dataset has moderated comments.
+        After applying moderation, rating_mat should still have all columns.
+        Moderated columns should be zeroed, not removed.
         """
-        # Check if Clojure blob has mod-out comments
-        mod_out = clojure_blob.get('mod-out', [])
+        mod_out = clojure_blob.get('mod-out') or []
         if not mod_out:
             pytest.skip(f"[{dataset_name}] No moderated comments in this dataset")
 
-        # If there ARE moderated comments, check Python's handling
-        n_cols_python = len(conv.rating_mat.columns)
-        n_tids_clojure = len(clojure_blob.get('tids', []))
+        # Apply moderation from the Clojure blob to the Python conversation
+        mod_conv = conv.update_moderation(
+            {'mod_out_tids': mod_out},
+            recompute=False,
+        )
 
-        print(f"[{dataset_name}] Moderated comments: {len(mod_out)}")
-        print(f"[{dataset_name}] Python matrix columns: {n_cols_python}, Clojure tids: {n_tids_clojure}")
+        n_cols_python = len(mod_conv.rating_mat.columns)
+        n_cols_raw = len(mod_conv.raw_rating_mat.columns)
 
-        # Clojure keeps all tids (zeroed for mod-out), Python removes them
-        check.equal(n_cols_python, n_tids_clojure,
-                     f"Matrix columns differ: Python={n_cols_python}, Clojure={n_tids_clojure} (mod-out={len(mod_out)})")
+        print(f"[{dataset_name}] mod-out: {len(mod_out)}")
+        print(f"[{dataset_name}] Python rating_mat cols: {n_cols_python}, raw cols: {n_cols_raw}")
+        print(f"[{dataset_name}] Clojure tids: {len(clojure_blob.get('tids', []))}")
+
+        # After zeroing (not removing), column count should match raw matrix
+        check.equal(
+            n_cols_python, n_cols_raw,
+            f"rating_mat should keep all columns (zeroed, not removed): "
+            f"got {n_cols_python}, expected {n_cols_raw}"
+        )
+
+        # Moderated columns should be all zeros (not NaN, not original values)
+        for tid in mod_out:
+            if tid in mod_conv.rating_mat.columns:
+                col_values = mod_conv.rating_mat[tid].values
+                check.is_true(
+                    np.all(col_values == 0.0),
+                    f"Moderated tid {tid} should be all zeros, "
+                    f"got non-zero values: {col_values[col_values != 0.0][:5]}"
+                )
+
+    def test_tids_include_moderated(self, conv, clojure_blob, dataset_name):
+        """The tids output should include moderated-out comments (matching Clojure)."""
+        mod_out = clojure_blob.get('mod-out') or []
+        if not mod_out:
+            pytest.skip(f"[{dataset_name}] No moderated comments in this dataset")
+
+        mod_conv = conv.update_moderation(
+            {'mod_out_tids': mod_out},
+            recompute=False,
+        )
+
+        # rating_mat.columns (used for tids output) should include moderated tids
+        for tid in mod_out:
+            if tid in mod_conv.raw_rating_mat.columns:
+                check.is_in(
+                    tid, set(mod_conv.rating_mat.columns),
+                    f"Moderated tid {tid} should still be in rating_mat columns"
+                )
+
+
+class TestD15SyntheticModeration:
+    """
+    Synthetic tests for D15 moderation handling.
+
+    Clojure zeros out moderated columns (named_matrix.clj:214-230).
+    Python must match: _apply_moderation() zeros columns, not removes them.
+    """
+
+    def _make_conversation_with_moderation(self, mod_out_tids):
+        """Create a small conversation and apply moderation."""
+        import pandas as pd
+
+        # 5 participants, 4 comments. Votes: agree=1, disagree=-1, pass=0, no vote=NaN
+        data = {
+            0: [1.0, -1.0, 1.0, np.nan, 0.0],
+            1: [-1.0, 1.0, 0.0, 1.0, -1.0],
+            2: [1.0, 1.0, -1.0, -1.0, 1.0],
+            3: [np.nan, 0.0, 1.0, 1.0, -1.0],
+        }
+        votes_df = pd.DataFrame(data, index=[0, 1, 2, 3, 4])
+
+        conv = Conversation("synthetic_d15")
+        conv.raw_rating_mat = votes_df.copy()
+        conv.rating_mat = votes_df.copy()
+        conv.participant_count, conv.comment_count = votes_df.shape
+
+        # Apply moderation
+        conv.mod_out_tids = set(mod_out_tids)
+        conv._apply_moderation()
+        return conv
+
+    def test_zeroing_preserves_columns(self):
+        """Moderated columns should still be present in rating_mat."""
+        conv = self._make_conversation_with_moderation(mod_out_tids=[1, 3])
+
+        # All 4 columns should still be present
+        assert len(conv.rating_mat.columns) == 4, (
+            f"Expected 4 columns, got {len(conv.rating_mat.columns)}: "
+            f"moderated columns should be zeroed, not removed"
+        )
+        assert set(conv.rating_mat.columns) == {0, 1, 2, 3}
+
+    def test_zeroed_columns_are_all_zero(self):
+        """Moderated columns should have all values set to 0.0."""
+        conv = self._make_conversation_with_moderation(mod_out_tids=[1, 3])
+
+        for tid in [1, 3]:
+            col = conv.rating_mat[tid].values
+            assert np.all(col == 0.0), (
+                f"Moderated column {tid} should be all zeros, got {col}"
+            )
+
+    def test_non_moderated_columns_unchanged(self):
+        """Non-moderated columns should retain their original values."""
+        conv = self._make_conversation_with_moderation(mod_out_tids=[1])
+
+        # Column 0 should be unchanged: [1, -1, 1, NaN, 0]
+        col0 = conv.rating_mat[0].values
+        assert col0[0] == 1.0
+        assert col0[1] == -1.0
+        assert np.isnan(col0[3])  # NaN preserved for non-moderated
+
+    def test_empty_moderation_no_change(self):
+        """No moderation should leave the matrix unchanged."""
+        conv = self._make_conversation_with_moderation(mod_out_tids=[])
+        assert len(conv.rating_mat.columns) == 4
+
+    def test_moderate_nonexistent_tid(self):
+        """Moderating a tid that doesn't exist in the matrix should be a no-op."""
+        conv = self._make_conversation_with_moderation(mod_out_tids=[99])
+        # All columns preserved, no crash
+        assert len(conv.rating_mat.columns) == 4
+        # Original values intact
+        assert conv.rating_mat[0].values[0] == 1.0
+
+    # ------------------------------------------------------------------
+    # Downstream parity tests: zeroed columns must NOT poison user-vote
+    # counts, per-comment votes-base, or _compute_vote_stats.
+    # Audit-discovered 2026-06-09. Clojure (conversation.clj:220-228, 593-600)
+    # routes these from raw-rating-mat, not the zeroed rating-mat.
+    # ------------------------------------------------------------------
+
+    def test_user_vote_counts_uses_raw_rating_mat(self):
+        """user-vote-counts must reflect actual votes, not the post-D15 zeros.
+
+        Synthetic conv has pid 3 with raw NaN on tid 0 (didn't vote). After
+        moderating tid 0, the OLD bug (reading from rating_mat) counts the
+        zeroed cell as a vote → pid 3 inflates from 3 to 4. The fix routes
+        through raw_rating_mat to match Clojure (conversation.clj:220-228).
+        """
+        conv = self._make_conversation_with_moderation(mod_out_tids=[0])
+        counts = conv._compute_user_vote_counts()
+        # Truth per raw matrix (NaN cells excluded):
+        #   pid 0 voted on tids 0,1,2 (NaN on 3) → 3
+        #   pid 1: all 4
+        #   pid 2: all 4
+        #   pid 3 voted on tids 1,2,3 (NaN on 0) → 3   ← would inflate to 4 with old bug
+        #   pid 4: all 4
+        assert counts.get(0) == 3
+        assert counts.get(1) == 4
+        assert counts.get(2) == 4
+        assert counts.get(3) == 3, (
+            "pid 3 didn't vote on moderated tid 0 (raw=NaN); count must stay 3, "
+            f"not inflate to {counts.get(3)}"
+        )
+        assert counts.get(4) == 4
+
+    def test_votes_base_uses_raw_rating_mat(self):
+        """to_dict's votes-base for moderated tids must reflect raw votes, not zeros.
+
+        After moderating tid 0 the OLD bug returns
+        {0: {'A': 0, 'D': 0, 'S': 5}} (all 5 pids appear as 'S' since 0.0 is
+        non-NaN). Truth (raw_rating_mat) is {'A': 2, 'D': 1, 'S': 4} (4 actual
+        votes; pid 3 NaN). Matches Clojure (conversation.clj:593-600).
+        """
+        conv = self._make_conversation_with_moderation(mod_out_tids=[0])
+        vb = conv._compute_votes_base()
+        # tid 0 (moderated): pid 0=1.0 (A), pid 1=-1.0 (D), pid 2=1.0 (A),
+        # pid 3=NaN, pid 4=0.0 (pass) → A=2, D=1, S=4
+        assert vb[0] == {'A': 2, 'D': 1, 'S': 4}, (
+            f"moderated tid 0 votes-base must come from raw_rating_mat: got {vb[0]}"
+        )
+        # tid 1 (not moderated): pid 0=-1, pid 1=1, pid 2=1, pid 3=0, pid 4=-1
+        # → A=2, D=2, S=5
+        assert vb[1] == {'A': 2, 'D': 2, 'S': 5}
+
+    def test_compute_vote_stats_uses_raw_rating_mat(self):
+        """_compute_vote_stats.n_votes must not count moderated-out zeros."""
+        conv = self._make_conversation_with_moderation(mod_out_tids=[0])
+        conv._compute_vote_stats()
+        # Truth (raw): 4 + 5 + 5 + 4 = 18 actual votes across all tids.
+        # OLD bug (rating_mat with zeroed tid 0): 5 (zeroed) + 5 + 5 + 4 = 19.
+        assert conv.vote_stats['n_votes'] == 18, (
+            f"n_votes must count raw votes only; got {conv.vote_stats['n_votes']}, expected 18"
+        )
+
+    def test_vote_counts_exclude_moderated_out_participants(self):
+        """Moderated-out *participants* (mod_out_ptpts) must NOT appear in vote stats.
+
+        D15 fixed moderated comment *columns* (zeroed, not removed). Polis also
+        supports moderated-out *participants* via `mod_out_ptpts`, which
+        `_apply_moderation` drops from `rating_mat.index`. The raw_rating_mat
+        routing for vote counting must NOT leak these participants — otherwise
+        excluded users' votes would still show up in `user-vote-counts`,
+        `votes-base`, and `_compute_vote_stats`.
+        """
+        import pandas as pd
+
+        # Same matrix as the helper, with pid 3 moderated out.
+        data = {
+            0: [1.0, -1.0, 1.0, np.nan, 0.0],
+            1: [-1.0, 1.0, 0.0, 1.0, -1.0],
+            2: [1.0, 1.0, -1.0, -1.0, 1.0],
+            3: [np.nan, 0.0, 1.0, 1.0, -1.0],
+        }
+        votes_df = pd.DataFrame(data, index=[0, 1, 2, 3, 4])
+        conv = Conversation("synthetic_d15_mod_ptpts")
+        conv.raw_rating_mat = votes_df.copy()
+        conv.rating_mat = votes_df.copy()
+        conv.participant_count, conv.comment_count = votes_df.shape
+        conv.mod_out_ptpts = {3}  # ban pid 3
+        conv._apply_moderation()
+
+        # rating_mat should have dropped pid 3
+        assert 3 not in conv.rating_mat.index, "_apply_moderation should drop mod_out_ptpts"
+
+        # user-vote-counts must not include pid 3
+        counts = conv._compute_user_vote_counts()
+        assert 3 not in counts, (
+            f"moderated-out pid 3 leaked into user-vote-counts: {sorted(counts.keys())}"
+        )
+
+        # votes-base counts must reflect 4 participants (0,1,2,4), not 5.
+        # tid 1 (not moderated): pid 0=-1 (D), pid 1=1 (A), pid 2=0 (pass),
+        #                        pid 3 dropped, pid 4=-1 (D)  → A=1, D=2, S=4
+        vb = conv._compute_votes_base()
+        assert vb[1] == {'A': 1, 'D': 2, 'S': 4}, (
+            f"tid 1 votes-base must exclude moderated-out pid 3; "
+            f"got {vb[1]}, expected {{A:1, D:2, S:4}}"
+        )
+
+        # vote_stats global n_votes: only count over the 4 remaining participants.
+        # pid 0: 3, pid 1: 4, pid 2: 4, pid 4: 4 → total 15 (not 18).
+        conv._compute_vote_stats()
+        assert conv.vote_stats['n_votes'] == 15, (
+            f"n_votes must exclude moderated-out participants: got "
+            f"{conv.vote_stats['n_votes']}, expected 15"
+        )
+
+    def test_to_dict_and_to_dynamo_dict_serialize_user_vote_counts_and_votes_base(self):
+        """End-to-end serialization shape regression for the 2026-06-09 refactor.
+
+        Before this session, `to_dict` and `to_dynamo_dict` each had their own
+        inline implementations of user-vote-counts and votes-base. Both were
+        refactored to route through `_compute_user_vote_counts()` /
+        `_compute_votes_base()`. This test pins the serializer output shape so
+        the refactor can't silently change the on-the-wire format:
+
+        - `to_dict.user-vote-counts`  : key `'user-vote-counts'` (hyphen),
+                                        value `{int-pid: int-count}` per Clojure naming.
+        - `to_dict.votes-base`        : key `'votes-base'`, value `{int-tid: {'A','D','S'}}`.
+        - `to_dynamo_dict.user_vote_counts` : key with **underscore**, same value shape.
+        - `to_dynamo_dict.votes_base`       : key with **underscore**, value
+                                              `{int-tid: {'agree','disagree','total'}}`
+                                              (DynamoDB key convention, NOT A/D/S).
+
+        Also: values must be `int` (DynamoDB rejects `numpy.int64` later in the
+        serialization pipeline; the helpers wrap with `int(...)`).
+        """
+        # Build a tiny conv with enough state for both serializers to reach
+        # the user-vote-counts / votes-base sections without crashing
+        # downstream on missing PCA / cluster state. Both serializers gate
+        # group-votes / projections on empty `group_clusters` / `proj`, so a
+        # bare-bones conv is enough.
+        conv = self._make_conversation_with_moderation(mod_out_tids=[])
+        # Minimal extra state for the serializers (set on default __init__
+        # values where possible; only add what the serializers actually read).
+        conv.conversation_id = 99999
+        conv.last_updated = 0
+
+        # ---- to_dict ----
+        try:
+            blob = conv.to_dict()
+        except Exception as e:  # pragma: no cover
+            pytest.fail(f"to_dict() raised on synthetic conv: {e!r}")
+
+        assert 'user-vote-counts' in blob, "to_dict must produce 'user-vote-counts' (hyphen) key"
+        assert 'votes-base' in blob, "to_dict must produce 'votes-base' (hyphen) key"
+
+        uvc = blob['user-vote-counts']
+        assert isinstance(uvc, dict)
+        assert len(uvc) == 5, f"5 participants → 5 vote-count entries, got {len(uvc)}"
+        for pid, count in uvc.items():
+            assert isinstance(pid, int), (
+                f"to_dict user-vote-counts pid must be int (numpy-safe), got {type(pid)}")
+            assert isinstance(count, int) and not isinstance(count, bool), (
+                f"to_dict user-vote-counts value must be int, got {type(count)}")
+
+        vb = blob['votes-base']
+        assert isinstance(vb, dict)
+        assert len(vb) == 4, f"4 comments → 4 votes-base entries, got {len(vb)}"
+        for tid, entry in vb.items():
+            assert isinstance(tid, int), (
+                f"to_dict votes-base tid must be int (numpy-safe), got {type(tid)}")
+            assert set(entry.keys()) == {'A', 'D', 'S'}, (
+                f"to_dict votes-base entry must have Clojure-style A/D/S keys, got {set(entry.keys())}")
+            for k, v in entry.items():
+                assert isinstance(v, int) and not isinstance(v, bool), (
+                    f"to_dict votes-base {k} must be int, got {type(v)}")
+
+        # ---- to_dynamo_dict ----
+        try:
+            dyn = conv.to_dynamo_dict()
+        except Exception as e:  # pragma: no cover
+            pytest.fail(f"to_dynamo_dict() raised on synthetic conv: {e!r}")
+
+        assert 'user_vote_counts' in dyn, "to_dynamo_dict must produce 'user_vote_counts' (underscore)"
+        assert 'votes_base' in dyn, "to_dynamo_dict must produce 'votes_base' (underscore)"
+        # Crucial: the OLD format used hyphens NOWHERE; the DynamoDB serializer
+        # must never emit Clojure-style keys.
+        assert 'user-vote-counts' not in dyn, "to_dynamo_dict must not emit hyphen-style key"
+        assert 'votes-base' not in dyn, "to_dynamo_dict must not emit hyphen-style key"
+
+        dyn_uvc = dyn['user_vote_counts']
+        assert isinstance(dyn_uvc, dict)
+        assert len(dyn_uvc) == 5
+        for pid, count in dyn_uvc.items():
+            assert isinstance(pid, int), (
+                f"to_dynamo_dict user_vote_counts pid must be int, got {type(pid)}")
+            assert isinstance(count, int) and not isinstance(count, bool), (
+                f"to_dynamo_dict user_vote_counts value must be int, got {type(count)}")
+
+        dyn_vb = dyn['votes_base']
+        assert isinstance(dyn_vb, dict)
+        assert len(dyn_vb) == 4
+        for tid, entry in dyn_vb.items():
+            assert isinstance(tid, int), (
+                f"to_dynamo_dict votes_base tid must be int, got {type(tid)}")
+            assert set(entry.keys()) == {'agree', 'disagree', 'total'}, (
+                "to_dynamo_dict votes_base entries must have DynamoDB-style "
+                f"agree/disagree/total keys (NOT A/D/S), got {set(entry.keys())}")
+            for k, v in entry.items():
+                assert isinstance(v, int) and not isinstance(v, bool), (
+                    f"to_dynamo_dict votes_base {k} must be int, got {type(v)}")
+
+        # Cross-check: the per-participant counts must match between the two
+        # serializers (same helper, just different key names on the way out).
+        for pid in uvc:
+            assert uvc[pid] == dyn_uvc[pid], (
+                f"user-vote-counts mismatch for pid {pid}: "
+                f"to_dict={uvc[pid]}, to_dynamo_dict={dyn_uvc[pid]}")
+
+        # And A/D/S vs agree/disagree/total must agree per-tid.
+        for tid in vb:
+            assert vb[tid]['A'] == dyn_vb[tid]['agree']
+            assert vb[tid]['D'] == dyn_vb[tid]['disagree']
+            assert vb[tid]['S'] == dyn_vb[tid]['total']
 
 
 # ============================================================================

--- a/delphi/tests/test_discrepancy_fixes.py
+++ b/delphi/tests/test_discrepancy_fixes.py
@@ -288,12 +288,13 @@ class TestD2cVoteCountSource:
             participant_votes={0: list(range(10))},
         )
 
-        # raw_rating_mat has all columns; rating_mat has only non-moderated-out
+        # Both raw_rating_mat and rating_mat have all columns (D15 fix:
+        # moderated-out columns are zeroed, not removed)
         n_cmts_raw = len(conv.raw_rating_mat.columns)
         n_cmts_filtered = len(conv.rating_mat.columns)
 
         assert n_cmts_raw == 10, f"raw_rating_mat should have 10 columns, got {n_cmts_raw}"
-        assert n_cmts_filtered == 5, f"rating_mat should have 5 columns, got {n_cmts_filtered}"
+        assert n_cmts_filtered == 10, f"rating_mat should keep all 10 columns (zeroed, not removed), got {n_cmts_filtered}"
 
         # The threshold used by _get_in_conv_participants should be min(7, 10) = 7,
         # not min(7, 5) = 5. Verify indirectly: participant with exactly 6 votes
@@ -1144,29 +1145,152 @@ class TestD15ModerationHandling:
     """
     D15: Python removes moderated comments entirely from matrix.
          Clojure zeros them out (keeps structure, sets values to 0).
+
+    Clojure behavior (named_matrix.clj:214-230):
+      zero-out-columns sets all values in moderated columns to 0,
+      preserving the matrix structure (same number of columns).
+
+    Python should match: _apply_moderation() must zero out moderated
+    columns rather than removing them, so that:
+      - rating_mat.columns includes moderated tids (zeroed)
+      - tids output includes moderated tids
+      - Matrix dimensions match Clojure
     """
 
     def test_moderated_comments_zeroed_not_removed(self, conv, clojure_blob, dataset_name):
         """
-        Moderated comments should be zeroed out, not removed, if any exist.
-
-        Note: This test only applies when the dataset has moderated comments.
+        After applying moderation, rating_mat should still have all columns.
+        Moderated columns should be zeroed, not removed.
         """
-        # Check if Clojure blob has mod-out comments
-        mod_out = clojure_blob.get('mod-out', [])
+        mod_out = clojure_blob.get('mod-out') or []
         if not mod_out:
             pytest.skip(f"[{dataset_name}] No moderated comments in this dataset")
 
-        # If there ARE moderated comments, check Python's handling
-        n_cols_python = len(conv.rating_mat.columns)
+        # Apply moderation from the Clojure blob to the Python conversation
+        mod_conv = conv.update_moderation(
+            {'mod_out_tids': mod_out},
+            recompute=False,
+        )
+
+        n_cols_python = len(mod_conv.rating_mat.columns)
+        n_cols_raw = len(mod_conv.raw_rating_mat.columns)
         n_tids_clojure = len(clojure_blob.get('tids', []))
 
-        print(f"[{dataset_name}] Moderated comments: {len(mod_out)}")
-        print(f"[{dataset_name}] Python matrix columns: {n_cols_python}, Clojure tids: {n_tids_clojure}")
+        print(f"[{dataset_name}] mod-out: {len(mod_out)}")
+        print(f"[{dataset_name}] Python rating_mat cols: {n_cols_python}, raw cols: {n_cols_raw}")
+        print(f"[{dataset_name}] Clojure tids: {n_tids_clojure}")
 
-        # Clojure keeps all tids (zeroed for mod-out), Python removes them
-        check.equal(n_cols_python, n_tids_clojure,
-                     f"Matrix columns differ: Python={n_cols_python}, Clojure={n_tids_clojure} (mod-out={len(mod_out)})")
+        # After zeroing (not removing), column count should match raw matrix
+        check.equal(
+            n_cols_python, n_cols_raw,
+            f"rating_mat should keep all columns (zeroed, not removed): "
+            f"got {n_cols_python}, expected {n_cols_raw}"
+        )
+
+        # Moderated columns should be all zeros (not NaN, not original values)
+        for tid in mod_out:
+            if tid in mod_conv.rating_mat.columns:
+                col_values = mod_conv.rating_mat[tid].values
+                check.is_true(
+                    np.all(col_values == 0.0),
+                    f"Moderated tid {tid} should be all zeros, "
+                    f"got non-zero values: {col_values[col_values != 0.0][:5]}"
+                )
+
+    def test_tids_include_moderated(self, conv, clojure_blob, dataset_name):
+        """The tids output should include moderated-out comments (matching Clojure)."""
+        mod_out = clojure_blob.get('mod-out') or []
+        if not mod_out:
+            pytest.skip(f"[{dataset_name}] No moderated comments in this dataset")
+
+        mod_conv = conv.update_moderation(
+            {'mod_out_tids': mod_out},
+            recompute=False,
+        )
+
+        # rating_mat.columns (used for tids output) should include moderated tids
+        for tid in mod_out:
+            if tid in mod_conv.raw_rating_mat.columns:
+                check.is_in(
+                    tid, set(mod_conv.rating_mat.columns),
+                    f"Moderated tid {tid} should still be in rating_mat columns"
+                )
+
+
+class TestD15SyntheticModeration:
+    """
+    Synthetic tests for D15 moderation handling.
+
+    Clojure zeros out moderated columns (named_matrix.clj:214-230).
+    Python must match: _apply_moderation() zeros columns, not removes them.
+    """
+
+    def _make_conversation_with_moderation(self, mod_out_tids):
+        """Create a small conversation and apply moderation."""
+        import pandas as pd
+
+        # 5 participants, 4 comments. Votes: agree=1, disagree=-1, pass=0, no vote=NaN
+        data = {
+            0: [1.0, -1.0, 1.0, np.nan, 0.0],
+            1: [-1.0, 1.0, 0.0, 1.0, -1.0],
+            2: [1.0, 1.0, -1.0, -1.0, 1.0],
+            3: [np.nan, 0.0, 1.0, 1.0, -1.0],
+        }
+        votes_df = pd.DataFrame(data, index=[0, 1, 2, 3, 4])
+
+        conv = Conversation("synthetic_d15")
+        conv.raw_rating_mat = votes_df.copy()
+        conv.rating_mat = votes_df.copy()
+        conv.participant_count, conv.comment_count = votes_df.shape
+
+        # Apply moderation
+        conv.mod_out_tids = set(mod_out_tids)
+        conv._apply_moderation()
+        return conv
+
+    def test_zeroing_preserves_columns(self):
+        """Moderated columns should still be present in rating_mat."""
+        conv = self._make_conversation_with_moderation(mod_out_tids=[1, 3])
+
+        # All 4 columns should still be present
+        assert len(conv.rating_mat.columns) == 4, (
+            f"Expected 4 columns, got {len(conv.rating_mat.columns)}: "
+            f"moderated columns should be zeroed, not removed"
+        )
+        assert set(conv.rating_mat.columns) == {0, 1, 2, 3}
+
+    def test_zeroed_columns_are_all_zero(self):
+        """Moderated columns should have all values set to 0.0."""
+        conv = self._make_conversation_with_moderation(mod_out_tids=[1, 3])
+
+        for tid in [1, 3]:
+            col = conv.rating_mat[tid].values
+            assert np.all(col == 0.0), (
+                f"Moderated column {tid} should be all zeros, got {col}"
+            )
+
+    def test_non_moderated_columns_unchanged(self):
+        """Non-moderated columns should retain their original values."""
+        conv = self._make_conversation_with_moderation(mod_out_tids=[1])
+
+        # Column 0 should be unchanged: [1, -1, 1, NaN, 0]
+        col0 = conv.rating_mat[0].values
+        assert col0[0] == 1.0
+        assert col0[1] == -1.0
+        assert np.isnan(col0[3])  # NaN preserved for non-moderated
+
+    def test_empty_moderation_no_change(self):
+        """No moderation should leave the matrix unchanged."""
+        conv = self._make_conversation_with_moderation(mod_out_tids=[])
+        assert len(conv.rating_mat.columns) == 4
+
+    def test_moderate_nonexistent_tid(self):
+        """Moderating a tid that doesn't exist in the matrix should be a no-op."""
+        conv = self._make_conversation_with_moderation(mod_out_tids=[99])
+        # All columns preserved, no crash
+        assert len(conv.rating_mat.columns) == 4
+        # Original values intact
+        assert conv.rating_mat[0].values[0] == 1.0
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary


Python's `_apply_moderation()` removed moderated-out comment columns entirely
from `rating_mat`. Clojure's `zero-out-columns` (named_matrix.clj:214-230) sets
all values in moderated columns to 0, preserving matrix structure.

This fix changes Python to match:
- Moderated-out comment columns are **zeroed** (values set to 0.0), not removed
- `rating_mat` retains the same column count as `raw_rating_mat`
- Moderated-out participants (rows) are still removed — unchanged

### Why zeroing matters

- **Matrix dimensions**: Clojure's `rating-mat` has the same shape as `raw-rating-mat`.
  Downstream code (PCA, repness) processes the same-shaped matrix.
- **tids list**: Column indices stay stable. Consumers depend on this.
- **Practical impact**: Zeroed columns have no signal (na=0, nd=0), so they fail
  significance tests and are excluded from repness/consensus. PCA sees zero variance.

## Changes
- `conversation.py`: `_apply_moderation()` — zero out columns instead of removing
- `test_discrepancy_fixes.py`: 5 new synthetic tests + 2 enhanced real-data tests
- `test_conversation.py`: Updated to expect zeroed columns

## Test plan
- [x] Synthetic tests: zeroing preserves columns, values are 0, non-moderated unchanged
- [x] Real-data test: biodiversity-incremental (169 mod-out comments)
- [x] Full public test suite: 328 passed, 0 failed
- [x] TDD cycle: RED (2 failures) → GREEN (all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Squashed commits

- Fix D15: match Clojure moderation handling (zero out columns, don't remove)

commit-id:c3450b9a

---
**Stack**:
- #2561
- #2524
- #2523 ⬅
- #2522
- #2521
- #2520
- #2519
- #2518
- #2517
- #2516
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*