### PR TITLE
fix(client-participation): mitigate CVE-2015-9251 in vendored jQuery

### DIFF
--- a/client-participation/js/3rdparty/jquery.js
+++ b/client-participation/js/3rdparty/jquery.js
@@ -8288,6 +8288,11 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 			// Convert response if prev dataType is non-auto and differs from current
 			} else if ( prev !== "*" && prev !== current ) {
 
+				// Mitigate possible XSS vulnerability (gh-2432)
+				if ( s.crossDomain && current === "script" ) {
+					continue;
+				}
+
 				// Seek a direct converter
 				conv = converters[ prev + " " + current ] || converters[ "* " + current ];
 

--- a/client-participation/package.json
+++ b/client-participation/package.json
@@ -2,6 +2,7 @@
   "name": "polis-client-participation",
   "version": "1.0.0",
   "scripts": {
+    "test": "node scripts/verify-jquery-cve-2015-9251.cjs",
     "start": "npm run dev",
     "analyze": "webpack --mode=production --analyze",
     "build": "npm run build:prod",

--- a/client-participation/scripts/verify-jquery-cve-2015-9251.cjs
+++ b/client-participation/scripts/verify-jquery-cve-2015-9251.cjs
@@ -1,0 +1,20 @@
+"use strict";
+
+/**
+ * Regression guard for CVE-2015-9251 mitigation in vendored jQuery (ajaxConvert).
+ * @see https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49
+ */
+const fs = require("fs");
+const path = require("path");
+
+const jqueryPath = path.join(__dirname, "..", "js", "3rdparty", "jquery.js");
+const src = fs.readFileSync(jqueryPath, "utf8");
+
+if (!src.includes('s.crossDomain && current === "script"')) {
+  console.error(
+    "verify-jquery-cve-2015-9251: expected gh-2432 / CVE-2015-9251 guard in ajaxConvert"
+  );
+  process.exit(1);
+}
+
+console.log("verify-jquery-cve-2015-9251: ok");


### PR DESCRIPTION
## Summary

Backports the jQuery **ajaxConvert** mitigation for cross-domain automatic `script` handling ([jquery/jquery@2546bb35](https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49), gh-2432 / **CVE-2015-9251**) into `client-participation/js/3rdparty/jquery.js`.

## Scope

- **Vendored jQuery:** insert `continue` when `s.crossDomain && current === "script"` inside `ajaxConvert`, matching upstream.
- **Regression guard:** `client-participation/scripts/verify-jquery-cve-2015-9251.cjs` and `npm test` in `client-participation`.

## Reproduction (before)

On `edge`, `ajaxConvert` in `js/3rdparty/jquery.js` lacked the cross-domain `script` skip, so behavior diverged from jQuery post-2546bb35 (see CVE-2015-9251 / gh-2432).

## Verification (after)

```bash
cd client-participation && npm test
```

Observed: `verify-jquery-cve-2015-9251: ok` (exit 0).

## Notes

- Upstream equivalence: same guard as jQuery commit above.
- Minimal change; no dependency version bumps.
