### PR TITLE
fix(delphi): coerce repness group_id to int for DynamoDB write

### DIFF
--- a/delphi/polismath/database/dynamodb.py
+++ b/delphi/polismath/database/dynamodb.py
@@ -451,7 +451,12 @@ class DynamoDBClient:
                     # Use pre-formatted data with Python-native keys
                     with repness_table.batch_writer() as batch:
                         for item in dynamo_data['repness']['comment_repness']:
-                            group_id = item.get('group_id', 0)
+                            # int() guards against a numpy/Python float group id
+                            # (e.g. float64 upcast upstream): boto3 rejects floats
+                            # ("Float types are not supported"). Group ids are
+                            # always integral, so this is lossless. Belt-and-braces
+                            # with the source coercion in repness.conv_repness.
+                            group_id = int(item.get('group_id', 0))
                             comment_id = item.get('comment_id', '')
                             
                             # Create composite key for group representativeness

--- a/delphi/polismath/pca_kmeans_rep/repness.py
+++ b/delphi/polismath/pca_kmeans_rep/repness.py
@@ -971,6 +971,16 @@ def conv_repness(vote_matrix_df: pd.DataFrame, group_clusters: List[Dict[str, An
     comment_repness = stats_df_reset[['comment', 'group_id', 'repness', 'pa', 'pd']].copy()
     comment_repness.columns = ['tid', 'gid', 'repness', 'pa', 'pd']
 
+    # Coerce gid back to int. `compute_group_comment_stats_df` builds group_id via
+    # `.map(ptpt_to_group)`, which injects NaN for ungrouped voters and upcasts the
+    # whole column to float64; the NaN rows are dropped but the dtype stays float.
+    # Without this, every gid flows out of `.to_dict('records')` below as a
+    # numpy.float64, which boto3 rejects when writing Delphi_RepresentativeComments
+    # ("Float types are not supported. Use Decimal types instead."). gid is always
+    # an integral group id (sourced from the full (group_id, comment) index), so the
+    # cast is lossless.
+    comment_repness['gid'] = comment_repness['gid'].astype(int)
+
     # Build result structure
     result = {
         'comment_ids': vote_matrix_df.columns.tolist(),

--- a/delphi/tests/test_dynamodb_float_serialization.py
+++ b/delphi/tests/test_dynamodb_float_serialization.py
@@ -1,0 +1,151 @@
+"""
+Regression test for the production Delphi_RepresentativeComments write crash:
+
+    botocore ...: Float types are not supported. Use Decimal types instead.
+    File ".../polismath/database/dynamodb.py", line 462, in write_conversation
+        batch.put_item(Item={...})
+
+Root cause (SYSTEMATIC, not data-dependent)
+--------------------------------------------
+`conv_repness` builds the `group_id` column with
+`.map(ptpt_to_group)` (repness.py:239). Any participant who voted but is
+not assigned to a group maps to NaN, which upcasts the *entire* `group_id`
+column to float64. `dropna(subset=['group_id'])` removes those rows but the
+column keeps its float64 dtype. Every `gid` that then flows out through
+`comment_repness.to_dict('records')` (repness.py:~831) is therefore a
+`numpy.float64`.
+
+`to_dynamo_dict` passes that value straight through
+(`'group_id': gid`, conversation.py:~2485) — only the `repness` score is
+Decimal-converted — and `write_conversation` writes it raw into the
+`Delphi_RepresentativeComments` item. `numpy.float64` is a subclass of
+Python `float`, so boto3's serializer raises the exact error above.
+
+Because real conversations almost always contain at least one ungrouped
+voter, the column is float64 on essentially every grouped conversation —
+hence "systematic", as reported.
+
+Why CI never caught this
+------------------------
+The existing DynamoDB tests (e.g. test_dynamodb_consensus_roundtrip.py)
+replace the boto3 `Table` with a `unittest.mock.MagicMock`. A MagicMock
+`put_item` / `batch_writer` merely *records* the Item — it never runs
+boto3's real `TypeSerializer`, which is the only thing that raises on a
+float. The only tests that exercise a real DynamoDB serializer
+(test_batch_id.py, test_math_pipeline_runs_e2e.py, test_postgres_real_data.py)
+are all in the skip list (no DynamoDB in CI/VM).
+
+These tests use boto3's REAL `TypeSerializer` — the same code path
+`batch.put_item` runs — so they reproduce the production failure with no
+live DynamoDB, and would have caught it in CI.
+"""
+
+import pandas as pd
+import pytest
+from boto3.dynamodb.types import TypeSerializer
+
+from polismath.conversation.conversation import Conversation
+from polismath.pca_kmeans_rep.repness import conv_repness
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — a tiny but realistic grouped conversation
+# ---------------------------------------------------------------------------
+
+# AGREE=1, DISAGREE=-1, PASS=0, unvoted=NaN. Rows are pids, columns are tids.
+# pid 4 votes but belongs to NO group: that is what injects a NaN into the
+# `.map(ptpt_to_group)` result and upcasts the group_id column to float64.
+# This mirrors every real conversation, where some voters are ungrouped.
+def _vote_matrix() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            [1.0, 1.0, -1.0],   # pid 0  -> group 0
+            [1.0, -1.0, 0.0],   # pid 1  -> group 0
+            [-1.0, 1.0, 1.0],   # pid 2  -> group 1
+            [-1.0, 1.0, -1.0],  # pid 3  -> group 1
+            [1.0, 0.0, -1.0],   # pid 4  -> ungrouped (drives the float64 upcast)
+        ],
+        index=[0, 1, 2, 3, 4],
+        columns=[10, 11, 12],
+    )
+
+
+def _groups():
+    return [
+        {'id': 0, 'members': [0, 1]},
+        {'id': 1, 'members': [2, 3]},
+    ]
+
+
+def _assert_dynamodb_serializable(value, *, context):
+    """Run boto3's real serializer — the same one `batch.put_item` uses.
+
+    Raises the production TypeError ("Float types are not supported. Use
+    Decimal types instead.") on any Python/numpy float, and "Unsupported
+    type" on a bare numpy.int64. Passing means the value is a clean
+    DynamoDB scalar (int / Decimal / str).
+    """
+    try:
+        TypeSerializer().serialize(value)
+    except TypeError as exc:  # pragma: no cover - the assertion is the point
+        pytest.fail(
+            f"{context} is not DynamoDB-serializable "
+            f"({type(value).__name__}={value!r}): {exc}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — root cause: conv_repness emits a float gid
+# ---------------------------------------------------------------------------
+
+class TestConvRepnessGidType:
+    """`comment_repness` rows must carry a DynamoDB-serializable group id."""
+
+    def test_gid_is_dynamodb_serializable(self):
+        result = conv_repness(_vote_matrix(), _groups())
+        records = result['comment_repness']
+
+        assert records, (
+            "fixture must produce representative-comment rows; got an empty "
+            "comment_repness — adjust the vote matrix so the test is not vacuous"
+        )
+
+        for rec in records:
+            _assert_dynamodb_serializable(
+                rec['gid'], context=f"comment_repness gid (tid={rec.get('tid')})"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — end-to-end: to_dynamo_dict output, serialized like write_conversation
+# ---------------------------------------------------------------------------
+
+class TestToDynamoDictRepnessSerialization:
+    """The repness records `write_conversation` writes must serialize cleanly."""
+
+    def _conversation_with_real_repness(self):
+        conv = Conversation(conversation_id='ztest-float-gid')
+        conv.repness = conv_repness(_vote_matrix(), _groups())
+        conv.comment_priorities = {}
+        return conv
+
+    def test_repness_records_serialize(self):
+        conv = self._conversation_with_real_repness()
+        dynamo_data = conv.to_dynamo_dict()
+
+        comment_repness = dynamo_data['repness']['comment_repness']
+        assert comment_repness, "expected non-empty comment_repness from to_dynamo_dict"
+
+        # Reproduce the exact Item that write_conversation builds in step 5
+        # (Delphi_RepresentativeComments) and serialize the whole thing.
+        for item in comment_repness:
+            put_item = {
+                'zid_tick_gid': f"42:30000:{item.get('group_id', 0)}",
+                'comment_id': str(item.get('comment_id', '')),
+                'repness': item.get('repness'),
+                'group_id': item.get('group_id', 0),
+                'zid': '42',
+            }
+            _assert_dynamodb_serializable(
+                put_item, context="Delphi_RepresentativeComments Item"
+            )


### PR DESCRIPTION
write_conversation crashed writing Delphi_RepresentativeComments:

    Float types are not supported. Use Decimal types instead.
    File ".../polismath/database/dynamodb.py", line 462, in write_conversation
        batch.put_item(Item={...})

Root cause (systematic, not data-dependent): conv_repness builds the group_id column via `.map(ptpt_to_group)` (repness.py), which injects NaN for ungrouped voters and upcasts the whole column to float64. dropna removes those rows but not the dtype, so every gid flows out of `comment_repness.to_dict('records')` as a numpy.float64. The Delphi_RepresentativeComments write passes group_id through unconverted (only the repness score is Decimal-converted), and boto3 rejects any float (numpy.float64 subclasses float). Because real conversations almost always contain ungrouped voters, the column is float64 on essentially every grouped conversation -- hence systematic.

Fix:
- repness.conv_repness: coerce comment_repness 'gid' back to int at the emission point. Lossless -- gid is always an integral group id sourced from the full (group_id, comment) index.
- dynamodb.write_conversation: defensively int() the step-5 group_id (belt-and-braces, so the write path is robust to any float-typed caller).

Test (tests/test_dynamodb_float_serialization.py): exercises boto3's real TypeSerializer -- the same code path batch.put_item runs -- so it reproduces the production failure with no live DynamoDB. The existing DynamoDB tests mock the boto3 Table with MagicMock, which records the Item but never serializes it; that is why CI never caught this. The only tests that hit a real serializer (test_batch_id, test_math_pipeline_runs_e2e, test_postgres_real_data) are all in the skip list.