### PR TITLE
fix(models): replace retired Anthropic model ids with pinned live models

### DIFF
--- a/client-report/src/components/commentsReport/CommentsReport.jsx
+++ b/client-report/src/components/commentsReport/CommentsReport.jsx
@@ -36,7 +36,7 @@ const CommentsReport = ({ math, comments, conversation, ptptCount, formatTid, vo
     priority: 50,
     max_votes: "",
     batch_size: "",
-    model: "claude-opus-4-20250514",
+    model: "claude-opus-4-8",
     include_topics: true,
     include_moderation: reportModLevel !== -2,
   };
@@ -283,7 +283,7 @@ const CommentsReport = ({ math, comments, conversation, ptptCount, formatTid, vo
     net
       .polisPost("/api/v3/delphi/batchReports", {
         report_id: report_id,
-        model: "claude-opus-4-20250514",
+        model: "claude-opus-4-8",
         no_cache: false,
         include_moderation: reportModLevel !== -2,
       }, authToken)

--- a/client-report/src/no-retired-model-ids.test.js
+++ b/client-report/src/no-retired-model-ids.test.js
@@ -1,0 +1,51 @@
+import { readdirSync, readFileSync } from "fs";
+import { basename, join, resolve } from "path";
+
+/**
+ * Anthropic model ids that are retired and return HTTP 404 from the Models API.
+ * The report client posts a `model` to the delphi pipeline endpoints, so a
+ * retired id here propagates a dead model server-side and breaks report
+ * generation. Verified retired (404) against the live Models API on 2026-07-04;
+ * the live Opus-tier replacement is `claude-opus-4-8`.
+ */
+const RETIRED_MODEL_IDS = [
+  "claude-3-5-sonnet-20241022",
+  "claude-3-7-sonnet-20250219",
+  "claude-opus-4-20250514",
+];
+
+// Resolve against Jest's working directory (the client-report package root)
+// instead of __dirname/__filename, which are CommonJS-only globals and are
+// rejected by this project's ESM eslint config (sourceType: module).
+const SRC_DIR = resolve("src");
+const GUARD_FILENAME = "no-retired-model-ids.test.js";
+const EXCLUDED_DIRS = new Set(["node_modules", "dist", "build"]);
+
+function collectSourceFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRS.has(entry.name)) continue;
+      files.push(...collectSourceFiles(join(dir, entry.name)));
+    } else if (/\.(jsx?|tsx?)$/.test(entry.name)) {
+      files.push(join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+describe("Anthropic model ids", () => {
+  it("no client-report source references a retired (HTTP 404) model id", () => {
+    const offenders = [];
+    for (const file of collectSourceFiles(SRC_DIR)) {
+      if (basename(file) === GUARD_FILENAME) continue; // this guard names the retired ids on purpose
+      const text = readFileSync(file, "utf8");
+      for (const modelId of RETIRED_MODEL_IDS) {
+        if (text.includes(modelId)) {
+          offenders.push(`${file}: ${modelId}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/delphi/docs/BATCH_NARRATIVE_README.md
+++ b/delphi/docs/BATCH_NARRATIVE_README.md
@@ -35,7 +35,7 @@ python 801_narrative_report_batch.py --conversation_id CONVERSATION_ID [--model 
 
 Arguments:
 - `--conversation_id` or `--zid`: Conversation ID to process
-- `--model`: LLM model to use (default: claude-3-5-sonnet-20241022)
+- `--model`: LLM model to use (default: claude-sonnet-5)
 - `--no-cache`: Ignore cached report data
 - `--max-batch-size`: Maximum number of topics in a batch (default: 20)
 

--- a/delphi/docs/DATA_FORMAT_STANDARDS.md
+++ b/delphi/docs/DATA_FORMAT_STANDARDS.md
@@ -13,7 +13,7 @@ DynamoDB tables use specific key format conventions that must be followed consis
 - **Primary Key (rid_section_model)**: `{report_id}#{section_name}#{model}`
   - **report_id**: The report identifier (e.g., "r123456" or numerical ID)
   - **section_name**: The section of the report (e.g., "topic_zebra_crossing")
-  - **model**: The LLM model used (e.g., "claude-3-5-sonnet-20241022")
+  - **model**: The LLM model used (e.g., "claude-sonnet-5")
   - **Delimiter**: Always use `#` as the delimiter (not underscores)
 
 ```python

--- a/delphi/docs/JOB_QUEUE_SCHEMA.md
+++ b/delphi/docs/JOB_QUEUE_SCHEMA.md
@@ -88,7 +88,7 @@ The `job_config` attribute will be a JSON object containing job-specific paramet
 #### For Report Generation Jobs
 ```json
 {
-  "model": "claude-3-7-sonnet-20250219",
+  "model": "claude-sonnet-5",
   "include_topics": true,
   "include_consensus": true,
   "include_uncertainty": true,
@@ -267,7 +267,7 @@ To manage the growth of the job queue table:
       {
         "stage": "REPORT",
         "config": {
-          "model": "claude-3-7-sonnet-20250219",
+          "model": "claude-sonnet-5",
           "include_topics": true
         }
       }

--- a/delphi/tests/test_no_retired_model_ids.py
+++ b/delphi/tests/test_no_retired_model_ids.py
@@ -1,0 +1,88 @@
+"""Guard tests: the codebase must not reference Anthropic model ids that have
+been retired.
+
+A retired model id returns HTTP 404 from the Anthropic Models API, which
+silently breaks every LLM code path that falls through to it as a default.
+The ids below were verified retired (404) against the live Models API on
+2026-07-04; their live replacements are ``claude-opus-4-8`` (Opus tier) and
+``claude-sonnet-5`` (Sonnet tier).
+"""
+
+import os
+import pathlib
+import sys
+
+# Mirror the existing delphi test convention for importing umap_narrative modules.
+UMAP_NARRATIVE_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "umap_narrative")
+)
+if UMAP_NARRATIVE_DIR not in sys.path:
+    sys.path.insert(0, UMAP_NARRATIVE_DIR)
+
+from llm_factory_constructor.model_provider import AnthropicProvider  # noqa: E402
+
+# Anthropic model ids that are retired and return HTTP 404 from the Models API.
+RETIRED_MODEL_IDS = frozenset(
+    {
+        "claude-3-5-sonnet-20241022",
+        "claude-3-7-sonnet-20250219",
+        "claude-opus-4-20250514",
+    }
+)
+
+DELPHI_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_THIS_FILE = pathlib.Path(__file__).resolve()
+_EXCLUDED_DIR_NAMES = {
+    ".venv",
+    "venv",
+    "site-packages",
+    "__pycache__",
+    "node_modules",
+    ".git",
+    "scratch",
+    "real_data",
+    ".local",
+    "build",
+    "dist",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+}
+
+
+def _delphi_python_sources():
+    # os.walk (not Path.rglob) so excluded directories are pruned in-place and
+    # never descended into -- a local ``.venv`` holds tens of thousands of
+    # vendored .py files, and rglob would enumerate and stat every one of them
+    # on each run before filtering.
+    for dirpath, dirnames, filenames in os.walk(DELPHI_ROOT):
+        dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIR_NAMES]
+        for name in filenames:
+            if not name.endswith(".py"):
+                continue
+            path = pathlib.Path(dirpath) / name
+            if path.resolve() == _THIS_FILE:
+                continue  # this guard names the retired ids on purpose
+            yield path
+
+
+def test_anthropic_provider_advertises_no_retired_models():
+    advertised = set(AnthropicProvider(api_key="test").list_available_models())
+    leaked = advertised & RETIRED_MODEL_IDS
+    assert not leaked, (
+        "AnthropicProvider.list_available_models() advertises retired "
+        f"(HTTP 404) model ids: {sorted(leaked)}"
+    )
+
+
+def test_delphi_source_references_no_retired_model_ids():
+    offenders = []
+    for path in _delphi_python_sources():
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for model_id in RETIRED_MODEL_IDS:
+            if model_id in text:
+                offenders.append(f"{path.relative_to(DELPHI_ROOT)}: {model_id}")
+    assert not offenders, (
+        "Retired Anthropic model ids found in delphi source:\n"
+        + "\n".join(sorted(offenders))
+    )

--- a/delphi/umap_narrative/802_process_batch_results.py
+++ b/delphi/umap_narrative/802_process_batch_results.py
@@ -399,7 +399,7 @@ class BatchResultProcessor:
             return False
         
         # Get model provider and request data
-        model_name = self.batch_job.get('model', 'claude-3-5-sonnet-20241022')
+        model_name = self.batch_job.get('model', 'claude-sonnet-5')
         model_provider = get_model_provider('anthropic', model_name)
         request_map = self.batch_job.get('request_map', {})
         total_requests = len(request_map)

--- a/delphi/umap_narrative/llm_factory_constructor/model_provider.py
+++ b/delphi/umap_narrative/llm_factory_constructor/model_provider.py
@@ -391,9 +391,8 @@ class AnthropicProvider(ModelProvider):
         """
         # Anthropic doesn't have a list models endpoint, so we hardcode the known models
         available_models = [
-            "claude-3-5-sonnet-20241022",
-            "claude-3-7-sonnet-20250219",
-            "claude-opus-4-20250514"
+            "claude-opus-4-8",
+            "claude-sonnet-5",
         ]
         logger.info(f"Available Anthropic models: {available_models}")
         return available_models

--- a/server/__tests__/unit/no-retired-model-ids.test.ts
+++ b/server/__tests__/unit/no-retired-model-ids.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "@jest/globals";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Anthropic model ids that are retired and return HTTP 404 from the Models API.
+ * Any source that hardcodes one (e.g. as a request default) is broken at
+ * runtime the moment that default is used. Verified retired (404) against the
+ * live Models API on 2026-07-04; live replacements are `claude-opus-4-8`
+ * (Opus tier) and `claude-sonnet-5` (Sonnet tier).
+ */
+const RETIRED_MODEL_IDS = [
+  "claude-3-5-sonnet-20241022",
+  "claude-3-7-sonnet-20250219",
+  "claude-opus-4-20250514",
+];
+
+const SRC_DIR = join(__dirname, "..", "..", "src");
+const EXCLUDED_DIRS = new Set(["node_modules", "dist", "build"]);
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRS.has(entry.name)) continue;
+      files.push(...collectSourceFiles(join(dir, entry.name)));
+    } else if (/\.(ts|js)$/.test(entry.name)) {
+      files.push(join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+describe("Anthropic model ids", () => {
+  test("no server source references a retired (HTTP 404) model id", () => {
+    const offenders: string[] = [];
+    for (const file of collectSourceFiles(SRC_DIR)) {
+      const text = readFileSync(file, "utf8");
+      for (const modelId of RETIRED_MODEL_IDS) {
+        if (text.includes(modelId)) {
+          offenders.push(`${file}: ${modelId}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/server/src/prompts/report_experimental/scripts/sonnet.ts
+++ b/server/src/prompts/report_experimental/scripts/sonnet.ts
@@ -135,7 +135,7 @@ async function main() {
   ); // then convert back to xml
   logger.debug(prompt_xml);
   const msg = await anthropic.messages.create({
-    model: "claude-3-7-sonnet-20250219",
+    model: "claude-sonnet-5",
     max_tokens: 1000,
     temperature: 0,
     system: system_lore,

--- a/server/src/routes/collectiveStatement.ts
+++ b/server/src/routes/collectiveStatement.ts
@@ -144,7 +144,7 @@ You MUST respond with valid JSON that follows the exact schema above. Each claus
 
   try {
     const response = await anthropic.messages.create({
-      model: "claude-opus-4-20250514",
+      model: "claude-opus-4-8",
       max_tokens: 3000,
       temperature: 0.7,
       system: systemPrompt,
@@ -340,7 +340,7 @@ export async function handle_POST_collectiveStatement(
       statement_data: JSON.stringify(result.statementData),
       comments_data: JSON.stringify(result.commentsData),
       created_at: new Date().toISOString(),
-      model: "claude-opus-4-20250514",
+      model: "claude-opus-4-8",
     };
 
     await docClient.send(

--- a/server/src/routes/delphi/jobs.ts
+++ b/server/src/routes/delphi/jobs.ts
@@ -55,7 +55,7 @@ export async function handle_POST_delphi_jobs(
       priority = 50,
       max_votes,
       batch_size,
-      model = "claude-3-7-sonnet-20250219",
+      model = "claude-sonnet-5",
       include_topics = true,
       include_moderation = false, // ignore comments that recieve a failing moderation score
     } = req.body;

--- a/server/src/routes/reportNarrative.ts
+++ b/server/src/routes/reportNarrative.ts
@@ -276,7 +276,7 @@ const getModelResponse = async (
           throw new Error("polis_err_anthropic_api_key_not_set");
         }
         const responseClaude = await anthropic.messages.create({
-          model: modelVersion || "claude-3-7-sonnet-20250219",
+          model: modelVersion || "claude-sonnet-5",
           max_tokens: 3000,
           temperature: 0,
           system: system_lore,


### PR DESCRIPTION
## Problem

Three Anthropic model IDs were hardcoded across the codebase and have since been **retired by Anthropic** — each now returns **HTTP 404** from the Models API (verified against the live API on 2026-07-04), silently breaking every LLM path that falls through to them as a default:

| Retired ID | Retired | Used in |
| --- | --- | --- |
| `claude-3-7-sonnet-20250219` | 2026-02-19 | server: `reportNarrative.ts`, `routes/delphi/jobs.ts`, `report_experimental/scripts/sonnet.ts` |
| `claude-opus-4-20250514` | 2026-06-15 | server: `collectiveStatement.ts`; client-report: `CommentsReport.jsx` |
| `claude-3-5-sonnet-20241022` | 2025-10-28 | delphi: batch-results fallback default + advertised model list |

The report client (`CommentsReport.jsx`) posts `claude-opus-4-20250514` to `/api/v3/delphi/batchReports` and the FULL_PIPELINE job form, so the report UI's "generate report" / "generate narrative report" actions ship a dead model into the delphi pipeline.

## Fix

Replace with the current pinned models. This generation has **no dated-snapshot IDs** — the versioned name is itself the immutable pin (the API rejects any date suffix for this generation; verified 2026-07-04):

- **Opus tier → `claude-opus-4-8`** — collective statements; report-pipeline job payloads
- **Sonnet tier → `claude-sonnet-5`** — narratives; experimental report; batch fallback

Each site keeps its existing tier; overridable defaults stay overridable (only the string literal changed). The three delphi docs that documented a retired ID as a default/example are updated to match.

## Guard tests

Adds a guard test in each affected ecosystem — delphi (pytest), server (jest), client-report (jest) — that fails if any source references a retired model ID, so this class of breakage cannot silently regress.

## Verification

- All three retired IDs → HTTP 404; both replacements → 200 (live Models API, 2026-07-04).
- delphi guard: RED (2 failed) → GREEN (2 passed) via `uv run pytest`.
- server + client-report guards: RED → GREEN witnessed.
- Independent code-review agent: no blocking issues (one guard-test efficiency finding — a scan walking the local `.venv` — was found and fixed).
- Commits are GPG-signed.

---

**Paired change:** this PR targets `stable`; a companion PR ports the identical fix to `edge` (the retired-ID footprint is identical on both branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
