### PR TITLE
ci: stop running CI on every push to spr/** PR branches

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -8,7 +8,6 @@ on:
       - edge
       - stable
       - 'jc/**'
-      - 'spr/**'
 
 concurrency:
   group: e2e-${{ github.ref }}

--- a/.github/workflows/jest-server-test.yml
+++ b/.github/workflows/jest-server-test.yml
@@ -8,7 +8,6 @@ on:
       - edge
       - stable
       - 'jc/**'
-      - 'spr/**'
 
 jobs:
   server-integration-tests:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -13,7 +13,6 @@ on:
       - edge
       - stable
       - 'jc/**'
-      - 'spr/**'
     paths: *paths
 
 jobs:


### PR DESCRIPTION
## Summary

My whole stack handling is overloading the CI, because each propagation of any change in the stack triggers CI on the whole stack above. In itself that's nice, *but* in practice our tests are heavy and the CI is chocking.  

So this PR removes `spr/**` from the `pull_request.branches` filter in `python-ci.yml`,
`cypress-tests.yml`, and `jest-server-test.yml`. PR #2508 added that filter to
get CI coverage on spr-managed stack PRs, but in practice it means **every
`jj spr update` force-pushes the entire stack and triggers 3 workflows × N stack
PRs in a single moment**, which has been overloading the CI system.

And I can manually run the CI when I need on higher up the stack -- plus of course running locally systematically.

## After this change

- The PR at the **bottom of the stack** (base = `edge`) still triggers CI on
  push.
- All other open stack PRs (base = `spr/edge/<sha>`) **no longer trigger** CI on
  push.
- When the bottom PR merges and the next PR's base auto-flips to `edge`, CI
  starts firing on it.

So at any moment, only **one** PR runs CI — the one that can actually be merged
next. Massive load reduction during stack rebase storms.

## Trade-off

We lose stack-wide CI feedback. Accepted because:
- The bottom PR is the only one that can be merged next, so it's the one CI
  signal that matters.
- Stack PRs sit behind it untouched (the base branch doesn't change), so a
  broken intermediate would also break at the bottom.
- We can still force a run via "Re-run all jobs" or `workflow_dispatch` when
  needed.

## Test plan

- [ ] Verify next force-push to a `spr/**`-based stack PR doesn't trigger CI.
- [ ] Verify next push to the bottom PR (base = `edge`) still triggers CI.
