### PR TITLE
fix(delphi): address Copilot review on D10-D12 stack (consensus blob keys, priority serialization, defensive fixes)

### DIFF
--- a/delphi/polismath/benchmarks/bench_repness.py
+++ b/delphi/polismath/benchmarks/bench_repness.py
@@ -28,7 +28,6 @@ from polismath.benchmarks.benchmark_utils import (
 from polismath.conversation import Conversation
 from polismath.pca_kmeans_rep.repness import (
     conv_repness,
-    comment_stats,
     compute_group_comment_stats_df,
     select_rep_comments_df,
     select_consensus_comments_df,

--- a/delphi/polismath/conversation/conversation.py
+++ b/delphi/polismath/conversation/conversation.py
@@ -1132,6 +1132,22 @@ class Conversation:
         cmnt_proj = pca_project_cmnts(center, comps)
         extremity_arr = compute_comment_extremity(cmnt_proj)
 
+        # Fail closed on desync: if the PCA vectors were computed on a
+        # different column set than the current rating_mat (e.g. moderation
+        # changed between recomputes), zip() would silently truncate and
+        # assign E=0 to the overflow tids — wrong priorities with no
+        # signal. Empty priorities degrade the TS server to uniform
+        # routing, which is honest; silently wrong extremities are not.
+        # (Copilot review 2026-07-04, g4.)
+        n_cols = len(self.rating_mat.columns)
+        if len(extremity_arr) != n_cols:
+            logger.error(
+                f"comment_priorities: extremity length {len(extremity_arr)} "
+                f"!= rating_mat column count {n_cols} (stale PCA?); "
+                f"skipping priorities for this tick")
+            self.comment_priorities = {}
+            return self.comment_priorities
+
         # Column order of `center`/`comps`/`extremity_arr` matches
         # `self.rating_mat.columns` (PCA is computed on rating_mat).
         tid_extremity = dict(zip(self.rating_mat.columns, extremity_arr))
@@ -1139,6 +1155,11 @@ class Conversation:
         # Per-group A/D/S aggregation. `_compute_group_votes` returns
         # {str(gid): {'n-members': N, 'votes': {tid: {A, D, S}}}}. S includes
         # PASS (line ~1222: `np.sum(~np.isnan(votes))`), matching Clojure.
+        # PERF (deferred, Copilot on PR #2568): this is an O(groups ×
+        # comments × members) scan on every recompute; vectorize or reuse
+        # the repness-stage aggregation — tracked in the follow-up issue
+        # "delphi: _compute_comment_priorities recomputes group votes on
+        # every tick".
         group_votes = self._compute_group_votes()
 
         priorities: Dict[Any, float] = {}
@@ -2454,10 +2475,18 @@ class Conversation:
             logger.info(f"[{time.time() - start_time:.2f}s] Processing comment priorities...")
             priorities = {}
             for cid, priority in self.comment_priorities.items():
+                # Preserve the float VALUE as Decimal (boto3 rejects raw
+                # floats). The previous int() truncation was harmless while
+                # the D12.6 bug-mirror pins every priority to 49.0, but the
+                # real formula (restored when issue #2571 resolves) spans
+                # ~0.18–31.46 on real data: int() floors sub-1 priorities
+                # to 0, which the TS server's weighted routing treats as
+                # "no priority data" — those comments would never be routed.
+                value = float_to_decimal(float(priority))
                 try:
-                    priorities[int(cid)] = int(priority)
+                    priorities[int(cid)] = value
                 except (ValueError, TypeError):
-                    priorities[cid] = int(priority)
+                    priorities[cid] = value
             result['comment_priorities'] = priorities
         
         # Process repness data efficiently

--- a/delphi/polismath/database/dynamodb.py
+++ b/delphi/polismath/database/dynamodb.py
@@ -300,12 +300,16 @@ class DynamoDBClient:
             if analysis_table:
                 if dynamo_data:
                     # Use pre-formatted data
-                    # D11 cascade fix (Investigation B, Site 1): source the FULL
-                    # consensus dict from repness.consensus_comments, preserving
-                    # both `agree` and `disagree` lists. The old code dropped
-                    # `disagree` entirely (`.get('consensus', {}).get('agree', [])`).
-                    consensus_comments = dynamo_data.get('repness', {}).get(
-                        'consensus_comments', {'agree': [], 'disagree': []}
+                    # D11 cascade fix (Investigation B, Site 1), corrected
+                    # 2026-07-04: `to_dynamo_dict()` surfaces consensus at
+                    # TOP-LEVEL `result['consensus']` — its `repness` dict
+                    # carries only `comment_repness`. The previous read of
+                    # `repness.consensus_comments` matched a key that never
+                    # exists, so the writer always stored the empty default
+                    # (the round-trip test masked this by stubbing
+                    # to_dynamo_dict with the wrong nested shape).
+                    consensus_comments = dynamo_data.get(
+                        'consensus', {'agree': [], 'disagree': []}
                     )
                     analysis_table.put_item(Item={
                         'zid': zid,
@@ -450,7 +454,13 @@ class DynamoDBClient:
                             batch.put_item(Item={
                                 'zid_tick': zid_tick,
                                 'comment_id': str(comment_id),
-                                'priority': comment_priorities.get(comment_id, 0),
+                                # Legacy branch reads conv.comment_priorities
+                                # directly (raw floats) — convert like the
+                                # stats/consensus_score fields above, or
+                                # boto3 rejects the write (Copilot
+                                # 2026-07-04, e).
+                                'priority': self._replace_floats_with_decimals(
+                                    comment_priorities.get(comment_id, 0)),
                                 'stats': stats,
                                 'consensus_score': consensus_score,
                                 'zid': zid,
@@ -861,9 +871,16 @@ class DynamoDBClient:
                     # new dict shape `{'agree': [], 'disagree': []}` rather than
                     # the obsolete empty list `[]`, so downstream consumers
                     # always receive a uniformly-shaped value.
-                    result['consensus'] = analysis.get(
+                    stored_consensus = analysis.get(
                         'consensus_comments', {'agree': [], 'disagree': []}
                     )
+                    # Normalize legacy blobs (Copilot 2026-07-04, g3):
+                    # pre-D11 writers stored consensus as a (hardcoded-empty)
+                    # LIST. Map any list to the empty dict shape so readers
+                    # of old ticks never see a list.
+                    if isinstance(stored_consensus, list):
+                        stored_consensus = {'agree': [], 'disagree': []}
+                    result['consensus'] = stored_consensus
             
             # 2. Get groups data
             groups_table = self.tables.get('Delphi_KMeansClusters')

--- a/delphi/polismath/pca_kmeans_rep/repness.py
+++ b/delphi/polismath/pca_kmeans_rep/repness.py
@@ -91,10 +91,12 @@ def prop_test_vectorized(succ: pd.Series, n: pd.Series) -> pd.Series:
 
     Args:
         succ: Series of success counts (e.g. `na` or `nd` per row).
-        n: Series of trial counts. In all current callers this is `ns = na + nd`
-           (AGREE + DISAGREE per row) — PASS votes are NOT included, matching
-           what Clojure passes as `n-trials`. If you call this from elsewhere,
-           supply `na + nd` rather than a "total votes seen including pass" count.
+        n: Series of trial counts. In all current callers this is `ns` = the
+           count of ALL non-nil votes INCLUDING PASS (`notna().sum()`),
+           matching Clojure's `count-votes` with no vote arg
+           (`(count (filter identity votes))` — 0/PASS is truthy in Clojure,
+           repness.clj:56-61; ns-PASS fix 2026-06-11). If you call this from
+           elsewhere, supply the PASS-inclusive non-nil count, NOT `na + nd`.
 
     Returns:
         Series of z-scores. Positive when the smoothed proportion (succ+1)/(n+1)
@@ -519,7 +521,9 @@ def select_rep_comments_df(stats_df: pd.DataFrame,
     if stats_df.empty:
         return empty_df, None
 
-    mod_out_set = set(mod_out) if mod_out else set()
+    # `is not None`, not truthiness: mod_out may be a numpy array / pandas
+    # Index, whose bare truth value raises for len>1 (Copilot 2026-07-04).
+    mod_out_set = set(mod_out) if mod_out is not None else set()
     sufficient: List[Dict[str, Any]] = []
     best: Optional[Dict[str, Any]] = None
     # Track best's max(rat, rdt) as a sidecar scalar so we never have to mutate
@@ -685,7 +689,9 @@ def consensus_stats_df(vote_matrix_df: pd.DataFrame,
     df['pat'] = prop_test_vectorized(df['na'], df['ns'])
     df['pdt'] = prop_test_vectorized(df['nd'], df['ns'])
 
-    if mod_out:
+    # `is not None`, not truthiness: mod_out may be a numpy array / pandas
+    # Index, whose bare truth value raises for len>1 (Copilot 2026-07-04).
+    if mod_out is not None:
         mod_out_set = set(mod_out)
         df = df[~df.index.isin(mod_out_set)]
 
@@ -706,9 +712,10 @@ def select_consensus_comments_df(
       - Agree: `pa > 0.5 AND z-sig-90(pat)`, sorted desc by `am = pa * pat`.
       - Disagree: `pd > 0.5 AND z-sig-90(pdt)`, sorted desc by `dm = pd * pdt`.
 
-    With PSEUDO_COUNT smoothing the constraint `pa + pd = 1` is exact (na+nd=ns
-    after smoothing), so `pa > 0.5 ⟺ pd < 0.5` — the same tid cannot appear in
-    both lists.
+    Since `ns` counts all non-nil votes including PASS (ns ≥ na+nd),
+    `pa + pd = (na+nd+PSEUDO_COUNT)/(ns+PSEUDO_COUNT) ≤ 1`, so pa and pd
+    cannot both exceed 0.5 — the same tid cannot appear in both lists. (The
+    equality pa+pd=1 holds only for PASS-free comments.)
 
     Args:
         cons_stats: DataFrame indexed by tid with cols [na, nd, ns, pa, pd,
@@ -716,9 +723,14 @@ def select_consensus_comments_df(
 
     Returns:
         Dict shape `{'agree': [entries], 'disagree': [entries]}`. Each entry
-        is `{comment_id, n_success, n_trials, p_success, p_test}` (Python
-        convention key naming per S1; math-blob alignment with Clojure's
-        hyphenated keys is a future PR).
+        is `{tid, n-success, n-trials, p-success, p-test}` — EXACTLY the
+        Clojure blob shape (repness.clj:181 + the ::consensus s/keys spec).
+        This narrows the S1 deferral (2026-07-04): consensus entries flow
+        raw into `result['consensus']` in to_dict / to_dynamo_dict, where
+        server-helpers.ts:298-313 and client-report's
+        majorityStrict.jsx:23-27 pluck `tid` — Python-convention keys broke
+        both. Rep-comment entries keep `comment_id` until the deferred
+        math-blob alignment PR.
     """
     if cons_stats.empty:
         return {'agree': [], 'disagree': []}
@@ -735,20 +747,20 @@ def select_consensus_comments_df(
 
     def _agree_entry(tid: Any, row: pd.Series) -> Dict[str, Any]:
         return {
-            'comment_id': int(tid),
-            'n_success': int(row['na']),
-            'n_trials': int(row['ns']),
-            'p_success': float(row['pa']),
-            'p_test': float(row['pat']),
+            'tid': int(tid),
+            'n-success': int(row['na']),
+            'n-trials': int(row['ns']),
+            'p-success': float(row['pa']),
+            'p-test': float(row['pat']),
         }
 
     def _disagree_entry(tid: Any, row: pd.Series) -> Dict[str, Any]:
         return {
-            'comment_id': int(tid),
-            'n_success': int(row['nd']),
-            'n_trials': int(row['ns']),
-            'p_success': float(row['pd']),
-            'p_test': float(row['pdt']),
+            'tid': int(tid),
+            'n-success': int(row['nd']),
+            'n-trials': int(row['ns']),
+            'p-success': float(row['pd']),
+            'p-test': float(row['pdt']),
         }
 
     return {

--- a/delphi/tests/test_benchmarks_importable.py
+++ b/delphi/tests/test_benchmarks_importable.py
@@ -1,0 +1,21 @@
+"""Benchmarks must stay importable as the production API evolves.
+
+PR 14a deleted the scalar repness functions; `bench_repness.py` still
+imported `comment_stats`, so running any benchmark in that module crashed
+with ImportError. Plain import tests catch this class of drift at CI time
+(Copilot review 2026-07-04, g2).
+"""
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize('module_name', [
+    'polismath.benchmarks.bench_repness',
+    'polismath.benchmarks.bench_pca',
+    'polismath.benchmarks.bench_update_votes',
+    'polismath.benchmarks.benchmark_utils',
+])
+def test_benchmark_module_imports(module_name):
+    importlib.import_module(module_name)

--- a/delphi/tests/test_discrepancy_fixes.py
+++ b/delphi/tests/test_discrepancy_fixes.py
@@ -1512,6 +1512,28 @@ class TestD10TestGaps:
         assert flagged[0]['comment_id'] == 2, \
             f"next-best (tid 2) should become best_agree, got {flagged[0]['comment_id']}"
 
+    def test_mod_out_accepts_ndarray(self):
+        """`mod_out` typed Optional[Iterable[int]] — callers may pass a numpy
+        array or pandas Index (e.g. sourced from a DataFrame column). Bare
+        `if mod_out:` truthiness raises 'truth value of an array is
+        ambiguous' for len>1 arrays; the check must be `is not None`
+        (Copilot review 2026-07-04, verified)."""
+        rows = [
+            _stats_row(1, na=8, nd=2, pa=0.8, pd_=0.2, pat=2.0, pdt=-2.0,
+                       ra=2.0, rd=0.5, rat=2.0, rdt=-2.0),
+            _stats_row(2, na=6, nd=3, pa=0.7, pd_=0.3, pat=1.5, pdt=-1.5,
+                       ra=1.5, rd=0.6, rat=1.5, rdt=-1.5),
+            _stats_row(3, na=5, nd=4, pa=0.55, pd_=0.45, pat=1.0, pdt=-1.0,
+                       ra=1.1, rd=0.9, rat=1.0, rdt=-1.0),
+        ]
+        df = pd.DataFrame(rows)
+        # len-2 ndarray: bare truthiness would raise ValueError.
+        result = _assemble_rep_comments(df, mod_out=np.array([1, 3]))
+        tids = [r['comment_id'] for r in result]
+        assert 1 not in tids and 3 not in tids, \
+            f"ndarray mod_out tids must be excluded, got {tids}"
+        assert 2 in tids
+
     def test_tied_agree_metric_in_sort_uses_deterministic_tiebreak(self):
         """Two `sufficient` rows with identical `agree_metric` resolve
         deterministically. `list.sort` is stable in CPython, so the lower-tid
@@ -1646,15 +1668,7 @@ class TestD11ConsensusSelection:
          Clojure uses per-comment pa > 0.5, top 5 agree + 5 disagree with z-test scores
     """
 
-    @pytest.mark.xfail(strict=False,
-                       reason="After ns-PASS fix (2026-06-11), 3/4 dataset variants "
-                              "(vw-incremental, vw-cold_start, biodiversity-cold_start) match "
-                              "Clojure exactly. biodiversity-incremental still mismatches on "
-                              "the disagree side (likely residual upstream PCA/KMeans "
-                              "group-membership divergence affecting which participants are "
-                              "in-conv at the incremental step). Tracked separately — see "
-                              "journal entry 2026-06-11.")
-    def test_consensus_matches_clojure(self, conv, clojure_blob, dataset_name):
+    def test_consensus_matches_clojure(self, request, conv, clojure_blob, dataset_name):
         """Consensus selection should match Clojure on cold_start.
 
         After D11 (PR 9), Python's `consensus_comments` is a dict
@@ -1666,6 +1680,29 @@ class TestD11ConsensusSelection:
         to `notna().sum()` — matches Clojure `(count (filter identity ...))`
         in repness.clj:56-61.
         """
+        # Per-variant xfail (g5, 2026-07-04): known-bad INCREMENTAL variants
+        # only. biodiversity-incremental was documented 2026-06-11 (residual
+        # upstream PCA/KMeans group-membership divergence affecting which
+        # participants are in-conv at the incremental step). Scoping the
+        # previously-blanket xfail(strict=False) then UNMASKED
+        # bg2018-incremental and pakistan-incremental (private datasets) —
+        # failures the blanket had silently absorbed, undocumented until
+        # 2026-07-04. Same incremental-divergence family; resolution belongs
+        # to the sequential-parity work (replay infra / warm-start port).
+        # ALL cold_start variants and vw-incremental match Clojure exactly
+        # and MUST keep gating.
+        _known_bad_incremental = ('biodiversity', 'bg2018', 'pakistan')
+        _callspec = request.node.callspec.id
+        if 'incremental' in _callspec and any(
+                ds in _callspec for ds in _known_bad_incremental):
+            request.applymarker(pytest.mark.xfail(
+                strict=False,
+                reason="known-bad incremental variant (biodiversity: journal "
+                       "2026-06-11; bg2018/pakistan: unmasked 2026-07-04 when "
+                       "the blanket xfail was scoped per-variant): residual "
+                       "upstream incremental divergence, deferred to the "
+                       "sequential-parity work"))
+
         clj_consensus = clojure_blob.get('consensus', {})
         if not clj_consensus:
             pytest.skip("No consensus in Clojure blob")
@@ -1676,9 +1713,9 @@ class TestD11ConsensusSelection:
 
         py_consensus = (conv.repness.get('consensus_comments', {})
                         if conv.repness else {})
-        py_agree_tids = set(int(c['comment_id'])
+        py_agree_tids = set(int(c['tid'])
                             for c in py_consensus.get('agree', []))
-        py_disagree_tids = set(int(c['comment_id'])
+        py_disagree_tids = set(int(c['tid'])
                                for c in py_consensus.get('disagree', []))
         py_all = py_agree_tids | py_disagree_tids
 
@@ -1749,6 +1786,20 @@ class TestD11ConsensusStatsDf:
         assert 2 not in df.index
         assert 3 in df.index
 
+    def test_mod_out_accepts_ndarray(self):
+        """Same `is not None` requirement as select_rep_comments_df: a len>1
+        numpy array as mod_out must filter, not raise 'truth value of an
+        array is ambiguous' (Copilot review 2026-07-04, verified)."""
+        votes = pd.DataFrame({
+            1: [AGREE, AGREE, AGREE],
+            2: [AGREE, AGREE, AGREE],
+            3: [AGREE, AGREE, AGREE],
+        })
+        df = consensus_stats_df(votes, mod_out=np.array([2, 3]))
+        assert 1 in df.index
+        assert 2 not in df.index
+        assert 3 not in df.index
+
     def test_ns_includes_pass_votes(self):
         """Clojure parity: ns counts all non-nil votes incl. PASS (repness.clj:56-61)."""
         votes = pd.DataFrame({
@@ -1780,7 +1831,7 @@ class TestD11SelectConsensusBoundary:
             (2, 8, 2, 10, 0.75, 0.25, 2.0, -2.0),  # agree
         ])
         result = select_consensus_comments_df(stats)
-        agree_tids = [e['comment_id'] for e in result['agree']]
+        agree_tids = [e['tid'] for e in result['agree']]
         assert 1 in agree_tids and 2 in agree_tids
         assert result['disagree'] == []
 
@@ -1791,7 +1842,7 @@ class TestD11SelectConsensusBoundary:
             (2, 2, 8, 10, 0.25, 0.75, -2.0, 2.0),
         ])
         result = select_consensus_comments_df(stats)
-        disagree_tids = [e['comment_id'] for e in result['disagree']]
+        disagree_tids = [e['tid'] for e in result['disagree']]
         assert 1 in disagree_tids and 2 in disagree_tids
         assert result['agree'] == []
 
@@ -1815,42 +1866,53 @@ class TestD11SelectConsensusBoundary:
         result = select_consensus_comments_df(stats)
         assert len(result['agree']) == 5
         # Highest am at front: pa*pat = 0.83 * 2.5 = 2.075
-        assert result['agree'][0]['comment_id'] == 1
+        assert result['agree'][0]['tid'] == 1
 
-    def test_entry_keys_python_convention(self):
-        """Per-entry keys: comment_id, n_success, n_trials, p_success, p_test.
-        Python underscore convention (decision S1), not Clojure hyphens."""
+    def test_entry_keys_match_clojure_blob(self):
+        """Per-entry keys: tid, n-success, n-trials, p-success, p-test —
+        EXACTLY the Clojure blob shape (repness.clj:181 + ::consensus spec).
+
+        Narrows the S1 deferral (2026-07-04): consensus entries are new in
+        D11 and flow raw into `result['consensus']` in to_dict /
+        to_dynamo_dict, where server-helpers.ts:298-313 and client-report's
+        majorityStrict.jsx:23-27 pluck `tid`. Python-convention keys would
+        break both consumers. Rep-comment entries keep `comment_id` until
+        the deferred math-blob alignment PR."""
         stats = self._stats([(1, 9, 1, 10, 0.83, 0.17, 2.5, -2.5)])
         result = select_consensus_comments_df(stats)
         entry = result['agree'][0]
-        assert set(entry.keys()) == {'comment_id', 'n_success', 'n_trials', 'p_success', 'p_test'}
-        assert entry['comment_id'] == 1
-        # For agree side, n_success = na, p_success = pa, p_test = pat
-        assert entry['n_success'] == 9
-        assert entry['n_trials'] == 10
-        assert abs(entry['p_success'] - 0.83) < 1e-10
-        assert abs(entry['p_test'] - 2.5) < 1e-10
+        assert set(entry.keys()) == {'tid', 'n-success', 'n-trials', 'p-success', 'p-test'}
+        assert entry['tid'] == 1
+        # For agree side, n-success = na, p-success = pa, p-test = pat
+        assert entry['n-success'] == 9
+        assert entry['n-trials'] == 10
+        assert abs(entry['p-success'] - 0.83) < 1e-10
+        assert abs(entry['p-test'] - 2.5) < 1e-10
 
     def test_disagree_entry_uses_d_keys(self):
-        """For disagree side, n_success = nd, p_success = pd, p_test = pdt."""
+        """For disagree side, n-success = nd, p-success = pd, p-test = pdt."""
         stats = self._stats([(1, 1, 9, 10, 0.17, 0.83, -2.5, 2.5)])
         result = select_consensus_comments_df(stats)
         entry = result['disagree'][0]
-        assert entry['n_success'] == 9   # = nd
-        assert abs(entry['p_success'] - 0.83) < 1e-10  # = pd
-        assert abs(entry['p_test'] - 2.5) < 1e-10  # = pdt
+        assert entry['n-success'] == 9   # = nd
+        assert abs(entry['p-success'] - 0.83) < 1e-10  # = pd
+        assert abs(entry['p-test'] - 2.5) < 1e-10  # = pdt
 
     def test_mutually_exclusive_lists(self):
-        """With PSEUDO_COUNT=2, pa + pd = 1 exactly (since na+nd=ns). So
-        pa > 0.5 ⟺ pd < 0.5 — the same tid cannot appear in both lists."""
-        # Build several rows. For each, na+nd MUST equal ns (consensus_stats_df invariant).
+        """With ns ≥ na+nd (ns includes PASS post-ns-PASS fix),
+        pa + pd = (na+nd+PSEUDO_COUNT)/(ns+PSEUDO_COUNT) ≤ 1, so pa and pd
+        cannot both exceed 0.5 — the same tid cannot appear in both lists.
+        (The equality pa+pd=1 only holds for PASS-free comments, as in this
+        fixture.)"""
+        # PASS-free rows: na+nd = ns here (but the invariant above holds
+        # generally, PASS or not).
         stats = self._stats([
             (1, 7, 3, 10, 0.67, 0.33, 1.5, -1.5),  # agree side
             (2, 3, 7, 10, 0.33, 0.67, -1.5, 1.5),  # disagree side
         ])
         result = select_consensus_comments_df(stats)
-        agree_tids = {e['comment_id'] for e in result['agree']}
-        disagree_tids = {e['comment_id'] for e in result['disagree']}
+        agree_tids = {e['tid'] for e in result['agree']}
+        disagree_tids = {e['tid'] for e in result['disagree']}
         assert agree_tids & disagree_tids == set(), \
             f"agree and disagree lists must be disjoint, got overlap {agree_tids & disagree_tids}"
 
@@ -1866,13 +1928,7 @@ class TestD12CommentPriorities:
          Clojure computes priorities based on PCA extremity and importance.
     """
 
-    @pytest.mark.xfail(reason="D12.6 incremental divergence: Clojure cold_start has the truthy-0 "
-                              "bug (all priorities = 49.0); Python mirrors that and matches on "
-                              "cold_start. But Clojure INCREMENTAL doesn't exhibit the bug (varied "
-                              "priorities), so Python's all-49 doesn't match incremental. Cold_start "
-                              "would pass if parametrize allowed per-variant xfail. Once the Clojure "
-                              "bug is fixed upstream, drop the Python mirror and this xfail.")
-    def test_comment_priorities_exist(self, conv, clojure_blob, dataset_name):
+    def test_comment_priorities_exist(self, request, conv, clojure_blob, dataset_name):
         """Python should produce comment-priorities matching Clojure.
 
         Per D12.6: Clojure's `(if 0 ...)` truthiness quirk means every tid
@@ -1884,6 +1940,19 @@ class TestD12CommentPriorities:
         meaningful when both sides have zero variance — we instead verify
         the constant-value parity directly.
         """
+        # Per-variant xfail (g5, 2026-07-04): only INCREMENTAL is known-bad —
+        # Clojure incremental doesn't exhibit the truthy-0 bug (varied
+        # priorities), so Python's all-49 mirror can't match it. Cold_start
+        # matches exactly and MUST keep gating; the previous blanket xfail
+        # masked cold_start regressions. Once the Clojure bug (#2571) is
+        # fixed upstream, drop the Python mirror and this xfail.
+        if 'incremental' in request.node.callspec.id:
+            request.applymarker(pytest.mark.xfail(
+                strict=False,
+                reason="D12.6: Clojure incremental has varied priorities "
+                       "(no truthy-0 bug there); Python's all-49 mirror "
+                       "cannot match. See issue #2571."))
+
         clj_priorities = clojure_blob.get('comment-priorities', {})
         check.greater(len(clj_priorities), 0,
                        f"Clojure has {len(clj_priorities)} comment priorities")
@@ -1930,6 +1999,50 @@ class TestD12CommentPriorities:
             (py_const,) = py_unique
             check.almost_equal(py_const, META_PRIORITY_SQ, abs=1e-9,
                                msg=f"Python constant priority should be META_PRIORITY**2={META_PRIORITY_SQ}")
+
+
+class TestD12PriorityExtremityAlignment:
+    """`_compute_comment_priorities` must fail closed on a PCA/columns desync.
+
+    `dict(zip(rating_mat.columns, extremity_arr))` silently truncates when
+    the PCA output was computed on a different column set than the current
+    rating_mat (e.g. moderation changed between recomputes). Silent
+    truncation assigns E=0 to the overflow tids — wrong priorities with no
+    signal. The guard logs an error and returns {} (server falls back to
+    uniform routing — degraded but honest). (Copilot review 2026-07-04, g4.)
+    """
+
+    def _conv_with_desync(self):
+        conv = Conversation(conversation_id='ztest-desync')
+        # 3 comments in the rating matrix...
+        conv.rating_mat = pd.DataFrame(
+            [[1.0, -1.0, 0.0], [1.0, 1.0, -1.0]],
+            index=[0, 1], columns=[10, 11, 12],
+        )
+        conv.raw_rating_mat = conv.rating_mat.copy()
+        # ...but PCA computed on only 2 (stale center/comps).
+        conv.pca = {
+            'center': np.array([0.5, -0.5]),
+            'comps': np.array([[0.7, 0.7], [0.7, -0.7]]),
+        }
+        conv.group_clusters = []
+        conv.meta_tids = set()
+        return conv
+
+    def test_desync_returns_empty_and_logs(self, caplog):
+        conv = self._conv_with_desync()
+        import logging
+        with caplog.at_level(logging.ERROR):
+            result = conv._compute_comment_priorities()
+        assert result == {}, (
+            f"desynced PCA/columns must fail closed (empty priorities), "
+            f"got {result!r} — silent zip truncation assigns E=0 to "
+            f"overflow tids"
+        )
+        assert any('extremity' in r.message.lower() or
+                   'priorit' in r.message.lower()
+                   for r in caplog.records), \
+            "expected an ERROR log naming the priorities/extremity desync"
 
 
 class TestD12PCAProjectComments:
@@ -2658,8 +2771,10 @@ class TestD11D12Serialization:
             ],
             'disagree': [],
         }
-        # Priorities use comment-id keys; the serializer coerces to int when
-        # possible and emits int values (see lines 2447-2456 of conversation.py).
+        # Priorities use comment-id keys; the serializer coerces KEYS to int
+        # when possible and preserves VALUES as Decimal (2026-07-04 fix —
+        # the old int(value) coercion floored sub-1 priorities to 0, which
+        # the TS server's weighted routing reads as "no priority data").
         priorities = {7: 1.5, 9: 0.25}
         conv = self._make_conversation_with_repness(consensus, priorities)
 
@@ -2672,7 +2787,9 @@ class TestD11D12Serialization:
             "to_dynamo_dict() must emit 'comment_priorities' when "
             "self.comment_priorities is populated; keys = "
             + repr(sorted(result.keys())))
-        # to_dynamo_dict coerces values to int via int(priority), so 1.5 -> 1
-        # and 0.25 -> 0. We assert the post-coercion shape rather than the
-        # raw input to lock in what actually lands in DynamoDB.
-        assert result['comment_priorities'] == {7: 1, 9: 0}
+        # Values land as Decimal (boto3-safe) with full precision — assert
+        # the post-serialization shape to lock in what actually lands in
+        # DynamoDB.
+        from decimal import Decimal
+        assert result['comment_priorities'] == {
+            7: Decimal('1.5'), 9: Decimal('0.25')}

--- a/delphi/tests/test_dynamodb_consensus_roundtrip.py
+++ b/delphi/tests/test_dynamodb_consensus_roundtrip.py
@@ -23,20 +23,23 @@ from polismath.database.dynamodb import DynamoDBClient
 # Helpers
 # ---------------------------------------------------------------------------
 
+# Entries use the Clojure blob shape (tid + hyphenated stats keys) — the
+# shape `select_consensus_comments_df` emits since 2026-07-04 (narrowed S1
+# deferral; server-helpers.ts and majorityStrict.jsx pluck `tid`).
 _AGREE_ENTRY = {
-    'comment_id': 1,
-    'n_success': 3,
-    'n_trials': 5,
-    'p_success': 0.6,
-    'p_test': 1.5,
+    'tid': 1,
+    'n-success': 3,
+    'n-trials': 5,
+    'p-success': 0.6,
+    'p-test': 1.5,
 }
 
 _DISAGREE_ENTRY = {
-    'comment_id': 2,
-    'n_success': 4,
-    'n_trials': 5,
-    'p_success': 0.8,
-    'p_test': 2.0,
+    'tid': 2,
+    'n-success': 4,
+    'n-trials': 5,
+    'p-success': 0.8,
+    'p-test': 2.0,
 }
 
 
@@ -102,15 +105,21 @@ class TestSite1DynamoDataBranch:
         # Stub the conversation so the writer takes the `dynamo_data` branch.
         conv = MagicMock(name='Conversation')
         conv.conversation_id = 42
+        # REAL `to_dynamo_dict()` shape (verified 2026-07-04): consensus is
+        # TOP-LEVEL `result['consensus']`; `repness` carries only
+        # `comment_repness`. The previous stub nested `consensus_comments`
+        # inside `repness` — matching the writer's (buggy) read path instead
+        # of the producer, so the test passed while production silently
+        # wrote the empty default.
         conv.to_dynamo_dict.return_value = {
             'participant_count': 10,
             'comment_count': 3,
             'group_count': 0,
             'pca': {},
             'math_tick': 30000,
+            'consensus': _make_consensus_dict(),
             'repness': {
                 'comment_repness': [],
-                'consensus_comments': _make_consensus_dict(),
             },
         }
 
@@ -129,8 +138,9 @@ class TestSite1DynamoDataBranch:
         assert written['agree'] == [_AGREE_ENTRY]
         assert written['disagree'] == [_DISAGREE_ENTRY]
 
-    def test_missing_repness_uses_dict_default(self):
-        """No repness in dynamo_data → empty dict, not list, not crash."""
+    def test_missing_consensus_uses_dict_default(self):
+        """No top-level consensus in dynamo_data → empty dict, not list,
+        not crash."""
         client, pca_results_table = _client_with_pca_results_only()
 
         conv = MagicMock(name='Conversation')
@@ -141,7 +151,7 @@ class TestSite1DynamoDataBranch:
             'group_count': 0,
             'pca': {},
             'math_tick': 30000,
-            # repness intentionally absent
+            # 'consensus' intentionally absent
         }
 
         ok = client.write_conversation(conv)
@@ -176,9 +186,9 @@ class TestSite2LegacyBranch:
         assert set(written.keys()) >= {'agree', 'disagree'}
         # _replace_floats_with_decimals converts floats to Decimal but
         # preserves the list structure and integer fields. Confirm the
-        # comment_ids round-trip cleanly.
-        assert [c['comment_id'] for c in written['agree']] == [1]
-        assert [c['comment_id'] for c in written['disagree']] == [2]
+        # tids round-trip cleanly.
+        assert [c['tid'] for c in written['agree']] == [1]
+        assert [c['tid'] for c in written['disagree']] == [2]
 
     def test_missing_repness_uses_dict_default(self):
         client, pca_results_table = _client_with_pca_results_only()
@@ -246,6 +256,32 @@ class TestSite3ReaderDefault:
         result = client.read_math_by_tick('42', 30000)
         assert result['consensus'] == stored
 
+    def test_legacy_list_consensus_normalized_to_dict(self):
+        """Pre-D11 blobs stored consensus as a (hardcoded-empty) LIST.
+        The reader must normalize it to the dict shape so downstream
+        consumers never see a list (Copilot review 2026-07-04, g3)."""
+        client = DynamoDBClient()
+        analysis_table = MagicMock(name='Delphi_PCAResults')
+        analysis_table.get_item.return_value = {
+            'Item': {
+                'participant_count': 10,
+                'comment_count': 3,
+                'pca': {'center': [], 'components': []},
+                'consensus_comments': [],  # legacy list shape
+            }
+        }
+        client.tables = {
+            'Delphi_PCAResults': analysis_table,
+            'Delphi_KMeansClusters': None,
+            'Delphi_CommentRouting': None,
+            'Delphi_RepresentativeComments': None,
+            'Delphi_ParticipantProjections': None,
+        }
+
+        result = client.read_math_by_tick('42', 30000)
+        assert result['consensus'] == {'agree': [], 'disagree': []}, \
+            f"legacy list must normalize to dict, got {result['consensus']!r}"
+
 
 # ---------------------------------------------------------------------------
 # Round-trip — write then read on the same in-memory store
@@ -257,7 +293,8 @@ class TestRoundTrip:
     def test_write_then_read_preserves_both_lists(self):
         client, pca_results_table = _client_with_pca_results_only()
 
-        # Record what the writer puts.
+        # Record what the writer puts (REAL to_dynamo_dict shape: top-level
+        # consensus, repness with only comment_repness — verified 2026-07-04).
         conv = MagicMock(name='Conversation')
         conv.conversation_id = 42
         conv.to_dynamo_dict.return_value = {
@@ -266,9 +303,9 @@ class TestRoundTrip:
             'group_count': 0,
             'pca': {},
             'math_tick': 30000,
+            'consensus': _make_consensus_dict(),
             'repness': {
                 'comment_repness': [],
-                'consensus_comments': _make_consensus_dict(),
             },
         }
         client.write_conversation(conv)
@@ -280,5 +317,5 @@ class TestRoundTrip:
         result = client.read_math_by_tick('42', 30000)
         consensus = result['consensus']
         assert isinstance(consensus, dict)
-        assert [c['comment_id'] for c in consensus['agree']] == [1]
-        assert [c['comment_id'] for c in consensus['disagree']] == [2]
+        assert [c['tid'] for c in consensus['agree']] == [1]
+        assert [c['tid'] for c in consensus['disagree']] == [2]

--- a/delphi/tests/test_dynamodb_float_serialization.py
+++ b/delphi/tests/test_dynamodb_float_serialization.py
@@ -149,3 +149,58 @@ class TestToDynamoDictRepnessSerialization:
             _assert_dynamodb_serializable(
                 put_item, context="Delphi_RepresentativeComments Item"
             )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2b — comment priorities: value-preserving AND serializable
+# ---------------------------------------------------------------------------
+
+class TestToDynamoDictPrioritiesSerialization:
+    """`to_dynamo_dict` must preserve priority VALUES, not truncate them.
+
+    The old code did `int(priority)`: harmless today (the D12.6 bug-mirror
+    makes every priority exactly 49.0) but a landmine for the day issue
+    #2571 resolves and the real formula returns — real-data priorities span
+    ~0.18–31.46 (decisions doc D12.6), so `int()` floors sub-1 priorities
+    to 0. The TS server's weighted routing treats 0 as "no priority data":
+    those comments would silently never be routed. Values must round-trip
+    as Decimal (raw floats crash boto3's TypeSerializer).
+    """
+
+    # Real-data-shaped values: sub-1 (floors to 0 under int()), fractional
+    # mid-range (loses 46% of its weight under int()), and the current
+    # bug-mirror constant.
+    _PRIORITIES = {10: 0.18, 11: 31.46, 12: 49.0}
+
+    def _conversation_with_priorities(self):
+        conv = Conversation(conversation_id='ztest-priorities')
+        conv.repness = conv_repness(_vote_matrix(), _groups())
+        conv.comment_priorities = dict(self._PRIORITIES)
+        return conv
+
+    def test_priorities_preserve_values(self):
+        conv = self._conversation_with_priorities()
+        dynamo_data = conv.to_dynamo_dict()
+
+        priorities = dynamo_data['comment_priorities']
+        assert priorities, "expected non-empty comment_priorities"
+
+        for tid, expected in self._PRIORITIES.items():
+            got = priorities[tid]
+            assert float(got) == pytest.approx(expected, abs=1e-9), (
+                f"priority for tid {tid} not preserved: expected {expected}, "
+                f"got {got!r} (int() truncation floors sub-1 priorities to 0)"
+            )
+
+    def test_priorities_serialize_for_dynamodb(self):
+        conv = self._conversation_with_priorities()
+        dynamo_data = conv.to_dynamo_dict()
+
+        for tid, value in dynamo_data['comment_priorities'].items():
+            _assert_dynamodb_serializable(
+                value, context=f"comment_priorities[{tid}]"
+            )
+            # The CommentRouting write path (dynamodb.py step 4) writes this
+            # value raw into `'priority': priorities.get(comment_id, 0)` —
+            # it must already be a DynamoDB scalar at this point.
+

--- a/delphi/tests/test_legacy_clojure_regression.py
+++ b/delphi/tests/test_legacy_clojure_regression.py
@@ -122,7 +122,7 @@ class TestClojureRegression:
         if conv.repness and 'comment_repness' in conv.repness:
             check.greater(len(conv.repness['comment_repness']), 0, "Should have representative comments")
 
-    def test_pca_components_match_clojure(self, conversation_data):
+    def test_pca_components_match_clojure(self, request, conversation_data):
         """
         Test that PCA components match the Clojure implementation.
 
@@ -133,6 +133,23 @@ class TestClojureRegression:
         Note: The centers will be negated due to vote sign convention difference
         (Python: agree=+1, Clojure: agree=-1), but the eigenvectors should match.
         """
+        # Pre-existing CCR failures, verified identical on edge 722640eb0
+        # (2026-07-04). Marked per-variant so every other variant keeps
+        # gating and an XPASS is visible the day the upstream fix lands.
+        _known_bad = {
+            'bg2050-incremental':
+                "pre-existing: PC2 angle 10.71° vs ≤10° tolerance — "
+                "incremental PCA drift (D1 sign-flip/replay territory, "
+                "needs replay infra; journal 'incremental PCA dimensions')",
+            'pakistan-incremental':
+                "pre-existing: PCA shape (2, 9030) vs Clojure (2, 194) — "
+                "incremental blob computed on a comment subset (large-conv "
+                "sampling/moderation divergence; journal 'incremental PCA "
+                "dimensions')",
+        }
+        if request.node.callspec.id in _known_bad:
+            request.applymarker(pytest.mark.xfail(
+                strict=False, reason=_known_bad[request.node.callspec.id]))
         import numpy as np
 
         conv = conversation_data['conv']
@@ -187,7 +204,7 @@ class TestClojureRegression:
             check.less_equal(norm_angle_deg, 10.0,
                             f"PC{i+1} angle difference should be ≤10° (got {norm_angle_deg:.2f}°)")
 
-    def test_group_clustering(self, conversation_data):
+    def test_group_clustering(self, request, conversation_data):
         """
         Test that group clustering matches the Clojure implementation.
 
@@ -197,6 +214,14 @@ class TestClojureRegression:
 
         Both sides are unfolded to participant-level membership for comparison.
         """
+        # Pre-existing CCR failure, verified identical on edge 722640eb0
+        # (2026-07-04). Per-variant so the other datasets keep gating.
+        if request.node.callspec.id == 'bg2018-cold_start':
+            request.applymarker(pytest.mark.xfail(
+                strict=False,
+                reason="pre-existing: bg2018 cold_start group membership "
+                       "divergence (same family as the gid 0↔1 label-swap / "
+                       "clustering-stability queue, S3-4 2026-06-11)"))
         conv = conversation_data['conv']
         clojure_output = conversation_data['clojure_output']
         dataset_name = conversation_data['dataset_name']
@@ -275,12 +300,7 @@ class TestClojureRegression:
         check.is_true(result['overall_match'],
                      f"Clustering should match Clojure output (distribution + membership)")
 
-    @pytest.mark.xfail(raises=AssertionError, strict=False,
-                       reason="D12 / D12.6 incremental: Python's Clojure-bug-mirror (all priorities = META_PRIORITY^2 = 49) "
-                              "matches Clojure cold_start exactly (XPASS), but Clojure incremental has varied priorities, "
-                              "so Python's all-49 doesn't match incremental. strict=False to allow both XPASS (cold_start) "
-                              "and FAIL (incremental) without test failure. Restore strict=True once Clojure bug is fixed upstream.")
-    def test_comment_priorities(self, conversation_data):
+    def test_comment_priorities(self, request, conversation_data):
         """
         Test that comment priorities match the Clojure implementation exactly.
 
@@ -291,6 +311,20 @@ class TestClojureRegression:
         conv = conversation_data['conv']
         clojure_output = conversation_data['clojure_output']
         dataset_name = conversation_data['dataset_name']
+
+        # Per-variant xfail (g5, 2026-07-04): only INCREMENTAL is known-bad —
+        # Python's Clojure-bug-mirror (all priorities = META_PRIORITY^2 = 49)
+        # matches Clojure cold_start exactly, but Clojure incremental has
+        # varied priorities. cold_start MUST keep gating; the previous
+        # blanket xfail(strict=False) silently allowed cold_start
+        # regressions. Drop this once the Clojure bug (#2571) is fixed and
+        # the Python mirror is removed.
+        if 'incremental' in request.node.callspec.id:
+            request.applymarker(pytest.mark.xfail(
+                raises=AssertionError, strict=False,
+                reason="D12.6: Clojure incremental has varied priorities "
+                       "(no truthy-0 bug there); Python's all-49 mirror "
+                       "cannot match. See issue #2571."))
 
         print(f"\n[{dataset_name}] Testing comment priorities...")
 

--- a/delphi/tests/test_legacy_repness_comparison.py
+++ b/delphi/tests/test_legacy_repness_comparison.py
@@ -206,7 +206,9 @@ class TestRepnessComparison:
 
                 # Extract comment IDs
                 clj_consensus_ids = [str(c.get('comment-id', c.get('tid', c.get('comment_id', '')))) for c in clj_consensus]
-                py_consensus_ids = [str(c.get('comment_id', '')) for c in py_consensus]
+                # Python consensus entries use `tid` (Clojure blob shape,
+                # 2026-07-04); `comment_id` fallback covers pre-fix blobs.
+                py_consensus_ids = [str(c.get('tid', c.get('comment_id', ''))) for c in py_consensus]
 
                 consensus_matches = set(clj_consensus_ids) & set(py_consensus_ids)
                 consensus_total = len(set(clj_consensus_ids) | set(py_consensus_ids))

--- a/delphi/tests/test_pipeline_integrity.py
+++ b/delphi/tests/test_pipeline_integrity.py
@@ -201,9 +201,9 @@ def test_full_pipeline(dataset_name: str) -> None:
             consensus = updated_conv.repness.get('consensus_comments', {})
             for side in ('agree', 'disagree'):
                 for i, comment in enumerate(consensus.get(side, [])):
-                    print(f"    - {side} #{i+1}: ID {comment.get('comment_id')}, "
-                          f"p_success={comment.get('p_success', 0):.2f}, "
-                          f"p_test={comment.get('p_test', 0):.2f}")
+                    print(f"    - {side} #{i+1}: ID {comment.get('tid')}, "
+                          f"p-success={comment.get('p-success', 0):.2f}, "
+                          f"p-test={comment.get('p-test', 0):.2f}")
         else:
             print("  No representativeness results available")
         

--- a/delphi/tests/test_regression.py
+++ b/delphi/tests/test_regression.py
@@ -26,6 +26,23 @@ _skip_golden = pytest.mark.skipif(
     reason="Golden snapshot tests disabled (SKIP_GOLDEN=1)",
 )
 
+# PGR (Python golden record) deferral — per Julien's 2026-06-11 decision
+# (D10_D11_D12_GOLDENS_DECISIONS.md "Goldens re-record" + deferred-PRs
+# handoff): goldens shift on every Clojure-parity fix and only add noise
+# during the parity phase. The existing private-dataset goldens predate the
+# D10/D11/D12 stack, so these comparisons fail by design, not by regression.
+# REACTIVATION CONDITION: remove this mark and re-record all goldens
+# (`uv run python scripts/regression_recorder.py <dataset>`) when the
+# Python-vs-Python refactor comparison phase begins — i.e. after the gid
+# 0↔1 label-swap fix lands and batch outputs stabilize.
+# (S3-5 2026-06-11 claimed this mark was applied; it never was — added
+# 2026-07-04.)
+_goldens_deferred = pytest.mark.skip(
+    reason="PGR goldens deferred during Clojure-parity phase (2026-06-11 "
+           "decision); stored goldens predate the D10/D11/D12 stack. "
+           "Re-record + reactivate at the Python-vs-Python phase.",
+)
+
 
 def _check_golden_exists(dataset_name: str):
     """
@@ -56,6 +73,7 @@ def _check_golden_exists(dataset_name: str):
         )
 
 
+@_goldens_deferred
 @_skip_golden
 @pytest.mark.use_discovered_datasets
 def test_conversation_regression(dataset_name):
@@ -106,6 +124,7 @@ def test_conversation_regression(dataset_name):
     )
 
 
+@_goldens_deferred
 @_skip_golden
 @pytest.mark.use_discovered_datasets
 def test_conversation_stages_individually(dataset_name):

--- a/delphi/tests/test_repness_smoke.py
+++ b/delphi/tests/test_repness_smoke.py
@@ -108,8 +108,12 @@ class TestRepnessImplementation:
             disagree = consensus.get('disagree', [])
             logger.debug(f"Consensus: {len(agree)} agree, {len(disagree)} disagree")
 
+            # Consensus entries use the Clojure blob shape (2026-07-04,
+            # narrowed S1 deferral): tid + hyphenated stats keys. Rep-comment
+            # entries above keep `comment_id` until the math-blob alignment PR.
             for entry in agree + disagree:
-                assert 'comment_id' in entry
+                assert set(entry.keys()) == {
+                    'tid', 'n-success', 'n-trials', 'p-success', 'p-test'}
 
         logger.debug("✓ Representativeness structure validated")
 


### PR DESCRIPTION
Verified triage of all 83 Copilot review threads on PRs #2564-#2573:
1 real blocker + 4 escalations confirmed by direct code verification;
the rest nitpicks / already-fixed / intentional bug-mirrors. All fixes
TDD RED->GREEN.

- Consensus entry keys -> Clojure blob shape {tid, n-success, n-trials,
  p-success, p-test} (was Python-convention comment_id/n_success/...).
  Narrows the S1 deferral: these entries flow raw into
  result['consensus'], where server-helpers.ts:298-313 and client-report
  majorityStrict.jsx:23-27 pluck `tid` - the Python keys broke both
  consumers. Rep-comment entries keep comment_id until the deferred
  math-blob alignment PR.
- DynamoDB writer read D11 consensus from a key to_dynamo_dict never
  emits (repness.consensus_comments) -> always wrote the empty default;
  D11 data never reached Delphi_PCAResults. Now reads top-level
  result['consensus']. The round-trip test had stubbed to_dynamo_dict
  with the writer's wrong nested shape - stub corrected to the real
  producer shape.
- to_dynamo_dict comment priorities: int(value) -> Decimal-preserving.
  int() floors sub-1 priorities to 0 (real formula spans ~0.18-31.46 per
  D12.6), which the TS server's weighted routing reads as "no priority
  data". Harmless today (bug-mirror pins 49.0), landmine once #2571
  resolves. Legacy writer path Decimal-wrapped too.
- DynamoDB reader normalizes legacy list-shaped consensus to the dict
  shape (pre-D11 blobs).
- mod_out truthiness -> `is not None` x2 in repness.py (numpy
  array/Index-safe).
- _compute_comment_priorities fails closed (error log + empty dict) on
  PCA/columns desync instead of silently zip-truncating extremities.
- bench_repness.py imported the 14a-deleted comment_stats (ImportError
  on any benchmark run); benchmark import test added.
- Per-variant xfails replace blanket xfail(strict=False) on D11/D12
  real-data tests, so the variants that match Clojure gate again.
  DISCOVERY: scoping the blanket unmasked two previously-invisible
  incremental divergences (bg2018-incremental, pakistan-incremental
  consensus vs Clojure) that the blanket had silently absorbed -
  documented as known-bad incremental xfails, same family as
  biodiversity-incremental, deferred to the sequential-parity work.
  3 pre-existing CCR failures (verified identical on edge 722640eb0)
  marked with precise per-variant reasons. PGR regression tests skip
  with the 2026-06-11 goldens-deferral reason - the mark S3-5 claimed
  to add but never committed.
- test_repness_smoke consensus-entry structure assertion updated to the
  Clojure key shape (exact key-set check).
- ns docstrings corrected (ns includes PASS post ns-PASS fix; pa+pd <= 1
  reasoning in select_consensus_comments_df).
- PERF deferral comment on the _compute_group_votes scan in
  _compute_comment_priorities (follow-up issue to be filed).

Baseline (2026-07-04, stack top, --include-local): 13 failed / 476
passed / 18 skipped / 143 xfailed. All 13 accounted for: 10 stale-PGR
comparisons (now skipped per deferral), 3 pre-existing CCR (now precise
xfails).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013CiESAwcrZ6BcVfdkumnxa

commit-id:4cc93a23

---
**Stack**:
- #2573
- #2572
- #2568
- #2567
- #2566
- #2570
- #2564
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*