### PR TITLE
ci: cache docker layers in GitHub Actions cache across runs

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -76,14 +76,26 @@ jobs:
         echo "Auth-related environment variables:"
         grep -E "AUTH_|CERT|DATABASE_URL|POSTGRES_" test.env || true
 
+    # bake-action goes straight to `docker buildx bake`, which honors the
+    # `cache-from`/`cache-to` set overrides. (`docker compose build` with
+    # COMPOSE_BAKE=true would NOT — compose strips x-bake from its bake
+    # payload, so cache config is silently lost.)
+    # postgres.no-cache=true preserves the pre-cache behavior of building
+    # postgres fresh every run: Docker layer caching has been known to
+    # retain stale migration files between builds.
     - name: Build Docker images
-      run: |
-        # Build postgres with --no-cache to ensure latest migrations are used
-        # Docker layer caching can cause old migration files to persist
-        docker compose -f docker-compose.test.yml --env-file test.env build --no-cache postgres
-        
-        # Build remaining services (caching OK for these)
-        docker compose -f docker-compose.test.yml --env-file test.env build
+      uses: docker/bake-action@v6
+      with:
+        # source: . makes bake use the workspace checkout. The default (git
+        # context) re-fetches per commit SHA, which busts the layer cache
+        # every commit even when the file contents are unchanged.
+        source: .
+        files: docker-compose.test.yml
+        load: true
+        set: |
+          *.cache-from=type=gha
+          *.cache-to=type=gha,mode=max
+          postgres.no-cache=true
 
     - name: Start services
       run: |

--- a/.github/workflows/jest-server-test.yml
+++ b/.github/workflows/jest-server-test.yml
@@ -69,11 +69,23 @@ jobs:
         echo "Environment variables:"
         grep -E "AUTH_|CERT|DATABASE_URL|POSTGRES_|JWT_|JWKS_URI" test.env || true
 
+    # Server is built on the host (tests run there). ses-local and dynamodb
+    # are pre-built images (no build:), so they are not bake targets.
     - name: Build Docker images
-      run: |
-        # Build all services except server (tests run on host)
-        docker compose -f docker-compose.test.yml --env-file test.env build \
-          math postgres file-server ses-local oidc-simulator dynamodb
+      uses: docker/bake-action@v6
+      with:
+        # source: . avoids re-fetching git context per commit (busts cache).
+        source: .
+        files: docker-compose.test.yml
+        targets: |
+          math
+          postgres
+          file-server
+          oidc-simulator
+        load: true
+        set: |
+          *.cache-from=type=gha
+          *.cache-to=type=gha,mode=max
 
     - name: Start services
       run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -57,9 +57,15 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: 3. Build Docker images
-      run: |
-        # Build all services in the test file (including delphi)
-        docker compose -f docker-compose.test.yml --env-file .env build
+      uses: docker/bake-action@v6
+      with:
+        # source: . avoids re-fetching git context per commit (busts cache).
+        source: .
+        files: docker-compose.test.yml
+        load: true
+        set: |
+          *.cache-from=type=gha
+          *.cache-to=type=gha,mode=max
 
     - name: 4. Start all services
       run: |

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,8 +4,15 @@
 
 # Run with: `docker compose -f docker-compose.test.yml --env-file test.env up --build`.
 
+# Explicit `image:` fields below match what compose's auto-naming would
+# produce (`<project>-<service>:latest`). They make the tags addressable by
+# `docker buildx bake` so the CI workflows can build via bake-action (for
+# the GitHub Actions cache) while `docker compose up -d` still finds the
+# images afterwards.
+
 services:
   client-participation-alpha:
+    image: ${COMPOSE_PROJECT_NAME:-polis-test}-client-participation-alpha:latest
     build:
       context: ./client-participation-alpha
       dockerfile: Dockerfile
@@ -27,6 +34,7 @@ services:
     restart: unless-stopped
 
   server:
+    image: ${COMPOSE_PROJECT_NAME:-polis-test}-server:latest
     environment:
       - DATABASE_SSL=false
       - DATABASE_URL=${DATABASE_URL}
@@ -56,6 +64,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   math:
+    image: ${COMPOSE_PROJECT_NAME:-polis-test}-math:latest
     build:
       context: ./math
     labels:
@@ -87,6 +96,7 @@ services:
       polis_tag: ${TAG:-test}
 
   oidc-simulator:
