### PR TITLE
Fix stale group-k-smoother crash on large conversations

### DIFF
--- a/math/src/polismath/math/conversation.clj
+++ b/math/src/polismath/math/conversation.clj
@@ -465,7 +465,13 @@
                            ; if seen > buffer many times, switch, OW, take last smoothed
               smoothed-k   (if (>= this-k-count count-buffer)
                              this-k
-                             (if smoothed-k smoothed-k this-k))]
+                             (if smoothed-k smoothed-k this-k))
+                           ; Clamp: if smoothed-k no longer exists in this iteration's
+                           ; clusterings (e.g. base-cluster count shrank), fall back to
+                           ; the best available k by silhouette.
+              smoothed-k   (if (contains? group-clusterings smoothed-k)
+                             smoothed-k
+                             this-k)]
           {:last-k       this-k
            :last-k-count this-k-count
            :smoothed-k   smoothed-k}))

--- a/math/src/polismath/math/conversation.clj
+++ b/math/src/polismath/math/conversation.clj
@@ -469,12 +469,13 @@
                            ; Clamp: if smoothed-k no longer exists in this iteration's
                            ; clusterings (e.g. base-cluster count shrank), fall back to
                            ; the best available k by silhouette.
-              smoothed-k   (if (contains? group-clusterings smoothed-k)
+              clamped-smoothed-k
+                           (if (contains? group-clusterings smoothed-k)
                              smoothed-k
                              this-k)]
           {:last-k       this-k
            :last-k-count this-k-count
-           :smoothed-k   smoothed-k}))
+           :smoothed-k   clamped-smoothed-k}))
 
       ; Pick the cluster corresponding to smoothed K value from group-k-smoother
       :group-clusters

--- a/math/src/polismath/math/repness.clj
+++ b/math/src/polismath/math/repness.clj
@@ -109,6 +109,9 @@
     n=#, p=prob, r=rep, t=test, a=agree, d=disagree, s=seen
   The :ids key maps to a vector of group ids in the same order they appear in the :stats sequence."
   [data group-clusters base-clusters]
+  (when (empty? group-clusters)
+    (throw (IllegalArgumentException.
+             "conv-repness: group-clusters is nil or empty — investigate upstream why group-clusters is nil.")))
   {:ids (map :id group-clusters)
    :tids (nm/colnames data)
    :stats

--- a/math/test/conv_edge_cases_test.clj
+++ b/math/test/conv_edge_cases_test.clj
@@ -6,7 +6,6 @@
   (:require [clojure.test :refer [deftest testing is]]
             [polismath.math.repness :as repness]
             [polismath.math.named-matrix :as nm]
-            [polismath.math.clusters :as clusters]
             [polismath.math.conversation :as conversation]))
 
 
@@ -64,8 +63,8 @@
 ;; and group-clusterings that only contain k=2,3.
 ;; ============================================================================
 
