### PR TITLE
docs: document the raw vote sign on the votes tables (-1 = Agree)

### DIFF
--- a/server/postgres/migrations/000000_initial.sql
+++ b/server/postgres/migrations/000000_initial.sql
@@ -768,6 +768,11 @@ CREATE TABLE votes(
     pid INTEGER NOT NULL,
     tid INTEGER NOT NULL,
 
+    -- The participant's vote on the comment (tid).
+    --   -1 = Agree, 1 = Disagree, 0 = Pass/Unsure.
+    -- IMPORTANT: this is the RAW storage sign, and it is the OPPOSITE of the value in the
+    -- participants-votes CSV export. The export negates every vote so that Agree = +1,
+    -- Disagree = -1.
     vote SMALLINT,
 
     -- Divide by 32767 before using! (and multiply by 32767 before storing). Applications should refer to this as "weight" after converting to a float in the range [-1, 1]
@@ -798,6 +803,11 @@ CREATE TABLE votes_latest_unique (
     pid INTEGER NOT NULL,
     tid INTEGER NOT NULL,
 
+    -- The participant's vote on the comment (tid).
+    --   -1 = Agree, 1 = Disagree, 0 = Pass/Unsure.
+    -- IMPORTANT: this is the RAW storage sign, and it is the OPPOSITE of the value in the
+    -- participants-votes CSV export. The export negates every vote so that Agree = +1,
+    -- Disagree = -1.
     vote SMALLINT,
 
     -- Divide by 32767 before using! (and multiply by 32767 before storing). Applications should refer to this as "weight" after converting to a float in the range [-1, 1]


### PR DESCRIPTION
The `vote` column on `votes` and `votes_latest_unique` has no comment, while the adjacent `weight_x_32767` does — so the storage sign convention is undocumented. It is also the **opposite** of the `participants-votes` CSV export, which negates it to Agree = +1 (`get-corrected-conversation-votes` in `math/src/polismath/darwin/export.clj`). So reading the table directly leads to the wrong conclusion.

This adds an inline comment on both `vote` columns: `-1 = Agree, 1 = Disagree, 0 = Pass`, noting the export's sign flip.

Comment-only; no schema change. Refs #2554.