### PR TITLE
feat(delphi): storage v2 P2 — backend-neutral delphi_storage repository (dual backends + conformance)

### DIFF
--- a/delphi/Dockerfile
+++ b/delphi/Dockerfile
@@ -56,6 +56,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
   # Copy source code - this layer rebuilds when code changes but reuses dependency layers above
   COPY polismath/ ./polismath/
   COPY umap_narrative/ ./umap_narrative/
+  COPY delphi_storage/ ./delphi_storage/
   COPY scripts/ ./scripts/
   COPY *.py ./
 
@@ -94,6 +95,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /app/polismath/ ./polismath/
 COPY --from=builder /app/scripts/ ./scripts/
 COPY --from=builder /app/umap_narrative/ ./umap_narrative/
+COPY --from=builder /app/delphi_storage/ ./delphi_storage/
 COPY --from=builder /app/*.py ./
 
 RUN mkdir -p data

--- a/delphi/delphi_storage/__init__.py
+++ b/delphi/delphi_storage/__init__.py
@@ -1,0 +1,40 @@
+"""Delphi Storage V2 — backend-neutral repository for runs, inputs, artifacts,
+and latest pointers (design: docs/STORAGE_V2_DESIGN.md).
+
+Public surface:
+
+    from delphi_storage import get_store
+    store = get_store()  # DELPHI_STORAGE_BACKEND=dynamodb|postgres|memory
+"""
+
+from delphi_storage.factory import get_store
+from delphi_storage.interface import (
+    AlreadyExists,
+    DelphiStore,
+    Invalid,
+    NotFound,
+    StorageError,
+)
+from delphi_storage.models import (
+    AdvanceResult,
+    JobType,
+    LatestPointer,
+    RunManifest,
+    RunStatus,
+    StoreItem,
+)
+
+__all__ = [
+    "AdvanceResult",
+    "AlreadyExists",
+    "DelphiStore",
+    "Invalid",
+    "JobType",
+    "LatestPointer",
+    "NotFound",
+    "RunManifest",
+    "RunStatus",
+    "StorageError",
+    "StoreItem",
+    "get_store",
+]

--- a/delphi/delphi_storage/backends/dynamodb.py
+++ b/delphi/delphi_storage/backends/dynamodb.py
@@ -1,0 +1,662 @@
+"""DynamoDB backend for Delphi Storage V2.
+
+Physical layout (table prefix configurable, default ``Delphi2_``):
+
+- ``<prefix>Runs``                 — PK job_id; sparse GSI ``claim-index``
+  (claim_status, claim_order) for queue claims; sparse GSIs ``zid-index`` /
+  ``rid-index`` (zid_key/rid_key, enqueued_at) for list_runs.
+- ``<prefix>Latest``               — PK scope.
+- ``<prefix>RunInputs`` / ``<prefix>Artifacts`` / ``<prefix>TopicModeration``
+  / ``<prefix>CollectiveStatements`` — PK pk, SK sk.
+
+Blobs larger than ``CHUNK_SIZE`` are split across chunk rows whose sort keys
+start with U+007F (forbidden in user keys); they are reassembled on read and
+invisible to queries. Claim/lease/version mutations are conditional writes on
+``version`` (the lift of the working job_poller optimistic-lock pattern,
+design §4.3); candidate discovery uses the GSI but every mutation conditions
+on the base table. Uses the low-level boto3 client (thread-safe, unlike the
+resource API) with TypeSerializer/TypeDeserializer.
+"""
+
+import os
+import uuid
+from typing import Any, Iterable, Optional, Union
+
+import boto3
+from boto3.dynamodb.types import Binary, TypeDeserializer, TypeSerializer
+from botocore.exceptions import ClientError
+
+from delphi_storage.codec import from_dynamo, to_dynamo
+from delphi_storage.interface import (
+    AlreadyExists,
+    coerce_job_type,
+    coerce_run_status,
+    DelphiStore,
+    Invalid,
+    NotFound,
+    StorageError,
+    validate_enqueueable,
+    validate_generic_read,
+    validate_generic_write,
+)
+from delphi_storage.keys import (
+    CHUNK_MARKER,
+    claim_order,
+    now_ts,
+    ts_add_seconds,
+    validate_ts,
+)
+from delphi_storage.models import (
+    AdvanceResult,
+    JobType,
+    LatestPointer,
+    RunManifest,
+    RunStatus,
+    StoreItem,
+    TERMINAL_STATUSES,
+)
+from delphi_storage.backends.memory import merge_manifest_fields
+
+#: Max blob bytes stored inline in one item (DynamoDB item limit is 400KB
+#: including attribute names; 300KB leaves ample headroom for attributes).
+CHUNK_SIZE = 300_000
+
+_ENTITY_TABLES = {
+    "run_inputs": "RunInputs",
+    "artifacts": "Artifacts",
+    "topic_moderation": "TopicModeration",
+    "collective_statements": "CollectiveStatements",
+}
+
+_KV_TABLE_NAMES = tuple(_ENTITY_TABLES.values())
+
+#: Fields stored as top-level item attributes purely for indexing; stripped
+#: before manifest deserialization.
+_RUNS_INDEX_ATTRS = ("claim_status", "claim_order", "zid_key", "rid_key")
+
+_MUTATION_RETRIES = 8
+
+
+def kv_table_schema(table_name: str) -> dict[str, Any]:
+    return {
+        "TableName": table_name,
+        "KeySchema": [
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    }
+
+
+def runs_table_schema(table_name: str) -> dict[str, Any]:
+    return {
+        "TableName": table_name,
+        "KeySchema": [{"AttributeName": "job_id", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "job_id", "AttributeType": "S"},
+            {"AttributeName": "claim_status", "AttributeType": "S"},
+            {"AttributeName": "claim_order", "AttributeType": "S"},
+            {"AttributeName": "zid_key", "AttributeType": "S"},
+            {"AttributeName": "rid_key", "AttributeType": "S"},
+            {"AttributeName": "enqueued_at", "AttributeType": "S"},
+        ],
+        "GlobalSecondaryIndexes": [
+            {
+                "IndexName": "claim-index",
+                "KeySchema": [
+                    {"AttributeName": "claim_status", "KeyType": "HASH"},
+                    {"AttributeName": "claim_order", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "KEYS_ONLY"},
+            },
+            {
+                "IndexName": "zid-index",
+                "KeySchema": [
+                    {"AttributeName": "zid_key", "KeyType": "HASH"},
+                    {"AttributeName": "enqueued_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "rid-index",
+                "KeySchema": [
+                    {"AttributeName": "rid_key", "KeyType": "HASH"},
+                    {"AttributeName": "enqueued_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    }
+
+
+def latest_table_schema(table_name: str) -> dict[str, Any]:
+    return {
+        "TableName": table_name,
+        "KeySchema": [{"AttributeName": "scope", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "scope", "AttributeType": "S"}],
+        "BillingMode": "PAY_PER_REQUEST",
+    }
+
+
+def table_schemas(prefix: str) -> list[dict[str, Any]]:
+    """All V2 table definitions — single source for ensure_tables() and for
+    create_dynamodb_tables.py (P4)."""
+    schemas = [
+        runs_table_schema(f"{prefix}Runs"),
+        latest_table_schema(f"{prefix}Latest"),
+    ]
+    schemas.extend(kv_table_schema(f"{prefix}{name}") for name in _KV_TABLE_NAMES)
+    return schemas
+
+
+def _chunk_prefix(sk: str) -> str:
+    return f"{CHUNK_MARKER}{sk}{CHUNK_MARKER}"
+
+
+def _chunk_sk(sk: str, gen: str, index: int) -> str:
+    return f"{_chunk_prefix(sk)}{gen}{CHUNK_MARKER}{index:05d}"
+
+
+def _is_chunk_sk(sk: str) -> bool:
+    return sk.startswith(CHUNK_MARKER)
+
+
+class DynamoDelphiStore(DelphiStore):
+    def __init__(
+        self,
+        table_prefix: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
+        region: Optional[str] = None,
+        ensure_tables: bool = False,
+    ) -> None:
+        self.table_prefix = table_prefix or os.environ.get(
+            "DELPHI_STORAGE_TABLE_PREFIX", "Delphi2_"
+        )
+        endpoint_url = endpoint_url or os.environ.get("DYNAMODB_ENDPOINT") or None
+        region = region or os.environ.get("AWS_REGION", "us-east-1")
+        kwargs: dict[str, Any] = {"region_name": region}
+        if endpoint_url:
+            kwargs["endpoint_url"] = endpoint_url
+        self._client = boto3.client("dynamodb", **kwargs)
+        self._ser = TypeSerializer()
+        self._deser = TypeDeserializer()
+        if ensure_tables:
+            self.ensure_tables()
+
+    # ---- table management (used by tests and P4 tooling) ----
+
+    def ensure_tables(self) -> None:
+        existing = set(self._list_table_names())
+        for schema in table_schemas(self.table_prefix):
+            if schema["TableName"] not in existing:
+                self._client.create_table(**schema)
+        waiter = self._client.get_waiter("table_exists")
+        for schema in table_schemas(self.table_prefix):
+            waiter.wait(TableName=schema["TableName"], WaiterConfig={"Delay": 1, "MaxAttempts": 60})
+
+    def drop_tables(self) -> None:
+        existing = set(self._list_table_names())
+        for schema in table_schemas(self.table_prefix):
+            if schema["TableName"] in existing:
+                self._client.delete_table(TableName=schema["TableName"])
+
+    def _list_table_names(self) -> Iterable[str]:
+        paginator = self._client.get_paginator("list_tables")
+        for page in paginator.paginate():
+            yield from page["TableNames"]
+
+    # ---- marshalling helpers ----
+
+    def _table(self, entity: str) -> str:
+        return f"{self.table_prefix}{_ENTITY_TABLES[entity]}"
+
+    def _marshal(self, obj: dict[str, Any]) -> dict[str, Any]:
+        return {k: self._ser.serialize(v) for k, v in to_dynamo(obj).items()}
+
+    def _unmarshal(self, item: dict[str, Any]) -> dict[str, Any]:
+        return from_dynamo({k: self._deser.deserialize(v) for k, v in item.items()})
+
+    def _query_all(self, **kwargs: Any) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        while True:
+            page = self._client.query(**kwargs)
+            items.extend(page.get("Items", []))
+            last = page.get("LastEvaluatedKey")
+            if not last:
+                return items
+            kwargs["ExclusiveStartKey"] = last
+
+    # ---- generic ----
+
+    def put(self, entity: str, item: StoreItem) -> None:
+        """Crash-safe write order for chunked blobs: new-generation chunk rows
+        first (invisible — the main item still references the old generation),
+        THEN the main item (the commit point flips readers atomically), THEN
+        stale-generation cleanup. A crash at any point leaves the previous
+        value fully readable; orphaned generations are swept by the next
+        successful put."""
+        validate_generic_write(entity, item)
+        table = self._table(entity)
+        blob = item.blob or b""
+        n_chunks = 0
+        if item.blob is not None and len(blob) > CHUNK_SIZE:
+            n_chunks = (len(blob) + CHUNK_SIZE - 1) // CHUNK_SIZE
+        gen = uuid.uuid4().hex[:12]
+        for i in range(n_chunks):
+            part = blob[i * CHUNK_SIZE : (i + 1) * CHUNK_SIZE]
+            self._client.put_item(
+                TableName=table,
+                Item={
+                    "pk": {"S": item.pk},
+                    "sk": {"S": _chunk_sk(item.sk, gen, i)},
+                    "part": {"B": part},
+                },
+            )
+        record: dict[str, Any] = {
+            "pk": {"S": item.pk},
+            "sk": {"S": item.sk},
+            "attributes": self._ser.serialize(to_dynamo(item.attributes)),
+        }
+        if item.blob is not None:
+            if n_chunks:
+                record["_chunks"] = {"N": str(n_chunks)}
+                record["_blob_len"] = {"N": str(len(blob))}
+                record["_blob_gen"] = {"S": gen}
+            else:
+                record["blob"] = {"B": blob}
+        self._client.put_item(TableName=table, Item=record)
+        self._delete_chunk_rows(table, item.pk, item.sk, keep_gen=gen if n_chunks else None)
+
+    def _delete_chunk_rows(
+        self, table: str, pk: str, sk: str, keep_gen: Optional[str] = None
+    ) -> None:
+        prefix = _chunk_prefix(sk)
+        keep_prefix = f"{prefix}{keep_gen}{CHUNK_MARKER}" if keep_gen is not None else None
+        rows = self._query_all(
+            TableName=table,
+            KeyConditionExpression="pk = :pk AND begins_with(sk, :prefix)",
+            ExpressionAttributeValues={":pk": {"S": pk}, ":prefix": {"S": prefix}},
+            ProjectionExpression="pk, sk",
+            ConsistentRead=True,
+        )
+        for row in rows:
+            if keep_prefix is not None and row["sk"]["S"].startswith(keep_prefix):
+                continue
+            self._client.delete_item(TableName=table, Key={"pk": row["pk"], "sk": row["sk"]})
+
+    def _read_blob(self, table: str, raw_item: dict[str, Any]) -> Optional[bytes]:
+        if "blob" in raw_item:
+            value = raw_item["blob"]["B"]
+            return bytes(value.value if isinstance(value, Binary) else value)
+        if "_chunks" not in raw_item:
+            return None
+        pk = raw_item["pk"]["S"]
+        sk = raw_item["sk"]["S"]
+        n_chunks = int(raw_item["_chunks"]["N"])
+        blob_len = int(raw_item["_blob_len"]["N"])
+        gen = raw_item["_blob_gen"]["S"]
+        # Fetch exactly the deterministic chunk keys of the committed
+        # generation — stale rows from other generations can never interfere.
+        parts: list[bytes] = []
+        for i in range(n_chunks):
+            response = self._client.get_item(
+                TableName=table,
+                Key={"pk": {"S": pk}, "sk": {"S": _chunk_sk(sk, gen, i)}},
+                ConsistentRead=True,
+            )
+            row = response.get("Item")
+            if row is None:
+                raise StorageError(
+                    f"corrupt chunked blob at {pk!r}/{sk!r}: missing chunk {i}/{n_chunks} "
+                    f"of generation {gen}"
+                )
+            value = row["part"]["B"]
+            parts.append(bytes(value.value if isinstance(value, Binary) else value))
+        blob = b"".join(parts)
+        if len(blob) != blob_len:
+            raise StorageError(
+                f"corrupt chunked blob at {pk!r}/{sk!r}: {len(blob)}/{blob_len} bytes"
+            )
+        return blob
+
+    def _to_store_item(self, table: str, raw_item: dict[str, Any]) -> StoreItem:
+        attributes = from_dynamo(self._deser.deserialize(raw_item["attributes"]))
+        return StoreItem(
+            pk=raw_item["pk"]["S"],
+            sk=raw_item["sk"]["S"],
+            attributes=attributes,
+            blob=self._read_blob(table, raw_item),
+        )
+
+    def get(self, entity: str, pk: str, sk: str) -> Optional[StoreItem]:
+        validate_generic_read(entity)
+        table = self._table(entity)
+        response = self._client.get_item(
+            TableName=table, Key={"pk": {"S": pk}, "sk": {"S": sk}}, ConsistentRead=True
+        )
+        raw_item = response.get("Item")
+        if raw_item is None:
+            return None
+        return self._to_store_item(table, raw_item)
+
+    def query_prefix(self, entity: str, pk: str, sk_prefix: str = "") -> list[StoreItem]:
+        validate_generic_read(entity)
+        table = self._table(entity)
+        kwargs: dict[str, Any] = {
+            "TableName": table,
+            "ConsistentRead": True,
+            "ExpressionAttributeValues": {":pk": {"S": pk}},
+            "KeyConditionExpression": "pk = :pk",
+        }
+        if sk_prefix:
+            kwargs["KeyConditionExpression"] += " AND begins_with(sk, :prefix)"
+            kwargs["ExpressionAttributeValues"][":prefix"] = {"S": sk_prefix}
+        rows = self._query_all(**kwargs)
+        return [
+            self._to_store_item(table, row) for row in rows if not _is_chunk_sk(row["sk"]["S"])
+        ]
+
+    def query_between(self, entity: str, pk: str, sk_from: str, sk_to: str) -> list[StoreItem]:
+        validate_generic_read(entity)
+        table = self._table(entity)
+        rows = self._query_all(
+            TableName=table,
+            ConsistentRead=True,
+            KeyConditionExpression="pk = :pk AND sk BETWEEN :lo AND :hi",
+            ExpressionAttributeValues={
+                ":pk": {"S": pk},
+                ":lo": {"S": sk_from},
+                ":hi": {"S": sk_to},
+            },
+        )
+        return [
+            self._to_store_item(table, row) for row in rows if not _is_chunk_sk(row["sk"]["S"])
+        ]
+
+    def delete_partition(self, entity: str, pk: str) -> int:
+        validate_generic_read(entity)
+        table = self._table(entity)
+        rows = self._query_all(
+            TableName=table,
+            ConsistentRead=True,
+            KeyConditionExpression="pk = :pk",
+            ExpressionAttributeValues={":pk": {"S": pk}},
+            ProjectionExpression="pk, sk",
+        )
+        logical = 0
+        for row in rows:
+            if not _is_chunk_sk(row["sk"]["S"]):
+                logical += 1
+            self._client.delete_item(TableName=table, Key={"pk": row["pk"], "sk": row["sk"]})
+        return logical
+
+    # ---- runs / queue ----
+
+    @property
+    def _runs_table(self) -> str:
+        return f"{self.table_prefix}Runs"
+
+    @property
+    def _latest_table(self) -> str:
+        return f"{self.table_prefix}Latest"
+
+    def _run_record(self, run: RunManifest) -> dict[str, Any]:
+        fields = run.model_dump(mode="json")
+        record = self._marshal(fields)
+        if run.status == RunStatus.QUEUED:
+            record["claim_status"] = {"S": RunStatus.QUEUED.value}
+            record["claim_order"] = {"S": claim_order(run.priority, run.enqueued_at, run.job_id)}
+        if run.zid is not None:
+            record["zid_key"] = {"S": str(run.zid)}
+        if run.rid is not None:
+            record["rid_key"] = {"S": str(run.rid)}
+        return record
+
+    def _record_to_run(self, raw_item: dict[str, Any]) -> RunManifest:
+        fields = self._unmarshal(raw_item)
+        for attr in _RUNS_INDEX_ATTRS:
+            fields.pop(attr, None)
+        return RunManifest(**fields)
+
+    def _get_run_raw(self, job_id: str) -> Optional[dict[str, Any]]:
+        response = self._client.get_item(
+            TableName=self._runs_table, Key={"job_id": {"S": job_id}}, ConsistentRead=True
+        )
+        return response.get("Item")
+
+    def _put_run_versioned(self, run: RunManifest, expected_version: int) -> bool:
+        """Full-item replace conditional on the version we read; False on a
+        lost race."""
+        try:
+            self._client.put_item(
+                TableName=self._runs_table,
+                Item=self._run_record(run),
+                ConditionExpression="#version = :v",
+                ExpressionAttributeNames={"#version": "version"},
+                ExpressionAttributeValues={":v": {"N": str(expected_version)}},
+            )
+            return True
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return False
+            raise
+
+    def enqueue_run(self, run: RunManifest) -> None:
+        validate_enqueueable(run)
+        try:
+            self._client.put_item(
+                TableName=self._runs_table,
+                Item=self._run_record(run),
+                ConditionExpression="attribute_not_exists(job_id)",
+            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                raise AlreadyExists(f"run {run.job_id!r} already exists") from e
+            raise
+
+    def get_run(self, job_id: str) -> Optional[RunManifest]:
+        raw_item = self._get_run_raw(job_id)
+        return self._record_to_run(raw_item) if raw_item else None
+
+    def claim_next_run(
+        self, worker_id: str, lease_seconds: int, now: Optional[str] = None
+    ) -> Optional[RunManifest]:
+        now = validate_ts(now) if now is not None else now_ts()
+        # Candidates come from the (eventually consistent) sparse GSI; the
+        # claim itself is a conditional write on the base table, so staleness
+        # only costs a wasted attempt, never a double claim.
+        kwargs: dict[str, Any] = {
+            "TableName": self._runs_table,
+            "IndexName": "claim-index",
+            "KeyConditionExpression": "claim_status = :queued",
+            "ExpressionAttributeValues": {":queued": {"S": RunStatus.QUEUED.value}},
+            "ScanIndexForward": True,
+            "Limit": 10,
+        }
+        while True:
+            page = self._client.query(**kwargs)
+            for candidate in page.get("Items", []):
+                job_id = candidate["job_id"]["S"]
+                raw_item = self._get_run_raw(job_id)
+                if raw_item is None or raw_item["status"]["S"] != RunStatus.QUEUED.value:
+                    continue
+                run = self._record_to_run(raw_item)
+                claimed = run.model_copy(
+                    update={
+                        "status": RunStatus.RUNNING,
+                        "worker_id": worker_id,
+                        "started_at": now,
+                        "lease_expires_at": ts_add_seconds(now, lease_seconds),
+                        "version": run.version + 1,
+                    }
+                )
+                if self._put_run_versioned(claimed, expected_version=run.version):
+                    return claimed
+            last = page.get("LastEvaluatedKey")
+            if not last:
+                return None
+            kwargs["ExclusiveStartKey"] = last
+
+    def extend_lease(
+        self, job_id: str, worker_id: str, lease_seconds: int, now: Optional[str] = None
+    ) -> bool:
+        now = validate_ts(now) if now is not None else now_ts()
+        for _ in range(_MUTATION_RETRIES):
+            raw_item = self._get_run_raw(job_id)
+            if raw_item is None:
+                return False
+            run = self._record_to_run(raw_item)
+            if run.status != RunStatus.RUNNING or run.worker_id != worker_id:
+                return False
+            extended = run.model_copy(
+                update={
+                    "lease_expires_at": ts_add_seconds(now, lease_seconds),
+                    "version": run.version + 1,
+                }
+            )
+            if self._put_run_versioned(extended, expected_version=run.version):
+                return True
+        return False
+
+    def _mutate_run(self, job_id: str, mutate) -> RunManifest:
+        """Read-mutate-conditionally-write loop shared by status/field updates."""
+        for _ in range(_MUTATION_RETRIES):
+            raw_item = self._get_run_raw(job_id)
+            if raw_item is None:
+                raise NotFound(f"run {job_id!r} not found")
+            run = self._record_to_run(raw_item)
+            updated = mutate(run).model_copy(update={"version": run.version + 1})
+            if self._put_run_versioned(updated, expected_version=run.version):
+                return updated
+        raise StorageError(f"run {job_id!r}: lost {_MUTATION_RETRIES} optimistic-lock races")
+
+    def update_run_status(
+        self,
+        job_id: str,
+        status: Union[RunStatus, str],
+        error: Optional[str] = None,
+        now: Optional[str] = None,
+    ) -> RunManifest:
+        status = coerce_run_status(status)
+        now = validate_ts(now) if now is not None else now_ts()
+
+        def mutate(run: RunManifest) -> RunManifest:
+            updates: dict[str, Any] = {"status": status}
+            if error is not None:
+                updates["error"] = error
+            if status in TERMINAL_STATUSES and run.completed_at is None:
+                updates["completed_at"] = now
+            return run.model_copy(update=updates)
+
+        return self._mutate_run(job_id, mutate)
+
+    def merge_run_fields(self, job_id: str, fields: dict[str, Any]) -> RunManifest:
+        return self._mutate_run(job_id, lambda run: merge_manifest_fields(run, fields))
+
+    def _increment_log_seq(self, job_id: str) -> int:
+        try:
+            response = self._client.update_item(
+                TableName=self._runs_table,
+                Key={"job_id": {"S": job_id}},
+                UpdateExpression="SET log_seq = log_seq + :one, #version = #version + :one",
+                ConditionExpression="attribute_exists(job_id)",
+                ExpressionAttributeNames={"#version": "version"},
+                ExpressionAttributeValues={":one": {"N": "1"}},
+                ReturnValues="UPDATED_NEW",
+            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                raise NotFound(f"run {job_id!r} not found") from e
+            raise
+        return int(response["Attributes"]["log_seq"]["N"])
+
+    # ---- latest ----
+
+    def advance_latest(
+        self,
+        scope: str,
+        job_id: str,
+        job_type: Union[JobType, str],
+        only_if_absent_or_imported: bool = False,
+        now: Optional[str] = None,
+    ) -> AdvanceResult:
+        job_type = coerce_job_type(job_type)
+        now = validate_ts(now) if now is not None else now_ts()
+        for _ in range(_MUTATION_RETRIES):
+            current = self.get_latest(scope)
+            if current is not None:
+                if current.job_id == job_id:
+                    return AdvanceResult(advanced=False, pointer=current)
+                if only_if_absent_or_imported and current.job_type != JobType.IMPORTED:
+                    return AdvanceResult(advanced=False, pointer=current)
+            pointer = LatestPointer(
+                scope=scope,
+                job_id=job_id,
+                seq=(current.seq + 1 if current else 1),
+                job_type=job_type,
+                updated_at=now,
+            )
+            item = self._marshal(pointer.model_dump(mode="json"))
+            try:
+                if current is None:
+                    self._client.put_item(
+                        TableName=self._latest_table,
+                        Item=item,
+                        ConditionExpression="attribute_not_exists(#scope)",
+                        ExpressionAttributeNames={"#scope": "scope"},
+                    )
+                else:
+                    self._client.put_item(
+                        TableName=self._latest_table,
+                        Item=item,
+                        ConditionExpression="#seq = :old",
+                        ExpressionAttributeNames={"#seq": "seq"},
+                        ExpressionAttributeValues={":old": {"N": str(current.seq)}},
+                    )
+                return AdvanceResult(advanced=True, pointer=pointer)
+            except ClientError as e:
+                if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                    continue  # concurrent advance — re-read and re-decide
+                raise
+        raise StorageError(f"latest {scope!r}: lost {_MUTATION_RETRIES} optimistic-lock races")
+
+    def get_latest(self, scope: str) -> Optional[LatestPointer]:
+        response = self._client.get_item(
+            TableName=self._latest_table, Key={"scope": {"S": scope}}, ConsistentRead=True
+        )
+        raw_item = response.get("Item")
+        if raw_item is None:
+            return None
+        return LatestPointer(**self._unmarshal(raw_item))
+
+    def list_runs(
+        self,
+        zid: Optional[int] = None,
+        rid: Optional[int] = None,
+        status: Optional[Union[RunStatus, str]] = None,
+        limit: int = 100,
+    ) -> list[RunManifest]:
+        if (zid is None) == (rid is None):
+            raise Invalid("exactly one of zid/rid is required")
+        status = coerce_run_status(status) if status is not None else None
+        if zid is not None:
+            index, attr, value = "zid-index", "zid_key", str(zid)
+        else:
+            index, attr, value = "rid-index", "rid_key", str(rid)
+        rows = self._query_all(
+            TableName=self._runs_table,
+            IndexName=index,
+            KeyConditionExpression=f"{attr} = :key",
+            ExpressionAttributeValues={":key": {"S": value}},
+            ScanIndexForward=False,
+        )
+        runs = [self._record_to_run(row) for row in rows]
+        if status is not None:
+            runs = [r for r in runs if r.status == status]
+        runs.sort(key=lambda r: (r.enqueued_at, r.job_id), reverse=True)
+        return runs[:limit]

--- a/delphi/delphi_storage/backends/memory.py
+++ b/delphi/delphi_storage/backends/memory.py
@@ -1,0 +1,270 @@
+"""In-memory reference implementation of the Delphi Storage V2 interface.
+
+The executable specification: the smallest honest implementation of the
+conformance contract, used by unit tests and as a test double. Thread-safe
+via a single lock (claim atomicity comes for free)."""
+
+import copy
+import threading
+from typing import Any, Optional, Union
+
+from delphi_storage.interface import (
+    AlreadyExists,
+    coerce_job_type,
+    coerce_run_status,
+    DelphiStore,
+    Invalid,
+    NotFound,
+    validate_enqueueable,
+    validate_generic_read,
+    validate_generic_write,
+)
+from delphi_storage.keys import claim_order, now_ts, validate_ts, ts_add_seconds
+from delphi_storage.models import (
+    AdvanceResult,
+    JobType,
+    LatestPointer,
+    RunManifest,
+    RunStatus,
+    StoreItem,
+    TERMINAL_STATUSES,
+)
+
+MERGEABLE_DICT_FIELDS = frozenset(
+    {
+        "config_requested",
+        "config_effective",
+        "code_version",
+        "seeds",
+        "input_fingerprints",
+        "stage_status",
+    }
+)
+MERGEABLE_SCALAR_FIELDS = frozenset(
+    {"math_tick_legacy", "replay_of", "provenance", "replayable", "imported_scope_type"}
+)
+
+
+def _utf8_key(sk: str) -> bytes:
+    return sk.encode("utf-8")
+
+
+def merge_manifest_fields(run: RunManifest, fields: dict[str, Any]) -> RunManifest:
+    """Shared shallow-merge semantics (also used by other backends)."""
+    updates: dict[str, Any] = {}
+    for key, value in fields.items():
+        if key in MERGEABLE_DICT_FIELDS:
+            if not isinstance(value, dict):
+                raise Invalid(f"field {key!r} must be a dict")
+            merged = dict(getattr(run, key))
+            merged.update(value)
+            updates[key] = merged
+        elif key in MERGEABLE_SCALAR_FIELDS:
+            updates[key] = value
+        else:
+            raise Invalid(f"field {key!r} is not mergeable")
+    return run.model_copy(update=updates)
+
+
+class MemoryDelphiStore(DelphiStore):
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        # entity -> pk -> sk -> (attributes, blob)
+        self._kv: dict[str, dict[str, dict[str, tuple[dict, Optional[bytes]]]]] = {}
+        self._runs: dict[str, RunManifest] = {}
+        self._latest: dict[str, LatestPointer] = {}
+
+    # ---- generic ----
+
+    def put(self, entity: str, item: StoreItem) -> None:
+        validate_generic_write(entity, item)
+        with self._lock:
+            partition = self._kv.setdefault(entity, {}).setdefault(item.pk, {})
+            partition[item.sk] = (copy.deepcopy(item.attributes), item.blob)
+
+    def get(self, entity: str, pk: str, sk: str) -> Optional[StoreItem]:
+        validate_generic_read(entity)
+        with self._lock:
+            found = self._kv.get(entity, {}).get(pk, {}).get(sk)
+            if found is None:
+                return None
+            attributes, blob = found
+            return StoreItem(pk=pk, sk=sk, attributes=copy.deepcopy(attributes), blob=blob)
+
+    def query_prefix(self, entity: str, pk: str, sk_prefix: str = "") -> list[StoreItem]:
+        validate_generic_read(entity)
+        with self._lock:
+            partition = self._kv.get(entity, {}).get(pk, {})
+            sks = sorted((sk for sk in partition if sk.startswith(sk_prefix)), key=_utf8_key)
+            return [
+                StoreItem(
+                    pk=pk, sk=sk, attributes=copy.deepcopy(partition[sk][0]), blob=partition[sk][1]
+                )
+                for sk in sks
+            ]
+
+    def query_between(self, entity: str, pk: str, sk_from: str, sk_to: str) -> list[StoreItem]:
+        validate_generic_read(entity)
+        lo, hi = _utf8_key(sk_from), _utf8_key(sk_to)
+        with self._lock:
+            partition = self._kv.get(entity, {}).get(pk, {})
+            sks = sorted((sk for sk in partition if lo <= _utf8_key(sk) <= hi), key=_utf8_key)
+            return [
+                StoreItem(
+                    pk=pk, sk=sk, attributes=copy.deepcopy(partition[sk][0]), blob=partition[sk][1]
+                )
+                for sk in sks
+            ]
+
+    def delete_partition(self, entity: str, pk: str) -> int:
+        validate_generic_read(entity)
+        with self._lock:
+            partition = self._kv.get(entity, {}).pop(pk, {})
+            return len(partition)
+
+    # ---- runs / queue ----
+
+    def enqueue_run(self, run: RunManifest) -> None:
+        validate_enqueueable(run)
+        with self._lock:
+            if run.job_id in self._runs:
+                raise AlreadyExists(f"run {run.job_id!r} already exists")
+            self._runs[run.job_id] = run.model_copy(deep=True)
+
+    def get_run(self, job_id: str) -> Optional[RunManifest]:
+        with self._lock:
+            run = self._runs.get(job_id)
+            return run.model_copy(deep=True) if run else None
+
+    def claim_next_run(
+        self, worker_id: str, lease_seconds: int, now: Optional[str] = None
+    ) -> Optional[RunManifest]:
+        now = validate_ts(now) if now is not None else now_ts()
+        with self._lock:
+            queued = [r for r in self._runs.values() if r.status == RunStatus.QUEUED]
+            if not queued:
+                return None
+            run = min(queued, key=lambda r: claim_order(r.priority, r.enqueued_at, r.job_id))
+            claimed = run.model_copy(
+                update={
+                    "status": RunStatus.RUNNING,
+                    "worker_id": worker_id,
+                    "started_at": now,
+                    "lease_expires_at": ts_add_seconds(now, lease_seconds),
+                    "version": run.version + 1,
+                }
+            )
+            self._runs[run.job_id] = claimed
+            return claimed.model_copy(deep=True)
+
+    def extend_lease(
+        self, job_id: str, worker_id: str, lease_seconds: int, now: Optional[str] = None
+    ) -> bool:
+        now = validate_ts(now) if now is not None else now_ts()
+        with self._lock:
+            run = self._runs.get(job_id)
+            if run is None or run.status != RunStatus.RUNNING or run.worker_id != worker_id:
+                return False
+            self._runs[job_id] = run.model_copy(
+                update={
+                    "lease_expires_at": ts_add_seconds(now, lease_seconds),
+                    "version": run.version + 1,
+                }
+            )
+            return True
+
+    def update_run_status(
+        self,
+        job_id: str,
+        status: Union[RunStatus, str],
+        error: Optional[str] = None,
+        now: Optional[str] = None,
+    ) -> RunManifest:
+        status = coerce_run_status(status)
+        now = validate_ts(now) if now is not None else now_ts()
+        with self._lock:
+            run = self._runs.get(job_id)
+            if run is None:
+                raise NotFound(f"run {job_id!r} not found")
+            updates: dict[str, Any] = {"status": status, "version": run.version + 1}
+            if error is not None:
+                updates["error"] = error
+            if status in TERMINAL_STATUSES and run.completed_at is None:
+                updates["completed_at"] = now
+            updated = run.model_copy(update=updates)
+            self._runs[job_id] = updated
+            return updated.model_copy(deep=True)
+
+    def merge_run_fields(self, job_id: str, fields: dict[str, Any]) -> RunManifest:
+        with self._lock:
+            run = self._runs.get(job_id)
+            if run is None:
+                raise NotFound(f"run {job_id!r} not found")
+            merged = merge_manifest_fields(run, fields).model_copy(
+                update={"version": run.version + 1}
+            )
+            self._runs[job_id] = merged
+            return merged.model_copy(deep=True)
+
+    def advance_latest(
+        self,
+        scope: str,
+        job_id: str,
+        job_type: Union[JobType, str],
+        only_if_absent_or_imported: bool = False,
+        now: Optional[str] = None,
+    ) -> AdvanceResult:
+        job_type = coerce_job_type(job_type)
+        now = validate_ts(now) if now is not None else now_ts()
+        with self._lock:
+            current = self._latest.get(scope)
+            if current is not None:
+                if current.job_id == job_id:
+                    return AdvanceResult(advanced=False, pointer=current.model_copy())
+                if only_if_absent_or_imported and current.job_type != JobType.IMPORTED:
+                    return AdvanceResult(advanced=False, pointer=current.model_copy())
+            pointer = LatestPointer(
+                scope=scope,
+                job_id=job_id,
+                seq=(current.seq + 1 if current else 1),
+                job_type=job_type,
+                updated_at=now,
+            )
+            self._latest[scope] = pointer
+            return AdvanceResult(advanced=True, pointer=pointer.model_copy())
+
+    def get_latest(self, scope: str) -> Optional[LatestPointer]:
+        with self._lock:
+            pointer = self._latest.get(scope)
+            return pointer.model_copy() if pointer else None
+
+    def list_runs(
+        self,
+        zid: Optional[int] = None,
+        rid: Optional[int] = None,
+        status: Optional[Union[RunStatus, str]] = None,
+        limit: int = 100,
+    ) -> list[RunManifest]:
+        if (zid is None) == (rid is None):
+            raise Invalid("exactly one of zid/rid is required")
+        status = coerce_run_status(status) if status is not None else None
+        with self._lock:
+            if zid is not None:
+                runs = [r for r in self._runs.values() if r.zid == zid]
+            else:
+                runs = [r for r in self._runs.values() if r.rid == rid]
+            if status is not None:
+                runs = [r for r in runs if r.status == status]
+            runs.sort(key=lambda r: (r.enqueued_at, r.job_id), reverse=True)
+            return [r.model_copy(deep=True) for r in runs[:limit]]
+
+    def _increment_log_seq(self, job_id: str) -> int:
+        with self._lock:
+            run = self._runs.get(job_id)
+            if run is None:
+                raise NotFound(f"run {job_id!r} not found")
+            seq = run.log_seq + 1
+            self._runs[job_id] = run.model_copy(
+                update={"log_seq": seq, "version": run.version + 1}
+            )
+            return seq

--- a/delphi/delphi_storage/backends/postgres.py
+++ b/delphi/delphi_storage/backends/postgres.py
@@ -1,0 +1,565 @@
+"""PostgreSQL backend for Delphi Storage V2.
+
+Physical layout: one PG schema (default ``delphi``, configurable via
+``DELPHI_STORAGE_PG_SCHEMA``) holding
+
+- ``runs``    — typed queue columns (job_id, status, claim_order, zid, rid,
+  enqueued_at, version) + the full manifest as JSONB, following the legacy
+  Clojure ``math_main`` JSONB pattern (design §3.6);
+- ``latest``  — scope-keyed pointer rows;
+- four KV tables (``run_inputs``, ``artifacts``, ``topic_moderation``,
+  ``collective_statements``) — (pk, sk COLLATE "C") + JSONB attributes +
+  BYTEA blob. COLLATE "C" gives UTF-8 byte order, matching DynamoDB's native
+  range-key order (conformance §Ordering).
+
+Queue claim uses ``FOR UPDATE SKIP LOCKED`` (design §4.3); no chunking is
+needed (BYTEA has no 400KB limit). The DDL here is the single Python-side
+source; migration 000019 (P4) materializes the same schema for server-managed
+deployments.
+"""
+
+import json
+import os
+import re
+from typing import Any, Optional, Sequence, Union
+
+import sqlalchemy
+from sqlalchemy import text
+
+from delphi_storage.codec import canonical_json_dumps
+from delphi_storage.interface import (
+    AlreadyExists,
+    coerce_job_type,
+    coerce_run_status,
+    DelphiStore,
+    Invalid,
+    NotFound,
+    StorageError,
+    validate_enqueueable,
+    validate_generic_read,
+    validate_generic_write,
+)
+from delphi_storage.keys import (
+    GENERIC_ENTITIES,
+    claim_order,
+    now_ts,
+    ts_add_seconds,
+    validate_ts,
+)
+from delphi_storage.models import (
+    AdvanceResult,
+    JobType,
+    LatestPointer,
+    RunManifest,
+    RunStatus,
+    StoreItem,
+    TERMINAL_STATUSES,
+)
+from delphi_storage.backends.memory import merge_manifest_fields
+
+_IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
+
+_MUTATION_RETRIES = 8
+
+
+def kv_tables_ddl(schema: str) -> list[str]:
+    return [
+        f"""
+        CREATE TABLE IF NOT EXISTS {schema}.{entity} (
+            pk text NOT NULL,
+            sk text COLLATE "C" NOT NULL,
+            attributes jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+            blob bytea,
+            PRIMARY KEY (pk, sk)
+        )
+        """
+        for entity in GENERIC_ENTITIES
+    ]
+
+
+def runs_ddl(schema: str) -> list[str]:
+    return [
+        f"""
+        CREATE TABLE IF NOT EXISTS {schema}.runs (
+            job_id text PRIMARY KEY,
+            status text NOT NULL,
+            claim_order text COLLATE "C",
+            zid bigint,
+            rid bigint,
+            enqueued_at text NOT NULL,
+            version bigint NOT NULL,
+            manifest jsonb NOT NULL
+        )
+        """,
+        f"""
+        CREATE INDEX IF NOT EXISTS runs_claim_idx
+            ON {schema}.runs (claim_order) WHERE status = 'QUEUED'
+        """,
+        f"CREATE INDEX IF NOT EXISTS runs_zid_idx ON {schema}.runs (zid, enqueued_at)",
+        f"CREATE INDEX IF NOT EXISTS runs_rid_idx ON {schema}.runs (rid, enqueued_at)",
+    ]
+
+
+def latest_ddl(schema: str) -> list[str]:
+    return [
+        f"""
+        CREATE TABLE IF NOT EXISTS {schema}.latest (
+            scope text PRIMARY KEY,
+            job_id text NOT NULL,
+            seq bigint NOT NULL,
+            job_type text NOT NULL,
+            updated_at text NOT NULL
+        )
+        """
+    ]
+
+
+def schema_ddl(schema: str) -> list[str]:
+    """Full DDL — single Python-side source, mirrored by migration 000019."""
+    statements = [f"CREATE SCHEMA IF NOT EXISTS {schema}"]
+    statements.extend(runs_ddl(schema))
+    statements.extend(latest_ddl(schema))
+    statements.extend(kv_tables_ddl(schema))
+    return statements
+
+
+class PostgresDelphiStore(DelphiStore):
+    def __init__(
+        self,
+        url: Optional[str] = None,
+        schema: Optional[str] = None,
+        ensure_schema: bool = False,
+    ) -> None:
+        url = url or os.environ.get("DELPHI_STORAGE_PG_URL") or os.environ.get("DATABASE_URL")
+        if not url:
+            raise Invalid("PostgresDelphiStore needs DELPHI_STORAGE_PG_URL or DATABASE_URL")
+        # SQLAlchemy 2.0 dropped the legacy ``postgres://`` alias and raises
+        # NoSuchModuleError on it, but that's still what many platforms (Heroku
+        # et al.) put in DATABASE_URL. Normalize just the scheme; any +driver
+        # suffix and the rest of the URL are left untouched.
+        if url.startswith("postgres://"):
+            url = "postgresql://" + url[len("postgres://"):]
+        schema = schema or os.environ.get("DELPHI_STORAGE_PG_SCHEMA", "delphi")
+        if not _IDENTIFIER_RE.match(schema):
+            raise Invalid(f"schema name {schema!r} must match {_IDENTIFIER_RE.pattern}")
+        self.schema = schema
+        self._engine = sqlalchemy.create_engine(
+            url,
+            pool_pre_ping=True,
+            connect_args={"connect_timeout": int(os.environ.get("POSTGRES_CONNECT_TIMEOUT", "30"))},
+        )
+        if ensure_schema:
+            self.ensure_schema()
+
+    # ---- schema management (used by tests and P4 tooling) ----
+
+    def ensure_schema(self) -> None:
+        with self._engine.begin() as conn:
+            for statement in schema_ddl(self.schema):
+                conn.execute(text(statement))
+
+    def drop_schema(self) -> None:
+        with self._engine.begin() as conn:
+            conn.execute(text(f"DROP SCHEMA IF EXISTS {self.schema} CASCADE"))
+        self._engine.dispose()
+
+    def _kv(self, entity: str) -> str:
+        validate_generic_read(entity)
+        return f"{self.schema}.{entity}"
+
+    # ---- generic ----
+
+    def put(self, entity: str, item: StoreItem) -> None:
+        validate_generic_write(entity, item)
+        table = self._kv(entity)
+        with self._engine.begin() as conn:
+            conn.execute(
+                text(
+                    f"""
+                    INSERT INTO {table} (pk, sk, attributes, blob)
+                    VALUES (:pk, :sk, CAST(:attributes AS jsonb), :blob)
+                    ON CONFLICT (pk, sk)
+                    DO UPDATE SET attributes = EXCLUDED.attributes, blob = EXCLUDED.blob
+                    """
+                ),
+                {
+                    "pk": item.pk,
+                    "sk": item.sk,
+                    "attributes": canonical_json_dumps(item.attributes),
+                    "blob": item.blob,
+                },
+            )
+
+    def put_batch(self, entity: str, items: Sequence[StoreItem]) -> None:
+        for item in items:
+            validate_generic_write(entity, item)
+        table = self._kv(entity)
+        with self._engine.begin() as conn:
+            for item in items:
+                conn.execute(
+                    text(
+                        f"""
+                        INSERT INTO {table} (pk, sk, attributes, blob)
+                        VALUES (:pk, :sk, CAST(:attributes AS jsonb), :blob)
+                        ON CONFLICT (pk, sk)
+                        DO UPDATE SET attributes = EXCLUDED.attributes, blob = EXCLUDED.blob
+                        """
+                    ),
+                    {
+                        "pk": item.pk,
+                        "sk": item.sk,
+                        "attributes": canonical_json_dumps(item.attributes),
+                        "blob": item.blob,
+                    },
+                )
+
+    @staticmethod
+    def _row_to_item(row: Any) -> StoreItem:
+        attributes = row.attributes
+        if isinstance(attributes, str):  # psycopg2 may hand JSONB back parsed or raw
+            attributes = json.loads(attributes)
+        blob = bytes(row.blob) if row.blob is not None else None
+        return StoreItem(pk=row.pk, sk=row.sk, attributes=attributes, blob=blob)
+
+    def get(self, entity: str, pk: str, sk: str) -> Optional[StoreItem]:
+        table = self._kv(entity)
+        with self._engine.begin() as conn:
+            row = conn.execute(
+                text(f"SELECT pk, sk, attributes, blob FROM {table} WHERE pk = :pk AND sk = :sk"),
+                {"pk": pk, "sk": sk},
+            ).fetchone()
+        return self._row_to_item(row) if row else None
+
+    def query_prefix(self, entity: str, pk: str, sk_prefix: str = "") -> list[StoreItem]:
+        table = self._kv(entity)
+        with self._engine.begin() as conn:
+            rows = conn.execute(
+                text(
+                    f"""
+                    SELECT pk, sk, attributes, blob FROM {table}
+                    WHERE pk = :pk AND left(sk, :n) = :prefix
+                    ORDER BY sk COLLATE "C"
+                    """
+                ),
+                {"pk": pk, "n": len(sk_prefix), "prefix": sk_prefix},
+            ).fetchall()
+        return [self._row_to_item(row) for row in rows]
+
+    def query_between(self, entity: str, pk: str, sk_from: str, sk_to: str) -> list[StoreItem]:
+        table = self._kv(entity)
+        with self._engine.begin() as conn:
+            rows = conn.execute(
+                text(
+                    f"""
+                    SELECT pk, sk, attributes, blob FROM {table}
+                    WHERE pk = :pk AND sk >= :lo AND sk <= :hi
+                    ORDER BY sk COLLATE "C"
+                    """
+                ),
+                {"pk": pk, "lo": sk_from, "hi": sk_to},
+            ).fetchall()
+        return [self._row_to_item(row) for row in rows]
+
+    def delete_partition(self, entity: str, pk: str) -> int:
+        table = self._kv(entity)
+        with self._engine.begin() as conn:
+            result = conn.execute(text(f"DELETE FROM {table} WHERE pk = :pk"), {"pk": pk})
+        return result.rowcount or 0
+
+    # ---- runs / queue ----
+
+    @property
+    def _runs(self) -> str:
+        return f"{self.schema}.runs"
+
+    @property
+    def _latest(self) -> str:
+        return f"{self.schema}.latest"
+
+    def _run_params(self, run: RunManifest) -> dict[str, Any]:
+        return {
+            "job_id": run.job_id,
+            "status": run.status.value,
+            "claim_order": (
+                claim_order(run.priority, run.enqueued_at, run.job_id)
+                if run.status == RunStatus.QUEUED
+                else None
+            ),
+            "zid": run.zid,
+            "rid": run.rid,
+            "enqueued_at": run.enqueued_at,
+            "version": run.version,
+            "manifest": canonical_json_dumps(run.model_dump(mode="json")),
+        }
+
+    @staticmethod
+    def _manifest_from(value: Any) -> RunManifest:
+        if isinstance(value, str):
+            value = json.loads(value)
+        return RunManifest(**value)
+
+    def enqueue_run(self, run: RunManifest) -> None:
+        validate_enqueueable(run)
+        with self._engine.begin() as conn:
+            result = conn.execute(
+                text(
+                    f"""
+                    INSERT INTO {self._runs}
+                        (job_id, status, claim_order, zid, rid, enqueued_at, version, manifest)
+                    VALUES (:job_id, :status, :claim_order, :zid, :rid, :enqueued_at,
+                            :version, CAST(:manifest AS jsonb))
+                    ON CONFLICT (job_id) DO NOTHING
+                    """
+                ),
+                self._run_params(run),
+            )
+        if not result.rowcount:
+            raise AlreadyExists(f"run {run.job_id!r} already exists")
+
+    def get_run(self, job_id: str) -> Optional[RunManifest]:
+        with self._engine.begin() as conn:
+            row = conn.execute(
+                text(f"SELECT manifest FROM {self._runs} WHERE job_id = :job_id"),
+                {"job_id": job_id},
+            ).fetchone()
+        return self._manifest_from(row.manifest) if row else None
+
+    def _write_run(self, conn: Any, run: RunManifest, expected_version: int) -> bool:
+        params = self._run_params(run)
+        params["expected_version"] = expected_version
+        result = conn.execute(
+            text(
+                f"""
+                UPDATE {self._runs}
+                SET status = :status, claim_order = :claim_order, version = :version,
+                    manifest = CAST(:manifest AS jsonb)
+                WHERE job_id = :job_id AND version = :expected_version
+                """
+            ),
+            params,
+        )
+        return bool(result.rowcount)
+
+    def claim_next_run(
+        self, worker_id: str, lease_seconds: int, now: Optional[str] = None
+    ) -> Optional[RunManifest]:
+        now = validate_ts(now) if now is not None else now_ts()
+        with self._engine.begin() as conn:
+            row = conn.execute(
+                text(
+                    f"""
+                    SELECT manifest FROM {self._runs}
+                    WHERE status = 'QUEUED'
+                    ORDER BY claim_order COLLATE "C"
+                    LIMIT 1
+                    FOR UPDATE SKIP LOCKED
+                    """
+                )
+            ).fetchone()
+            if row is None:
+                return None
+            run = self._manifest_from(row.manifest)
+            claimed = run.model_copy(
+                update={
+                    "status": RunStatus.RUNNING,
+                    "worker_id": worker_id,
+                    "started_at": now,
+                    "lease_expires_at": ts_add_seconds(now, lease_seconds),
+                    "version": run.version + 1,
+                }
+            )
+            if not self._write_run(conn, claimed, expected_version=run.version):
+                raise StorageError(f"claim of {run.job_id!r} lost a race despite row lock")
+            return claimed
+
+    def extend_lease(
+        self, job_id: str, worker_id: str, lease_seconds: int, now: Optional[str] = None
+    ) -> bool:
+        now = validate_ts(now) if now is not None else now_ts()
+        with self._engine.begin() as conn:
+            row = conn.execute(
+                text(f"SELECT manifest FROM {self._runs} WHERE job_id = :job_id FOR UPDATE"),
+                {"job_id": job_id},
+            ).fetchone()
+            if row is None:
+                return False
+            run = self._manifest_from(row.manifest)
+            if run.status != RunStatus.RUNNING or run.worker_id != worker_id:
+                return False
+            extended = run.model_copy(
+                update={
+                    "lease_expires_at": ts_add_seconds(now, lease_seconds),
+                    "version": run.version + 1,
+                }
+            )
+            return self._write_run(conn, extended, expected_version=run.version)
+
+    def _mutate_run(self, job_id: str, mutate) -> RunManifest:
+        with self._engine.begin() as conn:
+            row = conn.execute(
+                text(f"SELECT manifest FROM {self._runs} WHERE job_id = :job_id FOR UPDATE"),
+                {"job_id": job_id},
+            ).fetchone()
+            if row is None:
+                raise NotFound(f"run {job_id!r} not found")
+            run = self._manifest_from(row.manifest)
+            updated = mutate(run).model_copy(update={"version": run.version + 1})
+            if not self._write_run(conn, updated, expected_version=run.version):
+                raise StorageError(f"update of {job_id!r} lost a race despite row lock")
+            return updated
+
+    def update_run_status(
+        self,
+        job_id: str,
+        status: Union[RunStatus, str],
+        error: Optional[str] = None,
+        now: Optional[str] = None,
+    ) -> RunManifest:
+        status = coerce_run_status(status)
+        now = validate_ts(now) if now is not None else now_ts()
+
+        def mutate(run: RunManifest) -> RunManifest:
+            updates: dict[str, Any] = {"status": status}
+            if error is not None:
+                updates["error"] = error
+            if status in TERMINAL_STATUSES and run.completed_at is None:
+                updates["completed_at"] = now
+            return run.model_copy(update=updates)
+
+        return self._mutate_run(job_id, mutate)
+
+    def merge_run_fields(self, job_id: str, fields: dict[str, Any]) -> RunManifest:
+        return self._mutate_run(job_id, lambda run: merge_manifest_fields(run, fields))
+
+    def _increment_log_seq(self, job_id: str) -> int:
+        with self._engine.begin() as conn:
+            row = conn.execute(
+                text(
+                    f"""
+                    UPDATE {self._runs}
+                    SET version = version + 1,
+                        manifest = jsonb_set(
+                            jsonb_set(manifest, '{{log_seq}}',
+                                to_jsonb(COALESCE((manifest->>'log_seq')::bigint, 0) + 1)),
+                            '{{version}}', to_jsonb(version + 1))
+                    WHERE job_id = :job_id
+                    RETURNING (manifest->>'log_seq')::bigint AS log_seq
+                    """
+                ),
+                {"job_id": job_id},
+            ).fetchone()
+        if row is None:
+            raise NotFound(f"run {job_id!r} not found")
+        return int(row.log_seq)
+
+    # ---- latest ----
+
+    def advance_latest(
+        self,
+        scope: str,
+        job_id: str,
+        job_type: Union[JobType, str],
+        only_if_absent_or_imported: bool = False,
+        now: Optional[str] = None,
+    ) -> AdvanceResult:
+        job_type = coerce_job_type(job_type)
+        now = validate_ts(now) if now is not None else now_ts()
+        for _ in range(_MUTATION_RETRIES):
+            with self._engine.begin() as conn:
+                row = conn.execute(
+                    text(f"SELECT * FROM {self._latest} WHERE scope = :scope FOR UPDATE"),
+                    {"scope": scope},
+                ).fetchone()
+                if row is not None:
+                    current = LatestPointer(
+                        scope=row.scope,
+                        job_id=row.job_id,
+                        seq=row.seq,
+                        job_type=row.job_type,
+                        updated_at=row.updated_at,
+                    )
+                    if current.job_id == job_id:
+                        return AdvanceResult(advanced=False, pointer=current)
+                    if only_if_absent_or_imported and current.job_type != JobType.IMPORTED:
+                        return AdvanceResult(advanced=False, pointer=current)
+                    pointer = LatestPointer(
+                        scope=scope,
+                        job_id=job_id,
+                        seq=current.seq + 1,
+                        job_type=job_type,
+                        updated_at=now,
+                    )
+                    conn.execute(
+                        text(
+                            f"""
+                            UPDATE {self._latest}
+                            SET job_id = :job_id, seq = :seq, job_type = :job_type,
+                                updated_at = :updated_at
+                            WHERE scope = :scope
+                            """
+                        ),
+                        pointer.model_dump(mode="json"),
+                    )
+                    return AdvanceResult(advanced=True, pointer=pointer)
+                pointer = LatestPointer(
+                    scope=scope, job_id=job_id, seq=1, job_type=job_type, updated_at=now
+                )
+                result = conn.execute(
+                    text(
+                        f"""
+                        INSERT INTO {self._latest} (scope, job_id, seq, job_type, updated_at)
+                        VALUES (:scope, :job_id, :seq, :job_type, :updated_at)
+                        ON CONFLICT (scope) DO NOTHING
+                        """
+                    ),
+                    pointer.model_dump(mode="json"),
+                )
+                if result.rowcount:
+                    return AdvanceResult(advanced=True, pointer=pointer)
+                # lost the empty-scope insert race — re-read and re-decide
+        raise StorageError(f"latest {scope!r}: lost {_MUTATION_RETRIES} insert races")
+
+    def get_latest(self, scope: str) -> Optional[LatestPointer]:
+        with self._engine.begin() as conn:
+            row = conn.execute(
+                text(f"SELECT * FROM {self._latest} WHERE scope = :scope"), {"scope": scope}
+            ).fetchone()
+        if row is None:
+            return None
+        return LatestPointer(
+            scope=row.scope,
+            job_id=row.job_id,
+            seq=row.seq,
+            job_type=row.job_type,
+            updated_at=row.updated_at,
+        )
+
+    def list_runs(
+        self,
+        zid: Optional[int] = None,
+        rid: Optional[int] = None,
+        status: Optional[Union[RunStatus, str]] = None,
+        limit: int = 100,
+    ) -> list[RunManifest]:
+        if (zid is None) == (rid is None):
+            raise Invalid("exactly one of zid/rid is required")
+        status = coerce_run_status(status) if status is not None else None
+        column, value = ("zid", zid) if zid is not None else ("rid", rid)
+        clauses = f"{column} = :value"
+        params: dict[str, Any] = {"value": value, "limit": limit}
+        if status is not None:
+            clauses += " AND status = :status"
+            params["status"] = status.value
+        with self._engine.begin() as conn:
+            rows = conn.execute(
+                text(
+                    f"""
+                    SELECT manifest FROM {self._runs}
+                    WHERE {clauses}
+                    ORDER BY enqueued_at DESC, job_id DESC
+                    LIMIT :limit
+                    """
+                ),
+                params,
+            ).fetchall()
+        return [self._manifest_from(row.manifest) for row in rows]

--- a/delphi/delphi_storage/codec.py
+++ b/delphi/delphi_storage/codec.py
@@ -1,0 +1,148 @@
+"""Wire codec for Delphi Storage V2 payloads.
+
+Cross-language contract (mirrored by server/src/storage/delphi/codec.ts and
+pinned by delphi_storage/conformance/cases/codec_*.json):
+
+- canonical JSON: sorted keys, compact separators, UTF-8, no NaN/Infinity;
+- packed floats: little-endian IEEE-754 float64;
+- compression: zstd frames (with content size);
+- payload envelopes: ``meta`` (JSON attributes) + optional binary ``blob``:
+    - ``{"enc": "json", "body": <value>}``            — inline, no blob
+    - ``{"enc": "json+zstd", "bytes", "sha256"}``     — blob = zstd(canonical JSON)
+    - ``{"enc": "f64+zstd", "count", "bytes", "sha256"}`` — blob = zstd(packed f64)
+  ``bytes``/``sha256`` describe the UNCOMPRESSED payload (compressed bytes are
+  never compared or hashed: zstd output varies across implementations).
+
+DynamoDB number helpers (``to_dynamo``/``from_dynamo``) follow the existing
+Decimal(str(x)) convention (polismath/database/dynamodb.py,
+umap_narrative .../utils/converter.py) — numbers round-trip by value.
+"""
+
+import hashlib
+import json
+import math
+import struct
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any, Optional, Sequence
+
+import zstandard
+
+#: Canonical-JSON bodies up to this many UTF-8 bytes are stored inline;
+#: larger ones are zstd-compressed into the blob.
+INLINE_LIMIT = 65536
+
+_ZSTD_LEVEL = 3
+
+
+def canonical_json_dumps(obj: Any) -> str:
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    )
+
+
+def pack_f64(values: Sequence[float]) -> bytes:
+    return struct.pack(f"<{len(values)}d", *values)
+
+
+def unpack_f64(data: bytes) -> list[float]:
+    if len(data) % 8:
+        raise ValueError(f"packed f64 length must be a multiple of 8, got {len(data)}")
+    return list(struct.unpack(f"<{len(data) // 8}d", data))
+
+
+def compress(data: bytes) -> bytes:
+    return zstandard.ZstdCompressor(level=_ZSTD_LEVEL).compress(data)
+
+
+def decompress(data: bytes) -> bytes:
+    return zstandard.ZstdDecompressor().decompress(data)
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass
+class F64:
+    """Marker wrapper: encode this payload as a packed float64 array."""
+
+    values: list[float] = field(default_factory=list)
+
+
+@dataclass
+class EncodedPayload:
+    meta: dict[str, Any]
+    blob: Optional[bytes]
+
+
+def encode_payload(value: Any, force: Optional[str] = None) -> EncodedPayload:
+    """Encode a payload for storage. ``force`` pins the encoding
+    ('json', 'json+zstd'); by default small JSON stays inline."""
+    if isinstance(value, F64):
+        packed = pack_f64(value.values)
+        return EncodedPayload(
+            meta={
+                "enc": "f64+zstd",
+                "count": len(value.values),
+                "bytes": len(packed),
+                "sha256": _sha256(packed),
+            },
+            blob=compress(packed),
+        )
+    raw = canonical_json_dumps(value).encode("utf-8")
+    if force == "json" or (force is None and len(raw) <= INLINE_LIMIT):
+        return EncodedPayload(meta={"enc": "json", "body": value}, blob=None)
+    if force not in (None, "json+zstd"):
+        raise ValueError(f"unknown forced encoding {force!r}")
+    return EncodedPayload(
+        meta={"enc": "json+zstd", "bytes": len(raw), "sha256": _sha256(raw)},
+        blob=compress(raw),
+    )
+
+
+def decode_payload(meta: dict[str, Any], blob: Optional[bytes]) -> Any:
+    enc = meta.get("enc")
+    if enc == "json":
+        return meta["body"]
+    if enc in ("json+zstd", "f64+zstd"):
+        if blob is None:
+            raise ValueError(f"encoding {enc} requires a blob")
+        raw = decompress(blob)
+        expected_sha = meta.get("sha256")
+        if expected_sha is not None and _sha256(raw) != expected_sha:
+            raise ValueError("payload sha256 mismatch — corrupt blob")
+        expected_bytes = meta.get("bytes")
+        if expected_bytes is not None and len(raw) != expected_bytes:
+            raise ValueError("payload length mismatch — corrupt blob")
+        if enc == "json+zstd":
+            return json.loads(raw.decode("utf-8"))
+        return unpack_f64(raw)
+    raise ValueError(f"unknown payload encoding {enc!r}")
+
+
+def to_dynamo(obj: Any) -> Any:
+    """Recursively convert floats to Decimal(str(x)) for DynamoDB writes."""
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, float):
+        if not math.isfinite(obj):
+            raise ValueError(f"non-finite float not storable: {obj!r}")
+        return Decimal(str(obj))
+    if isinstance(obj, dict):
+        return {k: to_dynamo(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [to_dynamo(v) for v in obj]
+    return obj
+
+
+def from_dynamo(obj: Any) -> Any:
+    """Recursively convert DynamoDB Decimals back to int/float by value."""
+    if isinstance(obj, Decimal):
+        as_int = int(obj)
+        return as_int if obj == as_int else float(obj)
+    if isinstance(obj, dict):
+        return {k: from_dynamo(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [from_dynamo(v) for v in obj]
+    return obj

--- a/delphi/delphi_storage/conformance/README.md
+++ b/delphi/delphi_storage/conformance/README.md
@@ -1,0 +1,186 @@
+# Delphi Storage V2 — Conformance Spec
+
+This directory is the **shared contract** between every implementation of the
+Delphi Storage V2 repository interface:
+
+- Python: `delphi/delphi_storage/` (backends: memory, DynamoDB, PostgreSQL)
+- TypeScript: `server/src/storage/delphi/` (same backends)
+
+Both test suites (pytest and jest) execute the **same** JSON case files in
+`cases/`. A backend passes conformance iff every case passes. The prose below
+is normative; the case files are executable examples of it.
+
+Design: `delphi/docs/STORAGE_V2_DESIGN.md` (§4.2 entities, §4.3 interface).
+
+## Data model
+
+Six logical entities:
+
+| entity | keying | written by |
+|---|---|---|
+| `runs` | `job_id` | semantic ops only (queue + manifest) |
+| `run_inputs` | `(pk=job_id, sk=kind#part)` | generic ops |
+| `artifacts` | `(pk=job_id, sk=artifact_key)` | generic ops + `append_log` |
+| `latest` | `scope` | `complete_run` / `advance_latest` only |
+| `topic_moderation` | `(pk, sk)` | generic ops |
+| `collective_statements` | `(pk, sk)` | generic ops |
+
+Generic ops accept only `run_inputs`, `artifacts`, `topic_moderation`,
+`collective_statements`. `runs` and `latest` are mutated exclusively through
+the semantic operations so their invariants cannot be bypassed.
+
+### StoreItem
+
+```
+{ pk: string, sk: string, attributes: JSON object, blob: bytes | null }
+```
+
+- `attributes` is a JSON-safe object. Top-level keys starting with `_` are
+  **reserved for backends** (e.g. chunk bookkeeping) and MUST be rejected on
+  write (`invalid`).
+- `sk` MUST NOT contain U+007F (reserved as the backend chunk-row marker) and
+  MUST be non-empty. `pk` MUST be non-empty.
+- `blob` is an opaque byte string. Backends MUST store and return it
+  bit-exactly. The DynamoDB backend transparently splits blobs larger than
+  300 000 bytes across chunk rows (sk prefixed with U+007F) and reassembles
+  them on read; chunk rows are invisible to every read operation.
+- Numbers inside `attributes` round-trip **by value**: a backend may return
+  `2` for a stored `2.0` (DynamoDB does); conformance compares numbers
+  numerically, everything else strictly. Non-finite floats (NaN/±Inf) are
+  rejected (`invalid`).
+
+### Ordering
+
+All sort-key ordering (query results, claim order) is **UTF-8 byte order**
+(equivalently: Unicode code-point order). This is DynamoDB's native range-key
+order; PostgreSQL queries must use `COLLATE "C"`; in-memory implementations
+must compare UTF-8 bytes (JavaScript: compare `Buffer`s, NOT UTF-16 string
+comparison — they differ for astral-plane characters).
+
+### Timestamps
+
+All timestamps are strings, exactly `YYYY-MM-DDTHH:MM:SS.mmmZ` (UTC,
+millisecond precision, 24 chars) so lexicographic order equals time order.
+Semantic ops take an optional explicit `now` (used by conformance cases);
+production omits it and the implementation uses the current time.
+
+### RunManifest
+
+Required on enqueue: `job_id`, `job_type` (`FULL_PIPELINE` | `NARRATIVE_BATCH`
+| `SERVER_NARRATIVE` | `IMPORTED`), `enqueued_at`. Optional with defaults:
+`status` (`QUEUED`), `priority` (0), `version` (0), `zid`, `rid`,
+`replay_of`, `provenance` (`pipeline`; `legacy` for imports), `replayable`
+(true), `imported_scope_type`, `math_tick_legacy`, `log_seq` (0), and the
+dict fields `config_requested`, `config_effective`, `code_version`, `seeds`,
+`input_fingerprints`, `stage_status`.
+
+Statuses: `QUEUED → RUNNING → COMPLETED | FAILED`. Every mutation increments
+`version` (optimistic lock; all backend mutations are conditional on the
+version they read).
+
+### Latest pointers
+
+`scope` strings are `zid#<zid>#<job_type>` or `rid#<rid>#<job_type>`.
+A pointer holds `{scope, job_id, seq, job_type, updated_at}`. `seq` is
+**monotonic per scope**, starting at 1, incremented by exactly 1 on every
+advance. Advancing to the job the pointer already references is a successful
+no-op (`advanced=false`, seq unchanged) — this makes `complete_run`
+idempotent and crash-healing.
+
+`advance_latest(..., only_if_absent_or_imported=true)` (the backfill
+importer's mode, design §6.2 invariant 1) refuses (`advanced=false`) unless
+the current pointer is absent or references an `IMPORTED` run.
+
+### Queue semantics
+
+- `enqueue_run` fails with `already_exists` for a duplicate `job_id`, and with
+  `invalid` when the manifest's status is not QUEUED or the job_type↔zid/rid
+  coupling is unsatisfiable (FULL_PIPELINE needs `zid`; NARRATIVE_BATCH and
+  SERVER_NARRATIVE need `rid`) — a run must never be able to complete and then
+  fail to derive its latest scopes.
+- `claim_next_run` picks the QUEUED run with the smallest **claim order**
+  string `f"{9999 - clamp(priority, 0, 9999):04d}#{enqueued_at}#{job_id}"`
+  (i.e. highest priority first, then FIFO, then job_id as tiebreak), flips it
+  to RUNNING with `worker_id`, `started_at=now`,
+  `lease_expires_at = now + lease_seconds`, and returns the manifest; returns
+  null when nothing is claimable. Two claimants can never claim the same run
+  (conditional write on `version`; losers move to the next candidate).
+- `extend_lease` succeeds only if the run is RUNNING and `worker_id` matches.
+- `update_run_status` sets FAILED/RUNNING etc. without touching `latest`.
+- `merge_run_fields` shallow-merges manifest dict/provenance fields.
+- `complete_run` on a QUEUED/RUNNING run sets COMPLETED (+`completed_at`),
+  then advances `latest` for every scope derived from the run
+  (FULL_PIPELINE → `zid#<zid>#FULL_PIPELINE`; NARRATIVE_BATCH /
+  SERVER_NARRATIVE → `rid#<rid>#<job_type>`; IMPORTED → no automatic flip).
+  Latest is written **after** the manifest flips COMPLETED (design §4.2:
+  the pointer is the commit point). Calling it again is a no-op returning the
+  same state (seq does not advance twice). Completing a FAILED run is
+  `invalid`.
+- `append_log` appends `artifacts` items `sk = log#<seq zero-padded to 8>`
+  with `{ts, message}` attributes, allocating seq atomically per job (1-based).
+- `list_runs(zid=… | rid=…)` returns manifests newest-first by
+  `enqueued_at` (then job_id descending as tiebreak).
+
+## Case file format
+
+Each `cases/*.json`:
+
+```json
+{ "name": "...", "description": "...", "ops": [ <op>, ... ] }
+```
+
+Ops execute in order against a fresh, empty store. Every op object has `"op"`
+plus arguments; assertions live in `"expect"`. An op with `"expect_error": E`
+(op-level, instead of `expect`) MUST fail with that error class
+(`already_exists`, `not_found`, `invalid`); any other outcome fails the case.
+(`expect.error` inside a manifest expectation is the manifest's `error`
+field, e.g. after `update_run_status(FAILED, error=...)`.)
+
+Generic ops (arguments mirror the interface exactly):
+
+- `put`: `{entity, item}` where item = `{pk, sk, attributes, blob_b64?, blob_gen?}`.
+  `blob_b64` is base64; `blob_gen` generates deterministic bytes:
+  `{"kind": "f64_seq", "n": N}` = the little-endian IEEE-754 float64 packing
+  of `[0.0, 0.5, 1.0, ...]` (`i * 0.5` for i in `0..N-1`).
+- `put_batch`: `{entity, items: [...]}`
+- `get`: `{entity, pk, sk, expect: {found, attributes?, blob_b64?, blob_gen?, blob_len?}}`
+- `query_prefix`: `{entity, pk, sk_prefix, expect: {sks: [...]}}` (full result
+  list, in order)
+- `query_between`: `{entity, pk, sk_from, sk_to, expect: {sks: [...]}}`
+  (inclusive bounds)
+- `delete_partition`: `{entity, pk, expect: {deleted: N}}` (N = logical items)
+
+Semantic ops:
+
+- `enqueue_run`: `{run: {<manifest fields>}}`
+- `get_run`: `{job_id, expect: {found, <manifest field subset>}}`
+- `claim_next_run`: `{worker_id, lease_seconds, now, expect: {job_id: J | null, lease_expires_at?}}`
+- `extend_lease`: `{job_id, worker_id, lease_seconds, now, expect: {ok}}`
+- `update_run_status`: `{job_id, status, error?, now, expect?: {<subset>}}`
+- `merge_run_fields`: `{job_id, fields, expect?: {<subset>}}`
+- `complete_run`: `{job_id, now, expect: {status, latest: [{scope, job_id, seq}]}}`
+  (`latest` lists the expected post-state of every scope the run flips;
+  empty list = no flips)
+- `append_log`: `{job_id, message, now, expect: {seq}}`
+- `get_latest`: `{scope, expect: {found, job_id?, seq?, job_type?}}`
+- `advance_latest`: `{scope, job_id, job_type, only_if_absent_or_imported?, now, expect: {advanced, seq}}`
+- `list_runs`: `{zid? , rid?, status?, expect: {job_ids: [...]}}`
+
+`expect` subset-matching for manifests: every listed key must equal the
+manifest's value (numbers numerically); unlisted keys are unchecked.
+
+## Codec fixtures
+
+`cases/codec_*.json` files carry pre-encoded payload envelopes (see
+`codec.py` / `codec.ts`): ops
+
+- `codec_roundtrip`: `{value}` — `decode(encode(value)) == value`, for each
+  encoding the implementation would choose.
+- `codec_decode_fixture`: `{meta, blob_b64, expect_value}` — a blob encoded by
+  the *other* language (committed once, generated by Python) MUST decode to
+  `expect_value`. This pins the cross-language wire format: envelope `meta`
+  (`enc` ∈ `json`, `json+zstd`, `f64+zstd`), zstd frames, little-endian f64.
+
+Compressed bytes are NEVER compared or hashed (zstd output varies by
+implementation/level); only decoded payloads and uncompressed byte streams
+are.

--- a/delphi/delphi_storage/conformance/cases/blob_chunking.json
+++ b/delphi/delphi_storage/conformance/cases/blob_chunking.json
@@ -1,0 +1,82 @@
+{
+  "name": "blob_chunking",
+  "description": "large blobs round-trip bit-exactly (DynamoDB splits >300KB into hidden chunk rows); queries and delete see only logical items",
+  "ops": [
+    {
+      "op": "put",
+      "entity": "run_inputs",
+      "item": {
+        "pk": "job-blob-1",
+        "sk": "votes#0",
+        "attributes": {"kind": "votes", "count": 150000},
+        "blob_gen": {"kind": "f64_seq", "n": 150000}
+      }
+    },
+    {
+      "op": "put",
+      "entity": "run_inputs",
+      "item": {
+        "pk": "job-blob-1",
+        "sk": "comments#0",
+        "attributes": {"kind": "comments"},
+        "blob_b64": "eyJzbWFsbCI6IHRydWV9"
+      }
+    },
+    {
+      "op": "get",
+      "entity": "run_inputs",
+      "pk": "job-blob-1",
+      "sk": "votes#0",
+      "expect": {
+        "found": true,
+        "attributes": {"kind": "votes", "count": 150000},
+        "blob_gen": {"kind": "f64_seq", "n": 150000},
+        "blob_len": 1200000
+      }
+    },
+    {
+      "op": "get",
+      "entity": "run_inputs",
+      "pk": "job-blob-1",
+      "sk": "comments#0",
+      "expect": {"found": true, "blob_b64": "eyJzbWFsbCI6IHRydWV9", "blob_len": 15}
+    },
+    {
+      "op": "query_prefix",
+      "entity": "run_inputs",
+      "pk": "job-blob-1",
+      "sk_prefix": "",
+      "expect": {"sks": ["comments#0", "votes#0"]}
+    },
+    {
+      "op": "put",
+      "entity": "run_inputs",
+      "item": {
+        "pk": "job-blob-1",
+        "sk": "votes#0",
+        "attributes": {"kind": "votes", "count": 3},
+        "blob_gen": {"kind": "f64_seq", "n": 3}
+      }
+    },
+    {
+      "op": "get",
+      "entity": "run_inputs",
+      "pk": "job-blob-1",
+      "sk": "votes#0",
+      "expect": {
+        "found": true,
+        "attributes": {"kind": "votes", "count": 3},
+        "blob_gen": {"kind": "f64_seq", "n": 3},
+        "blob_len": 24
+      }
+    },
+    {"op": "delete_partition", "entity": "run_inputs", "pk": "job-blob-1", "expect": {"deleted": 2}},
+    {
+      "op": "query_prefix",
+      "entity": "run_inputs",
+      "pk": "job-blob-1",
+      "sk_prefix": "",
+      "expect": {"sks": []}
+    }
+  ]
+}

--- a/delphi/delphi_storage/conformance/cases/codec_fixtures.json
+++ b/delphi/delphi_storage/conformance/cases/codec_fixtures.json
@@ -1,0 +1,108 @@
+{
+  "name": "codec_fixtures",
+  "description": "cross-language payload envelopes: Python-encoded blobs decoded by both runners + self round-trips",
+  "ops": [
+    {
+      "op": "codec_decode_fixture",
+      "meta": {
+        "enc": "json",
+        "body": {
+          "unicode": "café 😀",
+          "nums": [
+            0.1,
+            1,
+            true,
+            null
+          ]
+        }
+      },
+      "blob_b64": null,
+      "expect_value": {
+        "unicode": "café 😀",
+        "nums": [
+          0.1,
+          1,
+          true,
+          null
+        ]
+      }
+    },
+    {
+      "op": "codec_decode_fixture",
+      "meta": {
+        "enc": "json+zstd",
+        "bytes": 102,
+        "sha256": "53a6b9d79b865c32df34342a558c49038e823f219a4dad84dc5b97cc6c8451ea"
+      },
+      "blob_b64": "KLUv/SBm9QIARAV7Imdyb3VwcyI6W3siY2VudGVyIjpbMC4xMjUsLTIuNV0sImlkIjowfSwxZS0wOSwzLjAxfV0sImxhYmVsIjoi5pel5pys6KqeINep15zXldedIn0CAEHlI2GoMg==",
+      "expect_value": {
+        "groups": [
+          {
+            "id": 0,
+            "center": [
+              0.125,
+              -2.5
+            ]
+          },
+          {
+            "id": 1,
+            "center": [
+              1e-09,
+              3.0
+            ]
+          }
+        ],
+        "label": "日本語 שלום"
+      }
+    },
+    {
+      "op": "codec_decode_fixture",
+      "meta": {
+        "enc": "f64+zstd",
+        "count": 7,
+        "bytes": 56,
+        "sha256": "b21fc984ed5a6d087227f3cbbb705b36c5778b2dcd46febcca7d6be3a6b2395e"
+      },
+      "blob_b64": "KLUv/SA4PQEA2AAA4D8A8ALAnHUAiDzkN34BAACamZmZmZm5PwQAM4WvJAOt40Ab",
+      "expect_value": [
+        0.0,
+        0.5,
+        1.0,
+        -2.25,
+        1e+300,
+        5e-324,
+        0.1
+      ]
+    },
+    {
+      "op": "codec_roundtrip",
+      "value": {
+        "nested": {
+          "a": [
+            1,
+            2.5
+          ],
+          "b": "text"
+        },
+        "n": null
+      }
+    },
+    {
+      "op": "codec_roundtrip",
+      "value": [
+        0.1,
+        0.2,
+        0.3,
+        1e-09,
+        12345.678
+      ]
+    },
+    {
+      "op": "codec_roundtrip",
+      "value": {
+        "unicode": "émile — 😀 — ~",
+        "empty": {}
+      }
+    }
+  ]
+}

--- a/delphi/delphi_storage/conformance/cases/latest_pointer.json
+++ b/delphi/delphi_storage/conformance/cases/latest_pointer.json
@@ -1,0 +1,160 @@
+{
+  "name": "latest_pointer",
+  "description": "monotonic seq per scope, idempotent completion, importer no-clobber invariant (design §6.2 invariant 1), rid scopes",
+  "ops": [
+    {"op": "get_latest", "scope": "zid#5#FULL_PIPELINE", "expect": {"found": false}},
+    {
+      "op": "enqueue_run",
+      "run": {"job_id": "r1", "job_type": "FULL_PIPELINE", "zid": 5, "enqueued_at": "2026-07-06T09:00:00.000Z"}
+    },
+    {
+      "op": "claim_next_run",
+      "worker_id": "w1",
+      "lease_seconds": 300,
+      "now": "2026-07-06T09:01:00.000Z",
+      "expect": {"job_id": "r1"}
+    },
+    {
+      "op": "complete_run",
+      "job_id": "r1",
+      "now": "2026-07-06T09:02:00.000Z",
+      "expect": {
+        "status": "COMPLETED",
+        "latest": [{"scope": "zid#5#FULL_PIPELINE", "job_id": "r1", "seq": 1}]
+      }
+    },
+    {
+      "op": "get_latest",
+      "scope": "zid#5#FULL_PIPELINE",
+      "expect": {"found": true, "job_id": "r1", "seq": 1, "job_type": "FULL_PIPELINE"}
+    },
+    {
+      "op": "complete_run",
+      "job_id": "r1",
+      "now": "2026-07-06T09:03:00.000Z",
+      "expect": {
+        "status": "COMPLETED",
+        "latest": [{"scope": "zid#5#FULL_PIPELINE", "job_id": "r1", "seq": 1}]
+      }
+    },
+    {
+      "op": "enqueue_run",
+      "run": {"job_id": "r2", "job_type": "FULL_PIPELINE", "zid": 5, "enqueued_at": "2026-07-06T09:10:00.000Z"}
+    },
+    {
+      "op": "claim_next_run",
+      "worker_id": "w1",
+      "lease_seconds": 300,
+      "now": "2026-07-06T09:11:00.000Z",
+      "expect": {"job_id": "r2"}
+    },
+    {
+      "op": "complete_run",
+      "job_id": "r2",
+      "now": "2026-07-06T09:12:00.000Z",
+      "expect": {
+        "status": "COMPLETED",
+        "latest": [{"scope": "zid#5#FULL_PIPELINE", "job_id": "r2", "seq": 2}]
+      }
+    },
+    {
+      "op": "advance_latest",
+      "scope": "zid#5#FULL_PIPELINE",
+      "job_id": "imp1",
+      "job_type": "IMPORTED",
+      "only_if_absent_or_imported": true,
+      "now": "2026-07-06T09:13:00.000Z",
+      "expect": {"advanced": false, "seq": 2}
+    },
+    {
+      "op": "get_latest",
+      "scope": "zid#5#FULL_PIPELINE",
+      "expect": {"found": true, "job_id": "r2", "seq": 2}
+    },
+    {
+      "op": "advance_latest",
+      "scope": "zid#6#FULL_PIPELINE",
+      "job_id": "imp2",
+      "job_type": "IMPORTED",
+      "only_if_absent_or_imported": true,
+      "now": "2026-07-06T09:14:00.000Z",
+      "expect": {"advanced": true, "seq": 1}
+    },
+    {
+      "op": "advance_latest",
+      "scope": "zid#6#FULL_PIPELINE",
+      "job_id": "imp3",
+      "job_type": "IMPORTED",
+      "only_if_absent_or_imported": true,
+      "now": "2026-07-06T09:15:00.000Z",
+      "expect": {"advanced": true, "seq": 2}
+    },
+    {
+      "op": "get_latest",
+      "scope": "zid#6#FULL_PIPELINE",
+      "expect": {"found": true, "job_id": "imp3", "seq": 2, "job_type": "IMPORTED"}
+    },
+    {
+      "op": "enqueue_run",
+      "run": {"job_id": "r3", "job_type": "FULL_PIPELINE", "zid": 6, "enqueued_at": "2026-07-06T09:20:00.000Z"}
+    },
+    {
+      "op": "claim_next_run",
+      "worker_id": "w1",
+      "lease_seconds": 300,
+      "now": "2026-07-06T09:21:00.000Z",
+      "expect": {"job_id": "r3"}
+    },
+    {
+      "op": "complete_run",
+      "job_id": "r3",
+      "now": "2026-07-06T09:22:00.000Z",
+      "expect": {
+        "status": "COMPLETED",
+        "latest": [{"scope": "zid#6#FULL_PIPELINE", "job_id": "r3", "seq": 3}]
+      }
+    },
+    {
+      "op": "advance_latest",
+      "scope": "zid#6#FULL_PIPELINE",
+      "job_id": "imp4",
+      "job_type": "IMPORTED",
+      "only_if_absent_or_imported": true,
+      "now": "2026-07-06T09:23:00.000Z",
+      "expect": {"advanced": false, "seq": 3}
+    },
+    {
+      "op": "advance_latest",
+      "scope": "zid#6#FULL_PIPELINE",
+      "job_id": "r3",
+      "job_type": "FULL_PIPELINE",
+      "now": "2026-07-06T09:24:00.000Z",
+      "expect": {"advanced": false, "seq": 3}
+    },
+    {
+      "op": "enqueue_run",
+      "run": {"job_id": "n1", "job_type": "NARRATIVE_BATCH", "zid": 5, "rid": 42, "enqueued_at": "2026-07-06T09:30:00.000Z"}
+    },
+    {
+      "op": "claim_next_run",
+      "worker_id": "w1",
+      "lease_seconds": 300,
+      "now": "2026-07-06T09:31:00.000Z",
+      "expect": {"job_id": "n1"}
+    },
+    {
+      "op": "complete_run",
+      "job_id": "n1",
+      "now": "2026-07-06T09:32:00.000Z",
+      "expect": {
+        "status": "COMPLETED",
+        "latest": [{"scope": "rid#42#NARRATIVE_BATCH", "job_id": "n1", "seq": 1}]
+      }
+    },
+    {
+      "op": "get_latest",
+      "scope": "zid#5#FULL_PIPELINE",
+      "expect": {"found": true, "job_id": "r2", "seq": 2}
+    }
+  ]
+}

--- a/delphi/delphi_storage/conformance/cases/query_ordering.json
+++ b/delphi/delphi_storage/conformance/cases/query_ordering.json
@@ -1,0 +1,74 @@
+{
+  "name": "query_ordering",
+  "description": "prefix/between queries return UTF-8 byte order (astral plane sorts after U+FFFD); delete_partition",
+  "ops": [
+    {"op": "put", "entity": "artifacts", "item": {"pk": "job-q-1", "sk": "b", "attributes": {"i": 4}}},
+    {"op": "put", "entity": "artifacts", "item": {"pk": "job-q-1", "sk": "😀", "attributes": {"i": 7}}},
+    {"op": "put", "entity": "artifacts", "item": {"pk": "job-q-1", "sk": "a#2", "attributes": {"i": 3}}},
+    {"op": "put", "entity": "artifacts", "item": {"pk": "job-q-1", "sk": "a", "attributes": {"i": 1}}},
+    {"op": "put", "entity": "artifacts", "item": {"pk": "job-q-1", "sk": "�", "attributes": {"i": 6}}},
+    {"op": "put", "entity": "artifacts", "item": {"pk": "job-q-1", "sk": "a#1", "attributes": {"i": 2}}},
+    {"op": "put", "entity": "artifacts", "item": {"pk": "job-q-1", "sk": "émile", "attributes": {"i": 5}}},
+    {"op": "put", "entity": "artifacts", "item": {"pk": "job-q-other", "sk": "a", "attributes": {"i": 99}}},
+    {
+      "op": "query_prefix",
+      "entity": "artifacts",
+      "pk": "job-q-1",
+      "sk_prefix": "",
+      "expect": {"sks": ["a", "a#1", "a#2", "b", "émile", "�", "😀"]}
+    },
+    {
+      "op": "query_prefix",
+      "entity": "artifacts",
+      "pk": "job-q-1",
+      "sk_prefix": "a#",
+      "expect": {"sks": ["a#1", "a#2"]}
+    },
+    {
+      "op": "query_prefix",
+      "entity": "artifacts",
+      "pk": "job-q-1",
+      "sk_prefix": "nope",
+      "expect": {"sks": []}
+    },
+    {
+      "op": "query_prefix",
+      "entity": "artifacts",
+      "pk": "job-q-missing",
+      "sk_prefix": "",
+      "expect": {"sks": []}
+    },
+    {
+      "op": "query_between",
+      "entity": "artifacts",
+      "pk": "job-q-1",
+      "sk_from": "a#1",
+      "sk_to": "b",
+      "expect": {"sks": ["a#1", "a#2", "b"]}
+    },
+    {
+      "op": "query_between",
+      "entity": "artifacts",
+      "pk": "job-q-1",
+      "sk_from": "b",
+      "sk_to": "😀",
+      "expect": {"sks": ["b", "émile", "�", "😀"]}
+    },
+    {"op": "delete_partition", "entity": "artifacts", "pk": "job-q-1", "expect": {"deleted": 7}},
+    {
+      "op": "query_prefix",
+      "entity": "artifacts",
+      "pk": "job-q-1",
+      "sk_prefix": "",
+      "expect": {"sks": []}
+    },
+    {
+      "op": "get",
+      "entity": "artifacts",
+      "pk": "job-q-other",
+      "sk": "a",
+      "expect": {"found": true, "attributes": {"i": 99}}
+    },
+    {"op": "delete_partition", "entity": "artifacts", "pk": "job-q-1", "expect": {"deleted": 0}}
+  ]
+}

--- a/delphi/delphi_storage/conformance/cases/queue_claim.json
+++ b/delphi/delphi_storage/conformance/cases/queue_claim.json
@@ -1,0 +1,233 @@
+{
+  "name": "queue_claim",
+  "description": "claim ordering (priority desc, then FIFO), leases, duplicate enqueue, failure path, list_runs",
+  "ops": [
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "jobA",
+        "job_type": "FULL_PIPELINE",
+        "zid": 7,
+        "priority": 0,
+        "enqueued_at": "2026-07-06T10:00:00.000Z"
+      }
+    },
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "jobB",
+        "job_type": "FULL_PIPELINE",
+        "zid": 7,
+        "priority": 5,
+        "enqueued_at": "2026-07-06T10:00:01.000Z"
+      }
+    },
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "jobC",
+        "job_type": "FULL_PIPELINE",
+        "zid": 7,
+        "priority": 0,
+        "enqueued_at": "2026-07-06T10:00:00.500Z"
+      }
+    },
+    {
+      "op": "get_run",
+      "job_id": "jobA",
+      "expect": {
+        "found": true,
+        "status": "QUEUED",
+        "version": 0,
+        "priority": 0,
+        "zid": 7
+      }
+    },
+    {
+      "op": "get_run",
+      "job_id": "missing",
+      "expect": {
+        "found": false
+      }
+    },
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "jobA",
+        "job_type": "FULL_PIPELINE",
+        "zid": 7,
+        "enqueued_at": "2026-07-06T10:00:02.000Z"
+      },
+      "expect_error": "already_exists"
+    },
+    {
+      "op": "claim_next_run",
+      "worker_id": "w1",
+      "lease_seconds": 300,
+      "now": "2026-07-06T10:01:00.000Z",
+      "expect": {
+        "job_id": "jobB",
+        "lease_expires_at": "2026-07-06T10:06:00.000Z"
+      }
+    },
+    {
+      "op": "claim_next_run",
+      "worker_id": "w2",
+      "lease_seconds": 300,
+      "now": "2026-07-06T10:01:01.000Z",
+      "expect": {
+        "job_id": "jobA"
+      }
+    },
+    {
+      "op": "get_run",
+      "job_id": "jobB",
+      "expect": {
+        "found": true,
+        "status": "RUNNING",
+        "worker_id": "w1",
+        "started_at": "2026-07-06T10:01:00.000Z"
+      }
+    },
+    {
+      "op": "extend_lease",
+      "job_id": "jobB",
+      "worker_id": "w2",
+      "lease_seconds": 300,
+      "now": "2026-07-06T10:02:00.000Z",
+      "expect": {
+        "ok": false
+      }
+    },
+    {
+      "op": "extend_lease",
+      "job_id": "jobB",
+      "worker_id": "w1",
+      "lease_seconds": 300,
+      "now": "2026-07-06T10:02:00.000Z",
+      "expect": {
+        "ok": true
+      }
+    },
+    {
+      "op": "get_run",
+      "job_id": "jobB",
+      "expect": {
+        "found": true,
+        "lease_expires_at": "2026-07-06T10:07:00.000Z"
+      }
+    },
+    {
+      "op": "extend_lease",
+      "job_id": "missing",
+      "worker_id": "w1",
+      "lease_seconds": 300,
+      "now": "2026-07-06T10:02:00.000Z",
+      "expect": {
+        "ok": false
+      }
+    },
+    {
+      "op": "claim_next_run",
+      "worker_id": "w3",
+      "lease_seconds": 60,
+      "now": "2026-07-06T10:01:02.000Z",
+      "expect": {
+        "job_id": "jobC"
+      }
+    },
+    {
+      "op": "claim_next_run",
+      "worker_id": "w4",
+      "lease_seconds": 60,
+      "now": "2026-07-06T10:01:03.000Z",
+      "expect": {
+        "job_id": null
+      }
+    },
+    {
+      "op": "update_run_status",
+      "job_id": "jobC",
+      "status": "FAILED",
+      "error": "boom",
+      "now": "2026-07-06T10:03:00.000Z",
+      "expect": {
+        "status": "FAILED",
+        "error": "boom",
+        "completed_at": "2026-07-06T10:03:00.000Z"
+      }
+    },
+    {
+      "op": "update_run_status",
+      "job_id": "missing",
+      "status": "FAILED",
+      "now": "2026-07-06T10:03:00.000Z",
+      "expect_error": "not_found"
+    },
+    {
+      "op": "complete_run",
+      "job_id": "jobC",
+      "now": "2026-07-06T10:04:00.000Z",
+      "expect_error": "invalid"
+    },
+    {
+      "op": "extend_lease",
+      "job_id": "jobC",
+      "worker_id": "w3",
+      "lease_seconds": 60,
+      "now": "2026-07-06T10:04:00.000Z",
+      "expect": {
+        "ok": false
+      }
+    },
+    {
+      "op": "complete_run",
+      "job_id": "jobA",
+      "now": "2026-07-06T10:05:00.000Z",
+      "expect": {
+        "status": "COMPLETED",
+        "latest": [
+          {
+            "scope": "zid#7#FULL_PIPELINE",
+            "job_id": "jobA",
+            "seq": 1
+          }
+        ]
+      }
+    },
+    {
+      "op": "complete_run",
+      "job_id": "missing",
+      "now": "2026-07-06T10:05:00.000Z",
+      "expect_error": "not_found"
+    },
+    {
+      "op": "list_runs",
+      "zid": 7,
+      "expect": {
+        "job_ids": [
+          "jobB",
+          "jobC",
+          "jobA"
+        ]
+      }
+    },
+    {
+      "op": "list_runs",
+      "zid": 7,
+      "status": "FAILED",
+      "expect": {
+        "job_ids": [
+          "jobC"
+        ]
+      }
+    },
+    {
+      "op": "list_runs",
+      "zid": 999,
+      "expect": {
+        "job_ids": []
+      }
+    }
+  ]
+}

--- a/delphi/delphi_storage/conformance/cases/roundtrip_basic.json
+++ b/delphi/delphi_storage/conformance/cases/roundtrip_basic.json
@@ -1,0 +1,124 @@
+{
+  "name": "roundtrip_basic",
+  "description": "put/get round-trips: unicode, nesting, numbers by value, nulls, empty containers, overwrite",
+  "ops": [
+    {
+      "op": "put",
+      "entity": "artifacts",
+      "item": {
+        "pk": "job-rt-1",
+        "sk": "math#pca",
+        "attributes": {
+          "enc": "json",
+          "body": {
+            "unicode": "café 日本語 שלום 😀",
+            "nested": {"a": [1, 2, 3], "b": {"deep": true}},
+            "int": 42,
+            "float": 0.1,
+            "negative": -2.25,
+            "tiny": 1e-09,
+            "big_int": 9007199254740991,
+            "zero": 0,
+            "bool_f": false,
+            "null_v": null,
+            "empty_str": "",
+            "empty_list": [],
+            "empty_obj": {}
+          }
+        }
+      }
+    },
+    {
+      "op": "get",
+      "entity": "artifacts",
+      "pk": "job-rt-1",
+      "sk": "math#pca",
+      "expect": {
+        "found": true,
+        "attributes": {
+          "enc": "json",
+          "body": {
+            "unicode": "café 日本語 שלום 😀",
+            "nested": {"a": [1, 2, 3], "b": {"deep": true}},
+            "int": 42,
+            "float": 0.1,
+            "negative": -2.25,
+            "tiny": 1e-09,
+            "big_int": 9007199254740991,
+            "zero": 0,
+            "bool_f": false,
+            "null_v": null,
+            "empty_str": "",
+            "empty_list": [],
+            "empty_obj": {}
+          }
+        }
+      }
+    },
+    {
+      "op": "get",
+      "entity": "artifacts",
+      "pk": "job-rt-1",
+      "sk": "does#not#exist",
+      "expect": {"found": false}
+    },
+    {
+      "op": "get",
+      "entity": "run_inputs",
+      "pk": "job-rt-1",
+      "sk": "math#pca",
+      "expect": {"found": false}
+    },
+    {
+      "op": "put",
+      "entity": "artifacts",
+      "item": {
+        "pk": "job-rt-1",
+        "sk": "math#pca",
+        "attributes": {"enc": "json", "body": {"overwritten": true}}
+      }
+    },
+    {
+      "op": "get",
+      "entity": "artifacts",
+      "pk": "job-rt-1",
+      "sk": "math#pca",
+      "expect": {
+        "found": true,
+        "attributes": {"enc": "json", "body": {"overwritten": true}}
+      }
+    },
+    {
+      "op": "put",
+      "entity": "run_inputs",
+      "item": {
+        "pk": "job-rt-1",
+        "sk": "votes#0",
+        "attributes": {"rows": 3},
+        "blob_b64": "AAECA/8="
+      }
+    },
+    {
+      "op": "get",
+      "entity": "run_inputs",
+      "pk": "job-rt-1",
+      "sk": "votes#0",
+      "expect": {"found": true, "attributes": {"rows": 3}, "blob_b64": "AAECA/8=", "blob_len": 5}
+    },
+    {
+      "op": "put_batch",
+      "entity": "topic_moderation",
+      "items": [
+        {"pk": "zid#7", "sk": "topic#0#1", "attributes": {"status": "approved"}},
+        {"pk": "zid#7", "sk": "topic#0#2", "attributes": {"status": "rejected"}}
+      ]
+    },
+    {
+      "op": "get",
+      "entity": "topic_moderation",
+      "pk": "zid#7",
+      "sk": "topic#0#2",
+      "expect": {"found": true, "attributes": {"status": "rejected"}}
+    }
+  ]
+}

--- a/delphi/delphi_storage/conformance/cases/run_manifest_fields.json
+++ b/delphi/delphi_storage/conformance/cases/run_manifest_fields.json
@@ -1,0 +1,253 @@
+{
+  "name": "run_manifest_fields",
+  "description": "merge_run_fields accumulates manifest provenance; append_log allocates ordered seqs as artifacts",
+  "ops": [
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "j1",
+        "job_type": "FULL_PIPELINE",
+        "zid": 9,
+        "enqueued_at": "2026-07-06T11:00:00.000Z",
+        "config_requested": {
+          "umap": {
+            "n_neighbors": 15
+          }
+        }
+      }
+    },
+    {
+      "op": "claim_next_run",
+      "worker_id": "w1",
+      "lease_seconds": 300,
+      "now": "2026-07-06T11:01:00.000Z",
+      "expect": {
+        "job_id": "j1"
+      }
+    },
+    {
+      "op": "merge_run_fields",
+      "job_id": "j1",
+      "fields": {
+        "seeds": {
+          "umap": 42,
+          "kmeans": 42
+        },
+        "config_effective": {
+          "umap": {
+            "n_neighbors": 15,
+            "min_dist": 0.1
+          }
+        }
+      }
+    },
+    {
+      "op": "merge_run_fields",
+      "job_id": "j1",
+      "fields": {
+        "code_version": {
+          "git_sha": "abc123"
+        },
+        "input_fingerprints": {
+          "votes": {
+            "sha256": "deadbeef",
+            "rows": 100
+          }
+        }
+      }
+    },
+    {
+      "op": "merge_run_fields",
+      "job_id": "j1",
+      "fields": {
+        "math_tick_legacy": 25042,
+        "replayable": false,
+        "provenance": "legacy",
+        "replay_of": "orig-1"
+      }
+    },
+    {
+      "op": "get_run",
+      "job_id": "j1",
+      "expect": {
+        "found": true,
+        "math_tick_legacy": 25042,
+        "replayable": false,
+        "provenance": "legacy",
+        "replay_of": "orig-1"
+      }
+    },
+    {
+      "op": "merge_run_fields",
+      "job_id": "j1",
+      "fields": {
+        "job_id": "nope"
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "merge_run_fields",
+      "job_id": "j1",
+      "fields": {
+        "seeds": "not-a-dict"
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "get_run",
+      "job_id": "j1",
+      "expect": {
+        "found": true,
+        "status": "RUNNING",
+        "seeds": {
+          "umap": 42,
+          "kmeans": 42
+        },
+        "config_effective": {
+          "umap": {
+            "n_neighbors": 15,
+            "min_dist": 0.1
+          }
+        },
+        "code_version": {
+          "git_sha": "abc123"
+        },
+        "input_fingerprints": {
+          "votes": {
+            "sha256": "deadbeef",
+            "rows": 100
+          }
+        },
+        "config_requested": {
+          "umap": {
+            "n_neighbors": 15
+          }
+        }
+      }
+    },
+    {
+      "op": "merge_run_fields",
+      "job_id": "missing",
+      "fields": {
+        "seeds": {}
+      },
+      "expect_error": "not_found"
+    },
+    {
+      "op": "append_log",
+      "job_id": "j1",
+      "message": "stage math started",
+      "now": "2026-07-06T11:02:00.000Z",
+      "expect": {
+        "seq": 1
+      }
+    },
+    {
+      "op": "append_log",
+      "job_id": "j1",
+      "message": "stage math done",
+      "now": "2026-07-06T11:03:00.000Z",
+      "expect": {
+        "seq": 2
+      }
+    },
+    {
+      "op": "append_log",
+      "job_id": "j1",
+      "message": "stage umap started",
+      "now": "2026-07-06T11:04:00.000Z",
+      "expect": {
+        "seq": 3
+      }
+    },
+    {
+      "op": "append_log",
+      "job_id": "missing",
+      "message": "nope",
+      "now": "2026-07-06T11:04:00.000Z",
+      "expect_error": "not_found"
+    },
+    {
+      "op": "query_prefix",
+      "entity": "artifacts",
+      "pk": "j1",
+      "sk_prefix": "log#",
+      "expect": {
+        "sks": [
+          "log#00000001",
+          "log#00000002",
+          "log#00000003"
+        ]
+      }
+    },
+    {
+      "op": "get",
+      "entity": "artifacts",
+      "pk": "j1",
+      "sk": "log#00000002",
+      "expect": {
+        "found": true,
+        "attributes": {
+          "ts": "2026-07-06T11:03:00.000Z",
+          "message": "stage math done"
+        }
+      }
+    },
+    {
+      "op": "put",
+      "entity": "artifacts",
+      "item": {
+        "pk": "j1",
+        "sk": "math#pca",
+        "attributes": {
+          "enc": "json",
+          "body": {
+            "comps": [
+              0.1,
+              0.2
+            ]
+          }
+        }
+      }
+    },
+    {
+      "op": "query_prefix",
+      "entity": "artifacts",
+      "pk": "j1",
+      "sk_prefix": "math#",
+      "expect": {
+        "sks": [
+          "math#pca"
+        ]
+      }
+    },
+    {
+      "op": "complete_run",
+      "job_id": "j1",
+      "now": "2026-07-06T11:05:00.000Z",
+      "expect": {
+        "status": "COMPLETED",
+        "latest": [
+          {
+            "scope": "zid#9#FULL_PIPELINE",
+            "job_id": "j1",
+            "seq": 1
+          }
+        ]
+      }
+    },
+    {
+      "op": "get_run",
+      "job_id": "j1",
+      "expect": {
+        "found": true,
+        "status": "COMPLETED",
+        "completed_at": "2026-07-06T11:05:00.000Z",
+        "seeds": {
+          "umap": 42,
+          "kmeans": 42
+        }
+      }
+    }
+  ]
+}

--- a/delphi/delphi_storage/conformance/cases/validation.json
+++ b/delphi/delphi_storage/conformance/cases/validation.json
@@ -1,0 +1,209 @@
+{
+  "name": "validation",
+  "description": "writes that violate the contract are rejected with `invalid`; runs/latest are unreachable via generic ops",
+  "ops": [
+    {
+      "op": "put",
+      "entity": "artifacts",
+      "item": {
+        "pk": "job-v-1",
+        "sk": "ok",
+        "attributes": {
+          "_reserved": 1
+        }
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "put",
+      "entity": "artifacts",
+      "item": {
+        "pk": "job-v-1",
+        "sk": "badkey",
+        "attributes": {}
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "put",
+      "entity": "artifacts",
+      "item": {
+        "pk": "job-v-1",
+        "sk": "",
+        "attributes": {}
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "put",
+      "entity": "artifacts",
+      "item": {
+        "pk": "",
+        "sk": "ok",
+        "attributes": {}
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "put",
+      "entity": "runs",
+      "item": {
+        "pk": "job-v-1",
+        "sk": "run",
+        "attributes": {}
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "put",
+      "entity": "latest",
+      "item": {
+        "pk": "zid#1#FULL_PIPELINE",
+        "sk": "latest",
+        "attributes": {}
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "put",
+      "entity": "nonsense",
+      "item": {
+        "pk": "job-v-1",
+        "sk": "ok",
+        "attributes": {}
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "v-run-1",
+        "job_type": "FULL_PIPELINE",
+        "zid": 1,
+        "status": "RUNNING",
+        "enqueued_at": "2026-07-06T10:00:00.000Z"
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "v-run-2",
+        "job_type": "FULL_PIPELINE",
+        "zid": 1,
+        "enqueued_at": "2026-07-06 10:00:00"
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "v-run-3",
+        "job_type": "NOT_A_TYPE",
+        "zid": 1,
+        "enqueued_at": "2026-07-06T10:00:00.000Z"
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "",
+        "job_type": "FULL_PIPELINE",
+        "zid": 1,
+        "enqueued_at": "2026-07-06T10:00:00.000Z"
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "get",
+      "entity": "artifacts",
+      "pk": "job-v-1",
+      "sk": "ok",
+      "expect": {
+        "found": false
+      }
+    },
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "v-run-4",
+        "job_type": "FULL_PIPELINE",
+        "enqueued_at": "2026-07-06T10:00:00.000Z"
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "v-run-5",
+        "job_type": "NARRATIVE_BATCH",
+        "zid": 1,
+        "enqueued_at": "2026-07-06T10:00:00.000Z"
+      },
+      "expect_error": "invalid"
+    },
+    {
+      "op": "get_run",
+      "job_id": "v-run-4",
+      "expect": {
+        "found": false
+      }
+    },
+    {
+      "op": "enqueue_run",
+      "run": {
+        "job_id": "v-ok-1",
+        "job_type": "FULL_PIPELINE",
+        "zid": 1,
+        "enqueued_at": "2026-07-06T10:00:00.000Z"
+      }
+    },
+    {
+      "op": "update_run_status",
+      "job_id": "v-ok-1",
+      "status": "BOGUS",
+      "now": "2026-07-06T10:01:00.000Z",
+      "expect_error": "invalid"
+    },
+    {
+      "op": "get_run",
+      "job_id": "v-ok-1",
+      "expect": {
+        "found": true,
+        "status": "QUEUED"
+      }
+    },
+    {
+      "op": "advance_latest",
+      "scope": "zid#1#FULL_PIPELINE",
+      "job_id": "v-ok-1",
+      "job_type": "BOGUS",
+      "now": "2026-07-06T10:01:00.000Z",
+      "expect_error": "invalid"
+    },
+    {
+      "op": "get_latest",
+      "scope": "zid#1#FULL_PIPELINE",
+      "expect": {
+        "found": false
+      }
+    },
+    {
+      "op": "list_runs",
+      "zid": 1,
+      "status": "BOGUS",
+      "expect_error": "invalid"
+    },
+    {
+      "op": "list_runs",
+      "zid": 1,
+      "rid": 2,
+      "expect_error": "invalid"
+    },
+    {
+      "op": "list_runs",
+      "expect_error": "invalid"
+    }
+  ]
+}

--- a/delphi/delphi_storage/conformance/runner.py
+++ b/delphi/delphi_storage/conformance/runner.py
@@ -1,0 +1,321 @@
+"""Executor for the shared conformance case files (cases/*.json).
+
+The pytest side of the cross-language contract; jest executes the SAME files
+against the TypeScript implementations. The op vocabulary is specified in
+README.md next to this file — keep the three in sync.
+"""
+
+import base64
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from pydantic import ValidationError
+
+from delphi_storage.codec import (
+    F64,
+    decode_payload,
+    encode_payload,
+    pack_f64,
+)
+from delphi_storage.interface import DelphiStore, StorageError
+from delphi_storage.models import RunManifest, StoreItem
+
+CASES_DIR = Path(__file__).parent / "cases"
+
+
+@dataclass
+class Case:
+    name: str
+    description: str = ""
+    ops: list[dict[str, Any]] = field(default_factory=list)
+    path: Optional[Path] = None
+
+
+def _load(path: Path) -> Case:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return Case(
+        name=data["name"], description=data.get("description", ""), ops=data["ops"], path=path
+    )
+
+
+def load_cases() -> list[Case]:
+    return [
+        _load(p) for p in sorted(CASES_DIR.glob("*.json")) if not p.name.startswith("codec_")
+    ]
+
+
+def load_codec_cases() -> list[Case]:
+    return [_load(p) for p in sorted(CASES_DIR.glob("codec_*.json"))]
+
+
+def gen_blob(spec: dict[str, Any]) -> bytes:
+    """Deterministic blob generators shared with the jest runner."""
+    if spec["kind"] == "f64_seq":
+        return pack_f64([i * 0.5 for i in range(spec["n"])])
+    raise ValueError(f"unknown blob generator {spec['kind']!r}")
+
+
+def _numbers_equal(a: Any, b: Any) -> bool:
+    return not isinstance(a, bool) and not isinstance(b, bool) and float(a) == float(b)
+
+
+def assert_json_equal(actual: Any, expected: Any, path: str = "$") -> None:
+    """Deep equality; numbers compare by value (DynamoDB may return 2 for a
+    stored 2.0), booleans strictly."""
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        assert actual is expected or actual == expected and isinstance(actual, bool) and isinstance(
+            expected, bool
+        ), f"{path}: expected {expected!r}, got {actual!r}"
+        return
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        assert _numbers_equal(actual, expected), f"{path}: expected {expected!r}, got {actual!r}"
+        return
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict), f"{path}: expected object, got {type(actual).__name__}"
+        assert set(actual) == set(expected), (
+            f"{path}: key mismatch — expected {sorted(expected)}, got {sorted(actual)}"
+        )
+        for key in expected:
+            assert_json_equal(actual[key], expected[key], f"{path}.{key}")
+        return
+    if isinstance(expected, list):
+        assert isinstance(actual, list), f"{path}: expected list, got {type(actual).__name__}"
+        assert len(actual) == len(expected), (
+            f"{path}: expected {len(expected)} elements, got {len(actual)}"
+        )
+        for i, (a, e) in enumerate(zip(actual, expected)):
+            assert_json_equal(a, e, f"{path}[{i}]")
+        return
+    assert actual == expected, f"{path}: expected {expected!r}, got {actual!r}"
+
+
+def _expected_blob(op_expect: dict[str, Any]) -> Optional[bytes]:
+    if "blob_b64" in op_expect:
+        return base64.b64decode(op_expect["blob_b64"])
+    if "blob_gen" in op_expect:
+        return gen_blob(op_expect["blob_gen"])
+    return None
+
+
+def _item_from_spec(spec: dict[str, Any]) -> StoreItem:
+    blob: Optional[bytes] = None
+    if spec.get("blob_b64") is not None:
+        blob = base64.b64decode(spec["blob_b64"])
+    elif spec.get("blob_gen") is not None:
+        blob = gen_blob(spec["blob_gen"])
+    return StoreItem(pk=spec["pk"], sk=spec["sk"], attributes=spec.get("attributes", {}), blob=blob)
+
+
+def _assert_manifest_subset(run: Any, expect: dict[str, Any], context: str) -> None:
+    for key, expected in expect.items():
+        if key in ("found", "latest"):
+            continue
+        actual = getattr(run, key)
+        actual = getattr(actual, "value", actual)  # enums compare by value
+        assert_json_equal(actual, expected, f"{context}.{key}")
+
+
+def _run_op(store: DelphiStore, op: dict[str, Any]) -> None:
+    kind = op["op"]
+    expect = op.get("expect") or {}
+    expected_error = op.get("expect_error")
+
+    def call():
+        if kind == "put":
+            return store.put(op["entity"], _item_from_spec(op["item"]))
+        if kind == "put_batch":
+            return store.put_batch(op["entity"], [_item_from_spec(s) for s in op["items"]])
+        if kind == "get":
+            return store.get(op["entity"], op["pk"], op["sk"])
+        if kind == "query_prefix":
+            return store.query_prefix(op["entity"], op["pk"], op.get("sk_prefix", ""))
+        if kind == "query_between":
+            return store.query_between(op["entity"], op["pk"], op["sk_from"], op["sk_to"])
+        if kind == "delete_partition":
+            return store.delete_partition(op["entity"], op["pk"])
+        if kind == "enqueue_run":
+            return store.enqueue_run(RunManifest(**op["run"]))
+        if kind == "get_run":
+            return store.get_run(op["job_id"])
+        if kind == "claim_next_run":
+            return store.claim_next_run(
+                worker_id=op["worker_id"],
+                lease_seconds=op["lease_seconds"],
+                now=op.get("now"),
+            )
+        if kind == "extend_lease":
+            return store.extend_lease(
+                job_id=op["job_id"],
+                worker_id=op["worker_id"],
+                lease_seconds=op["lease_seconds"],
+                now=op.get("now"),
+            )
+        if kind == "update_run_status":
+            return store.update_run_status(
+                op["job_id"], op["status"], error=op.get("error"), now=op.get("now")
+            )
+        if kind == "merge_run_fields":
+            return store.merge_run_fields(op["job_id"], op["fields"])
+        if kind == "complete_run":
+            return store.complete_run(op["job_id"], now=op.get("now"))
+        if kind == "append_log":
+            return store.append_log(op["job_id"], op["message"], now=op.get("now"))
+        if kind == "advance_latest":
+            return store.advance_latest(
+                scope=op["scope"],
+                job_id=op["job_id"],
+                job_type=op["job_type"],
+                only_if_absent_or_imported=op.get("only_if_absent_or_imported", False),
+                now=op.get("now"),
+            )
+        if kind == "get_latest":
+            return store.get_latest(op["scope"])
+        if kind == "list_runs":
+            return store.list_runs(
+                zid=op.get("zid"), rid=op.get("rid"), status=op.get("status")
+            )
+        raise ValueError(f"unknown op {kind!r}")
+
+    if expected_error is not None:
+        try:
+            call()
+        except StorageError as e:
+            assert e.code == expected_error, (
+                f"expected error {expected_error!r}, got {e.code!r} ({e})"
+            )
+            return
+        except (ValidationError, ValueError) as e:
+            assert expected_error == "invalid", (
+                f"expected error {expected_error!r}, got invalid ({e})"
+            )
+            return
+        raise AssertionError(f"expected error {expected_error!r}, but op succeeded")
+
+    result = call()
+
+    if kind == "get":
+        if not expect:
+            return
+        if not expect["found"]:
+            assert result is None, f"expected absent item, got {result!r}"
+            return
+        assert result is not None, "expected item, got None"
+        if "attributes" in expect:
+            assert_json_equal(result.attributes, expect["attributes"], "attributes")
+        expected_blob = _expected_blob(expect)
+        if expected_blob is not None:
+            assert result.blob == expected_blob, "blob bytes differ"
+        if "blob_len" in expect:
+            assert result.blob is not None and len(result.blob) == expect["blob_len"], (
+                f"expected blob of {expect['blob_len']} bytes, "
+                f"got {len(result.blob) if result.blob else None}"
+            )
+    elif kind in ("query_prefix", "query_between"):
+        if "sks" in expect:
+            assert [item.sk for item in result] == expect["sks"], (
+                f"expected sks {expect['sks']}, got {[item.sk for item in result]}"
+            )
+    elif kind == "delete_partition":
+        if "deleted" in expect:
+            assert result == expect["deleted"], f"expected {expect['deleted']} deleted, got {result}"
+    elif kind == "get_run":
+        if not expect:
+            return
+        if not expect["found"]:
+            assert result is None, f"expected absent run, got {result!r}"
+            return
+        assert result is not None, "expected run, got None"
+        _assert_manifest_subset(result, expect, "run")
+    elif kind == "claim_next_run":
+        if "job_id" in expect:
+            if expect["job_id"] is None:
+                assert result is None, f"expected no claim, got {result.job_id if result else None}"
+            else:
+                assert result is not None and result.job_id == expect["job_id"], (
+                    f"expected claim of {expect['job_id']!r}, "
+                    f"got {result.job_id if result else None!r}"
+                )
+                _assert_manifest_subset(result, {k: v for k, v in expect.items() if k != "job_id"}, "claim")
+    elif kind == "extend_lease":
+        if "ok" in expect:
+            assert result is expect["ok"], f"expected ok={expect['ok']}, got {result}"
+    elif kind in ("update_run_status", "merge_run_fields", "complete_run"):
+        if expect:
+            _assert_manifest_subset(result, expect, kind)
+        if kind == "complete_run" and "latest" in expect:
+            for pointer_expect in expect["latest"]:
+                pointer = store.get_latest(pointer_expect["scope"])
+                assert pointer is not None, f"no latest pointer for {pointer_expect['scope']!r}"
+                assert pointer.job_id == pointer_expect["job_id"], (
+                    f"latest {pointer_expect['scope']!r}: expected job "
+                    f"{pointer_expect['job_id']!r}, got {pointer.job_id!r}"
+                )
+                assert pointer.seq == pointer_expect["seq"], (
+                    f"latest {pointer_expect['scope']!r}: expected seq "
+                    f"{pointer_expect['seq']}, got {pointer.seq}"
+                )
+    elif kind == "append_log":
+        if "seq" in expect:
+            assert result == expect["seq"], f"expected seq {expect['seq']}, got {result}"
+    elif kind == "advance_latest":
+        if "advanced" in expect:
+            assert result.advanced is expect["advanced"], (
+                f"expected advanced={expect['advanced']}, got {result.advanced}"
+            )
+        if "seq" in expect:
+            assert result.pointer.seq == expect["seq"], (
+                f"expected seq {expect['seq']}, got {result.pointer.seq}"
+            )
+    elif kind == "get_latest":
+        if not expect:
+            return
+        if not expect["found"]:
+            assert result is None, f"expected no pointer, got {result!r}"
+            return
+        assert result is not None, "expected pointer, got None"
+        for key in ("job_id", "seq", "job_type"):
+            if key in expect:
+                actual = getattr(result, key)
+                actual = getattr(actual, "value", actual)
+                assert_json_equal(actual, expect[key], f"latest.{key}")
+    elif kind == "list_runs":
+        if "job_ids" in expect:
+            assert [r.job_id for r in result] == expect["job_ids"], (
+                f"expected {expect['job_ids']}, got {[r.job_id for r in result]}"
+            )
+
+
+def run_case(store: DelphiStore, case: Case) -> None:
+    for i, op in enumerate(case.ops):
+        try:
+            _run_op(store, op)
+        except AssertionError as e:
+            raise AssertionError(f"case {case.name!r}, op {i} ({op['op']}): {e}") from e
+
+
+def run_codec_case(case: Case) -> None:
+    for i, op in enumerate(case.ops):
+        kind = op["op"]
+        try:
+            if kind == "codec_roundtrip":
+                value = op["value"]
+                enc = encode_payload(value)
+                assert_json_equal(decode_payload(enc.meta, enc.blob), value)
+                forced = encode_payload(value, force="json+zstd")
+                assert_json_equal(decode_payload(forced.meta, forced.blob), value)
+                if isinstance(value, list) and value and all(
+                    isinstance(v, (int, float)) and not isinstance(v, bool) for v in value
+                ):
+                    f64 = encode_payload(F64([float(v) for v in value]))
+                    decoded = decode_payload(f64.meta, f64.blob)
+                    assert decoded == [float(v) for v in value], "f64 round-trip differs"
+            elif kind == "codec_decode_fixture":
+                blob = base64.b64decode(op["blob_b64"]) if op.get("blob_b64") else None
+                decoded = decode_payload(op["meta"], blob)
+                assert_json_equal(decoded, op["expect_value"])
+            else:
+                raise ValueError(f"unknown codec op {kind!r}")
+        except AssertionError as e:
+            raise AssertionError(f"case {case.name!r}, op {i} ({kind}): {e}") from e

--- a/delphi/delphi_storage/factory.py
+++ b/delphi/delphi_storage/factory.py
@@ -1,0 +1,34 @@
+"""Backend selection for Delphi Storage V2 (design §4.3).
+
+Config surface:
+
+- ``DELPHI_STORAGE_BACKEND``      — ``dynamodb`` (default) | ``postgres`` | ``memory``
+- ``DELPHI_STORAGE_TABLE_PREFIX`` — DynamoDB table prefix (default ``Delphi2_``)
+- ``DELPHI_STORAGE_PG_SCHEMA``    — PostgreSQL schema (default ``delphi``)
+- ``DELPHI_STORAGE_PG_URL``       — PostgreSQL URL (falls back to ``DATABASE_URL``)
+- ``DYNAMODB_ENDPOINT`` / ``AWS_REGION`` — existing vocabulary, reused as-is
+"""
+
+import os
+from typing import Optional
+
+from delphi_storage.interface import DelphiStore, Invalid
+
+
+def get_store(backend: Optional[str] = None, **overrides) -> DelphiStore:
+    backend = backend or os.environ.get("DELPHI_STORAGE_BACKEND", "dynamodb")
+    if backend == "memory":
+        from delphi_storage.backends.memory import MemoryDelphiStore
+
+        return MemoryDelphiStore()
+    if backend == "dynamodb":
+        from delphi_storage.backends.dynamodb import DynamoDelphiStore
+
+        return DynamoDelphiStore(**overrides)
+    if backend == "postgres":
+        from delphi_storage.backends.postgres import PostgresDelphiStore
+
+        return PostgresDelphiStore(**overrides)
+    raise Invalid(
+        f"unknown DELPHI_STORAGE_BACKEND {backend!r} (expected dynamodb|postgres|memory)"
+    )

--- a/delphi/delphi_storage/interface.py
+++ b/delphi/delphi_storage/interface.py
@@ -1,0 +1,253 @@
+"""The backend-neutral Delphi Storage V2 repository interface.
+
+Neither DynamoDB nor PostgreSQL is privileged (design §2): every backend
+implements this ABC and must pass the shared conformance suite
+(delphi_storage/conformance/). The TypeScript twin lives in
+server/src/storage/delphi/interface.ts.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Optional, Sequence, Union
+
+from delphi_storage.codec import canonical_json_dumps
+from delphi_storage.keys import (
+    CHUNK_MARKER,
+    GENERIC_ENTITIES,
+    log_sk,
+    now_ts,
+    scopes_for_run,
+    validate_ts,
+)
+from delphi_storage.models import (
+    AdvanceResult,
+    JobType,
+    LatestPointer,
+    RunManifest,
+    RunStatus,
+    StoreItem,
+)
+
+
+class StorageError(Exception):
+    """Base class; ``code`` is the cross-language error name used by the
+    conformance cases."""
+
+    code = "storage_error"
+
+
+class AlreadyExists(StorageError):
+    code = "already_exists"
+
+
+class NotFound(StorageError):
+    code = "not_found"
+
+
+class Invalid(StorageError):
+    code = "invalid"
+
+
+def validate_generic_write(entity: str, item: StoreItem) -> None:
+    """Contract checks shared by every backend's generic write path."""
+    if entity not in GENERIC_ENTITIES:
+        raise Invalid(
+            f"entity {entity!r} is not writable through generic ops "
+            f"(allowed: {', '.join(GENERIC_ENTITIES)})"
+        )
+    if not item.pk:
+        raise Invalid("pk must be non-empty")
+    if not item.sk:
+        raise Invalid("sk must be non-empty")
+    if CHUNK_MARKER in item.sk or CHUNK_MARKER in item.pk:
+        raise Invalid("keys must not contain U+007F (reserved chunk marker)")
+    for key in item.attributes:
+        if key.startswith("_"):
+            raise Invalid(f"attribute {key!r}: top-level '_' prefix is reserved for backends")
+    try:
+        canonical_json_dumps(item.attributes)
+    except (TypeError, ValueError) as e:
+        raise Invalid(f"attributes must be JSON-safe (no NaN/Infinity): {e}") from e
+
+
+def validate_generic_read(entity: str) -> None:
+    if entity not in GENERIC_ENTITIES:
+        raise Invalid(f"entity {entity!r} is not readable through generic ops")
+
+
+def coerce_run_status(status: Union[RunStatus, str]) -> RunStatus:
+    """Backends validate every externally supplied status (a typo'd status
+    silently persisted would make a run permanently unclaimable)."""
+    try:
+        return RunStatus(status)
+    except ValueError as e:
+        raise Invalid(str(e)) from e
+
+
+def coerce_job_type(job_type: Union[JobType, str]) -> JobType:
+    try:
+        return JobType(job_type)
+    except ValueError as e:
+        raise Invalid(str(e)) from e
+
+
+def validate_enqueueable(run: RunManifest) -> None:
+    """Contract checks shared by every backend's enqueue_run: status must be
+    QUEUED and the job_type↔zid/rid coupling must already be satisfiable, so
+    a run can never reach COMPLETED and then fail to derive its latest scopes
+    (that would leave it stuck: completed but never published)."""
+    if run.status != RunStatus.QUEUED:
+        raise Invalid(f"enqueued runs must be QUEUED, got {run.status}")
+    try:
+        scopes_for_run(run)
+    except ValueError as e:
+        raise Invalid(str(e)) from e
+
+
+class DelphiStore(ABC):
+    """Neutral repository over runs / run_inputs / artifacts / latest /
+    topic_moderation / collective_statements (design §4.2-4.3)."""
+
+    # ---- generic operations (run_inputs, artifacts, topic_moderation,
+    # ---- collective_statements) ----
+
+    @abstractmethod
+    def put(self, entity: str, item: StoreItem) -> None:
+        """Upsert one item. Blobs round-trip bit-exactly regardless of size."""
+
+    def put_batch(self, entity: str, items: Sequence[StoreItem]) -> None:
+        for item in items:
+            self.put(entity, item)
+
+    @abstractmethod
+    def get(self, entity: str, pk: str, sk: str) -> Optional[StoreItem]:
+        """Fetch one item (blob fully reassembled), or None."""
+
+    @abstractmethod
+    def query_prefix(self, entity: str, pk: str, sk_prefix: str = "") -> list[StoreItem]:
+        """All items in a partition whose sk starts with the prefix, in UTF-8
+        byte order."""
+
+    @abstractmethod
+    def query_between(self, entity: str, pk: str, sk_from: str, sk_to: str) -> list[StoreItem]:
+        """All items with sk_from <= sk <= sk_to (inclusive), in UTF-8 byte order."""
+
+    @abstractmethod
+    def delete_partition(self, entity: str, pk: str) -> int:
+        """Delete every item in the partition; returns the number of logical
+        items removed."""
+
+    # ---- runs / queue ----
+
+    @abstractmethod
+    def enqueue_run(self, run: RunManifest) -> None:
+        """Create a QUEUED run. Raises AlreadyExists for a duplicate job_id,
+        Invalid if the manifest's status is not QUEUED."""
+
+    @abstractmethod
+    def get_run(self, job_id: str) -> Optional[RunManifest]: ...
+
+    @abstractmethod
+    def claim_next_run(
+        self,
+        worker_id: str,
+        lease_seconds: int,
+        now: Optional[str] = None,
+    ) -> Optional[RunManifest]:
+        """Atomically claim the QUEUED run with the smallest claim order
+        (priority desc, then FIFO); None when nothing is claimable. Two
+        claimants can never claim the same run."""
+
+    @abstractmethod
+    def extend_lease(
+        self,
+        job_id: str,
+        worker_id: str,
+        lease_seconds: int,
+        now: Optional[str] = None,
+    ) -> bool:
+        """True iff the run is RUNNING and owned by worker_id."""
+
+    @abstractmethod
+    def update_run_status(
+        self,
+        job_id: str,
+        status: Union[RunStatus, str],
+        error: Optional[str] = None,
+        now: Optional[str] = None,
+    ) -> RunManifest:
+        """Set the run status (no latest flip); terminal statuses stamp
+        completed_at. Raises NotFound."""
+
+    @abstractmethod
+    def merge_run_fields(self, job_id: str, fields: dict[str, Any]) -> RunManifest:
+        """Shallow-merge provenance fields (config_effective, seeds, ...) into
+        the manifest. Raises NotFound; Invalid for non-mergeable fields."""
+
+    @abstractmethod
+    def advance_latest(
+        self,
+        scope: str,
+        job_id: str,
+        job_type: Union[JobType, str],
+        only_if_absent_or_imported: bool = False,
+        now: Optional[str] = None,
+    ) -> AdvanceResult:
+        """Advance the latest pointer for a scope: seq is monotonic (+1 per
+        advance). Advancing to the already-referenced job is a successful
+        no-op. With only_if_absent_or_imported (backfill importer mode,
+        design §6.2 invariant 1) the advance is refused unless the current
+        pointer is absent or references an IMPORTED run."""
+
+    @abstractmethod
+    def get_latest(self, scope: str) -> Optional[LatestPointer]: ...
+
+    @abstractmethod
+    def list_runs(
+        self,
+        zid: Optional[int] = None,
+        rid: Optional[int] = None,
+        status: Optional[Union[RunStatus, str]] = None,
+        limit: int = 100,
+    ) -> list[RunManifest]:
+        """Runs for a conversation (zid) or report (rid), newest-first by
+        enqueued_at (job_id desc as tiebreak). Exactly one of zid/rid."""
+
+    # ---- concrete semantics shared by all backends ----
+
+    def complete_run(self, job_id: str, now: Optional[str] = None) -> RunManifest:
+        """Mark COMPLETED then advance latest for the run's scopes — the
+        pointer is the commit point, written last (design §4.2). Idempotent
+        and crash-healing: re-completing re-attempts the pointer advance
+        without double-incrementing seq. Raises Invalid on FAILED runs."""
+        now = validate_ts(now) if now is not None else now_ts()
+        run = self.get_run(job_id)
+        if run is None:
+            raise NotFound(f"run {job_id!r} not found")
+        if run.status == RunStatus.FAILED:
+            raise Invalid(f"run {job_id!r} is FAILED and cannot be completed")
+        try:
+            # Derive scopes BEFORE flipping the status: a run that cannot
+            # publish must fail cleanly, not end up COMPLETED-but-unpublished.
+            scopes = scopes_for_run(run)
+        except ValueError as e:
+            raise Invalid(str(e)) from e
+        if run.status != RunStatus.COMPLETED:
+            run = self.update_run_status(job_id, RunStatus.COMPLETED, now=now)
+        for scope in scopes:
+            self.advance_latest(scope, run.job_id, run.job_type, now=now)
+        return run
+
+    def append_log(self, job_id: str, message: str, now: Optional[str] = None) -> int:
+        """Append-only run log as artifacts items (replaces the old
+        truncate-to-50 job log). Returns the 1-based seq."""
+        now = validate_ts(now) if now is not None else now_ts()
+        seq = self._increment_log_seq(job_id)
+        self.put(
+            "artifacts",
+            StoreItem(pk=job_id, sk=log_sk(seq), attributes={"ts": now, "message": message}),
+        )
+        return seq
+
+    @abstractmethod
+    def _increment_log_seq(self, job_id: str) -> int:
+        """Atomically allocate the next log seq for a run. Raises NotFound."""

--- a/delphi/delphi_storage/keys.py
+++ b/delphi/delphi_storage/keys.py
@@ -1,0 +1,121 @@
+"""Key construction and shared constants for Delphi Storage V2.
+
+The rules here are part of the cross-language conformance contract
+(delphi_storage/conformance/README.md); server/src/storage/delphi/keys.ts
+mirrors them exactly.
+"""
+
+import re
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids a runtime cycle
+    from delphi_storage.models import JobType, RunManifest
+
+ENTITY_RUNS = "runs"
+ENTITY_RUN_INPUTS = "run_inputs"
+ENTITY_ARTIFACTS = "artifacts"
+ENTITY_LATEST = "latest"
+ENTITY_TOPIC_MODERATION = "topic_moderation"
+ENTITY_COLLECTIVE_STATEMENTS = "collective_statements"
+
+# Entities addressable through the generic put/get/query/delete operations.
+# `runs` and `latest` are mutated exclusively through the semantic ops so
+# their invariants (optimistic lock, monotonic seq) cannot be bypassed.
+GENERIC_ENTITIES = (
+    ENTITY_RUN_INPUTS,
+    ENTITY_ARTIFACTS,
+    ENTITY_TOPIC_MODERATION,
+    ENTITY_COLLECTIVE_STATEMENTS,
+)
+
+ALL_ENTITIES = (ENTITY_RUNS, ENTITY_LATEST) + GENERIC_ENTITIES
+
+# Reserved for backend-internal chunk rows (DynamoDB 400KB item limit);
+# forbidden in user-supplied keys.
+CHUNK_MARKER = "\x7f"
+
+KEY_SEPARATOR = "#"
+
+LOG_PREFIX = "log#"
+
+_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+_TS_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def validate_ts(ts: str) -> str:
+    """Validate the canonical timestamp format YYYY-MM-DDTHH:MM:SS.mmmZ."""
+    if not isinstance(ts, str) or not _TS_RE.match(ts):
+        raise ValueError(f"timestamp must be YYYY-MM-DDTHH:MM:SS.mmmZ, got {ts!r}")
+    datetime.strptime(ts, _TS_FORMAT)  # reject e.g. month 13
+    return ts
+
+
+def format_ts(dt: datetime) -> str:
+    dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+def now_ts() -> str:
+    return format_ts(datetime.now(timezone.utc))
+
+
+def ts_add_seconds(ts: str, seconds: float) -> str:
+    validate_ts(ts)
+    dt = datetime.strptime(ts, _TS_FORMAT).replace(tzinfo=timezone.utc)
+    return format_ts(dt + timedelta(seconds=seconds))
+
+
+def _job_type_value(job_type: Union[str, "JobType"]) -> str:
+    return getattr(job_type, "value", job_type)
+
+
+def claim_order(priority: int, enqueued_at: str, job_id: str) -> str:
+    """Claim-order string: ascending sort = highest priority first, then FIFO,
+    then job_id as tiebreak."""
+    p = min(max(int(priority), 0), 9999)
+    return f"{9999 - p:04d}#{enqueued_at}#{job_id}"
+
+
+def scope_for_zid(zid: int, job_type: Union[str, "JobType"]) -> str:
+    return f"zid#{zid}#{_job_type_value(job_type)}"
+
+
+def scope_for_rid(rid: int, job_type: Union[str, "JobType"]) -> str:
+    return f"rid#{rid}#{_job_type_value(job_type)}"
+
+
+def scopes_for_run(run: "RunManifest") -> list[str]:
+    """Latest-pointer scopes a completed run flips (design §4.2 entity 4).
+
+    IMPORTED runs never auto-flip: the backfill importer advances pointers
+    explicitly under the no-clobber invariant (design §6.2 invariant 1).
+    """
+    job_type = _job_type_value(run.job_type)
+    if job_type == "FULL_PIPELINE":
+        if run.zid is None:
+            raise ValueError(f"run {run.job_id}: FULL_PIPELINE requires zid")
+        return [scope_for_zid(run.zid, job_type)]
+    if job_type in ("NARRATIVE_BATCH", "SERVER_NARRATIVE"):
+        if run.rid is None:
+            raise ValueError(f"run {run.job_id}: {job_type} requires rid")
+        return [scope_for_rid(run.rid, job_type)]
+    if job_type == "IMPORTED":
+        return []
+    raise ValueError(f"run {run.job_id}: unknown job_type {job_type!r}")
+
+
+def log_sk(seq: int) -> str:
+    return f"{LOG_PREFIX}{seq:08d}"
+
+
+def artifact_key(*parts: Union[str, int]) -> str:
+    """Compose an artifact sort key from parts using the existing '#'
+    composite convention (e.g. artifact_key('umap', 'topic', 0, 3))."""
+    strs = [str(p) for p in parts]
+    for s in strs:
+        if not s:
+            raise ValueError("artifact key parts must be non-empty")
+        if CHUNK_MARKER in s:
+            raise ValueError("artifact key parts must not contain U+007F")
+    return KEY_SEPARATOR.join(strs)

--- a/delphi/delphi_storage/models.py
+++ b/delphi/delphi_storage/models.py
@@ -1,0 +1,99 @@
+"""Pydantic models for Delphi Storage V2 (design: docs/STORAGE_V2_DESIGN.md §4.2).
+
+All timestamps are strings, exactly ``YYYY-MM-DDTHH:MM:SS.mmmZ`` (UTC,
+millisecond precision) so lexicographic order equals time order — see
+delphi_storage/conformance/README.md.
+"""
+
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from delphi_storage.keys import validate_ts
+
+
+class RunStatus(str, Enum):
+    QUEUED = "QUEUED"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+
+
+TERMINAL_STATUSES = frozenset({RunStatus.COMPLETED, RunStatus.FAILED})
+
+
+class JobType(str, Enum):
+    FULL_PIPELINE = "FULL_PIPELINE"
+    NARRATIVE_BATCH = "NARRATIVE_BATCH"
+    SERVER_NARRATIVE = "SERVER_NARRATIVE"
+    IMPORTED = "IMPORTED"
+
+
+class StoreItem(BaseModel):
+    """One logical item in a generic entity: JSON attributes + optional blob."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pk: str
+    sk: str
+    attributes: dict[str, Any] = Field(default_factory=dict)
+    blob: Optional[bytes] = None
+
+
+class RunManifest(BaseModel):
+    """Queue row and run manifest in one — the row becomes the manifest as the
+    job executes (design §4.2 entity 1)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    job_id: str = Field(min_length=1)
+    job_type: JobType
+    enqueued_at: str
+    status: RunStatus = RunStatus.QUEUED
+    zid: Optional[int] = None
+    rid: Optional[int] = None
+    priority: int = 0
+    version: int = 0
+    worker_id: Optional[str] = None
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    lease_expires_at: Optional[str] = None
+    error: Optional[str] = None
+    replay_of: Optional[str] = None
+    provenance: str = "pipeline"
+    replayable: bool = True
+    imported_scope_type: Optional[str] = None
+    math_tick_legacy: Optional[int] = None
+    log_seq: int = 0
+    config_requested: dict[str, Any] = Field(default_factory=dict)
+    config_effective: dict[str, Any] = Field(default_factory=dict)
+    code_version: dict[str, Any] = Field(default_factory=dict)
+    seeds: dict[str, Any] = Field(default_factory=dict)
+    input_fingerprints: dict[str, Any] = Field(default_factory=dict)
+    stage_status: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("enqueued_at")
+    @classmethod
+    def _valid_enqueued_at(cls, v: str) -> str:
+        return validate_ts(v)
+
+    @field_validator("started_at", "completed_at", "lease_expires_at")
+    @classmethod
+    def _valid_optional_ts(cls, v: Optional[str]) -> Optional[str]:
+        return None if v is None else validate_ts(v)
+
+
+class LatestPointer(BaseModel):
+    """First-class 'latest successful run' pointer (design §4.2 entity 4)."""
+
+    scope: str
+    job_id: str
+    seq: int
+    job_type: JobType
+    updated_at: str
+
+
+class AdvanceResult(BaseModel):
+    advanced: bool
+    pointer: LatestPointer

--- a/delphi/pyproject.toml
+++ b/delphi/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "pynamodb>=5.4.0",
     "aws-lambda-powertools>=2.15.0",
     "aws-xray-sdk>=2.12.0",
+    # Storage V2 codec (delphi_storage)
+    "zstandard>=0.23.0",
     # LLM and reporting
     "requests>=2.28.0",
     "xmltodict>=0.13.0",
@@ -113,12 +115,13 @@ setup-minio = "setup_minio:setup_minio_bucket"
 
 # Hatchling configuration
 [tool.hatch.build.targets.wheel]
-packages = ["polismath", "umap_narrative"]
+packages = ["polismath", "umap_narrative", "delphi_storage"]
 
 [tool.hatch.build.targets.sdist]
 include = [
     "/polismath",
     "/umap_narrative",
+    "/delphi_storage",
     "/scripts",
     "/tests",
     "/docs",

--- a/delphi/requirements.lock
+++ b/delphi/requirements.lock
@@ -458,6 +458,8 @@ zict==3.0.0
     # via distributed
 zipp==3.23.0
     # via importlib-metadata
+zstandard==0.25.0
+    # via delphi-polis (pyproject.toml)
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/delphi/tests/test_delphi_storage_codec.py
+++ b/delphi/tests/test_delphi_storage_codec.py
@@ -1,0 +1,155 @@
+"""Unit tests for delphi_storage.codec — canonical JSON, packed floats, zstd, envelopes.
+
+Pure unit level: no backend, no services. The cross-language wire format these
+pin down is shared with server/src/storage/delphi/codec.ts via the conformance
+fixtures in delphi_storage/conformance/cases/.
+"""
+
+import hashlib
+import math
+from decimal import Decimal
+
+import pytest
+
+from delphi_storage.codec import (
+    F64,
+    INLINE_LIMIT,
+    canonical_json_dumps,
+    compress,
+    decode_payload,
+    decompress,
+    encode_payload,
+    from_dynamo,
+    pack_f64,
+    to_dynamo,
+    unpack_f64,
+)
+
+
+class TestCanonicalJson:
+    def test_sorted_keys_compact(self):
+        assert canonical_json_dumps({"b": 1, "a": [1.5, "x"]}) == '{"a":[1.5,"x"],"b":1}'
+
+    def test_unicode_not_escaped(self):
+        assert canonical_json_dumps({"k": "café 😀"}) == '{"k":"café 😀"}'
+
+    def test_deterministic(self):
+        obj = {"z": {"y": [3, 2, 1]}, "a": None, "m": True}
+        assert canonical_json_dumps(obj) == canonical_json_dumps(obj)
+
+    def test_nested_keys_sorted(self):
+        assert canonical_json_dumps({"o": {"b": 1, "a": 2}}) == '{"o":{"a":2,"b":1}}'
+
+    def test_rejects_nan(self):
+        with pytest.raises(ValueError):
+            canonical_json_dumps({"x": float("nan")})
+
+    def test_rejects_inf(self):
+        with pytest.raises(ValueError):
+            canonical_json_dumps({"x": float("inf")})
+
+
+class TestPackF64:
+    def test_roundtrip(self):
+        values = [0.0, 0.5, -1.25, 1e300, 5e-324, math.pi]
+        assert unpack_f64(pack_f64(values)) == values
+
+    def test_little_endian_ieee754(self):
+        # 0.5 in little-endian IEEE-754 float64
+        assert pack_f64([0.5]) == bytes.fromhex("000000000000e03f")
+
+    def test_length(self):
+        assert len(pack_f64([0.0] * 7)) == 56
+
+    def test_nan_bits_survive(self):
+        [out] = unpack_f64(pack_f64([float("nan")]))
+        assert math.isnan(out)
+
+    def test_empty(self):
+        assert pack_f64([]) == b""
+        assert unpack_f64(b"") == []
+
+
+class TestZstd:
+    def test_roundtrip(self):
+        raw = b"delphi storage v2" * 1000
+        comp = compress(raw)
+        assert len(comp) < len(raw)
+        assert decompress(comp) == raw
+
+    def test_binary_safe(self):
+        raw = bytes(range(256)) * 10
+        assert decompress(compress(raw)) == raw
+
+
+class TestEnvelope:
+    def test_small_json_inline(self):
+        value = {"pca": [0.1, 0.2], "n": 3}
+        enc = encode_payload(value)
+        assert enc.meta["enc"] == "json"
+        assert enc.blob is None
+        assert decode_payload(enc.meta, enc.blob) == value
+
+    def test_large_json_compressed(self):
+        value = {"rows": [{"i": i, "v": i * 0.5} for i in range(20000)]}
+        assert len(canonical_json_dumps(value)) > INLINE_LIMIT
+        enc = encode_payload(value)
+        assert enc.meta["enc"] == "json+zstd"
+        assert enc.blob is not None
+        raw = canonical_json_dumps(value).encode("utf-8")
+        assert enc.meta["bytes"] == len(raw)
+        assert enc.meta["sha256"] == hashlib.sha256(raw).hexdigest()
+        assert decode_payload(enc.meta, enc.blob) == value
+
+    def test_f64_payload(self):
+        values = [i * 0.25 for i in range(1000)]
+        enc = encode_payload(F64(values))
+        assert enc.meta["enc"] == "f64+zstd"
+        assert enc.meta["count"] == 1000
+        packed = pack_f64(values)
+        assert enc.meta["bytes"] == len(packed)
+        assert enc.meta["sha256"] == hashlib.sha256(packed).hexdigest()
+        assert decode_payload(enc.meta, enc.blob) == values
+
+    def test_f64_bit_exact(self):
+        values = [0.1, 1e-9, 1e300, -0.0, 5e-324]
+        enc = encode_payload(F64(values))
+        out = decode_payload(enc.meta, enc.blob)
+        assert [v.hex() for v in out] == [v.hex() for v in values]
+
+    def test_unknown_enc_rejected(self):
+        with pytest.raises(ValueError):
+            decode_payload({"enc": "protobuf"}, b"")
+
+
+class TestDynamoNumbers:
+    def test_floats_become_decimal(self):
+        out = to_dynamo({"a": 0.1, "b": [1.5, {"c": 2.25}], "n": 3})
+        assert out["a"] == Decimal("0.1")
+        assert out["b"][0] == Decimal("1.5")
+        assert out["b"][1]["c"] == Decimal("2.25")
+        assert out["n"] == 3 and isinstance(out["n"], int)
+
+    def test_from_dynamo_restores_numbers(self):
+        back = from_dynamo({"a": Decimal("0.1"), "n": Decimal("3"), "l": [Decimal("2.5")]})
+        assert back["a"] == 0.1 and isinstance(back["a"], float)
+        assert back["n"] == 3 and isinstance(back["n"], int)
+        assert back["l"] == [2.5]
+
+    def test_roundtrip_by_value(self):
+        obj = {"x": 0.1, "y": 42, "z": [1e-9, 2.0]}
+        back = from_dynamo(to_dynamo(obj))
+        assert back["x"] == obj["x"]
+        assert back["y"] == obj["y"]
+        assert back["z"][0] == obj["z"][0]
+        assert back["z"][1] == 2.0
+
+    def test_bools_untouched(self):
+        out = to_dynamo({"t": True, "f": False})
+        assert out["t"] is True and out["f"] is False
+        back = from_dynamo(out)
+        assert back["t"] is True and back["f"] is False
+
+    def test_rejects_nan(self):
+        with pytest.raises(ValueError):
+            to_dynamo({"x": float("nan")})

--- a/delphi/tests/test_delphi_storage_conformance.py
+++ b/delphi/tests/test_delphi_storage_conformance.py
@@ -1,0 +1,220 @@
+"""Conformance suite for Delphi Storage V2 backends.
+
+Executes the shared JSON operation-scripts in delphi_storage/conformance/cases/
+against every backend. The same case files are executed by jest against the
+TypeScript implementations (server/src/storage/delphi/) — see
+delphi_storage/conformance/README.md for the normative spec.
+
+Backends:
+- memory          — always runs (pure in-process reference implementation)
+- moto            — always runs (DynamoDB backend against moto's mock)
+- dynamodb        — real DynamoDB endpoint (DYNAMODB_ENDPOINT, default
+                    http://localhost:8000); skipped locally when unreachable,
+                    fails loudly in GitHub Actions where the service is up
+- postgres        — real PostgreSQL (DELPHI_STORAGE_PG_URL or DATABASE_URL);
+                    same skip/fail convention; isolated per-test schema
+"""
+
+import os
+import threading
+import uuid
+
+import pytest
+
+from delphi_storage.conformance.runner import (
+    load_cases,
+    load_codec_cases,
+    run_case,
+    run_codec_case,
+)
+from delphi_storage.models import JobType, RunManifest
+
+CASES = load_cases()
+CODEC_CASES = load_codec_cases()
+
+STORE_BACKENDS = ["memory", "moto", "dynamodb", "postgres"]
+# moto's in-process mock is not safe under concurrent conditional writes, and
+# the race test is about real atomicity anyway.
+RACE_BACKENDS = ["memory", "dynamodb", "postgres"]
+
+_IN_GHA = os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def _unavailable(what: str, detail: str):
+    """Skip locally; fail loudly in CI where the service is guaranteed up."""
+    if _IN_GHA:
+        pytest.fail(f"{what} must be available in GitHub Actions: {detail}")
+    pytest.skip(f"{what} unavailable: {detail}")
+
+
+def _dynamo_endpoint() -> str:
+    return os.environ.get("DYNAMODB_ENDPOINT", "http://localhost:8000")
+
+
+def _check_dynamo(endpoint: str):
+    import boto3
+    from botocore.config import Config as BotoConfig
+
+    try:
+        client = boto3.client(
+            "dynamodb",
+            endpoint_url=endpoint,
+            region_name="us-east-1",
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", "dummy"),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", "dummy"),
+            config=BotoConfig(
+                connect_timeout=3, read_timeout=3, retries={"max_attempts": 0}
+            ),
+        )
+        client.list_tables(Limit=1)
+    except Exception as e:  # noqa: BLE001 - any failure means "not reachable"
+        _unavailable("DynamoDB", f"{endpoint}: {e}")
+
+
+def _pg_url() -> str | None:
+    return os.environ.get("DELPHI_STORAGE_PG_URL") or os.environ.get("DATABASE_URL")
+
+
+def _check_postgres(url: str | None):
+    if not url:
+        _unavailable("PostgreSQL", "neither DELPHI_STORAGE_PG_URL nor DATABASE_URL is set")
+    import sqlalchemy
+
+    try:
+        engine = sqlalchemy.create_engine(
+            url, connect_args={"connect_timeout": 3}, pool_pre_ping=True
+        )
+        with engine.connect():
+            pass
+        engine.dispose()
+    except Exception as e:  # noqa: BLE001
+        _unavailable("PostgreSQL", f"{url}: {e}")
+
+
+def _make_store(kind: str):
+    """Yield a fresh, empty store of the requested kind, tearing it down after."""
+    if kind == "memory":
+        from delphi_storage.backends.memory import MemoryDelphiStore
+
+        yield MemoryDelphiStore()
+        return
+
+    if kind == "moto":
+        moto = pytest.importorskip("moto")
+        from delphi_storage.backends.dynamodb import DynamoDelphiStore
+
+        with moto.mock_aws():
+            os.environ.setdefault("AWS_ACCESS_KEY_ID", "dummy")
+            os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "dummy")
+            store = DynamoDelphiStore(
+                table_prefix=f"ConfM{uuid.uuid4().hex[:8]}_",
+                region="us-east-1",
+                ensure_tables=True,
+            )
+            yield store
+        return
+
+    if kind == "dynamodb":
+        endpoint = _dynamo_endpoint()
+        _check_dynamo(endpoint)
+        from delphi_storage.backends.dynamodb import DynamoDelphiStore
+
+        store = DynamoDelphiStore(
+            table_prefix=f"ConfT{uuid.uuid4().hex[:8]}_",
+            endpoint_url=endpoint,
+            region="us-east-1",
+            ensure_tables=True,
+        )
+        try:
+            yield store
+        finally:
+            store.drop_tables()
+        return
+
+    if kind == "postgres":
+        url = _pg_url()
+        _check_postgres(url)
+        from delphi_storage.backends.postgres import PostgresDelphiStore
+
+        store = PostgresDelphiStore(
+            url=url,
+            schema=f"conf_{uuid.uuid4().hex[:10]}",
+            ensure_schema=True,
+        )
+        try:
+            yield store
+        finally:
+            store.drop_schema()
+        return
+
+    raise ValueError(f"unknown backend kind {kind!r}")
+
+
+@pytest.fixture(params=STORE_BACKENDS)
+def store(request):
+    yield from _make_store(request.param)
+
+
+@pytest.fixture(params=RACE_BACKENDS)
+def race_store(request):
+    yield from _make_store(request.param)
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.name)
+def test_conformance_case(store, case):
+    run_case(store, case)
+
+
+@pytest.mark.parametrize("case", CODEC_CASES, ids=lambda c: c.name)
+def test_codec_case(case):
+    run_codec_case(case)
+
+
+def test_cases_present():
+    """The shared contract must not silently shrink."""
+    names = {c.name for c in CASES}
+    assert {
+        "roundtrip_basic",
+        "query_ordering",
+        "blob_chunking",
+        "queue_claim",
+        "latest_pointer",
+        "run_manifest_fields",
+        "validation",
+    } <= names
+    assert CODEC_CASES, "codec fixture cases missing"
+
+
+def test_two_claimants_one_wins(race_store):
+    """Design §4.3: queue claim race — concurrent claimants never share a run."""
+    store = race_store
+    n_jobs, n_workers = 4, 10
+    for i in range(n_jobs):
+        store.enqueue_run(
+            RunManifest(
+                job_id=f"race-{i}",
+                job_type=JobType.FULL_PIPELINE,
+                zid=1,
+                enqueued_at=f"2026-07-06T10:00:0{i}.000Z",
+            )
+        )
+
+    results: list[str | None] = [None] * n_workers
+    barrier = threading.Barrier(n_workers)
+
+    def worker(idx: int):
+        barrier.wait()
+        run = store.claim_next_run(worker_id=f"w{idx}", lease_seconds=300)
+        results[idx] = run.job_id if run else None
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_workers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+
+    claimed = [r for r in results if r is not None]
+    assert len(claimed) == n_jobs, f"expected all {n_jobs} runs claimed, got {claimed}"
+    assert len(set(claimed)) == n_jobs, f"a run was claimed twice: {claimed}"
+    # queue is drained
+    assert store.claim_next_run(worker_id="late", lease_seconds=300) is None

--- a/delphi/tests/test_delphi_storage_dynamodb.py
+++ b/delphi/tests/test_delphi_storage_dynamodb.py
@@ -1,0 +1,105 @@
+"""DynamoDB-backend-specific tests: crash-safety of chunked blob writes.
+
+The chunking protocol (generation-tagged chunk rows, main item as commit
+point) is a Dynamo-only concern hidden behind the interface, so these run on
+moto rather than through the shared conformance cases.
+"""
+
+import uuid
+
+import pytest
+
+moto = pytest.importorskip("moto")
+
+from delphi_storage.backends.dynamodb import (  # noqa: E402 - after importorskip
+    CHUNK_SIZE,
+    DynamoDelphiStore,
+    _chunk_prefix,
+    _chunk_sk,
+)
+from delphi_storage.models import StoreItem  # noqa: E402
+
+
+@pytest.fixture()
+def store():
+    with moto.mock_aws():
+        yield DynamoDelphiStore(
+            table_prefix=f"ChunkT{uuid.uuid4().hex[:8]}_",
+            region="us-east-1",
+            ensure_tables=True,
+        )
+
+
+def _big_blob(seed: int, n_chunks: int = 2) -> bytes:
+    unit = bytes([seed % 256]) * 1000
+    return unit * ((CHUNK_SIZE * n_chunks) // 1000 + 1)
+
+
+def _chunk_row_sks(store: DynamoDelphiStore, pk: str, sk: str) -> list[str]:
+    rows = store._query_all(
+        TableName=f"{store.table_prefix}RunInputs",
+        KeyConditionExpression="pk = :pk AND begins_with(sk, :prefix)",
+        ExpressionAttributeValues={":pk": {"S": pk}, ":prefix": {"S": _chunk_prefix(sk)}},
+        ProjectionExpression="pk, sk",
+        ConsistentRead=True,
+    )
+    return [row["sk"]["S"] for row in rows]
+
+
+class TestChunkGenerations:
+    def test_stale_generation_rows_are_ignored_on_read(self, store):
+        blob = _big_blob(1)
+        store.put("run_inputs", StoreItem(pk="j1", sk="votes#0", blob=blob))
+        # Inject a bogus chunk row from a phantom generation.
+        store._client.put_item(
+            TableName=f"{store.table_prefix}RunInputs",
+            Item={
+                "pk": {"S": "j1"},
+                "sk": {"S": _chunk_sk("votes#0", "deadbeef0000", 0)},
+                "part": {"B": b"garbage"},
+            },
+        )
+        item = store.get("run_inputs", "j1", "votes#0")
+        assert item is not None and item.blob == blob
+
+    def test_crashed_write_leaves_previous_value_readable(self, store):
+        old = _big_blob(1)
+        store.put("run_inputs", StoreItem(pk="j1", sk="votes#0", blob=old))
+        # Simulate a writer that crashed after writing its new-generation
+        # chunk rows but BEFORE the main-item commit point.
+        new = _big_blob(2)
+        crashed_gen = uuid.uuid4().hex[:12]
+        for i in range(0, len(new), CHUNK_SIZE):
+            store._client.put_item(
+                TableName=f"{store.table_prefix}RunInputs",
+                Item={
+                    "pk": {"S": "j1"},
+                    "sk": {"S": _chunk_sk("votes#0", crashed_gen, i // CHUNK_SIZE)},
+                    "part": {"B": new[i : i + CHUNK_SIZE]},
+                },
+            )
+        item = store.get("run_inputs", "j1", "votes#0")
+        assert item is not None and item.blob == old, "old value must survive a crashed write"
+        # The next successful put sweeps the orphaned generation.
+        final = _big_blob(3)
+        store.put("run_inputs", StoreItem(pk="j1", sk="votes#0", blob=final))
+        item = store.get("run_inputs", "j1", "votes#0")
+        assert item is not None and item.blob == final
+        remaining = _chunk_row_sks(store, "j1", "votes#0")
+        gens = {sk.split("\x7f")[2] for sk in remaining}
+        assert len(gens) == 1 and crashed_gen not in gens
+
+    def test_shrinking_overwrite_removes_all_chunk_rows(self, store):
+        store.put("run_inputs", StoreItem(pk="j1", sk="votes#0", blob=_big_blob(1)))
+        assert len(_chunk_row_sks(store, "j1", "votes#0")) >= 2
+        store.put("run_inputs", StoreItem(pk="j1", sk="votes#0", blob=b"tiny"))
+        assert _chunk_row_sks(store, "j1", "votes#0") == []
+        item = store.get("run_inputs", "j1", "votes#0")
+        assert item is not None and item.blob == b"tiny"
+
+    def test_same_size_overwrite_reads_consistently(self, store):
+        store.put("run_inputs", StoreItem(pk="j1", sk="votes#0", blob=_big_blob(1)))
+        replacement = _big_blob(2)
+        store.put("run_inputs", StoreItem(pk="j1", sk="votes#0", blob=replacement))
+        item = store.get("run_inputs", "j1", "votes#0")
+        assert item is not None and item.blob == replacement

--- a/delphi/tests/test_delphi_storage_keys.py
+++ b/delphi/tests/test_delphi_storage_keys.py
@@ -1,0 +1,123 @@
+"""Unit tests for delphi_storage.keys — claim order, timestamps, scopes, key builders."""
+
+import pytest
+
+from delphi_storage.keys import (
+    CHUNK_MARKER,
+    GENERIC_ENTITIES,
+    artifact_key,
+    claim_order,
+    log_sk,
+    scope_for_rid,
+    scope_for_zid,
+    scopes_for_run,
+    ts_add_seconds,
+    validate_ts,
+)
+from delphi_storage.models import JobType, RunManifest
+
+T0 = "2026-07-06T10:00:00.000Z"
+T1 = "2026-07-06T10:00:01.000Z"
+
+
+class TestClaimOrder:
+    def test_format(self):
+        assert claim_order(5, T1, "jobB") == f"9994#{T1}#jobB"
+        assert claim_order(0, T0, "jobA") == f"9999#{T0}#jobA"
+
+    def test_higher_priority_sorts_first(self):
+        assert claim_order(5, T1, "b") < claim_order(0, T0, "a")
+
+    def test_fifo_within_priority(self):
+        assert claim_order(0, T0, "a") < claim_order(0, T1, "b")
+
+    def test_job_id_tiebreak(self):
+        assert claim_order(0, T0, "a") < claim_order(0, T0, "b")
+
+    def test_clamping(self):
+        assert claim_order(-3, T0, "x").startswith("9999#")
+        assert claim_order(20000, T0, "x").startswith("0000#")
+
+
+class TestTimestamps:
+    def test_valid(self):
+        assert validate_ts(T0) == T0
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "2026-07-06 10:00:00",
+            "2026-07-06T10:00:00Z",
+            "2026-07-06T10:00:00.000+00:00",
+            "2026-07-06T10:00:00.000",
+            "not a ts",
+            "",
+        ],
+    )
+    def test_invalid(self, bad):
+        with pytest.raises(ValueError):
+            validate_ts(bad)
+
+    def test_add_seconds(self):
+        assert ts_add_seconds("2026-07-06T10:01:00.000Z", 300) == "2026-07-06T10:06:00.000Z"
+
+    def test_add_seconds_rolls_over_midnight(self):
+        assert ts_add_seconds("2026-07-06T23:59:30.500Z", 60) == "2026-07-07T00:00:30.500Z"
+
+
+class TestScopes:
+    def test_scope_builders(self):
+        assert scope_for_zid(7, JobType.FULL_PIPELINE) == "zid#7#FULL_PIPELINE"
+        assert scope_for_rid(42, JobType.NARRATIVE_BATCH) == "rid#42#NARRATIVE_BATCH"
+
+    def _run(self, **kw):
+        base = dict(job_id="j", job_type=JobType.FULL_PIPELINE, enqueued_at=T0)
+        base.update(kw)
+        return RunManifest(**base)
+
+    def test_full_pipeline_scope(self):
+        assert scopes_for_run(self._run(zid=7)) == ["zid#7#FULL_PIPELINE"]
+
+    def test_narrative_batch_scope(self):
+        run = self._run(job_type=JobType.NARRATIVE_BATCH, zid=7, rid=42)
+        assert scopes_for_run(run) == ["rid#42#NARRATIVE_BATCH"]
+
+    def test_server_narrative_scope(self):
+        run = self._run(job_type=JobType.SERVER_NARRATIVE, rid=42)
+        assert scopes_for_run(run) == ["rid#42#SERVER_NARRATIVE"]
+
+    def test_imported_never_autoflips(self):
+        run = self._run(job_type=JobType.IMPORTED, zid=7, rid=42)
+        assert scopes_for_run(run) == []
+
+    def test_missing_zid_raises(self):
+        with pytest.raises(ValueError):
+            scopes_for_run(self._run(zid=None))
+
+    def test_missing_rid_raises(self):
+        with pytest.raises(ValueError):
+            scopes_for_run(self._run(job_type=JobType.NARRATIVE_BATCH, zid=7, rid=None))
+
+
+class TestKeys:
+    def test_log_sk_zero_padded(self):
+        assert log_sk(1) == "log#00000001"
+        assert log_sk(12345678) == "log#12345678"
+
+    def test_log_sks_sort_numerically(self):
+        assert sorted([log_sk(2), log_sk(10), log_sk(1)]) == [log_sk(1), log_sk(2), log_sk(10)]
+
+    def test_artifact_key(self):
+        assert artifact_key("math", "pca") == "math#pca"
+        assert artifact_key("umap", "topic", 0, 3) == "umap#topic#0#3"
+
+    def test_artifact_key_rejects_chunk_marker(self):
+        with pytest.raises(ValueError):
+            artifact_key("math", f"bad{CHUNK_MARKER}part")
+
+    def test_generic_entities_exclude_runs_and_latest(self):
+        assert "runs" not in GENERIC_ENTITIES
+        assert "latest" not in GENERIC_ENTITIES
+        assert {"run_inputs", "artifacts", "topic_moderation", "collective_statements"} == set(
+            GENERIC_ENTITIES
+        )

--- a/delphi/tests/test_delphi_storage_postgres.py
+++ b/delphi/tests/test_delphi_storage_postgres.py
@@ -1,0 +1,35 @@
+"""Unit tests for the Postgres backend that need no live database.
+
+``sqlalchemy.create_engine`` resolves the dialect eagerly (it does NOT open a
+connection), so these exercise URL handling without a running Postgres.
+"""
+
+import pytest
+
+sqlalchemy = pytest.importorskip("sqlalchemy")
+
+from delphi_storage.backends.postgres import PostgresDelphiStore
+
+
+class TestPgUrlSchemeNormalization:
+    """SQLAlchemy 2.0 dropped the legacy ``postgres://`` alias and raises
+    ``NoSuchModuleError`` on it, but ``postgres://`` is still what many
+    platforms (Heroku et al.) put in ``DATABASE_URL``. The backend must
+    normalize it to ``postgresql://`` so a production ``DATABASE_URL`` doesn't
+    crash engine creation.
+    """
+
+    def test_legacy_postgres_scheme_is_normalized(self):
+        store = PostgresDelphiStore(url="postgres://u:p@localhost:5432/db")
+        assert store._engine.url.drivername == "postgresql"
+
+    def test_postgresql_scheme_is_untouched(self):
+        store = PostgresDelphiStore(url="postgresql://u:p@localhost:5432/db")
+        assert store._engine.url.drivername == "postgresql"
+
+    def test_explicit_driver_suffix_is_preserved(self):
+        # A caller who pins the DBAPI driver must keep it — only the bare
+        # postgres:// alias is rewritten, never postgres+<driver> or an
+        # already-correct postgresql+<driver>.
+        store = PostgresDelphiStore(url="postgresql+psycopg2://u:p@localhost:5432/db")
+        assert store._engine.url.drivername == "postgresql+psycopg2"


### PR DESCRIPTION
Stack 1 / P2 of the Storage V2 effort — design doc in #2597 (`delphi/docs/STORAGE_V2_DESIGN.md`, §4.2–4.3, §7).

## What this adds

A new Python package `delphi/delphi_storage/`: the **backend-neutral repository** over the six V2 logical entities (`runs`, `run_inputs`, `artifacts`, `latest`, `topic_moderation`, `collective_statements`), with **both** production backends and the **shared conformance spec** that will keep the Python and TypeScript implementations honest.

### Interface (`interface.py`)
- Generic ops: `put / put_batch / get / query_prefix / query_between / delete_partition` — only for the four KV entities; `runs`/`latest` are reachable exclusively through semantic ops so their invariants can't be bypassed.
- Semantic queue/run ops: `enqueue_run`, `claim_next_run` (priority desc → FIFO → job_id, conditional-write atomicity), `extend_lease`, `update_run_status`, `merge_run_fields`, `complete_run`, `append_log`, `advance_latest`, `get_latest`, `list_runs`.
- `complete_run` writes the `latest` pointer **last** (the commit point, design §4.2), is idempotent, and heals a crash between manifest-COMPLETED and pointer flip.
- `advance_latest(only_if_absent_or_imported=True)` implements the backfill importer's no-clobber invariant (§6.2 invariant 1) — conformance-tested now, used by P9.

### Codec (`codec.py`)
Canonical JSON (sorted keys, compact, UTF-8, NaN rejected), little-endian packed float64 (bit-exact), zstd, and versioned payload envelopes (`json` / `json+zstd` / `f64+zstd`) carrying sha256 + byte counts of the **uncompressed** payload (compressed bytes are never compared: zstd output is implementation-dependent). Decimal↔float conversion for DynamoDB follows the existing `Decimal(str(x))` convention.

### Backends
- **DynamoDB** (`backends/dynamodb.py`): thread-safe low-level client + TypeSerializer; optimistic-lock conditional writes on `version` (the lift of the working `job_poller.py` claim logic); sparse `claim-index` GSI for queue ordering; `zid-index`/`rid-index` for `list_runs`; blobs >300KB transparently chunked across hidden rows (sk prefixed U+007F) and reassembled on read — invisible to queries, stale chunks cleaned on overwrite.
- **PostgreSQL** (`backends/postgres.py`): schema-scoped tables (default `delphi`), `COLLATE "C"` sort keys (= DynamoDB byte order), `FOR UPDATE SKIP LOCKED` claims, JSONB manifests following the legacy `math_main` pattern. The DDL in this file is the single Python-side source that migration `000019` (P4) mirrors.
- **Memory** (`backends/memory.py`): in-process reference implementation / executable spec.
- `factory.py`: `DELPHI_STORAGE_BACKEND=dynamodb|postgres|memory` (+ `DELPHI_STORAGE_TABLE_PREFIX`, `DELPHI_STORAGE_PG_SCHEMA`, `DELPHI_STORAGE_PG_URL`), reusing the existing `DYNAMODB_ENDPOINT`/`AWS_REGION`/`DATABASE_URL` vocabulary.

### Conformance suite (`conformance/`)
- Normative spec in `conformance/README.md` + **8 JSON operation-script case files** — the same files P3's jest suite executes against the TS backends.
- Coverage: unicode/float/null round-trips, UTF-8 byte-order prefix/between queries (incl. an astral-plane case that catches UTF-16 comparison bugs), chunk-spanning blob round-trips + overwrite-shrink cleanup, queue claim ordering/leases/duplicate-enqueue, monotonic latest seq, idempotent completion, importer no-clobber, validation rejections, and cross-language codec fixtures (Python-encoded zstd blobs the TS side must decode).
- pytest runs every case against **all four** backend params: `memory` and `moto` always; real `dynamodb`/`postgres` skip locally when unreachable and fail loudly under `GITHUB_ACTIONS` (both services are up in CI).
- A threaded two-claimants-one-wins race test runs against memory + both real backends.

## Testing

- Full suite: **398 passed, 28 skipped, 58 xfailed** (baseline before this PR: 332/12/58; the 5 pre-existing DynamoDB-unavailable errors unchanged).
- With DynamoDB local (`:8002`) + dockerized PG 16: all backend×case params green, including the race tests.
- TDD: cases + tests written first (RED: 3 collection errors), then the package (GREEN).

## Dependencies

Adds `zstandard>=0.23` to `pyproject.toml` and the matching pin to `requirements.lock` (Docker build).

## Stack

- P1: #2597 (design doc)
- **P2: this PR**
- P3: TypeScript twin `server/src/storage/delphi/` + jest on the same case files (next)
- P4: DDL — `create_dynamodb_tables.py` additions + PG migration `000019`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