-(deftest stale-smoothed-k-causes-nil-group-clusters
-  (testing "group-clusters is nil when smoothed-k exceeds available range"
+(deftest stale-smoothed-k-is-clamped-to-available-group-clusters
+  (testing "smoothed-k is clamped to an available range so group-clusters stays non-nil"
     ;; Simulate: previous iteration had smoothed-k=5, but current base-cluster
     ;; count only supports k=2,3
     (let [;; Minimal group clusterings for k=2 and k=3

--- a/math/test/conv_edge_cases_test.clj
+++ b/math/test/conv_edge_cases_test.clj
@@ -1,0 +1,128 @@
+;; Copyright (C) 2012-present, The Authors. This program is free software: you can redistribute it and/or  modify it under the terms of the GNU Affero General Public License, version 3, as published by the Free Software Foundation. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(ns conv-edge-cases-test
+  "Tests for edge cases in the conversation update pipeline that can cause
+  crashes on large or evolving conversations."
+  (:require [clojure.test :refer [deftest testing is]]
+            [polismath.math.repness :as repness]
+            [polismath.math.named-matrix :as nm]
+            [polismath.math.clusters :as clusters]
+            [polismath.math.conversation :as conversation]))
+
+
+;; ============================================================================
+;; Bug 1: conv-repness crashes with empty group-clusters
+;;
+;; When group-clusters is nil or empty, (apply map f []) returns a transducer
+;; (function object) instead of a sequence. Downstream code that tries to
+;; iterate over :stats gets:
+;;   IllegalArgumentException: Don't know how to create ISeq from: clojure.core$map$fn__XXXX
+;;
+;; This happens in production when the k-smoother holds a stale smoothed-k
+;; that no longer exists in group-clusterings (see Bug 2 below).
+;; ============================================================================
+
+(def test-rating-mat
+  (nm/named-matrix
+    [:p1 :p2 :p3 :p4]
+    [:c1 :c2 :c3]
+    [[-1  1  0]
+     [ 1 -1  1]
+     [-1 -1  0]
+     [ 1  1 -1]]))
+
+(def test-base-clusters
+  [{:id :b1 :members [:p1 :p2]}
+   {:id :b2 :members [:p3 :p4]}])
+
+
+(deftest conv-repness-with-empty-group-clusters
+  (testing "conv-repness throws an informative error when group-clusters is empty"
+    ;; Without the guard, (apply map f []) silently returns a transducer that
+    ;; crashes downstream with a cryptic "Don't know how to create ISeq" error.
+    ;; The guard throws immediately with a message pointing to the root cause.
+    (is (thrown-with-msg? IllegalArgumentException
+                          #"group-clusters is nil or empty"
+                          (repness/conv-repness test-rating-mat [] test-base-clusters))))
+
+  (testing "conv-repness throws an informative error when group-clusters is nil"
+    (is (thrown-with-msg? IllegalArgumentException
+                          #"group-clusters is nil or empty"
+                          (repness/conv-repness test-rating-mat nil test-base-clusters)))))
+
+
+;; ============================================================================
+;; Bug 2: stale smoothed-k in group-k-smoother
+;;
+;; The k-smoother preserves the old smoothed-k for :group-k-buffer iterations
+;; to dampen oscillation. But it doesn't check whether the old k still exists
+;; in the current group-clusterings. When the number of non-empty base-clusters
+;; drops (e.g. due to PCA rotation after a batch of new votes), the k-range
+;; shrinks and (get group-clusterings old-smoothed-k) returns nil.
+;;
+;; We test this by feeding the smoother a conv with a previous smoothed-k=5
+;; and group-clusterings that only contain k=2,3.
+;; ============================================================================
+
+(deftest stale-smoothed-k-causes-nil-group-clusters
+  (testing "group-clusters is nil when smoothed-k exceeds available range"
+    ;; Simulate: previous iteration had smoothed-k=5, but current base-cluster
+    ;; count only supports k=2,3
+    (let [;; Minimal group clusterings for k=2 and k=3
+          dummy-clustering-k2 [{:id 0 :members [:b1]} {:id 1 :members [:b2]}]
+          dummy-clustering-k3 [{:id 0 :members [:b1]} {:id 1 :members [:b2]} {:id 2 :members []}]
+          group-clusterings {2 dummy-clustering-k2
+                             3 dummy-clustering-k3}
+          ;; Old smoother state with smoothed-k=5 (stale!)
+          old-smoother {:last-k 5 :last-k-count 1 :smoothed-k 5}
+          ;; Current smoother picks the best available k, but preserves old smoothed-k
+          ;; because buffer hasn't been exceeded
+          group-clusterings-silhouettes {2 0.6, 3 0.8}
+          smoother-fnk (:group-k-smoother conversation/small-conv-update-graph)
+          new-smoother (smoother-fnk
+                         {:conv {:group-k-smoother old-smoother}
+                          :group-clusterings group-clusterings
+                          :group-clusterings-silhouettes group-clusterings-silhouettes
+                          :opts' {:group-k-buffer 4}})
+          ;; Now look up group-clusters using the smoother's smoothed-k
+          group-clusters (get group-clusterings (:smoothed-k new-smoother))]
+
+      ;; With the current (unfixed) code, smoothed-k stays at 5 and the lookup returns nil.
+      ;; After the fix, smoothed-k should be clamped to an available k.
+      (testing "smoothed-k should be a key that exists in group-clusterings"
+        (is (contains? group-clusterings (:smoothed-k new-smoother))
+            (str "smoothed-k=" (:smoothed-k new-smoother)
+                 " not in " (keys group-clusterings))))
+
+      (testing "group-clusters should not be nil"
+        (is (some? group-clusters)
+            "group-clusters lookup must not return nil")))))
+
+
+;; ============================================================================
+;; Bug 3 (colleague's fix): agg-bucket-votes-for-tid with unknown pids
+;;
+;; When base-cluster members include pids not present in the rating matrix
+;; (e.g. after incremental updates where clusters lag behind the matrix),
+;; the pid-to-row lookup returns nil, and (get person-rows nil) can fail
+;; depending on the matrix implementation.
+;; ============================================================================
+
+(deftest agg-bucket-votes-unknown-pid
+  (testing "agg-bucket-votes-for-tid handles pids not in the rating matrix"
+    (let [;; rating-mat only has :p1 and :p2
+          rating-mat (nm/named-matrix
+                       [:p1 :p2]
+                       [:c1 :c2]
+                       [[-1 1]
+                        [ 1 0]])
+          ;; but bid-to-pid references :p3 which doesn't exist in rating-mat
+          bid-to-pid [[:p1 :p3] [:p2]]
+          result (conversation/agg-bucket-votes-for-tid
+                   bid-to-pid rating-mat number? :c1)]
+      ;; Should not throw; :p3's vote is nil, filtered out by number?
+      (is (vector? result))
+      ;; bucket 0 has :p1 (voted) and :p3 (unknown → nil, filtered out) → count 1
+      (is (= 1 (first result)))
+      ;; bucket 1 has :p2 (voted) → count 1
+      (is (= 1 (second result))))))

--- a/math/test/test_runner.clj
+++ b/math/test/test_runner.clj
@@ -4,6 +4,7 @@
   (:require [cluster-tests]
             [conv-man-tests]
             [conversation-test]
+            [conv-edge-cases-test]
             [index-hash-test]
             [named-matrix-test]
             [pca-test]
@@ -14,6 +15,12 @@
             [clojure.test :as test]))
 
 
+;; Print each deftest name as it starts, so we can see progress and detect hangs.
+(defmethod test/report :begin-test-var [m]
+  (let [v (:var m)]
+    (println "  " (-> v meta :name))
+    (flush)))
+
 (defn -main
   "Run all the pure tests for polisapp. The one integration test is in conv-man-tests, and should be run separately (and
   needs to be cleaned up to run on a separate poller system)"
@@ -22,6 +29,7 @@
     test/run-tests
     '[cluster-tests
       conversation-test
+      conv-edge-cases-test
       index-hash-test
       named-matrix-test
       pca-test

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4275,6 +4275,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -6737,6 +6738,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
       "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -8022,6 +8024,7 @@
       "version": "22.19.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -8293,6 +8296,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -8506,6 +8510,7 @@
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9100,6 +9105,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -10471,6 +10477,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12293,6 +12300,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -12911,6 +12919,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -14177,6 +14186,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -14765,6 +14775,7 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "peer": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -16333,6 +16344,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16853,6 +16865,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.50.tgz",
       "integrity": "sha512-VstOnRxf4tlSq0raIwbn0n+LA34SxVoZ8r3pkwSUM0jqNiA/HCMQEVjTuS5FZmHsge+9MDGTiAuHyml5T0um6A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4275,7 +4275,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -6738,7 +6737,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
       "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -8024,7 +8022,6 @@
       "version": "22.19.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -8296,7 +8293,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -8510,7 +8506,6 @@
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9105,7 +9100,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -10477,7 +10471,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12300,7 +12293,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -12919,7 +12911,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -14186,7 +14177,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -14775,7 +14765,6 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "peer": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -16344,7 +16333,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16865,7 +16853,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.50.tgz",
       "integrity": "sha512-VstOnRxf4tlSq0raIwbn0n+LA34SxVoZ8r3pkwSUM0jqNiA/HCMQEVjTuS5FZmHsge+9MDGTiAuHyml5T0um6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

- **Root cause fix**: Clamp `smoothed-k` in `group-k-smoother` to keys that exist in the current `group-clusterings` map. When base-cluster count shrinks between iterations (e.g. PCA rotation after a batch of new votes), the old `smoothed-k` could fall outside the current k-range, making `(get group-clusterings stale-k)` return nil and crashing downstream.
- **Informative error**: Add an explicit check in `conv-repness` so that nil/empty `group-clusters` throws a clear `IllegalArgumentException` instead of the cryptic `Don't know how to create ISeq from: clojure.core$map$fn__5931` (caused by `(apply map f [])` returning a transducer).
- **Verbose test runner**: Print each test name as it starts, so hangs are immediately visible.

Triggered by a prod error on a large conversation (12k+ votes):
```
java.lang.IllegalArgumentException: Don't know how to create ISeq from: clojure.core$map$fn__5931
```

## Test plan

- [x] New tests in `conv_edge_cases_test.clj` on synthetic data:
  - `stale-smoothed-k-causes-nil-group-clusters`: verifies the k-smoother clamp
  - `conv-repness-with-empty-group-clusters`: verifies the informative error message
  - `agg-bucket-votes-unknown-pid`: verifies graceful handling of unknown pids in clusters
- [x] Full math test suite passes (52 tests, 148 assertions, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
