### PR TITLE
chore(db): remove never-implemented 2013 org/permissions table sketches

### DIFF
--- a/server/postgres/migrations/000000_initial.sql
+++ b/server/postgres/migrations/000000_initial.sql
@@ -135,29 +135,6 @@ CREATE INDEX apikeysndvweifu_uid_idx ON apikeysndvweifu USING btree (uid);
 CREATE INDEX apikeysndvweifu_apikey_idx ON apikeysndvweifu USING btree (apikey);
 
 
-
-
-
-
---CREATE TABLE orgs (
-    --oid SERIAL,
-    --oname VARCHAR(999)
---);
-
---CREATE TABLE oadmins (
-    --uid REFERENCES users(uid),
-    --oid REFERENCES orgs(oid),
-    --UNIQUE (uid, oid)
---);
-
---CREATE TABLE omemberships(
-    --oid REFERENCES orgs(oid),
-    --uid REFERENCES users(uid),
-    --UNIQUE (uid, oid)
---);
-
---CREATE TABLE org_member_metadata_types (
-
 CREATE TABLE courses(
     course_id SERIAL,
     topic VARCHAR(1000),
@@ -502,12 +479,6 @@ CREATE TABLE suzinvites (
 CREATE INDEX suzinvites_owner_zid_idx ON suzinvites USING btree (owner, zid);
 
 
---CREATE TABLE permissions(
-    --uid INTEGER NOT NULL REFERENCES users(uid),
-    --zid INTEGER NOT NULL REFERENCES conversations(zid),
-    --rwx?
-    --admin bool
---);
 
 
  -- can't rely on SEQUENCEs since they may have gaps.. or maybe we can live with that? maybe we use a trigger incrementer like on the participants table? that would mean locking on a per conv basis, maybe ok for starters


### PR DESCRIPTION
`000000_initial.sql` carries commented-out `CREATE TABLE` stubs for `orgs`, `oadmins`, `omemberships`, `org_member_metadata_types`, and `permissions`. They are **commented**, so never created — this is a comment-only change with no schema effect (verified: 000000 still loads clean).

**Provenance:** blame traces them to 2013 — `a01dc71c` ("update schema for metadata") and `0341bf95` ("update sql tables") — early design sketches that were never implemented (the tells: bare stub columns, and unresolved notes like `--rwx?` / `--admin bool` under `permissions`). The org concept that shipped is modeled on `users` (`conversations.org_id → users.uid`, `users.is_owner`); per-conversation permissions live in `conversations` flags + `participants.mod`. So these dedicated tables were never needed.

**Why:** they read as real tables to anyone grepping the schema.

**Please confirm before merge:** can a maintainer confirm the dedicated `orgs`/`permissions` approach is genuinely abandoned? If there is intent to revive them, happy to close this instead. Refs #2554.