### PR TITLE
chore(delphi): install pandas-stubs to fix pyright false positives

### DIFF
--- a/delphi/polismath/pca_kmeans_rep/repness.py
+++ b/delphi/polismath/pca_kmeans_rep/repness.py
@@ -463,8 +463,10 @@ def calculate_kl_divergence(p: np.ndarray, q: np.ndarray) -> float:
     # Replace zeros to avoid division by zero
     p = np.where(p == 0, 1e-10, p)
     q = np.where(q == 0, 1e-10, q)
-    
-    return np.sum(p * np.log(p / q))
+
+    # numpy stubs: np.where widens p to ndarray|bool_, so np.sum is typed bool_.
+    # See pyright #2811.
+    return np.sum(p * np.log(p / q))  # pyright: ignore[reportReturnType]
 
 
 def select_consensus_comments(all_stats: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -538,7 +540,9 @@ def prop_test_vectorized(succ: pd.Series, n: pd.Series) -> pd.Series:
     z = 2 * np.sqrt(n_pc) * (succ_pc / n_pc - 0.5)
     # No n=0 short-circuit — Clojure parity (see scalar prop_test). n=0 rows
     # collapse to 1.0 via the +1 pseudocount; downstream callers do not gate on it.
-    z = z.fillna(0.0)
+    # numpy stubs lose Series-ness through np.sqrt, so pyright types z as NDArray
+    # and can't see .fillna. See pyright #4081.
+    z = z.fillna(0.0)  # pyright: ignore[reportAttributeAccessIssue]
     return z
 
 

--- a/delphi/pyproject.toml
+++ b/delphi/pyproject.toml
@@ -79,6 +79,11 @@ dev = [
     # Type stubs
     "types-requests",
     "types-psycopg2",
+    # pandas 2.3 has no `py.typed` marker, so pyright falls back to bundled
+    # stubs that mistype DataFrame.__getitem__ as ndarray. pandas-stubs is the
+    # official stubs package from the pandas-dev org and resolves ~50 false
+    # positives in polismath/pca_kmeans_rep/repness.py alone.
+    "pandas-stubs>=3.0.3.260530",
     # Profiling
     "line_profiler>=4.0.0",
 ]


### PR DESCRIPTION
## Summary

`pandas` 2.3 ships **no `py.typed` marker**, so pyright fell back to its bundled stubs and mistyped `DataFrame.__getitem__` as `ndarray`, producing **55 errors in `polismath/pca_kmeans_rep/repness.py`** alone. Installing the official [`pandas-stubs`](https://github.com/pandas-dev/pandas-stubs) (from the `pandas-dev` org) drops that to **2 errors**.

The 2 remaining errors are **numpy-stubs limitations**, not pandas:

- `repness.py:467` — `np.where` widens `p` from `np.ndarray` to `np.ndarray | bool_`, so `np.sum(...)` is typed `bool_` (pyright [#2811](https://github.com/microsoft/pyright/issues/2811)).
- `repness.py:541` — `np.sqrt(Series)` loses Series-ness, so `.fillna()` looks like an attribute error (pyright [#4081](https://github.com/microsoft/pyright/issues/4081)).

Each is silenced with a **line-scoped** `# pyright: ignore[reportXxx]` that names the specific category and links to the upstream issue. No global rule overrides, no `typeCheckingMode = "off"`.

## What changed

- `delphi/pyproject.toml` — new `[dependency-groups] dev = ["pandas-stubs>=3.0.3.260530"]` with an explanatory comment.
- `delphi/polismath/pca_kmeans_rep/repness.py` — two single-line `# pyright: ignore[...]` comments + 2 explanatory lines above them. No runtime behavior change.

## Why not just disable the report categories globally

The handoff doc that prompted this work (`HANDOFF_PYRIGHT_PANDAS_STUBS.md`) explicitly called that out as the **wrong** answer: `reportArgumentType = "none"` and friends would also kill real argument-type signal everywhere. Targeted ignores keep the rest of the codebase honest.

## Test plan

- [x] `uv run pyright polismath/pca_kmeans_rep/repness.py` → **0 errors** (was 55).
- [x] A deliberate `int`-where-`Series`-is-expected bug is still caught (verified with a 5-line scratch script — pyright flagged both args).
- [x] `tests/test_repness_unit.py` → 22/22 pass.
- [ ] CI green.

## Notes

- `pandas-stubs` is an official endorsed-by-pandas-dev package and is what Pylance ships with by default.
- `delphi/uv.lock` is not tracked in this repo (only `delphi/requirements.lock`, which holds **prod** deps via `pip-compile`). Dev deps live in `pyproject.toml` only, same convention as PR #2560.
- A blog post claims pandas is now "100% type-complete" without stubs — but pandas 2.3.3 in our venv has no `py.typed` marker, so PEP 561 means pyright ignores its inline annotations. Confirmed by `find .venv ... -name py.typed`.
