### PR TITLE
PROD DEPLOY 07/04/2026 🇺🇸 

### DIFF
--- a/client-report/src/components/commentsReport/CommentsReport.jsx
+++ b/client-report/src/components/commentsReport/CommentsReport.jsx
@@ -36,7 +36,7 @@ const CommentsReport = ({ math, comments, conversation, ptptCount, formatTid, vo
     priority: 50,
     max_votes: "",
     batch_size: "",
-    model: "claude-opus-4-20250514",
+    model: "claude-opus-4-8",
     include_topics: true,
     include_moderation: reportModLevel !== -2,
   };
@@ -283,7 +283,7 @@ const CommentsReport = ({ math, comments, conversation, ptptCount, formatTid, vo
     net
       .polisPost("/api/v3/delphi/batchReports", {
         report_id: report_id,
-        model: "claude-opus-4-20250514",
+        model: "claude-opus-4-8",
         no_cache: false,
         include_moderation: reportModLevel !== -2,
       }, authToken)

--- a/delphi/Dockerfile
+++ b/delphi/Dockerfile
@@ -111,7 +111,7 @@ CMD ["bash", "-c", "\
   if [ -n \"${DYNAMODB_ENDPOINT}\" ]; then \
     echo 'DYNAMODB_ENDPOINT is set, assuming local/dev environment. Running additional local setup scripts...'; \
     echo 'Setting up MinIO bucket...' && python setup_minio.py && \
-    echo 'Setting up Ollama model (local script)...' && ./scripts/setup_ollama.sh && \
+    echo 'Setting up Ollama model (local script)...' && ./scripts/setup_ollama.sh || echo 'Ollama setup failed or skipped — continuing to start job poller...'; \
     echo 'Starting job poller without ddtrace...' && \
     python scripts/job_poller.py --interval=2; \
   else \

--- a/delphi/docs/BATCH_NARRATIVE_README.md
+++ b/delphi/docs/BATCH_NARRATIVE_README.md
@@ -35,7 +35,7 @@ python 801_narrative_report_batch.py --conversation_id CONVERSATION_ID [--model 
 
 Arguments:
 - `--conversation_id` or `--zid`: Conversation ID to process
-- `--model`: LLM model to use (default: claude-3-5-sonnet-20241022)
+- `--model`: LLM model to use (default: claude-sonnet-5)
 - `--no-cache`: Ignore cached report data
 - `--max-batch-size`: Maximum number of topics in a batch (default: 20)
 

--- a/delphi/docs/DATA_FORMAT_STANDARDS.md
+++ b/delphi/docs/DATA_FORMAT_STANDARDS.md
@@ -13,7 +13,7 @@ DynamoDB tables use specific key format conventions that must be followed consis
 - **Primary Key (rid_section_model)**: `{report_id}#{section_name}#{model}`
   - **report_id**: The report identifier (e.g., "r123456" or numerical ID)
   - **section_name**: The section of the report (e.g., "topic_zebra_crossing")
-  - **model**: The LLM model used (e.g., "claude-3-5-sonnet-20241022")
+  - **model**: The LLM model used (e.g., "claude-sonnet-5")
   - **Delimiter**: Always use `#` as the delimiter (not underscores)
 
 ```python

--- a/delphi/docs/JOB_QUEUE_SCHEMA.md
+++ b/delphi/docs/JOB_QUEUE_SCHEMA.md
@@ -88,7 +88,7 @@ The `job_config` attribute will be a JSON object containing job-specific paramet
 #### For Report Generation Jobs
 ```json
 {
-  "model": "claude-3-7-sonnet-20250219",
+  "model": "claude-sonnet-5",
   "include_topics": true,
   "include_consensus": true,
   "include_uncertainty": true,
@@ -267,7 +267,7 @@ To manage the growth of the job queue table:
       {
         "stage": "REPORT",
         "config": {
-          "model": "claude-3-7-sonnet-20250219",
+          "model": "claude-sonnet-5",
           "include_topics": true
         }
       }

--- a/delphi/pyproject.toml
+++ b/delphi/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     # LLM and reporting
     "requests>=2.28.0",
     "xmltodict>=0.13.0",
-    "anthropic>=0.5.0",
+    "anthropic>=0.116.0",
     "ollama>=0.5.1",
     "llvmlite>=0.44.0",
     # CLI

--- a/delphi/requirements.lock
+++ b/delphi/requirements.lock
@@ -6,7 +6,7 @@
 #
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.74.0
+anthropic==0.116.0
     # via delphi-polis (pyproject.toml)
 anyio==4.11.0
     # via
@@ -39,6 +39,7 @@ charset-normalizer==3.4.4
 click==8.3.1
     # via
     #   dask
+    #   delphi-polis (pyproject.toml)
     #   distributed
     #   uvicorn
 cloudpickle==3.1.2

--- a/delphi/scripts/setup_ollama.sh
+++ b/delphi/scripts/setup_ollama.sh
@@ -11,36 +11,38 @@ NC='\033[0m' # No Color
 MODEL=${OLLAMA_MODEL:-llama3.1:8b}
 OLLAMA_HOST=${OLLAMA_HOST:-http://ollama:11434}
 
+# How long to wait for the pull to complete (default 30 min; override via env)
+PULL_TIMEOUT=${OLLAMA_PULL_TIMEOUT:-1800}
+
 echo -e "${YELLOW}Setting up Ollama model: $MODEL at $OLLAMA_HOST${NC}"
 
 # Function to check if Ollama is available
 check_ollama_status() {
   local max_attempts=30
   local attempt=1
-  local status=false
-  
+
   echo -e "${YELLOW}Waiting for Ollama service to be available...${NC}"
-  
+
   while [ $attempt -le $max_attempts ]; do
-    # Try to ping the Ollama API
     if curl --silent --max-time 5 "${OLLAMA_HOST}/api/tags" > /dev/null 2>&1; then
       echo -e "${GREEN}Ollama service is available!${NC}"
-      status=true
-      break
+      return 0
     fi
-    
+
     echo -e "${YELLOW}Attempt $attempt/$max_attempts: Ollama service not ready yet. Waiting...${NC}"
     sleep 2
     attempt=$((attempt + 1))
   done
-  
-  if [ "$status" = false ]; then
-    echo -e "${RED}Ollama service is not available after $max_attempts attempts.${NC}"
-    echo -e "${RED}Please check if Ollama is running properly.${NC}"
-    return 1
-  fi
-  
-  return 0
+
+  echo -e "${RED}Ollama service is not available after $max_attempts attempts.${NC}"
+  return 1
+}
+
+# Function to check if a model is already present locally
+model_already_pulled() {
+  local model=$1
+  curl --silent --max-time 5 "${OLLAMA_HOST}/api/tags" \
+    | grep -q "\"name\":\"${model}\""
 }
 
 # Function to pull Ollama model
@@ -48,44 +50,81 @@ pull_ollama_model() {
   local model=$1
   local max_attempts=3
   local attempt=1
-  
-  echo -e "${YELLOW}Pulling Ollama model: $model${NC}"
-  
+
+  # Skip pull if already present
+  if model_already_pulled "$model"; then
+    echo -e "${GREEN}Model $model is already available locally, skipping pull.${NC}"
+    return 0
+  fi
+
+  echo -e "${YELLOW}Pulling Ollama model: $model (timeout: ${PULL_TIMEOUT}s)${NC}"
+
   while [ $attempt -le $max_attempts ]; do
-    # Try to pull the model
-    if curl --silent --max-time 120 -X POST "${OLLAMA_HOST}/api/pull" -d "{\"name\":\"$model\"}" > /dev/null 2>&1; then
+    # Stream pull progress, filtering JSON to one summary line per 100MB
+    curl --no-buffer --max-time "$PULL_TIMEOUT" \
+         -X POST "${OLLAMA_HOST}/api/pull" \
+         -H "Content-Type: application/json" \
+         -d "{\"name\":\"$model\"}" \
+    | python3 -u -c "
+import sys, json
+last_reported = 0
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        obj = json.loads(line)
+    except Exception:
+        print(line)
+        continue
+    status = obj.get('status', '')
+    total = obj.get('total', 0)
+    completed = obj.get('completed', 0)
+    if total and completed:
+        pct = completed / total * 100
+        # Print at most once per 100 MB
+        if completed - last_reported >= 100 * 1024 * 1024:
+            last_reported = completed
+            print(f'  {status}: {completed/1e9:.2f} / {total/1e9:.2f} GB ({pct:.1f}%)', flush=True)
+    elif status and status != 'pulling manifest':
+        print(f'  {status}', flush=True)
+"
+    local pipe_exit=${PIPESTATUS[0]}
+    if [ $pipe_exit -eq 0 ]; then
       echo -e "${GREEN}Successfully pulled Ollama model: $model${NC}"
       return 0
     fi
-    
-    echo -e "${YELLOW}Attempt $attempt/$max_attempts: Failed to pull model. Retrying...${NC}"
-    sleep 2
+
+    local exit_code=$pipe_exit
+    if [ $exit_code -eq 28 ]; then
+      echo -e "${RED}Attempt $attempt/$max_attempts: Pull timed out after ${PULL_TIMEOUT}s.${NC}"
+    else
+      echo -e "${RED}Attempt $attempt/$max_attempts: Pull failed (exit code $exit_code).${NC}"
+    fi
+
     attempt=$((attempt + 1))
+    [ $attempt -le $max_attempts ] && sleep 5
   done
-  
+
   echo -e "${RED}Failed to pull Ollama model: $model after $max_attempts attempts.${NC}"
   return 1
 }
 
 # Main script execution
 main() {
-  # Check if Ollama service is available
   if ! check_ollama_status; then
-    echo -e "${RED}Skipping model setup due to Ollama service unavailability.${NC}"
+    echo -e "${RED}Ollama service unavailable — skipping model setup.${NC}"
     return 1
   fi
-  
-  # Pull the model
+
   if ! pull_ollama_model "$MODEL"; then
-    echo -e "${RED}Failed to set up Ollama model.${NC}"
-    echo -e "${YELLOW}The system will attempt to use the model anyway, which may succeed if it's already available.${NC}"
+    echo -e "${YELLOW}Model pull failed. The poller will use Anthropic if LLM_PROVIDER=anthropic, or may fail if Ollama is required.${NC}"
     return 1
   fi
-  
+
   echo -e "${GREEN}Ollama model setup completed successfully!${NC}"
   return 0
 }
 
-# Run the main function
 main
 exit $?

--- a/delphi/umap_narrative/802_process_batch_results.py
+++ b/delphi/umap_narrative/802_process_batch_results.py
@@ -182,7 +182,7 @@ class AnthropicBatchChecker:
             return response_data
             
         except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 404:
+            if e.response is not None and e.response.status_code == 404:
                 logger.warning("Anthropic Batch API endpoint not found (404)")
                 return {"error": "Batch API not available"}
             else:
@@ -337,13 +337,17 @@ class BatchResultProcessor:
                 logger.warning(f"No content found in message for request {req_id}")
                 continue
             
-            # Extract content text
+            # Extract content text — filter by type to skip thinking blocks (Sonnet 5+)
             content = message.get('content', [])
-            if not content or not isinstance(content, list) or 'text' not in content[0]:
+            if not content or not isinstance(content, list):
                 logger.warning(f"Invalid content format for request {req_id}")
                 continue
-            
-            response_text = content[0].get('text', '')
+            text_block = next((b for b in content if b.get('type') == 'text'), None)
+            if not text_block:
+                logger.warning(f"No text block found in response for request {req_id}")
+                continue
+
+            response_text = text_block.get('text', '')
             
             # Store in Delphi_NarrativeReports
             rid_section_model = f"{conversation_id}#{section_name}#{self.batch_job.get('model')}"
@@ -399,7 +403,7 @@ class BatchResultProcessor:
             return False
         
         # Get model provider and request data
-        model_name = self.batch_job.get('model', 'claude-3-5-sonnet-20241022')
+        model_name = self.batch_job.get('model', 'claude-sonnet-5')
         model_provider = get_model_provider('anthropic', model_name)
         request_map = self.batch_job.get('request_map', {})
         total_requests = len(request_map)
@@ -476,7 +480,7 @@ class BatchResultProcessor:
                         await asyncio.sleep(1)
                         
                         # Get response from the LLM
-                        response_text = await model_provider.get_response(system, user_message)
+                        response_text = model_provider.get_response(system, user_message)
                         
                         # Store in Delphi_NarrativeReports
                         report_item = {
@@ -546,5 +550,4 @@ async def main():
         print(f"Failed to process batch job {args.batch_id}. See logs for details.")
 
 if __name__ == "__main__":
-    import asyncio
     asyncio.run(main())

--- a/delphi/umap_narrative/803_check_batch_status.py
+++ b/delphi/umap_narrative/803_check_batch_status.py
@@ -135,7 +135,8 @@ class BatchStatusChecker:
                     custom_id = entry.custom_id
                     response_message = entry.result.message
                     model = response_message.model
-                    content = response_message.content[0].text if response_message.content else "{}"
+                    text_block = next((b for b in response_message.content if b.type == "text"), None)
+                    content = text_block.text if text_block else "{}"
 
                     # Reconstruct the section name from the custom_id
                     parts = custom_id.split('_', 1)

--- a/delphi/umap_narrative/llm_factory_constructor/README.md
+++ b/delphi/umap_narrative/llm_factory_constructor/README.md
@@ -33,7 +33,7 @@ response = provider.get_response(
 provider = get_model_provider("ollama", "llama3.1:8b")
 
 # Use Anthropic
-provider = get_model_provider("anthropic", "claude-3-sonnet-20240229")
+provider = get_model_provider("anthropic", "claude-sonnet-5")
 ```
 
 ### Environment Variables
@@ -49,7 +49,7 @@ export OLLAMA_MODEL=llama3
 export OLLAMA_ENDPOINT=http://localhost:11434
 
 # Anthropic configuration
-export ANTHROPIC_MODEL=claude-3-sonnet-20240229
+export ANTHROPIC_MODEL=claude-sonnet-5
 export ANTHROPIC_API_KEY=your_api_key_here
 ```
 

--- a/delphi/umap_narrative/llm_factory_constructor/model_provider.py
+++ b/delphi/umap_narrative/llm_factory_constructor/model_provider.py
@@ -10,7 +10,7 @@ import os
 import json
 import logging
 import requests
-from typing import Dict, List, Optional, Union, Any
+from typing import Dict, List, Optional, Any
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -145,15 +145,15 @@ class OllamaProvider(ModelProvider):
                 models_response = self.ollama.list()
                 # Handle new Ollama API response format which has a 'models' list of Model objects
                 if hasattr(models_response, 'models') and isinstance(models_response.models, list):
-                    available_models = [m.model for m in models_response.models]
+                    available_models = [m.model for m in models_response.models if m.model is not None]
                 else:
                     # Fallback for older API versions or different response format
-                    available_models = [model.get('name') for model in models_response.get('models', [])]
+                    available_models = [n for model in models_response.get('models', []) if (n := model.get('name')) is not None]
             else:
                 # Use direct HTTP request as fallback
                 response = requests.get(f"{self.endpoint}/api/tags")
                 response.raise_for_status()
-                available_models = [model.get('name') for model in response.json().get('models', [])]
+                available_models = [n for model in response.json().get('models', []) if (n := model.get('name')) is not None]
             
             logger.info(f"Available Ollama models: {available_models}")
             return available_models
@@ -165,7 +165,7 @@ class OllamaProvider(ModelProvider):
 class AnthropicProvider(ModelProvider):
     """Provider for Anthropic Claude models."""
 
-    def __init__(self, model_name: str = None, api_key: Optional[str] = None):
+    def __init__(self, model_name: Optional[str] = None, api_key: Optional[str] = None):
         """
         Initialize the Anthropic provider.
 
@@ -226,49 +226,34 @@ class AnthropicProvider(ModelProvider):
         
         try:
             logger.info(f"Using Anthropic model: {self.model_name}")
-            
-            if self.client:
-                # Use the Anthropic package if available
-                message = self.client.messages.create(
-                    model=self.model_name,
-                    system=system_message,
-                    messages=[
-                        {"role": "user", "content": user_message}
-                    ],
-                    max_tokens=4000
-                )
-                result = message.content[0].text
-            else:
-                # Use direct HTTP request
-                headers = {
-                    "x-api-key": self.api_key,
-                    "anthropic-version": "2023-06-01",
-                    "content-type": "application/json"
-                }
-                
-                # Add more debugging
-                logger.info(f"Using Anthropic model '{self.model_name}' via direct HTTP request")
-                logger.info(f"API key starts with: {self.api_key[:8]}...")
-                
-                data = {
-                    "model": self.model_name,
-                    "system": system_message,
-                    "messages": [
-                        {"role": "user", "content": user_message}
-                    ],
-                    "max_tokens": 4000
-                }
-                
-                response = requests.post(
-                    "https://api.anthropic.com/v1/messages",
-                    headers=headers,
-                    json=data
-                )
-                response.raise_for_status()
-                result = response.json()["content"][0]["text"]
-            
+
+            headers = {
+                "x-api-key": self.api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json"
+            }
+            logger.info(f"Using Anthropic model '{self.model_name}' via direct HTTP request")
+            logger.info(f"API key starts with: {self.api_key[:8]}...")
+            data = {
+                "model": self.model_name,
+                "system": system_message,
+                "messages": [
+                    {"role": "user", "content": user_message}
+                ],
+                "max_tokens": 4000
+            }
+            response = requests.post(
+                "https://api.anthropic.com/v1/messages",
+                headers=headers,
+                json=data
+            )
+            response.raise_for_status()
+            content = response.json()["content"]
+            text_blocks = [b for b in content if b.get("type") == "text"]
+            result = text_blocks[0]["text"] if text_blocks else ""
+
             return result
-        
+
         except Exception as e:
             logger.error(f"Error using Anthropic API: {str(e)}")
             # Return a JSON error response
@@ -367,7 +352,7 @@ class AnthropicProvider(ModelProvider):
                 return response_data
                 
             except requests.exceptions.HTTPError as e:
-                if e.response.status_code == 404:
+                if e.response is not None and e.response.status_code == 404:
                     logger.warning("Anthropic Batch API endpoint not found (404). Falling back to sequential processing.")
                     return {"error": "Batch API not available", "fallback": "sequential"}
                 else:
@@ -391,9 +376,9 @@ class AnthropicProvider(ModelProvider):
         """
         # Anthropic doesn't have a list models endpoint, so we hardcode the known models
         available_models = [
-            "claude-3-5-sonnet-20241022",
-            "claude-3-7-sonnet-20250219",
-            "claude-opus-4-20250514"
+            "claude-sonnet-5",
+            "claude-opus-4-8",
+            "claude-sonnet-4-6",
         ]
         logger.info(f"Available Anthropic models: {available_models}")
         return available_models
@@ -462,9 +447,11 @@ class AnthropicProvider(ModelProvider):
             # Raise for HTTP errors
             response.raise_for_status()
 
-            # Parse response
+            # Parse response — filter by type to skip thinking blocks (Sonnet 5+)
             response_data = response.json()
-            result = response_data["content"][0]["text"]
+            content = response_data["content"]
+            text_blocks = [b for b in content if b.get("type") == "text"]
+            result = text_blocks[0]["text"] if text_blocks else ""
 
             return {"content": result}
 
@@ -491,7 +478,7 @@ class AnthropicProvider(ModelProvider):
                 ]
             })}
 
-def get_model_provider(provider_type: str = None, model_name: str = None) -> ModelProvider:
+def get_model_provider(provider_type: Optional[str] = None, model_name: Optional[str] = None) -> ModelProvider:
     """
     Factory function to get the appropriate model provider.
     
@@ -504,7 +491,10 @@ def get_model_provider(provider_type: str = None, model_name: str = None) -> Mod
     """
     # Check for environment variable configuration
     provider_type = provider_type or os.environ.get("LLM_PROVIDER")
-    
+
+    if not provider_type:
+        raise ValueError("provider_type must be specified or LLM_PROVIDER environment variable must be set")
+
     if provider_type.lower() == "anthropic":
         model_name = model_name or os.environ.get("ANTHROPIC_MODEL")
         if not model_name:

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.55.1",
+        "@anthropic-ai/sdk": "^0.110.0",
         "@anthropic-ai/tokenizer": "^0.0.4",
         "@aws-sdk/client-cloudwatch-logs": "^3.911.0",
         "@aws-sdk/client-dynamodb": "^3.840.0",
@@ -119,7 +119,7 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": ">=22 <25"
+        "node": ">=22 <23"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -135,12 +135,24 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.55.1.tgz",
-      "integrity": "sha512-gjOMS4chmm8BxClKmCjNHmvf1FrO1Cn++CSX6K3YCZjz5JG4I9ZttQ/xEH4FBsz6HQyZvnUpiKlOAkmxaGmEaQ==",
+      "version": "0.110.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
+      "integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
       "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@anthropic-ai/tokenizer": {
@@ -5737,6 +5749,15 @@
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -7543,6 +7564,12 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@tevko/sensemaking-tools": {
       "version": "1.0.15",
@@ -11054,6 +11081,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
@@ -12949,6 +12982,19 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -15708,6 +15754,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -16085,6 +16141,12 @@
       "engines": {
         "node": ">= 14.0.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,7 @@
     "node": ">=22 <23"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.55.1",
+    "@anthropic-ai/sdk": "^0.110.0",
     "@anthropic-ai/tokenizer": "^0.0.4",
     "@aws-sdk/client-cloudwatch-logs": "^3.911.0",
     "@aws-sdk/client-dynamodb": "^3.840.0",

--- a/server/src/prompts/report_experimental/scripts/sonnet.ts
+++ b/server/src/prompts/report_experimental/scripts/sonnet.ts
@@ -135,32 +135,18 @@ async function main() {
   ); // then convert back to xml
   logger.debug(prompt_xml);
   const msg = await anthropic.messages.create({
-    model: "claude-3-7-sonnet-20250219",
+    model: "claude-sonnet-5",
     max_tokens: 1000,
-    temperature: 0,
     system: system_lore,
     messages: [
       {
         role: "user",
-        content: [
-          {
-            type: "text",
-            text: prompt_xml,
-          },
-        ],
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "text",
-            text: "{",
-          },
-        ],
+        content: [{ type: "text", text: prompt_xml }],
       },
     ],
   });
-  logger.debug(msg);
+  const textBlock = msg.content.find((b) => b.type === "text");
+  logger.debug(textBlock?.type === "text" ? textBlock.text : "");
 }
 
 main().catch(logger.error);

--- a/server/src/routes/collectiveStatement.ts
+++ b/server/src/routes/collectiveStatement.ts
@@ -144,26 +144,22 @@ You MUST respond with valid JSON that follows the exact schema above. Each claus
 
   try {
     const response = await anthropic.messages.create({
-      model: "claude-opus-4-20250514",
+      model: "claude-opus-4-8",
       max_tokens: 3000,
-      temperature: 0.7,
       system: systemPrompt,
       messages: [
         {
           role: "user",
           content: userPrompt,
         },
-        {
-          role: "assistant",
-          content: "{",
-        },
       ],
     });
 
-    // Parse the JSON response
-    const responseText =
-      "{" +
-      (response.content[0].type === "text" ? response.content[0].text : "");
+    // Parse the JSON response — find text block (adaptive thinking may add thinking blocks)
+    const textBlock = response.content.find((b) => b.type === "text");
+    let responseText = textBlock?.type === "text" ? textBlock.text : "";
+    // Strip markdown code fences if the model wraps the JSON
+    responseText = responseText.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
 
     try {
       const statementData = JSON.parse(responseText);
@@ -340,7 +336,7 @@ export async function handle_POST_collectiveStatement(
       statement_data: JSON.stringify(result.statementData),
       comments_data: JSON.stringify(result.commentsData),
       created_at: new Date().toISOString(),
-      model: "claude-opus-4-20250514",
+      model: "claude-opus-4-8",
     };
 
     await docClient.send(

--- a/server/src/routes/delphi/jobs.ts
+++ b/server/src/routes/delphi/jobs.ts
@@ -55,7 +55,7 @@ export async function handle_POST_delphi_jobs(
       priority = 50,
       max_votes,
       batch_size,
-      model = "claude-3-7-sonnet-20250219",
+      model = "claude-sonnet-5",
       include_topics = true,
       include_moderation = false, // ignore comments that recieve a failing moderation score
     } = req.body;

--- a/server/src/routes/reportNarrative.ts
+++ b/server/src/routes/reportNarrative.ts
@@ -276,23 +276,20 @@ const getModelResponse = async (
           throw new Error("polis_err_anthropic_api_key_not_set");
         }
         const responseClaude = await anthropic.messages.create({
-          model: modelVersion || "claude-3-7-sonnet-20250219",
+          model: modelVersion || "claude-sonnet-5",
           max_tokens: 3000,
-          temperature: 0,
           system: system_lore,
           messages: [
             {
               role: "user",
               content: [{ type: "text", text: prompt_xml }],
             },
-            {
-              role: "assistant",
-              content: [{ type: "text", text: "{" }],
-            },
           ],
         });
-        // Claude API response structure might change with version updates
-        return `{${(responseClaude as any)?.content[0]?.text}`;
+        const textBlock = responseClaude.content.find((b) => b.type === "text");
+        const rawText = textBlock?.type === "text" ? textBlock.text : "";
+        // Strip markdown code fences if present
+        return rawText.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
       }
       case "openai": {
         if (!openai) {


### PR DESCRIPTION
* chore: update Anthropic models and SDK versions

Model updates:
- claude-3-5-sonnet / claude-3-7-sonnet → claude-sonnet-5 throughout
- claude-opus-4-20250514 → claude-opus-4-8 throughout
- ANTHROPIC_MODEL env var updated in .env

SDK/dependency updates:
- delphi: anthropic>=0.5.0 → >=0.116.0; requirements.lock regenerated
- server: @anthropic-ai/sdk ^0.55.1 → ^0.110.0

API breaking-change fixes (claude-sonnet-5 / opus-4-8):
- Remove temperature param from all Anthropic API calls (rejected on 4.7+)
- Remove assistant prefill from all calls (unsupported on 4.6+ family)
- Fix response parsing to find text block by type, skipping thinking blocks (adaptive thinking is on by default in claude-sonnet-5)
- Strip markdown code fences from responses where prefill was removed

Bug fixes in delphi:
- 802_process_batch_results.py: remove erroneous `await` on sync get_response
- 802_process_batch_results.py: fix batch response content parsing for thinking blocks
- model_provider.py: remove dead SDK code branch (self.client always None)
- model_provider.py: fix Optional[str] annotations, unused Union import, None guard on HTTPError.response, None guard before provider_type.lower()
- OllamaProvider.list_available_models: filter None from model name lists



* fix(delphi): graceful Ollama setup + thinking block fix in batch status

- Dockerfile: Ollama setup failure no longer blocks job poller startup (|| true so poller runs regardless of whether model pull succeeds)
- setup_ollama.sh: raise pull timeout 120s → 1800s (configurable via OLLAMA_PULL_TIMEOUT); skip pull if model already present; pipe progress through Python filter showing one line per 100MB instead of raw JSON flood
- 803_check_batch_status.py: fix BetaThinkingBlock AttributeError — find text block by type rather than assuming content[0] is text (claude-sonnet-5 adaptive thinking prepends thinking blocks to the content array)



---------