+    image: ${COMPOSE_PROJECT_NAME:-polis-test}-oidc-simulator:latest
     build:
       context: ./oidc-simulator
       dockerfile: Dockerfile
@@ -106,6 +116,7 @@ services:
       - ${AUTH_CERTS_PATH:-~/.simulacrum/certs}:/root/.simulacrum/certs:ro
 
   postgres:
+    image: ${COMPOSE_PROJECT_NAME:-polis-test}-postgres:latest
     build:
       context: ./server
       dockerfile: Dockerfile-db
@@ -144,6 +155,7 @@ services:
       -c autovacuum_naptime=30s
 
   nginx-proxy:
+    image: ${COMPOSE_PROJECT_NAME:-polis-test}-nginx-proxy:latest
     build:
       context: ./file-server
       dockerfile: nginx.Dockerfile
@@ -161,6 +173,7 @@ services:
       - 443:443
 
   file-server:
+    image: ${COMPOSE_PROJECT_NAME:-polis-test}-file-server:latest
     build:
       context: ./
       dockerfile: file-server/Dockerfile


### PR DESCRIPTION
## Summary

Stacked on #2562. Together they fix the ECONNRESET flake **and** cut docker-build time on cache hits.

- #2562 places `RUN --mount=type=cache,target=/root/.npm` on every npm Dockerfile (the cache infrastructure).
- **This PR exports that cache — and every other layer — to GitHub Actions cache**, so a fresh runner starts warm instead of empty. That's the half that makes #2562's npm cache mount actually pay off across CI runs.

## How

**1. `docker-compose.test.yml`** — each buildable service gets an explicit `image: ${COMPOSE_PROJECT_NAME:-polis-test}-<service>:latest`. This matches what compose's auto-naming was already producing, but makes the tags addressable by `docker buildx bake` (used below).

**2. Three workflows** (`cypress-tests.yml`, `jest-server-test.yml`, `python-ci.yml`) — the `docker compose build` step is replaced with `docker/bake-action@v6`. Cache config is passed via `set:`:
```
*.cache-from=type=gha
*.cache-to=type=gha,mode=max
```
`cypress-tests.yml` also keeps `postgres.no-cache=true` (Docker layer caching has been known to retain stale migration files).

The subsequent `docker compose up -d` finds the bake-built images because the `image:` tags match what compose expects.

## Why not `COMPOSE_BAKE=true` + `x-bake:` (the prior attempt)

`COMPOSE_BAKE=true` does delegate `docker compose build` to bake, but the compose-to-bake serialization layer **silently drops `x-bake:` fields entirely**. Confirmed by `docker compose ... build --print`: the bake JSON payload has no `cache-from`/`cache-to` whatsoever. The build succeeds but no cache is read or written. A real CI run with that approach produced cold-baseline timings on both a supposed cache-populate batch and a supposed cache-hit batch — the "speedup" was zero because the cache was never engaged.

`docker/bake-action` bypasses that serialization and applies `--set` directly, so cache config arrives intact.

## No-op for local devs

Adding `image:` to compose services is the only externally visible change for non-CI users. It doesn't change behavior — it just locks in the tag that compose was already auto-generating, so it's equivalent for everyone running `docker compose ...` locally.

## Expected impact

| Workflow | Cold-cache baseline | Warm-cache target |
|---|---|---|
| E2E Tests | ~16m | ~12-13m |
| Server Integration | ~4m 10s | ~2m |
| Delphi Python | ~7m 55s | ~5m |

(Build step compresses to ~30-60s on cache hit, per handoff doc estimate. First run after merge writes the cache; subsequent runs benefit.)

## Verified locally

- `docker buildx bake -f docker-compose.test.yml --print` shows correct tags (`polis-test-<service>:latest`) for every buildable service, including the delphi ECR tag for delphi.
- After a fresh `docker rmi`, a second `docker buildx bake` against a local cache backend reports `#10-#16 CACHED` for every Dockerfile RUN step and `importing cache manifest from local:...` — cache import + load both work end-to-end.

CI verification (cache-populate + cache-hit batches) is in progress on this PR. Description will be edited with the numbers once both batches complete.

## Stacked PR note

Base is `jc/ci-econnreset-fix` (the #2562 branch). When #2562 merges, GitHub auto-retargets this PR to `edge`. With jj, edits to the base commit propagate via `jj rebase`/`jj squash`.
