### PR TITLE
ci: add workflow_dispatch to enable manual CI runs on stack branches

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -8,6 +8,11 @@ on:
       - edge
       - stable
       - 'jc/**'
+  # Manual trigger: lets repo write-access users run CI on any branch
+  # (including spr/edge/* stack branches, which `pull_request` no longer
+  # auto-triggers for). UI: Actions → E2E Tests → "Run workflow".
+  # CLI: `gh workflow run "E2E Tests" --ref <branch>`.
+  workflow_dispatch:
 
 concurrency:
   group: e2e-${{ github.ref }}

--- a/.github/workflows/jest-server-test.yml
+++ b/.github/workflows/jest-server-test.yml
@@ -8,6 +8,11 @@ on:
       - edge
       - stable
       - 'jc/**'
+  # Manual trigger: lets repo write-access users run CI on any branch
+  # (including spr/edge/* stack branches, which `pull_request` no longer
+  # auto-triggers for). UI: Actions → Server Integration Tests → "Run workflow".
+  # CLI: `gh workflow run "Server Integration Tests" --ref <branch>`.
+  workflow_dispatch:
 
 jobs:
   server-integration-tests:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -14,6 +14,11 @@ on:
       - stable
       - 'jc/**'
     paths: *paths
+  # Manual trigger: lets repo write-access users run CI on any branch
+  # (including spr/edge/* stack branches, which `pull_request` no longer
+  # auto-triggers for). UI: Actions → Delphi Python Tests → "Run workflow".
+  # CLI: `gh workflow run "Delphi Python Tests" --ref <branch>`.
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch:` to `python-ci.yml`, `cypress-tests.yml`, and
`jest-server-test.yml`. Companion to #2558.

#2558 stopped the rebase-storm by removing `spr/**` from the
`pull_request.branches` filter. That left only the **bottom-of-stack PR**
(base = `edge`) auto-running CI; intermediate stack PRs no longer trigger
on every force-push.

This PR restores a way to validate an intermediate stack PR on demand,
without re-introducing the rebase storms:

- **UI**: Actions tab → workflow → **Run workflow** dropdown → pick the
  spr branch → Run.
- **CLI**: `gh workflow run "Delphi Python Tests" --ref spr/edge/<sha>`.

## Security

`workflow_dispatch` is restricted by GitHub to users with `write`
permission on the repo. Fork-PR authors get 403 when they try to invoke
it. So this is **strictly additive** for repo maintainers and does not
change anything about the existing fork-PR safeguards (which control the
`pull_request` event, governed separately in repo Settings → Actions →
"Fork pull request workflows from outside collaborators").

## Note on `lint.yml`

Not modified — it already runs unconditionally on every PR via its
`types: [opened, reopened, synchronize]` filter.

## Test plan

After merge:
- [ ] Visit Actions → Delphi Python Tests; confirm "Run workflow" dropdown appears.
- [ ] Trigger it against `spr/edge/<sha>` for an open stack PR and confirm the run starts.
