### PR TITLE
fix: prevent createXidRecord failure from aborting xid participant creation

### DIFF
--- a/server/src/auth/ensure-participant.ts
+++ b/server/src/auth/ensure-participant.ts
@@ -197,16 +197,27 @@ async function _handleUserIdentification(
     // Create new anonymous user for this XID
     const newUid = await createAnonUser();
 
-    // Create XID record linking the XID to the new user
-    await createXidRecord(
-      req.p.xid,
-      conv.owner,
-      newUid,
-      zid,
-      undefined,
-      undefined,
-      undefined
-    );
+    // Create XID record linking the XID to the new user.
+    // Note: the participant row doesn't exist yet at this point, so
+    // createXidRecord will insert with pid=null. A failure here must not
+    // abort participant creation — wrap in try/catch.
+    // See: https://github.com/compdemocracy/polis/issues/2538
+    try {
+      await createXidRecord(
+        req.p.xid,
+        conv.owner,
+        newUid,
+        zid,
+        undefined,
+        undefined,
+        undefined
+      );
+    } catch (err) {
+      logger.warn(
+        "createXidRecord failed during user identification; participant creation will continue",
+        { xid: req.p.xid, zid, uid: newUid, err }
+      );
+    }
 
     return newUid;
   }


### PR DESCRIPTION
## Summary

When an xid user visits for the first time, `createXidRecord` is called inside `_handleUserIdentification` before any participant row exists. If the INSERT fails (e.g. due to the composite FK constraint `(zid, pid) REFERENCES participants(zid, pid)` added by migration 000015), the error propagates through `ensureParticipantOptional`'s catch block, setting `pid = -1`. Every subsequent vote or comment then returns a 500.

This wraps the `createXidRecord` call in a try/catch so a failure doesn't abort participant creation. The participant is still created correctly and the user can vote and comment. The xid record will be inserted with `pid = null` rather than the correct pid — that ordering issue is tracked separately and addressed in the root cause fix (also in #2538).

## Test plan

- [ ] Embed a conversation with `data-xid` or `xid=` URL param in an incognito window (logged out)
- [ ] Votes and comments should succeed (previously returned 500 with `pid: -1`)
- [ ] Confirm xid CSV still empty after this fix (xid-to-pid link not yet restored — expected, see #2538)

Fixes #2538
Related: #1848