### PR TITLE
fix: register xid record after participant creation, not before

### DIFF
--- a/server/src/auth/ensure-participant.ts
+++ b/server/src/auth/ensure-participant.ts
@@ -18,7 +18,7 @@ import { Response, NextFunction } from "express";
 import { addParticipantAndMetadata } from "../participant";
 import { checkLegacyCookieAndIssueJWT } from "./legacyCookies";
 import { createAnonUser } from "./create-user";
-import { createXidRecord, getXidRecord, isXidAllowed } from "../xids";
+import { createXidRecord, getXidRecord, isXidAllowed, xidExists } from "../xids";
 import { failJson } from "../utils/fail";
 import { getConversationInfo, getZidFromConversationId } from "../conversation";
 import { getPidPromise } from "../user";
@@ -194,19 +194,11 @@ async function _handleUserIdentification(
       return existingXidRecords[0].uid;
     }
 
-    // Create new anonymous user for this XID
+    // Create new anonymous user for this XID.
+    // Note: we do NOT call createXidRecord here — the participant row doesn't
+    // exist yet, so the FK (zid, pid) → participants(zid, pid) can't be
+    // satisfied. xid registration happens after participant creation below.
     const newUid = await createAnonUser();
-
-    // Create XID record linking the XID to the new user
-    await createXidRecord(
-      req.p.xid,
-      conv.owner,
-      newUid,
-      zid,
-      undefined,
-      undefined,
-      undefined
-    );
 
     return newUid;
   }
@@ -464,6 +456,26 @@ async function _ensureParticipantInternal(
     const participantResult = await _getOrCreateParticipant(zid, uid, pid, req);
     pid = participantResult.pid;
     isNewlyCreatedParticipant = participantResult.isNewlyCreated;
+
+    // Register the xid record now that the participant row exists.
+    // This mirrors the order used by _joinWithZidOrSuzinvite and ensures
+    // the FK (zid, pid) → participants(zid, pid) can be satisfied.
+    // See: https://github.com/compdemocracy/polis/issues/2538
+    if (req.p.xid && isNewlyCreatedUser && pid !== undefined) {
+      const conv = await getConversationInfo(zid);
+      const alreadyExists = await xidExists(req.p.xid, conv.owner, uid);
+      if (!alreadyExists) {
+        await createXidRecord(
+          req.p.xid,
+          conv.owner,
+          uid,
+          zid,
+          req.p.x_profile_image_url,
+          req.p.x_name,
+          req.p.x_email
+        );
+      }
+    }
   } else if ((pid === undefined || pid === -1) && uid !== undefined) {
     // Just look up existing participant if we have a uid
     const existingPid = await getPidPromise(zid, uid, true);


### PR DESCRIPTION
## Root cause

`createXidRecord` was called inside `_handleUserIdentification` before any participant row existed. Migration `000015_add_xid_requirements.sql` added a composite FK constraint to the `xids` table:

```sql
FOREIGN KEY (zid, pid) REFERENCES participants(zid, pid)
```

With this constraint in place, inserting an xid record with`pid = null` (because no participant exists yet at that point) either:
- fails outright if `pid` has a NOT NULL constraint, or
- succeeds but leaves the xid record permanently unlinked from a participant — breaking CSV exports and `GET /api/v3/participation`

When `createXidRecord` throws, the error propagates through `ensureParticipantOptional`'s catch block, `pid` is set to `-1`, and all subsequent votes and comments return 500.

## Fix

Remove `createXidRecord` from `_handleUserIdentification` and move it to `_ensureParticipantInternal`, after `_getOrCreateParticipant` — where both `uid` and `pid` are known and the participant row already exists. This mirrors the correct ordering already used by `_joinWithZidOrSuzinvite` (the suzinvite join flow).

## Test plan

Tested locally with `NOT NULL` constraint on `xids.pid` to simulate the production schema.

- [x] First visit with xid: `participationInit` returns `pid=1` (not `-1`); vote returns `{"currentPid": 1}`
- [x] xid CSV: xid record created in DB with correct pid — `uid=7, owner=1, xid='testuser1', zid=1, pid=1`; FK join to `participants` resolves correctly
- [x] Returning xid user (new session, same xid): same `pid=1` returned; no duplicate row in `xids`
- [x] Anonymous users (no xid): vote returns `{"currentPid": 2}`; no xid record created; unaffected

## Notes

- A minimal interim fix (wrapping `createXidRecord` in try/catch) was shipped in #2539 — this PR supersedes it with the correct fix
- Regression introduced in #2279 (merged 2025-11-18, deployed 2025-12-06)

Fixes #2538
Related: #1848, #2539