### PR TITLE
feat(server): storage v2 P3 — TypeScript delphi storage twin (dual backends + jest conformance)

### DIFF
--- a/server/__tests__/integration/delphiStorage.backends.test.ts
+++ b/server/__tests__/integration/delphiStorage.backends.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Conformance suite against the real backends (DynamoDB local + PostgreSQL),
+ * plus the two-claimants-one-wins race. Services are provided by
+ * docker-compose.test.yml in CI (DYNAMODB_ENDPOINT / DATABASE_URL), matching
+ * the other integration suites.
+ *
+ * Spec + case files: delphi/delphi_storage/conformance/ (shared with pytest).
+ */
+import { loadCases, runCase } from "../setup/delphi-storage-conformance";
+import { DynamoDelphiStore } from "../../src/storage/delphi/dynamoStore";
+import { PostgresDelphiStore } from "../../src/storage/delphi/postgresStore";
+import { DelphiStore, normalizeRunManifest } from "../../src/storage/delphi/interface";
+
+const cases = loadCases();
+
+const DYNAMO_ENDPOINT = process.env.DYNAMODB_ENDPOINT || "http://localhost:8000";
+const PG_URL =
+  process.env.DELPHI_STORAGE_PG_URL ||
+  process.env.DATABASE_URL ||
+  "postgres://postgres:postgres@localhost:5432/polis-test";
+
+function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}${Math.floor(Math.random() * 1e6).toString(36)}`;
+}
+
+async function raceTest(store: DelphiStore): Promise<void> {
+  const nJobs = 4;
+  const nWorkers = 10;
+  for (let i = 0; i < nJobs; i++) {
+    await store.enqueueRun(
+      normalizeRunManifest({
+        job_id: `race-${i}`,
+        job_type: "FULL_PIPELINE",
+        zid: 1,
+        enqueued_at: `2026-07-06T10:00:0${i}.000Z`,
+      })
+    );
+  }
+  const claims = await Promise.all(
+    Array.from({ length: nWorkers }, (_, i) =>
+      store.claimNextRun({ workerId: `w${i}`, leaseSeconds: 300 })
+    )
+  );
+  const claimed = claims.filter((r) => r !== null).map((r) => r!.job_id);
+  expect(claimed.length).toBe(nJobs);
+  expect(new Set(claimed).size).toBe(nJobs);
+  expect(await store.claimNextRun({ workerId: "late", leaseSeconds: 300 })).toBeNull();
+}
+
+describe("delphi storage conformance — dynamodb backend", () => {
+  let store: DynamoDelphiStore;
+
+  afterEach(async () => {
+    if (store) await store.dropTables();
+  });
+
+  it.each(cases)("case $name", async (c) => {
+    store = new DynamoDelphiStore({
+      tablePrefix: `ConfTs${uniqueSuffix()}_`,
+      endpoint: DYNAMO_ENDPOINT,
+      region: "us-east-1",
+    });
+    await store.ensureTables();
+    await runCase(store, c);
+  });
+
+  it("two claimants never share a run", async () => {
+    store = new DynamoDelphiStore({
+      tablePrefix: `ConfTs${uniqueSuffix()}_`,
+      endpoint: DYNAMO_ENDPOINT,
+      region: "us-east-1",
+    });
+    await store.ensureTables();
+    await raceTest(store);
+  });
+});
+
+describe("delphi storage conformance — postgres backend", () => {
+  let store: PostgresDelphiStore;
+
+  afterEach(async () => {
+    if (store) await store.dropSchema();
+  });
+
+  it.each(cases)("case $name", async (c) => {
+    store = new PostgresDelphiStore({ url: PG_URL, schema: `conf_ts_${uniqueSuffix()}` });
+    await store.ensureSchema();
+    await runCase(store, c);
+  });
+
+  it("two claimants never share a run", async () => {
+    store = new PostgresDelphiStore({ url: PG_URL, schema: `conf_ts_${uniqueSuffix()}` });
+    await store.ensureSchema();
+    await raceTest(store);
+  });
+});

--- a/server/__tests__/setup/delphi-storage-conformance.ts
+++ b/server/__tests__/setup/delphi-storage-conformance.ts
@@ -1,0 +1,451 @@
+/**
+ * Jest executor for the shared Delphi Storage V2 conformance case files —
+ * twin of delphi/delphi_storage/conformance/runner.py, executing the SAME
+ * JSON operation-scripts from delphi/delphi_storage/conformance/cases/.
+ * The op vocabulary is specified in the README next to the cases; keep the
+ * three in sync.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+import {
+  F64,
+  decodePayload,
+  encodePayload,
+  packF64,
+} from "../../src/storage/delphi/codec";
+import { StorageError } from "../../src/storage/delphi/errors";
+import {
+  DelphiStore,
+  RunManifest,
+  StoreItem,
+  normalizeRunManifest,
+} from "../../src/storage/delphi/interface";
+
+export const CASES_DIR = path.resolve(
+  __dirname,
+  "../../../delphi/delphi_storage/conformance/cases"
+);
+
+export interface ConformanceOp {
+  op: string;
+  expect?: Record<string, unknown>;
+  expect_error?: string;
+  [key: string]: unknown;
+}
+
+export interface ConformanceCase {
+  name: string;
+  description: string;
+  ops: ConformanceOp[];
+}
+
+function loadFile(file: string): ConformanceCase {
+  return JSON.parse(fs.readFileSync(path.join(CASES_DIR, file), "utf8")) as ConformanceCase;
+}
+
+export function loadCases(): ConformanceCase[] {
+  return fs
+    .readdirSync(CASES_DIR)
+    .filter((f) => f.endsWith(".json") && !f.startsWith("codec_"))
+    .sort()
+    .map(loadFile);
+}
+
+export function loadCodecCases(): ConformanceCase[] {
+  return fs
+    .readdirSync(CASES_DIR)
+    .filter((f) => f.endsWith(".json") && f.startsWith("codec_"))
+    .sort()
+    .map(loadFile);
+}
+
+/** Deterministic blob generators shared with the pytest runner. */
+export function genBlob(spec: { kind: string; n: number }): Buffer {
+  if (spec.kind === "f64_seq") {
+    return packF64(Array.from({ length: spec.n }, (_, i) => i * 0.5));
+  }
+  throw new Error(`unknown blob generator ${JSON.stringify(spec.kind)}`);
+}
+
+function isPlainNumber(value: unknown): value is number {
+  return typeof value === "number";
+}
+
+/**
+ * Deep equality; numbers compare by value (DynamoDB may return 2 for a
+ * stored 2.0), booleans strictly.
+ */
+export function assertJsonEqual(actual: unknown, expected: unknown, at = "$"): void {
+  if (typeof expected === "boolean" || typeof actual === "boolean") {
+    if (actual !== expected) {
+      throw new Error(`${at}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    }
+    return;
+  }
+  if (isPlainNumber(expected) && isPlainNumber(actual)) {
+    if (actual !== expected) {
+      throw new Error(`${at}: expected ${expected}, got ${actual}`);
+    }
+    return;
+  }
+  if (expected !== null && typeof expected === "object" && !Array.isArray(expected)) {
+    if (actual === null || typeof actual !== "object" || Array.isArray(actual)) {
+      throw new Error(`${at}: expected object, got ${JSON.stringify(actual)}`);
+    }
+    const expectedKeys = Object.keys(expected as Record<string, unknown>).sort();
+    const actualKeys = Object.keys(actual as Record<string, unknown>).sort();
+    if (JSON.stringify(expectedKeys) !== JSON.stringify(actualKeys)) {
+      throw new Error(
+        `${at}: key mismatch — expected ${JSON.stringify(expectedKeys)}, got ${JSON.stringify(actualKeys)}`
+      );
+    }
+    for (const key of expectedKeys) {
+      assertJsonEqual(
+        (actual as Record<string, unknown>)[key],
+        (expected as Record<string, unknown>)[key],
+        `${at}.${key}`
+      );
+    }
+    return;
+  }
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || actual.length !== expected.length) {
+      throw new Error(
+        `${at}: expected ${expected.length}-element list, got ${JSON.stringify(actual)}`
+      );
+    }
+    expected.forEach((e, i) => assertJsonEqual(actual[i], e, `${at}[${i}]`));
+    return;
+  }
+  if (actual !== expected) {
+    throw new Error(`${at}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function itemFromSpec(spec: Record<string, unknown>): StoreItem {
+  let blob: Buffer | null = null;
+  if (spec.blob_b64 !== undefined && spec.blob_b64 !== null) {
+    blob = Buffer.from(spec.blob_b64 as string, "base64");
+  } else if (spec.blob_gen !== undefined && spec.blob_gen !== null) {
+    blob = genBlob(spec.blob_gen as { kind: string; n: number });
+  }
+  return {
+    pk: spec.pk as string,
+    sk: spec.sk as string,
+    attributes: (spec.attributes as Record<string, unknown>) ?? {},
+    blob,
+  };
+}
+
+function expectedBlob(expect: Record<string, unknown>): Buffer | null {
+  if (expect.blob_b64 !== undefined && expect.blob_b64 !== null) {
+    return Buffer.from(expect.blob_b64 as string, "base64");
+  }
+  if (expect.blob_gen !== undefined && expect.blob_gen !== null) {
+    return genBlob(expect.blob_gen as { kind: string; n: number });
+  }
+  return null;
+}
+
+function assertManifestSubset(
+  run: RunManifest,
+  expect: Record<string, unknown>,
+  context: string
+): void {
+  for (const [key, expected] of Object.entries(expect)) {
+    if (key === "found" || key === "latest") continue;
+    assertJsonEqual(
+      (run as unknown as Record<string, unknown>)[key],
+      expected,
+      `${context}.${key}`
+    );
+  }
+}
+
+async function runOp(store: DelphiStore, op: ConformanceOp): Promise<void> {
+  const expect = op.expect ?? {};
+  const expectedError = op.expect_error;
+
+  const call = async (): Promise<unknown> => {
+    switch (op.op) {
+      case "put":
+        return store.put(op.entity as string, itemFromSpec(op.item as Record<string, unknown>));
+      case "put_batch":
+        return store.putBatch(
+          op.entity as string,
+          (op.items as Record<string, unknown>[]).map(itemFromSpec)
+        );
+      case "get":
+        return store.get(op.entity as string, op.pk as string, op.sk as string);
+      case "query_prefix":
+        return store.queryPrefix(
+          op.entity as string,
+          op.pk as string,
+          (op.sk_prefix as string) ?? ""
+        );
+      case "query_between":
+        return store.queryBetween(
+          op.entity as string,
+          op.pk as string,
+          op.sk_from as string,
+          op.sk_to as string
+        );
+      case "delete_partition":
+        return store.deletePartition(op.entity as string, op.pk as string);
+      case "enqueue_run":
+        return store.enqueueRun(normalizeRunManifest(op.run as Record<string, unknown>));
+      case "get_run":
+        return store.getRun(op.job_id as string);
+      case "claim_next_run":
+        return store.claimNextRun({
+          workerId: op.worker_id as string,
+          leaseSeconds: op.lease_seconds as number,
+          now: op.now as string | undefined,
+        });
+      case "extend_lease":
+        return store.extendLease({
+          jobId: op.job_id as string,
+          workerId: op.worker_id as string,
+          leaseSeconds: op.lease_seconds as number,
+          now: op.now as string | undefined,
+        });
+      case "update_run_status":
+        return store.updateRunStatus(op.job_id as string, op.status as string, {
+          error: op.error as string | undefined,
+          now: op.now as string | undefined,
+        });
+      case "merge_run_fields":
+        return store.mergeRunFields(op.job_id as string, op.fields as Record<string, unknown>);
+      case "complete_run":
+        return store.completeRun(op.job_id as string, op.now as string | undefined);
+      case "append_log":
+        return store.appendLog(
+          op.job_id as string,
+          op.message as string,
+          op.now as string | undefined
+        );
+      case "advance_latest":
+        return store.advanceLatest({
+          scope: op.scope as string,
+          jobId: op.job_id as string,
+          jobType: op.job_type as string,
+          onlyIfAbsentOrImported: (op.only_if_absent_or_imported as boolean) ?? false,
+          now: op.now as string | undefined,
+        });
+      case "get_latest":
+        return store.getLatest(op.scope as string);
+      case "list_runs":
+        return store.listRuns({
+          zid: op.zid as number | undefined,
+          rid: op.rid as number | undefined,
+          status: op.status as string | undefined,
+        });
+      default:
+        throw new Error(`unknown op ${JSON.stringify(op.op)}`);
+    }
+  };
+
+  if (expectedError !== undefined) {
+    try {
+      await call();
+    } catch (error) {
+      if (error instanceof StorageError) {
+        if (error.code !== expectedError) {
+          throw new Error(
+            `expected error ${JSON.stringify(expectedError)}, got ${error.code} (${error.message})`
+          );
+        }
+        return;
+      }
+      throw error;
+    }
+    throw new Error(`expected error ${JSON.stringify(expectedError)}, but op succeeded`);
+  }
+
+  const result = await call();
+
+  switch (op.op) {
+    case "get": {
+      if (!Object.keys(expect).length) return;
+      const item = result as StoreItem | null;
+      if (!expect.found) {
+        if (item !== null) throw new Error(`expected absent item, got ${JSON.stringify(item)}`);
+        return;
+      }
+      if (item === null) throw new Error("expected item, got null");
+      if (expect.attributes !== undefined) {
+        assertJsonEqual(item.attributes, expect.attributes, "attributes");
+      }
+      const blob = expectedBlob(expect);
+      if (blob !== null) {
+        if (item.blob === null || !blob.equals(item.blob)) {
+          throw new Error("blob bytes differ");
+        }
+      }
+      if (expect.blob_len !== undefined) {
+        if (item.blob === null || item.blob.length !== expect.blob_len) {
+          throw new Error(
+            `expected blob of ${expect.blob_len} bytes, got ${item.blob?.length ?? null}`
+          );
+        }
+      }
+      return;
+    }
+    case "query_prefix":
+    case "query_between": {
+      if (expect.sks !== undefined) {
+        const sks = (result as StoreItem[]).map((i) => i.sk);
+        assertJsonEqual(sks, expect.sks, "sks");
+      }
+      return;
+    }
+    case "delete_partition": {
+      if (expect.deleted !== undefined) {
+        assertJsonEqual(result, expect.deleted, "deleted");
+      }
+      return;
+    }
+    case "get_run": {
+      if (!Object.keys(expect).length) return;
+      const run = result as RunManifest | null;
+      if (!expect.found) {
+        if (run !== null) throw new Error(`expected absent run, got ${JSON.stringify(run)}`);
+        return;
+      }
+      if (run === null) throw new Error("expected run, got null");
+      assertManifestSubset(run, expect, "run");
+      return;
+    }
+    case "claim_next_run": {
+      if (!("job_id" in expect)) return;
+      const run = result as RunManifest | null;
+      if (expect.job_id === null) {
+        if (run !== null) throw new Error(`expected no claim, got ${run.job_id}`);
+        return;
+      }
+      if (run === null || run.job_id !== expect.job_id) {
+        throw new Error(
+          `expected claim of ${JSON.stringify(expect.job_id)}, got ${run ? run.job_id : null}`
+        );
+      }
+      const rest = { ...expect };
+      delete rest.job_id;
+      assertManifestSubset(run, rest, "claim");
+      return;
+    }
+    case "extend_lease": {
+      if (expect.ok !== undefined && result !== expect.ok) {
+        throw new Error(`expected ok=${expect.ok}, got ${result}`);
+      }
+      return;
+    }
+    case "update_run_status":
+    case "merge_run_fields":
+    case "complete_run": {
+      const run = result as RunManifest;
+      assertManifestSubset(run, expect, op.op);
+      if (op.op === "complete_run" && expect.latest !== undefined) {
+        for (const pointerExpect of expect.latest as Array<Record<string, unknown>>) {
+          const pointer = await store.getLatest(pointerExpect.scope as string);
+          if (pointer === null) {
+            throw new Error(`no latest pointer for ${JSON.stringify(pointerExpect.scope)}`);
+          }
+          assertJsonEqual(pointer.job_id, pointerExpect.job_id, "latest.job_id");
+          assertJsonEqual(pointer.seq, pointerExpect.seq, "latest.seq");
+        }
+      }
+      return;
+    }
+    case "append_log": {
+      if (expect.seq !== undefined) assertJsonEqual(result, expect.seq, "seq");
+      return;
+    }
+    case "advance_latest": {
+      const advance = result as { advanced: boolean; pointer: { seq: number } };
+      if (expect.advanced !== undefined && advance.advanced !== expect.advanced) {
+        throw new Error(`expected advanced=${expect.advanced}, got ${advance.advanced}`);
+      }
+      if (expect.seq !== undefined) assertJsonEqual(advance.pointer.seq, expect.seq, "seq");
+      return;
+    }
+    case "get_latest": {
+      if (!Object.keys(expect).length) return;
+      const pointer = result as Record<string, unknown> | null;
+      if (!expect.found) {
+        if (pointer !== null) {
+          throw new Error(`expected no pointer, got ${JSON.stringify(pointer)}`);
+        }
+        return;
+      }
+      if (pointer === null) throw new Error("expected pointer, got null");
+      for (const key of ["job_id", "seq", "job_type"]) {
+        if (expect[key] !== undefined) {
+          assertJsonEqual(pointer[key], expect[key], `latest.${key}`);
+        }
+      }
+      return;
+    }
+    case "list_runs": {
+      if (expect.job_ids !== undefined) {
+        const jobIds = (result as RunManifest[]).map((r) => r.job_id);
+        assertJsonEqual(jobIds, expect.job_ids, "job_ids");
+      }
+      return;
+    }
+    default:
+      return;
+  }
+}
+
+export async function runCase(store: DelphiStore, testCase: ConformanceCase): Promise<void> {
+  for (let i = 0; i < testCase.ops.length; i++) {
+    try {
+      await runOp(store, testCase.ops[i]);
+    } catch (error) {
+      throw new Error(
+        `case ${testCase.name}, op ${i} (${testCase.ops[i].op}): ${(error as Error).message}`
+      );
+    }
+  }
+}
+
+export function runCodecCase(testCase: ConformanceCase): void {
+  for (let i = 0; i < testCase.ops.length; i++) {
+    const op = testCase.ops[i];
+    try {
+      if (op.op === "codec_roundtrip") {
+        const value = op.value;
+        const enc = encodePayload(value);
+        assertJsonEqual(decodePayload(enc.meta, enc.blob), value);
+        const forced = encodePayload(value, "json+zstd");
+        assertJsonEqual(decodePayload(forced.meta, forced.blob), value);
+        if (
+          Array.isArray(value) &&
+          value.length > 0 &&
+          value.every((v) => typeof v === "number")
+        ) {
+          const f64 = encodePayload(new F64(value as number[]));
+          const decoded = decodePayload(f64.meta, f64.blob) as number[];
+          assertJsonEqual(decoded, value);
+        }
+      } else if (op.op === "codec_decode_fixture") {
+        const blob =
+          op.blob_b64 !== undefined && op.blob_b64 !== null
+            ? Buffer.from(op.blob_b64 as string, "base64")
+            : null;
+        const decoded = decodePayload(
+          op.meta as { enc: string; [key: string]: unknown },
+          blob
+        );
+        assertJsonEqual(decoded, op.expect_value);
+      } else {
+        throw new Error(`unknown codec op ${JSON.stringify(op.op)}`);
+      }
+    } catch (error) {
+      throw new Error(
+        `case ${testCase.name}, op ${i} (${op.op}): ${(error as Error).message}`
+      );
+    }
+  }
+}

--- a/server/__tests__/unit/delphiStorage.codec.test.ts
+++ b/server/__tests__/unit/delphiStorage.codec.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for the Delphi Storage V2 TypeScript codec + keys.
+ *
+ * These pin the same cross-language wire format as delphi's
+ * tests/test_delphi_storage_codec.py and tests/test_delphi_storage_keys.py —
+ * canonical JSON, little-endian packed float64, zstd envelopes, claim-order
+ * strings, canonical timestamps. The normative spec lives in
+ * delphi/delphi_storage/conformance/README.md.
+ */
+import * as crypto from "crypto";
+
+import {
+  F64,
+  INLINE_LIMIT,
+  canonicalJsonDumps,
+  compress,
+  decodePayload,
+  decompress,
+  encodePayload,
+  packF64,
+  unpackF64,
+} from "../../src/storage/delphi/codec";
+import {
+  CHUNK_MARKER,
+  GENERIC_ENTITIES,
+  artifactKey,
+  claimOrder,
+  logSk,
+  scopeForRid,
+  scopeForZid,
+  scopesForRun,
+  tsAddSeconds,
+  validateTs,
+} from "../../src/storage/delphi/keys";
+import { normalizeRunManifest } from "../../src/storage/delphi/interface";
+
+const T0 = "2026-07-06T10:00:00.000Z";
+const T1 = "2026-07-06T10:00:01.000Z";
+
+describe("canonicalJsonDumps", () => {
+  it("sorts keys compactly", () => {
+    expect(canonicalJsonDumps({ b: 1, a: [1.5, "x"] })).toBe('{"a":[1.5,"x"],"b":1}');
+  });
+
+  it("does not escape unicode", () => {
+    expect(canonicalJsonDumps({ k: "café 😀" })).toBe('{"k":"café 😀"}');
+  });
+
+  it("sorts nested keys", () => {
+    expect(canonicalJsonDumps({ o: { b: 1, a: 2 } })).toBe('{"o":{"a":2,"b":1}}');
+  });
+
+  it("rejects NaN and Infinity", () => {
+    expect(() => canonicalJsonDumps({ x: NaN })).toThrow();
+    expect(() => canonicalJsonDumps({ x: Infinity })).toThrow();
+  });
+});
+
+describe("packF64", () => {
+  it("round-trips", () => {
+    const values = [0.0, 0.5, -1.25, 1e300, 5e-324, Math.PI];
+    expect(unpackF64(packF64(values))).toEqual(values);
+  });
+
+  it("is little-endian IEEE-754", () => {
+    expect(packF64([0.5]).toString("hex")).toBe("000000000000e03f");
+  });
+
+  it("handles empty arrays", () => {
+    expect(packF64([]).length).toBe(0);
+    expect(unpackF64(Buffer.alloc(0))).toEqual([]);
+  });
+});
+
+describe("zstd", () => {
+  it("round-trips binary data", () => {
+    const raw = Buffer.concat(
+      Array.from({ length: 10 }, () => Buffer.from(Array.from({ length: 256 }, (_, i) => i)))
+    );
+    const comp = compress(raw);
+    expect(decompress(comp).equals(raw)).toBe(true);
+  });
+});
+
+describe("payload envelopes", () => {
+  it("keeps small JSON inline", () => {
+    const value = { pca: [0.1, 0.2], n: 3 };
+    const enc = encodePayload(value);
+    expect(enc.meta.enc).toBe("json");
+    expect(enc.blob).toBeNull();
+    expect(decodePayload(enc.meta, enc.blob)).toEqual(value);
+  });
+
+  it("compresses large JSON with sha256 of the uncompressed bytes", () => {
+    const value = { rows: Array.from({ length: 20000 }, (_, i) => ({ i, v: i * 0.5 })) };
+    const raw = Buffer.from(canonicalJsonDumps(value), "utf8");
+    expect(raw.length).toBeGreaterThan(INLINE_LIMIT);
+    const enc = encodePayload(value);
+    expect(enc.meta.enc).toBe("json+zstd");
+    expect(enc.meta.bytes).toBe(raw.length);
+    expect(enc.meta.sha256).toBe(crypto.createHash("sha256").update(raw).digest("hex"));
+    expect(decodePayload(enc.meta, enc.blob)).toEqual(value);
+  });
+
+  it("encodes float64 payloads bit-exactly", () => {
+    const values = [0.1, 1e-9, 1e300, -0.0, 5e-324];
+    const enc = encodePayload(new F64(values));
+    expect(enc.meta.enc).toBe("f64+zstd");
+    expect(enc.meta.count).toBe(5);
+    const out = decodePayload(enc.meta, enc.blob) as number[];
+    expect(packF64(out).equals(packF64(values))).toBe(true);
+  });
+
+  it("rejects unknown encodings", () => {
+    expect(() => decodePayload({ enc: "protobuf" }, Buffer.alloc(0))).toThrow();
+  });
+});
+
+describe("claimOrder", () => {
+  it("formats priority-inverted fixed width", () => {
+    expect(claimOrder(5, T1, "jobB")).toBe(`9994#${T1}#jobB`);
+    expect(claimOrder(0, T0, "jobA")).toBe(`9999#${T0}#jobA`);
+  });
+
+  it("sorts higher priority first, then FIFO, then job_id", () => {
+    expect(claimOrder(5, T1, "b") < claimOrder(0, T0, "a")).toBe(true);
+    expect(claimOrder(0, T0, "a") < claimOrder(0, T1, "b")).toBe(true);
+    expect(claimOrder(0, T0, "a") < claimOrder(0, T0, "b")).toBe(true);
+  });
+
+  it("clamps priority", () => {
+    expect(claimOrder(-3, T0, "x").startsWith("9999#")).toBe(true);
+    expect(claimOrder(20000, T0, "x").startsWith("0000#")).toBe(true);
+  });
+});
+
+describe("timestamps", () => {
+  it("accepts the canonical format", () => {
+    expect(validateTs(T0)).toBe(T0);
+  });
+
+  it.each([
+    "2026-07-06 10:00:00",
+    "2026-07-06T10:00:00Z",
+    "2026-07-06T10:00:00.000+00:00",
+    "2026-07-06T10:00:00.000",
+    "not a ts",
+    "",
+  ])("rejects %s", (bad) => {
+    expect(() => validateTs(bad)).toThrow();
+  });
+
+  it("adds seconds", () => {
+    expect(tsAddSeconds("2026-07-06T10:01:00.000Z", 300)).toBe("2026-07-06T10:06:00.000Z");
+    expect(tsAddSeconds("2026-07-06T23:59:30.500Z", 60)).toBe("2026-07-07T00:00:30.500Z");
+  });
+});
+
+describe("scopes and keys", () => {
+  it("builds scopes", () => {
+    expect(scopeForZid(7, "FULL_PIPELINE")).toBe("zid#7#FULL_PIPELINE");
+    expect(scopeForRid(42, "NARRATIVE_BATCH")).toBe("rid#42#NARRATIVE_BATCH");
+  });
+
+  it("derives scopes from runs", () => {
+    const base = { job_id: "j", enqueued_at: T0 };
+    expect(
+      scopesForRun(normalizeRunManifest({ ...base, job_type: "FULL_PIPELINE", zid: 7 }))
+    ).toEqual(["zid#7#FULL_PIPELINE"]);
+    expect(
+      scopesForRun(
+        normalizeRunManifest({ ...base, job_type: "NARRATIVE_BATCH", zid: 7, rid: 42 })
+      )
+    ).toEqual(["rid#42#NARRATIVE_BATCH"]);
+    expect(
+      scopesForRun(normalizeRunManifest({ ...base, job_type: "IMPORTED", zid: 7 }))
+    ).toEqual([]);
+    expect(() =>
+      scopesForRun(normalizeRunManifest({ ...base, job_type: "FULL_PIPELINE" }))
+    ).toThrow();
+  });
+
+  it("builds zero-padded log keys", () => {
+    expect(logSk(1)).toBe("log#00000001");
+    expect(logSk(12345678)).toBe("log#12345678");
+  });
+
+  it("builds artifact keys and rejects the chunk marker", () => {
+    expect(artifactKey("umap", "topic", 0, 3)).toBe("umap#topic#0#3");
+    expect(() => artifactKey("math", `bad${CHUNK_MARKER}part`)).toThrow();
+  });
+
+  it("excludes runs and latest from generic entities", () => {
+    expect(GENERIC_ENTITIES).toEqual([
+      "run_inputs",
+      "artifacts",
+      "topic_moderation",
+      "collective_statements",
+    ]);
+  });
+});

--- a/server/__tests__/unit/delphiStorage.memory.test.ts
+++ b/server/__tests__/unit/delphiStorage.memory.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Conformance suite (memory backend) + codec fixture cases.
+ *
+ * Executes the SAME JSON operation-scripts as delphi's pytest suite
+ * (delphi/delphi_storage/conformance/cases/) — the cross-language contract.
+ * Spec: delphi/delphi_storage/conformance/README.md.
+ */
+import {
+  loadCases,
+  loadCodecCases,
+  runCase,
+  runCodecCase,
+} from "../setup/delphi-storage-conformance";
+import { MemoryDelphiStore } from "../../src/storage/delphi/memoryStore";
+
+const cases = loadCases();
+const codecCases = loadCodecCases();
+
+describe("delphi storage conformance — memory backend", () => {
+  it("finds the shared contract case files", () => {
+    const names = cases.map((c) => c.name);
+    for (const expected of [
+      "roundtrip_basic",
+      "query_ordering",
+      "blob_chunking",
+      "queue_claim",
+      "latest_pointer",
+      "run_manifest_fields",
+      "validation",
+    ]) {
+      expect(names).toContain(expected);
+    }
+    expect(codecCases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)("case $name", async (c) => {
+    await runCase(new MemoryDelphiStore(), c);
+  });
+
+  it.each(codecCases)("codec case $name", (c) => {
+    runCodecCase(c);
+  });
+});

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -97,6 +97,12 @@ export default {
   databaseSSL: isTrue(process.env.DATABASE_SSL),
   databaseURL: process.env.DATABASE_URL as string,
   ddEnv: process.env.DD_ENV as string,
+  delphiStorageBackend: process.env.DELPHI_STORAGE_BACKEND || ("dynamodb" as string),
+  delphiStoragePgSchema: process.env.DELPHI_STORAGE_PG_SCHEMA || ("delphi" as string),
+  delphiStoragePgUrl:
+    process.env.DELPHI_STORAGE_PG_URL || process.env.DATABASE_URL || null,
+  delphiStorageTablePrefix:
+    process.env.DELPHI_STORAGE_TABLE_PREFIX || ("Delphi2_" as string),
   dynamoDbEndpoint: process.env.DYNAMODB_ENDPOINT || null,
   emailTransportTypes: process.env.EMAIL_TRANSPORT_TYPES || null,
   geminiApiKey: process.env.GEMINI_API_KEY || null,

--- a/server/src/storage/delphi/codec.ts
+++ b/server/src/storage/delphi/codec.ts
@@ -1,0 +1,161 @@
+/**
+ * Wire codec for Delphi Storage V2 payloads — TypeScript twin of
+ * delphi/delphi_storage/codec.py. The format is pinned by the shared
+ * conformance fixtures (delphi/delphi_storage/conformance/cases/codec_*.json):
+ *
+ * - canonical JSON: keys sorted by UTF-8 byte order, compact, no NaN/Infinity;
+ * - packed floats: little-endian IEEE-754 float64;
+ * - compression: zstd frames (Node's built-in zlib zstd support, Node >= 22.15);
+ * - payload envelopes: `meta` (JSON attributes) + optional binary `blob`:
+ *     {"enc": "json", "body": <value>}                    — inline, no blob
+ *     {"enc": "json+zstd", "bytes", "sha256"}             — blob = zstd(canonical JSON)
+ *     {"enc": "f64+zstd", "count", "bytes", "sha256"}     — blob = zstd(packed f64)
+ *   bytes/sha256 describe the UNCOMPRESSED payload (compressed bytes are never
+ *   compared: zstd output varies across implementations).
+ */
+import * as crypto from "crypto";
+import * as zlib from "zlib";
+
+import { InvalidError } from "./errors";
+import { utf8Compare } from "./keys";
+
+/**
+ * Canonical-JSON bodies up to this many UTF-8 bytes are stored inline;
+ * larger ones are zstd-compressed into the blob.
+ */
+export const INLINE_LIMIT = 65536;
+
+type ZstdCapableZlib = typeof zlib & {
+  zstdCompressSync?: (buf: Buffer, options?: unknown) => Buffer;
+  zstdDecompressSync?: (buf: Buffer, options?: unknown) => Buffer;
+};
+
+const z = zlib as ZstdCapableZlib;
+
+function requireZstd<T>(fn: T | undefined, name: string): T {
+  if (typeof fn !== "function") {
+    throw new Error(`${name} unavailable — Node >= 22.15 is required for zstd support`);
+  }
+  return fn;
+}
+
+export function compress(data: Buffer): Buffer {
+  return requireZstd(z.zstdCompressSync, "zlib.zstdCompressSync")(data);
+}
+
+export function decompress(data: Buffer): Buffer {
+  return requireZstd(z.zstdDecompressSync, "zlib.zstdDecompressSync")(data);
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null) return "null";
+  const kind = typeof value;
+  if (kind === "number") {
+    if (!Number.isFinite(value as number)) {
+      throw new InvalidError(`non-finite number not JSON-serializable: ${String(value)}`);
+    }
+    return JSON.stringify(value);
+  }
+  if (kind === "string" || kind === "boolean") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => canonicalize(v === undefined ? null : v)).join(",")}]`;
+  }
+  if (kind === "object") {
+    const record = value as Record<string, unknown>;
+    // Sort keys by UTF-8 byte order to match Python's sort_keys (code points).
+    const keys = Object.keys(record)
+      .filter((k) => record[k] !== undefined)
+      .sort(utf8Compare);
+    const parts = keys.map((k) => `${JSON.stringify(k)}:${canonicalize(record[k])}`);
+    return `{${parts.join(",")}}`;
+  }
+  throw new InvalidError(`value of type ${kind} is not JSON-serializable`);
+}
+
+export function canonicalJsonDumps(value: unknown): string {
+  return canonicalize(value);
+}
+
+export function packF64(values: number[]): Buffer {
+  const buf = Buffer.allocUnsafe(values.length * 8);
+  values.forEach((v, i) => buf.writeDoubleLE(v, i * 8));
+  return buf;
+}
+
+export function unpackF64(data: Buffer): number[] {
+  if (data.length % 8 !== 0) {
+    throw new InvalidError(`packed f64 length must be a multiple of 8, got ${data.length}`);
+  }
+  const out: number[] = new Array(data.length / 8);
+  for (let i = 0; i < out.length; i++) out[i] = data.readDoubleLE(i * 8);
+  return out;
+}
+
+function sha256hex(data: Buffer): string {
+  return crypto.createHash("sha256").update(data).digest("hex");
+}
+
+/** Marker wrapper: encode this payload as a packed float64 array. */
+export class F64 {
+  constructor(public values: number[]) {}
+}
+
+export interface PayloadMeta {
+  enc: string;
+  body?: unknown;
+  bytes?: number;
+  sha256?: string;
+  count?: number;
+}
+
+export interface EncodedPayload {
+  meta: PayloadMeta;
+  blob: Buffer | null;
+}
+
+/**
+ * Encode a payload for storage. `force` pins the encoding ('json',
+ * 'json+zstd'); by default small JSON stays inline.
+ */
+export function encodePayload(value: unknown, force?: string): EncodedPayload {
+  if (value instanceof F64) {
+    const packed = packF64(value.values);
+    return {
+      meta: {
+        enc: "f64+zstd",
+        count: value.values.length,
+        bytes: packed.length,
+        sha256: sha256hex(packed),
+      },
+      blob: compress(packed),
+    };
+  }
+  const raw = Buffer.from(canonicalJsonDumps(value), "utf8");
+  if (force === "json" || (force === undefined && raw.length <= INLINE_LIMIT)) {
+    return { meta: { enc: "json", body: value }, blob: null };
+  }
+  if (force !== undefined && force !== "json+zstd") {
+    throw new InvalidError(`unknown forced encoding ${JSON.stringify(force)}`);
+  }
+  return {
+    meta: { enc: "json+zstd", bytes: raw.length, sha256: sha256hex(raw) },
+    blob: compress(raw),
+  };
+}
+
+export function decodePayload(meta: PayloadMeta, blob: Buffer | null): unknown {
+  const enc = meta.enc;
+  if (enc === "json") return meta.body;
+  if (enc === "json+zstd" || enc === "f64+zstd") {
+    if (blob === null) throw new InvalidError(`encoding ${enc} requires a blob`);
+    const raw = decompress(blob);
+    if (meta.sha256 !== undefined && sha256hex(raw) !== meta.sha256) {
+      throw new InvalidError("payload sha256 mismatch — corrupt blob");
+    }
+    if (meta.bytes !== undefined && raw.length !== meta.bytes) {
+      throw new InvalidError("payload length mismatch — corrupt blob");
+    }
+    return enc === "json+zstd" ? JSON.parse(raw.toString("utf8")) : unpackF64(raw);
+  }
+  throw new InvalidError(`unknown payload encoding ${JSON.stringify(enc)}`);
+}

--- a/server/src/storage/delphi/dynamoStore.ts
+++ b/server/src/storage/delphi/dynamoStore.ts
@@ -1,0 +1,710 @@
+/**
+ * DynamoDB backend — twin of delphi/delphi_storage/backends/dynamodb.py.
+ * Same physical layout (tables, sparse claim GSI, U+007F chunk rows for
+ * blobs >300KB) and the same conditional-write discipline: every run/latest
+ * mutation conditions on the version/seq that was read.
+ *
+ * Marshalling note: uses DynamoDBDocumentClient WITHOUT convertEmptyValues
+ * (deliberate deviation from the older house pattern) — empty strings must
+ * round-trip, per the conformance contract.
+ */
+import * as crypto from "crypto";
+
+import {
+  CreateTableCommand,
+  DeleteTableCommand,
+  DynamoDBClient,
+  DynamoDBClientConfig,
+  ListTablesCommand,
+  waitUntilTableExists,
+} from "@aws-sdk/client-dynamodb";
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import {
+  AdvanceLatestOptions,
+  AdvanceResult,
+  AlreadyExistsError,
+  BaseDelphiStore,
+  ClaimOptions,
+  ExtendLeaseOptions,
+  InvalidError,
+  LatestPointer,
+  ListRunsOptions,
+  NotFoundError,
+  RunManifest,
+  RunStatus,
+  StorageError,
+  StoreItem,
+  TERMINAL_STATUSES,
+  coerceJobType,
+  coerceRunStatus,
+  mergeManifestFields,
+  validateEnqueueable,
+  validateGenericRead,
+  validateGenericWrite,
+} from "./interface";
+import { CHUNK_MARKER, claimOrder, nowTs, tsAddSeconds, utf8Compare, validateTs } from "./keys";
+
+/**
+ * Max blob bytes stored inline in one item (DynamoDB item limit is 400KB
+ * including attribute names; 300KB leaves ample headroom for attributes).
+ */
+export const CHUNK_SIZE = 300_000;
+
+const ENTITY_TABLES: Record<string, string> = {
+  run_inputs: "RunInputs",
+  artifacts: "Artifacts",
+  topic_moderation: "TopicModeration",
+  collective_statements: "CollectiveStatements",
+};
+
+const RUNS_INDEX_ATTRS = ["claim_status", "claim_order", "zid_key", "rid_key"];
+
+const MUTATION_RETRIES = 8;
+
+function kvTableSchema(tableName: string) {
+  return {
+    TableName: tableName,
+    KeySchema: [
+      { AttributeName: "pk", KeyType: "HASH" as const },
+      { AttributeName: "sk", KeyType: "RANGE" as const },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "pk", AttributeType: "S" as const },
+      { AttributeName: "sk", AttributeType: "S" as const },
+    ],
+    BillingMode: "PAY_PER_REQUEST" as const,
+  };
+}
+
+function runsTableSchema(tableName: string) {
+  return {
+    TableName: tableName,
+    KeySchema: [{ AttributeName: "job_id", KeyType: "HASH" as const }],
+    AttributeDefinitions: [
+      { AttributeName: "job_id", AttributeType: "S" as const },
+      { AttributeName: "claim_status", AttributeType: "S" as const },
+      { AttributeName: "claim_order", AttributeType: "S" as const },
+      { AttributeName: "zid_key", AttributeType: "S" as const },
+      { AttributeName: "rid_key", AttributeType: "S" as const },
+      { AttributeName: "enqueued_at", AttributeType: "S" as const },
+    ],
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: "claim-index",
+        KeySchema: [
+          { AttributeName: "claim_status", KeyType: "HASH" as const },
+          { AttributeName: "claim_order", KeyType: "RANGE" as const },
+        ],
+        Projection: { ProjectionType: "KEYS_ONLY" as const },
+      },
+      {
+        IndexName: "zid-index",
+        KeySchema: [
+          { AttributeName: "zid_key", KeyType: "HASH" as const },
+          { AttributeName: "enqueued_at", KeyType: "RANGE" as const },
+        ],
+        Projection: { ProjectionType: "ALL" as const },
+      },
+      {
+        IndexName: "rid-index",
+        KeySchema: [
+          { AttributeName: "rid_key", KeyType: "HASH" as const },
+          { AttributeName: "enqueued_at", KeyType: "RANGE" as const },
+        ],
+        Projection: { ProjectionType: "ALL" as const },
+      },
+    ],
+    BillingMode: "PAY_PER_REQUEST" as const,
+  };
+}
+
+function latestTableSchema(tableName: string) {
+  return {
+    TableName: tableName,
+    KeySchema: [{ AttributeName: "scope", KeyType: "HASH" as const }],
+    AttributeDefinitions: [{ AttributeName: "scope", AttributeType: "S" as const }],
+    BillingMode: "PAY_PER_REQUEST" as const,
+  };
+}
+
+function chunkPrefix(sk: string): string {
+  return `${CHUNK_MARKER}${sk}${CHUNK_MARKER}`;
+}
+
+function chunkSk(sk: string, gen: string, index: number): string {
+  return `${chunkPrefix(sk)}${gen}${CHUNK_MARKER}${String(index).padStart(5, "0")}`;
+}
+
+function newGeneration(): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+}
+
+function isChunkSk(sk: string): boolean {
+  return sk.startsWith(CHUNK_MARKER);
+}
+
+function isConditionalCheckFailed(error: unknown): boolean {
+  return (error as { name?: string })?.name === "ConditionalCheckFailedException";
+}
+
+export interface DynamoDelphiStoreOptions {
+  tablePrefix: string;
+  endpoint?: string;
+  region?: string;
+}
+
+interface RawItem {
+  pk: string;
+  sk: string;
+  attributes: Record<string, unknown>;
+  blob?: Uint8Array;
+  _chunks?: number;
+  _blob_len?: number;
+  _blob_gen?: string;
+}
+
+export class DynamoDelphiStore extends BaseDelphiStore {
+  private readonly tablePrefix: string;
+  private readonly client: DynamoDBClient;
+  private readonly doc: DynamoDBDocumentClient;
+
+  constructor(options: DynamoDelphiStoreOptions) {
+    super();
+    this.tablePrefix = options.tablePrefix;
+    const config: DynamoDBClientConfig = { region: options.region || "us-east-1" };
+    if (options.endpoint) {
+      config.endpoint = options.endpoint;
+      config.credentials = {
+        accessKeyId: "DUMMYIDEXAMPLE",
+        secretAccessKey: "DUMMYEXAMPLEKEY",
+      };
+    }
+    this.client = new DynamoDBClient(config);
+    this.doc = DynamoDBDocumentClient.from(this.client, {
+      // No convertEmptyValues: empty strings must round-trip (conformance).
+      marshallOptions: { removeUndefinedValues: true },
+    });
+  }
+
+  private tableSchemas() {
+    return [
+      runsTableSchema(`${this.tablePrefix}Runs`),
+      latestTableSchema(`${this.tablePrefix}Latest`),
+      ...Object.values(ENTITY_TABLES).map((name) => kvTableSchema(`${this.tablePrefix}${name}`)),
+    ];
+  }
+
+  async ensureTables(): Promise<void> {
+    const existing = new Set<string>();
+    let start: string | undefined;
+    do {
+      const page = await this.client.send(
+        new ListTablesCommand(start ? { ExclusiveStartTableName: start } : {})
+      );
+      (page.TableNames || []).forEach((n) => existing.add(n));
+      start = page.LastEvaluatedTableName;
+    } while (start);
+    for (const schema of this.tableSchemas()) {
+      if (!existing.has(schema.TableName)) {
+        await this.client.send(new CreateTableCommand(schema));
+      }
+    }
+    for (const schema of this.tableSchemas()) {
+      await waitUntilTableExists(
+        { client: this.client, maxWaitTime: 60 },
+        { TableName: schema.TableName }
+      );
+    }
+  }
+
+  async dropTables(): Promise<void> {
+    for (const schema of this.tableSchemas()) {
+      try {
+        await this.client.send(new DeleteTableCommand({ TableName: schema.TableName }));
+      } catch (error) {
+        if ((error as { name?: string })?.name !== "ResourceNotFoundException") throw error;
+      }
+    }
+    this.client.destroy();
+  }
+
+  private table(entity: string): string {
+    return `${this.tablePrefix}${ENTITY_TABLES[entity]}`;
+  }
+
+  private async queryAll(input: {
+    TableName: string;
+    IndexName?: string;
+    KeyConditionExpression: string;
+    ExpressionAttributeValues: Record<string, unknown>;
+    ProjectionExpression?: string;
+    ConsistentRead?: boolean;
+    ScanIndexForward?: boolean;
+  }): Promise<Record<string, unknown>[]> {
+    const items: Record<string, unknown>[] = [];
+    let startKey: Record<string, unknown> | undefined;
+    do {
+      const page = await this.doc.send(
+        new QueryCommand({ ...input, ExclusiveStartKey: startKey })
+      );
+      items.push(...((page.Items as Record<string, unknown>[]) || []));
+      startKey = page.LastEvaluatedKey as Record<string, unknown> | undefined;
+    } while (startKey);
+    return items;
+  }
+
+  // ---- generic ----
+
+  /**
+   * Crash-safe write order for chunked blobs: new-generation chunk rows first
+   * (invisible — the main item still references the old generation), THEN the
+   * main item (the commit point flips readers atomically), THEN
+   * stale-generation cleanup. A crash at any point leaves the previous value
+   * fully readable; orphaned generations are swept by the next successful put.
+   */
+  async put(entity: string, item: StoreItem): Promise<void> {
+    validateGenericWrite(entity, item);
+    const table = this.table(entity);
+    const blob = item.blob ?? Buffer.alloc(0);
+    const nChunks =
+      item.blob !== null && blob.length > CHUNK_SIZE ? Math.ceil(blob.length / CHUNK_SIZE) : 0;
+    const gen = newGeneration();
+    for (let i = 0; i < nChunks; i++) {
+      await this.doc.send(
+        new PutCommand({
+          TableName: table,
+          Item: {
+            pk: item.pk,
+            sk: chunkSk(item.sk, gen, i),
+            part: blob.subarray(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE),
+          },
+        })
+      );
+    }
+    const record: Record<string, unknown> = {
+      pk: item.pk,
+      sk: item.sk,
+      attributes: item.attributes,
+    };
+    if (item.blob !== null) {
+      if (nChunks > 0) {
+        record._chunks = nChunks;
+        record._blob_len = blob.length;
+        record._blob_gen = gen;
+      } else {
+        record.blob = blob;
+      }
+    }
+    await this.doc.send(new PutCommand({ TableName: table, Item: record }));
+    await this.deleteChunkRows(table, item.pk, item.sk, nChunks > 0 ? gen : undefined);
+  }
+
+  private async deleteChunkRows(
+    table: string,
+    pk: string,
+    sk: string,
+    keepGen?: string
+  ): Promise<void> {
+    const prefix = chunkPrefix(sk);
+    const keepPrefix = keepGen !== undefined ? `${prefix}${keepGen}${CHUNK_MARKER}` : undefined;
+    const rows = await this.queryAll({
+      TableName: table,
+      KeyConditionExpression: "pk = :pk AND begins_with(sk, :prefix)",
+      ExpressionAttributeValues: { ":pk": pk, ":prefix": prefix },
+      ProjectionExpression: "pk, sk",
+      ConsistentRead: true,
+    });
+    for (const row of rows) {
+      if (keepPrefix !== undefined && (row.sk as string).startsWith(keepPrefix)) continue;
+      await this.doc.send(
+        new DeleteCommand({ TableName: table, Key: { pk: row.pk, sk: row.sk } })
+      );
+    }
+  }
+
+  private async readBlob(table: string, raw: RawItem): Promise<Buffer | null> {
+    if (raw.blob !== undefined) return Buffer.from(raw.blob);
+    if (raw._chunks === undefined) return null;
+    // Fetch exactly the deterministic chunk keys of the committed generation —
+    // stale rows from other generations can never interfere.
+    const gen = raw._blob_gen as string;
+    const parts: Buffer[] = [];
+    for (let i = 0; i < raw._chunks; i++) {
+      const response = await this.doc.send(
+        new GetCommand({
+          TableName: table,
+          Key: { pk: raw.pk, sk: chunkSk(raw.sk, gen, i) },
+          ConsistentRead: true,
+        })
+      );
+      if (!response.Item) {
+        throw new StorageError(
+          `corrupt chunked blob at ${raw.pk}/${raw.sk}: missing chunk ${i}/${raw._chunks} ` +
+            `of generation ${gen}`
+        );
+      }
+      parts.push(Buffer.from(response.Item.part as Uint8Array));
+    }
+    const blob = Buffer.concat(parts);
+    if (blob.length !== raw._blob_len) {
+      throw new StorageError(
+        `corrupt chunked blob at ${raw.pk}/${raw.sk}: ${blob.length}/${raw._blob_len} bytes`
+      );
+    }
+    return blob;
+  }
+
+  private async toStoreItem(table: string, raw: RawItem): Promise<StoreItem> {
+    return {
+      pk: raw.pk,
+      sk: raw.sk,
+      attributes: raw.attributes,
+      blob: await this.readBlob(table, raw),
+    };
+  }
+
+  async get(entity: string, pk: string, sk: string): Promise<StoreItem | null> {
+    validateGenericRead(entity);
+    const table = this.table(entity);
+    const response = await this.doc.send(
+      new GetCommand({ TableName: table, Key: { pk, sk }, ConsistentRead: true })
+    );
+    if (!response.Item) return null;
+    return this.toStoreItem(table, response.Item as unknown as RawItem);
+  }
+
+  async queryPrefix(entity: string, pk: string, skPrefix = ""): Promise<StoreItem[]> {
+    validateGenericRead(entity);
+    const table = this.table(entity);
+    const input = {
+      TableName: table,
+      ConsistentRead: true,
+      KeyConditionExpression: skPrefix ? "pk = :pk AND begins_with(sk, :prefix)" : "pk = :pk",
+      ExpressionAttributeValues: skPrefix ? { ":pk": pk, ":prefix": skPrefix } : { ":pk": pk },
+    };
+    const rows = (await this.queryAll(input)) as unknown as RawItem[];
+    const logical = rows.filter((row) => !isChunkSk(row.sk));
+    return Promise.all(logical.map((row) => this.toStoreItem(table, row)));
+  }
+
+  async queryBetween(
+    entity: string,
+    pk: string,
+    skFrom: string,
+    skTo: string
+  ): Promise<StoreItem[]> {
+    validateGenericRead(entity);
+    const table = this.table(entity);
+    const rows = (await this.queryAll({
+      TableName: table,
+      ConsistentRead: true,
+      KeyConditionExpression: "pk = :pk AND sk BETWEEN :lo AND :hi",
+      ExpressionAttributeValues: { ":pk": pk, ":lo": skFrom, ":hi": skTo },
+    })) as unknown as RawItem[];
+    const logical = rows.filter((row) => !isChunkSk(row.sk));
+    return Promise.all(logical.map((row) => this.toStoreItem(table, row)));
+  }
+
+  async deletePartition(entity: string, pk: string): Promise<number> {
+    validateGenericRead(entity);
+    const table = this.table(entity);
+    const rows = await this.queryAll({
+      TableName: table,
+      ConsistentRead: true,
+      KeyConditionExpression: "pk = :pk",
+      ExpressionAttributeValues: { ":pk": pk },
+      ProjectionExpression: "pk, sk",
+    });
+    let logical = 0;
+    for (const row of rows) {
+      if (!isChunkSk(row.sk as string)) logical += 1;
+      await this.doc.send(
+        new DeleteCommand({ TableName: table, Key: { pk: row.pk, sk: row.sk } })
+      );
+    }
+    return logical;
+  }
+
+  // ---- runs / queue ----
+
+  private get runsTable(): string {
+    return `${this.tablePrefix}Runs`;
+  }
+
+  private get latestTable(): string {
+    return `${this.tablePrefix}Latest`;
+  }
+
+  private runRecord(run: RunManifest): Record<string, unknown> {
+    const record: Record<string, unknown> = { ...run };
+    if (run.status === "QUEUED") {
+      record.claim_status = "QUEUED";
+      record.claim_order = claimOrder(run.priority, run.enqueued_at, run.job_id);
+    }
+    if (run.zid !== null && run.zid !== undefined) record.zid_key = String(run.zid);
+    if (run.rid !== null && run.rid !== undefined) record.rid_key = String(run.rid);
+    return record;
+  }
+
+  private recordToRun(raw: Record<string, unknown>): RunManifest {
+    const fields = { ...raw };
+    for (const attr of RUNS_INDEX_ATTRS) delete fields[attr];
+    return fields as unknown as RunManifest;
+  }
+
+  private async getRunRaw(jobId: string): Promise<Record<string, unknown> | null> {
+    const response = await this.doc.send(
+      new GetCommand({ TableName: this.runsTable, Key: { job_id: jobId }, ConsistentRead: true })
+    );
+    return (response.Item as Record<string, unknown>) ?? null;
+  }
+
+  /** Full-item replace conditional on the version we read; false on a lost race. */
+  private async putRunVersioned(run: RunManifest, expectedVersion: number): Promise<boolean> {
+    try {
+      await this.doc.send(
+        new PutCommand({
+          TableName: this.runsTable,
+          Item: this.runRecord(run),
+          ConditionExpression: "#version = :v",
+          ExpressionAttributeNames: { "#version": "version" },
+          ExpressionAttributeValues: { ":v": expectedVersion },
+        })
+      );
+      return true;
+    } catch (error) {
+      if (isConditionalCheckFailed(error)) return false;
+      throw error;
+    }
+  }
+
+  async enqueueRun(run: RunManifest): Promise<void> {
+    validateEnqueueable(run);
+    try {
+      await this.doc.send(
+        new PutCommand({
+          TableName: this.runsTable,
+          Item: this.runRecord(run),
+          ConditionExpression: "attribute_not_exists(job_id)",
+        })
+      );
+    } catch (error) {
+      if (isConditionalCheckFailed(error)) {
+        throw new AlreadyExistsError(`run ${JSON.stringify(run.job_id)} already exists`);
+      }
+      throw error;
+    }
+  }
+
+  async getRun(jobId: string): Promise<RunManifest | null> {
+    const raw = await this.getRunRaw(jobId);
+    return raw ? this.recordToRun(raw) : null;
+  }
+
+  async claimNextRun(options: ClaimOptions): Promise<RunManifest | null> {
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    // Candidates come from the (eventually consistent) sparse GSI; the claim
+    // itself is a conditional write on the base table, so staleness only
+    // costs a wasted attempt, never a double claim.
+    let startKey: Record<string, unknown> | undefined;
+    do {
+      const page = await this.doc.send(
+        new QueryCommand({
+          TableName: this.runsTable,
+          IndexName: "claim-index",
+          KeyConditionExpression: "claim_status = :queued",
+          ExpressionAttributeValues: { ":queued": "QUEUED" },
+          ScanIndexForward: true,
+          Limit: 10,
+          ExclusiveStartKey: startKey,
+        })
+      );
+      for (const candidate of (page.Items as Record<string, unknown>[]) || []) {
+        const raw = await this.getRunRaw(candidate.job_id as string);
+        if (!raw || raw.status !== "QUEUED") continue;
+        const run = this.recordToRun(raw);
+        const claimed: RunManifest = {
+          ...run,
+          status: "RUNNING",
+          worker_id: options.workerId,
+          started_at: at,
+          lease_expires_at: tsAddSeconds(at, options.leaseSeconds),
+          version: run.version + 1,
+        };
+        if (await this.putRunVersioned(claimed, run.version)) {
+          return claimed;
+        }
+      }
+      startKey = page.LastEvaluatedKey as Record<string, unknown> | undefined;
+    } while (startKey);
+    return null;
+  }
+
+  async extendLease(options: ExtendLeaseOptions): Promise<boolean> {
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    for (let attempt = 0; attempt < MUTATION_RETRIES; attempt++) {
+      const raw = await this.getRunRaw(options.jobId);
+      if (!raw) return false;
+      const run = this.recordToRun(raw);
+      if (run.status !== "RUNNING" || run.worker_id !== options.workerId) return false;
+      const extended: RunManifest = {
+        ...run,
+        lease_expires_at: tsAddSeconds(at, options.leaseSeconds),
+        version: run.version + 1,
+      };
+      if (await this.putRunVersioned(extended, run.version)) return true;
+    }
+    return false;
+  }
+
+  private async mutateRun(
+    jobId: string,
+    mutate: (run: RunManifest) => RunManifest
+  ): Promise<RunManifest> {
+    for (let attempt = 0; attempt < MUTATION_RETRIES; attempt++) {
+      const raw = await this.getRunRaw(jobId);
+      if (!raw) throw new NotFoundError(`run ${JSON.stringify(jobId)} not found`);
+      const run = this.recordToRun(raw);
+      const updated: RunManifest = { ...mutate(run), version: run.version + 1 };
+      if (await this.putRunVersioned(updated, run.version)) return updated;
+    }
+    throw new StorageError(
+      `run ${JSON.stringify(jobId)}: lost ${MUTATION_RETRIES} optimistic-lock races`
+    );
+  }
+
+  async updateRunStatus(
+    jobId: string,
+    status: RunStatus | string,
+    options: { error?: string | null; now?: string } = {}
+  ): Promise<RunManifest> {
+    status = coerceRunStatus(status);
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    return this.mutateRun(jobId, (run) => {
+      const updated: RunManifest = { ...run, status: status as RunStatus };
+      if (options.error !== undefined && options.error !== null) updated.error = options.error;
+      if ((TERMINAL_STATUSES as string[]).includes(status as string) && run.completed_at === null) {
+        updated.completed_at = at;
+      }
+      return updated;
+    });
+  }
+
+  async mergeRunFields(jobId: string, fields: Record<string, unknown>): Promise<RunManifest> {
+    return this.mutateRun(jobId, (run) => mergeManifestFields(run, fields));
+  }
+
+  protected async incrementLogSeq(jobId: string): Promise<number> {
+    try {
+      const response = await this.doc.send(
+        new UpdateCommand({
+          TableName: this.runsTable,
+          Key: { job_id: jobId },
+          UpdateExpression: "SET log_seq = log_seq + :one, #version = #version + :one",
+          ConditionExpression: "attribute_exists(job_id)",
+          ExpressionAttributeNames: { "#version": "version" },
+          ExpressionAttributeValues: { ":one": 1 },
+          ReturnValues: "UPDATED_NEW",
+        })
+      );
+      return (response.Attributes as { log_seq: number }).log_seq;
+    } catch (error) {
+      if (isConditionalCheckFailed(error)) {
+        throw new NotFoundError(`run ${JSON.stringify(jobId)} not found`);
+      }
+      throw error;
+    }
+  }
+
+  // ---- latest ----
+
+  async advanceLatest(options: AdvanceLatestOptions): Promise<AdvanceResult> {
+    const jobType = coerceJobType(options.jobType);
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    for (let attempt = 0; attempt < MUTATION_RETRIES; attempt++) {
+      const current = await this.getLatest(options.scope);
+      if (current) {
+        if (current.job_id === options.jobId) return { advanced: false, pointer: current };
+        if (options.onlyIfAbsentOrImported && current.job_type !== "IMPORTED") {
+          return { advanced: false, pointer: current };
+        }
+      }
+      const pointer: LatestPointer = {
+        scope: options.scope,
+        job_id: options.jobId,
+        seq: current ? current.seq + 1 : 1,
+        job_type: jobType,
+        updated_at: at,
+      };
+      try {
+        await this.doc.send(
+          new PutCommand({
+            TableName: this.latestTable,
+            Item: pointer as unknown as Record<string, unknown>,
+            ...(current
+              ? {
+                  ConditionExpression: "#seq = :old",
+                  ExpressionAttributeNames: { "#seq": "seq" },
+                  ExpressionAttributeValues: { ":old": current.seq },
+                }
+              : {
+                  ConditionExpression: "attribute_not_exists(#scope)",
+                  ExpressionAttributeNames: { "#scope": "scope" },
+                }),
+          })
+        );
+        return { advanced: true, pointer };
+      } catch (error) {
+        if (isConditionalCheckFailed(error)) continue; // concurrent advance — re-read
+        throw error;
+      }
+    }
+    throw new StorageError(
+      `latest ${JSON.stringify(options.scope)}: lost ${MUTATION_RETRIES} optimistic-lock races`
+    );
+  }
+
+  async getLatest(scope: string): Promise<LatestPointer | null> {
+    const response = await this.doc.send(
+      new GetCommand({ TableName: this.latestTable, Key: { scope }, ConsistentRead: true })
+    );
+    return (response.Item as unknown as LatestPointer) ?? null;
+  }
+
+  async listRuns(options: ListRunsOptions): Promise<RunManifest[]> {
+    const hasZid = options.zid !== undefined && options.zid !== null;
+    const hasRid = options.rid !== undefined && options.rid !== null;
+    if (hasZid === hasRid) throw new InvalidError("exactly one of zid/rid is required");
+    const statusFilter =
+      options.status !== undefined && options.status !== null
+        ? coerceRunStatus(options.status)
+        : null;
+    const [index, attr, value] = hasZid
+      ? ["zid-index", "zid_key", String(options.zid)]
+      : ["rid-index", "rid_key", String(options.rid)];
+    const rows = await this.queryAll({
+      TableName: this.runsTable,
+      IndexName: index,
+      KeyConditionExpression: `${attr} = :key`,
+      ExpressionAttributeValues: { ":key": value },
+      ScanIndexForward: false,
+    });
+    let runs = rows.map((row) => this.recordToRun(row));
+    if (statusFilter !== null) {
+      runs = runs.filter((r) => r.status === statusFilter);
+    }
+    runs.sort((a, b) => {
+      const byTime = utf8Compare(b.enqueued_at, a.enqueued_at);
+      return byTime !== 0 ? byTime : utf8Compare(b.job_id, a.job_id);
+    });
+    return runs.slice(0, options.limit ?? 100);
+  }
+}

--- a/server/src/storage/delphi/errors.ts
+++ b/server/src/storage/delphi/errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Delphi Storage V2 error classes. The `code` values are the cross-language
+ * error names used by the conformance cases
+ * (delphi/delphi_storage/conformance/README.md): already_exists, not_found,
+ * invalid.
+ */
+export class StorageError extends Error {
+  code = "storage_error";
+
+  constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
+export class AlreadyExistsError extends StorageError {
+  code = "already_exists";
+}
+
+export class NotFoundError extends StorageError {
+  code = "not_found";
+}
+
+export class InvalidError extends StorageError {
+  code = "invalid";
+}

--- a/server/src/storage/delphi/factory.ts
+++ b/server/src/storage/delphi/factory.ts
@@ -1,0 +1,42 @@
+/**
+ * Backend selection for Delphi Storage V2 — twin of
+ * delphi/delphi_storage/factory.py, wired through src/config.ts:
+ *
+ * - DELPHI_STORAGE_BACKEND      — dynamodb (default) | postgres | memory
+ * - DELPHI_STORAGE_TABLE_PREFIX — DynamoDB table prefix (default Delphi2_)
+ * - DELPHI_STORAGE_PG_SCHEMA    — PostgreSQL schema (default delphi)
+ * - DELPHI_STORAGE_PG_URL       — PostgreSQL URL (falls back to DATABASE_URL)
+ * - DYNAMODB_ENDPOINT / AWS_REGION — existing vocabulary, reused as-is
+ */
+import Config from "../../config";
+import { InvalidError } from "./errors";
+import { DelphiStore } from "./interface";
+import { DynamoDelphiStore } from "./dynamoStore";
+import { MemoryDelphiStore } from "./memoryStore";
+import { PostgresDelphiStore } from "./postgresStore";
+
+export function getDelphiStore(backend?: string): DelphiStore {
+  const kind = backend || Config.delphiStorageBackend;
+  if (kind === "memory") {
+    return new MemoryDelphiStore();
+  }
+  if (kind === "dynamodb") {
+    return new DynamoDelphiStore({
+      tablePrefix: Config.delphiStorageTablePrefix,
+      endpoint: Config.dynamoDbEndpoint || undefined,
+      region: Config.awsRegion,
+    });
+  }
+  if (kind === "postgres") {
+    if (!Config.delphiStoragePgUrl) {
+      throw new InvalidError("postgres backend needs DELPHI_STORAGE_PG_URL or DATABASE_URL");
+    }
+    return new PostgresDelphiStore({
+      url: Config.delphiStoragePgUrl,
+      schema: Config.delphiStoragePgSchema,
+    });
+  }
+  throw new InvalidError(
+    `unknown DELPHI_STORAGE_BACKEND ${JSON.stringify(kind)} (expected dynamodb|postgres|memory)`
+  );
+}

--- a/server/src/storage/delphi/interface.ts
+++ b/server/src/storage/delphi/interface.ts
@@ -1,0 +1,379 @@
+/**
+ * The backend-neutral Delphi Storage V2 repository interface — TypeScript
+ * twin of delphi/delphi_storage/interface.py.
+ *
+ * Method names are camelCase, but DATA FIELD NAMES ARE snake_case: manifests
+ * and pointers are shared wire objects, written by the Python pipeline and
+ * read here (and vice versa). Design: delphi/docs/STORAGE_V2_DESIGN.md
+ * (§4.2 entities, §4.3 interface); normative conformance spec in
+ * delphi/delphi_storage/conformance/README.md.
+ */
+import { canonicalJsonDumps } from "./codec";
+import { AlreadyExistsError, InvalidError, NotFoundError, StorageError } from "./errors";
+import {
+  CHUNK_MARKER,
+  GENERIC_ENTITIES,
+  logSk,
+  nowTs,
+  scopesForRun,
+  validateTs,
+} from "./keys";
+
+export { AlreadyExistsError, InvalidError, NotFoundError, StorageError };
+
+export type RunStatus = "QUEUED" | "RUNNING" | "COMPLETED" | "FAILED";
+export type JobType = "FULL_PIPELINE" | "NARRATIVE_BATCH" | "SERVER_NARRATIVE" | "IMPORTED";
+
+export const RUN_STATUSES: readonly RunStatus[] = ["QUEUED", "RUNNING", "COMPLETED", "FAILED"];
+export const JOB_TYPES: readonly JobType[] = [
+  "FULL_PIPELINE",
+  "NARRATIVE_BATCH",
+  "SERVER_NARRATIVE",
+  "IMPORTED",
+];
+export const TERMINAL_STATUSES: readonly RunStatus[] = ["COMPLETED", "FAILED"];
+
+/** One logical item in a generic entity: JSON attributes + optional blob. */
+export interface StoreItem {
+  pk: string;
+  sk: string;
+  attributes: Record<string, unknown>;
+  blob: Buffer | null;
+}
+
+/**
+ * Queue row and run manifest in one — the row becomes the manifest as the
+ * job executes (design §4.2 entity 1).
+ */
+export interface RunManifest {
+  job_id: string;
+  job_type: JobType;
+  enqueued_at: string;
+  status: RunStatus;
+  zid: number | null;
+  rid: number | null;
+  priority: number;
+  version: number;
+  worker_id: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  lease_expires_at: string | null;
+  error: string | null;
+  replay_of: string | null;
+  provenance: string;
+  replayable: boolean;
+  imported_scope_type: string | null;
+  math_tick_legacy: number | null;
+  log_seq: number;
+  config_requested: Record<string, unknown>;
+  config_effective: Record<string, unknown>;
+  code_version: Record<string, unknown>;
+  seeds: Record<string, unknown>;
+  input_fingerprints: Record<string, unknown>;
+  stage_status: Record<string, unknown>;
+}
+
+/** First-class 'latest successful run' pointer (design §4.2 entity 4). */
+export interface LatestPointer {
+  scope: string;
+  job_id: string;
+  seq: number;
+  job_type: JobType;
+  updated_at: string;
+}
+
+export interface AdvanceResult {
+  advanced: boolean;
+  pointer: LatestPointer;
+}
+
+const OPTIONAL_TS_FIELDS = ["started_at", "completed_at", "lease_expires_at"] as const;
+const DICT_FIELDS = [
+  "config_requested",
+  "config_effective",
+  "code_version",
+  "seeds",
+  "input_fingerprints",
+  "stage_status",
+] as const;
+
+export const MERGEABLE_DICT_FIELDS: readonly string[] = DICT_FIELDS;
+export const MERGEABLE_SCALAR_FIELDS: readonly string[] = [
+  "math_tick_legacy",
+  "replay_of",
+  "provenance",
+  "replayable",
+  "imported_scope_type",
+];
+
+/**
+ * Apply defaults and validate — the equivalent of constructing the Python
+ * Pydantic RunManifest. Throws InvalidError on contract violations.
+ */
+export function normalizeRunManifest(input: Record<string, unknown>): RunManifest {
+  const jobId = input.job_id;
+  if (typeof jobId !== "string" || jobId.length === 0) {
+    throw new InvalidError("job_id must be a non-empty string");
+  }
+  const jobType = input.job_type as JobType;
+  if (!JOB_TYPES.includes(jobType)) {
+    throw new InvalidError(`unknown job_type ${JSON.stringify(input.job_type)}`);
+  }
+  const status = (input.status ?? "QUEUED") as RunStatus;
+  if (!RUN_STATUSES.includes(status)) {
+    throw new InvalidError(`unknown status ${JSON.stringify(input.status)}`);
+  }
+  validateTs(input.enqueued_at as string);
+  for (const field of OPTIONAL_TS_FIELDS) {
+    const value = input[field];
+    if (value !== undefined && value !== null) validateTs(value as string);
+  }
+  const manifest: RunManifest = {
+    job_id: jobId,
+    job_type: jobType,
+    enqueued_at: input.enqueued_at as string,
+    status,
+    zid: (input.zid as number | null | undefined) ?? null,
+    rid: (input.rid as number | null | undefined) ?? null,
+    priority: (input.priority as number | undefined) ?? 0,
+    version: (input.version as number | undefined) ?? 0,
+    worker_id: (input.worker_id as string | null | undefined) ?? null,
+    started_at: (input.started_at as string | null | undefined) ?? null,
+    completed_at: (input.completed_at as string | null | undefined) ?? null,
+    lease_expires_at: (input.lease_expires_at as string | null | undefined) ?? null,
+    error: (input.error as string | null | undefined) ?? null,
+    replay_of: (input.replay_of as string | null | undefined) ?? null,
+    provenance: (input.provenance as string | undefined) ?? "pipeline",
+    replayable: (input.replayable as boolean | undefined) ?? true,
+    imported_scope_type: (input.imported_scope_type as string | null | undefined) ?? null,
+    math_tick_legacy: (input.math_tick_legacy as number | null | undefined) ?? null,
+    log_seq: (input.log_seq as number | undefined) ?? 0,
+    config_requested: (input.config_requested as Record<string, unknown> | undefined) ?? {},
+    config_effective: (input.config_effective as Record<string, unknown> | undefined) ?? {},
+    code_version: (input.code_version as Record<string, unknown> | undefined) ?? {},
+    seeds: (input.seeds as Record<string, unknown> | undefined) ?? {},
+    input_fingerprints: (input.input_fingerprints as Record<string, unknown> | undefined) ?? {},
+    stage_status: (input.stage_status as Record<string, unknown> | undefined) ?? {},
+  };
+  return manifest;
+}
+
+/** Shared shallow-merge semantics for merge_run_fields (mirrors memory.py). */
+export function mergeManifestFields(
+  run: RunManifest,
+  fields: Record<string, unknown>
+): RunManifest {
+  const merged: RunManifest = { ...run };
+  for (const [key, value] of Object.entries(fields)) {
+    if ((MERGEABLE_DICT_FIELDS as string[]).includes(key)) {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new InvalidError(`field ${JSON.stringify(key)} must be a dict`);
+      }
+      (merged as unknown as Record<string, unknown>)[key] = {
+        ...(run as unknown as Record<string, unknown>)[key] as Record<string, unknown>,
+        ...(value as Record<string, unknown>),
+      };
+    } else if ((MERGEABLE_SCALAR_FIELDS as string[]).includes(key)) {
+      (merged as unknown as Record<string, unknown>)[key] = value;
+    } else {
+      throw new InvalidError(`field ${JSON.stringify(key)} is not mergeable`);
+    }
+  }
+  return merged;
+}
+
+/** Contract checks shared by every backend's generic write path. */
+export function validateGenericWrite(entity: string, item: StoreItem): void {
+  if (!(GENERIC_ENTITIES as readonly string[]).includes(entity)) {
+    throw new InvalidError(
+      `entity ${JSON.stringify(entity)} is not writable through generic ops ` +
+        `(allowed: ${GENERIC_ENTITIES.join(", ")})`
+    );
+  }
+  if (!item.pk) throw new InvalidError("pk must be non-empty");
+  if (!item.sk) throw new InvalidError("sk must be non-empty");
+  if (item.sk.includes(CHUNK_MARKER) || item.pk.includes(CHUNK_MARKER)) {
+    throw new InvalidError("keys must not contain U+007F (reserved chunk marker)");
+  }
+  for (const key of Object.keys(item.attributes)) {
+    if (key.startsWith("_")) {
+      throw new InvalidError(
+        `attribute ${JSON.stringify(key)}: top-level '_' prefix is reserved for backends`
+      );
+    }
+  }
+  canonicalJsonDumps(item.attributes); // throws InvalidError on NaN etc.
+}
+
+export function validateGenericRead(entity: string): void {
+  if (!(GENERIC_ENTITIES as readonly string[]).includes(entity)) {
+    throw new InvalidError(`entity ${JSON.stringify(entity)} is not readable through generic ops`);
+  }
+}
+
+/**
+ * Backends validate every externally supplied status — a typo'd status
+ * silently persisted would make a run permanently unclaimable. Twin of
+ * Python's RunStatus(status) coercion.
+ */
+export function coerceRunStatus(status: RunStatus | string): RunStatus {
+  if (!RUN_STATUSES.includes(status as RunStatus)) {
+    throw new InvalidError(`unknown status ${JSON.stringify(status)}`);
+  }
+  return status as RunStatus;
+}
+
+export function coerceJobType(jobType: JobType | string): JobType {
+  if (!JOB_TYPES.includes(jobType as JobType)) {
+    throw new InvalidError(`unknown job_type ${JSON.stringify(jobType)}`);
+  }
+  return jobType as JobType;
+}
+
+/**
+ * Contract checks shared by every backend's enqueueRun: status must be QUEUED
+ * and the job_type↔zid/rid coupling must already be satisfiable, so a run can
+ * never reach COMPLETED and then fail to derive its latest scopes (that would
+ * leave it stuck: completed but never published).
+ */
+export function validateEnqueueable(run: RunManifest): void {
+  if (run.status !== "QUEUED") {
+    throw new InvalidError(`enqueued runs must be QUEUED, got ${run.status}`);
+  }
+  scopesForRun(run); // throws InvalidError on an unsatisfiable coupling
+}
+
+export interface ClaimOptions {
+  workerId: string;
+  leaseSeconds: number;
+  now?: string;
+}
+
+export interface ExtendLeaseOptions {
+  jobId: string;
+  workerId: string;
+  leaseSeconds: number;
+  now?: string;
+}
+
+export interface AdvanceLatestOptions {
+  scope: string;
+  jobId: string;
+  jobType: JobType | string;
+  onlyIfAbsentOrImported?: boolean;
+  now?: string;
+}
+
+export interface ListRunsOptions {
+  zid?: number | null;
+  rid?: number | null;
+  status?: RunStatus | string | null;
+  limit?: number;
+}
+
+/**
+ * Neutral repository over runs / run_inputs / artifacts / latest /
+ * topic_moderation / collective_statements (design §4.2-4.3).
+ */
+export interface DelphiStore {
+  put(entity: string, item: StoreItem): Promise<void>;
+  putBatch(entity: string, items: StoreItem[]): Promise<void>;
+  get(entity: string, pk: string, sk: string): Promise<StoreItem | null>;
+  queryPrefix(entity: string, pk: string, skPrefix?: string): Promise<StoreItem[]>;
+  queryBetween(entity: string, pk: string, skFrom: string, skTo: string): Promise<StoreItem[]>;
+  deletePartition(entity: string, pk: string): Promise<number>;
+
+  enqueueRun(run: RunManifest): Promise<void>;
+  getRun(jobId: string): Promise<RunManifest | null>;
+  claimNextRun(options: ClaimOptions): Promise<RunManifest | null>;
+  extendLease(options: ExtendLeaseOptions): Promise<boolean>;
+  updateRunStatus(
+    jobId: string,
+    status: RunStatus | string,
+    options?: { error?: string | null; now?: string }
+  ): Promise<RunManifest>;
+  mergeRunFields(jobId: string, fields: Record<string, unknown>): Promise<RunManifest>;
+  completeRun(jobId: string, now?: string): Promise<RunManifest>;
+  appendLog(jobId: string, message: string, now?: string): Promise<number>;
+  advanceLatest(options: AdvanceLatestOptions): Promise<AdvanceResult>;
+  getLatest(scope: string): Promise<LatestPointer | null>;
+  listRuns(options: ListRunsOptions): Promise<RunManifest[]>;
+}
+
+/**
+ * Shared semantics implemented once for all backends (twin of the concrete
+ * methods on the Python ABC).
+ */
+export abstract class BaseDelphiStore implements DelphiStore {
+  abstract put(entity: string, item: StoreItem): Promise<void>;
+  abstract get(entity: string, pk: string, sk: string): Promise<StoreItem | null>;
+  abstract queryPrefix(entity: string, pk: string, skPrefix?: string): Promise<StoreItem[]>;
+  abstract queryBetween(
+    entity: string,
+    pk: string,
+    skFrom: string,
+    skTo: string
+  ): Promise<StoreItem[]>;
+  abstract deletePartition(entity: string, pk: string): Promise<number>;
+  abstract enqueueRun(run: RunManifest): Promise<void>;
+  abstract getRun(jobId: string): Promise<RunManifest | null>;
+  abstract claimNextRun(options: ClaimOptions): Promise<RunManifest | null>;
+  abstract extendLease(options: ExtendLeaseOptions): Promise<boolean>;
+  abstract updateRunStatus(
+    jobId: string,
+    status: RunStatus | string,
+    options?: { error?: string | null; now?: string }
+  ): Promise<RunManifest>;
+  abstract mergeRunFields(jobId: string, fields: Record<string, unknown>): Promise<RunManifest>;
+  abstract advanceLatest(options: AdvanceLatestOptions): Promise<AdvanceResult>;
+  abstract getLatest(scope: string): Promise<LatestPointer | null>;
+  abstract listRuns(options: ListRunsOptions): Promise<RunManifest[]>;
+
+  protected abstract incrementLogSeq(jobId: string): Promise<number>;
+
+  async putBatch(entity: string, items: StoreItem[]): Promise<void> {
+    for (const item of items) {
+      await this.put(entity, item);
+    }
+  }
+
+  /**
+   * Mark COMPLETED then advance latest for the run's scopes — the pointer is
+   * the commit point, written last (design §4.2). Idempotent and
+   * crash-healing. Throws InvalidError on FAILED runs.
+   */
+  async completeRun(jobId: string, now?: string): Promise<RunManifest> {
+    const at = now !== undefined ? validateTs(now) : nowTs();
+    let run = await this.getRun(jobId);
+    if (run === null) throw new NotFoundError(`run ${JSON.stringify(jobId)} not found`);
+    if (run.status === "FAILED") {
+      throw new InvalidError(`run ${JSON.stringify(jobId)} is FAILED and cannot be completed`);
+    }
+    // Derive scopes BEFORE flipping the status: a run that cannot publish
+    // must fail cleanly, not end up COMPLETED-but-unpublished.
+    const scopes = scopesForRun(run);
+    if (run.status !== "COMPLETED") {
+      run = await this.updateRunStatus(jobId, "COMPLETED", { now: at });
+    }
+    for (const scope of scopes) {
+      await this.advanceLatest({ scope, jobId: run.job_id, jobType: run.job_type, now: at });
+    }
+    return run;
+  }
+
+  /**
+   * Append-only run log as artifacts items (replaces the old truncate-to-50
+   * job log). Returns the 1-based seq.
+   */
+  async appendLog(jobId: string, message: string, now?: string): Promise<number> {
+    const at = now !== undefined ? validateTs(now) : nowTs();
+    const seq = await this.incrementLogSeq(jobId);
+    await this.put("artifacts", {
+      pk: jobId,
+      sk: logSk(seq),
+      attributes: { ts: at, message },
+      blob: null,
+    });
+    return seq;
+  }
+}

--- a/server/src/storage/delphi/keys.ts
+++ b/server/src/storage/delphi/keys.ts
@@ -1,0 +1,131 @@
+/**
+ * Key construction and shared constants for Delphi Storage V2.
+ *
+ * TypeScript twin of delphi/delphi_storage/keys.py — the rules here are part
+ * of the cross-language conformance contract
+ * (delphi/delphi_storage/conformance/README.md); keep the two in sync.
+ */
+import { InvalidError } from "./errors";
+import type { RunManifest } from "./interface";
+
+export const ENTITY_RUNS = "runs";
+export const ENTITY_RUN_INPUTS = "run_inputs";
+export const ENTITY_ARTIFACTS = "artifacts";
+export const ENTITY_LATEST = "latest";
+export const ENTITY_TOPIC_MODERATION = "topic_moderation";
+export const ENTITY_COLLECTIVE_STATEMENTS = "collective_statements";
+
+/**
+ * Entities addressable through the generic put/get/query/delete operations.
+ * `runs` and `latest` are mutated exclusively through the semantic ops so
+ * their invariants (optimistic lock, monotonic seq) cannot be bypassed.
+ */
+export const GENERIC_ENTITIES = [
+  ENTITY_RUN_INPUTS,
+  ENTITY_ARTIFACTS,
+  ENTITY_TOPIC_MODERATION,
+  ENTITY_COLLECTIVE_STATEMENTS,
+] as const;
+
+export type GenericEntity = (typeof GENERIC_ENTITIES)[number];
+
+/**
+ * Reserved for backend-internal chunk rows (DynamoDB 400KB item limit);
+ * forbidden in user-supplied keys.
+ */
+export const CHUNK_MARKER = "\u007f";
+
+export const LOG_PREFIX = "log#";
+
+const TS_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+/** Validate the canonical timestamp format YYYY-MM-DDTHH:MM:SS.mmmZ. */
+export function validateTs(ts: string): string {
+  if (typeof ts !== "string" || !TS_RE.test(ts)) {
+    throw new InvalidError(`timestamp must be YYYY-MM-DDTHH:MM:SS.mmmZ, got ${JSON.stringify(ts)}`);
+  }
+  if (Number.isNaN(Date.parse(ts))) {
+    throw new InvalidError(`timestamp is not a real date: ${ts}`);
+  }
+  return ts;
+}
+
+export function nowTs(): string {
+  // Date#toISOString always emits the canonical YYYY-MM-DDTHH:MM:SS.mmmZ form.
+  return new Date().toISOString();
+}
+
+export function tsAddSeconds(ts: string, seconds: number): string {
+  validateTs(ts);
+  return new Date(Date.parse(ts) + seconds * 1000).toISOString();
+}
+
+/**
+ * Compare strings by UTF-8 byte order (= Unicode code-point order, and
+ * DynamoDB's native range-key order). NOT the same as JavaScript's default
+ * `<` comparison, which uses UTF-16 code units and misorders astral-plane
+ * characters relative to U+E000..U+FFFF.
+ */
+export function utf8Compare(a: string, b: string): number {
+  return Buffer.compare(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
+}
+
+/**
+ * Claim-order string: ascending sort = highest priority first, then FIFO,
+ * then job_id as tiebreak.
+ */
+export function claimOrder(priority: number, enqueuedAt: string, jobId: string): string {
+  const p = Math.min(Math.max(Math.trunc(priority), 0), 9999);
+  return `${String(9999 - p).padStart(4, "0")}#${enqueuedAt}#${jobId}`;
+}
+
+export function scopeForZid(zid: number, jobType: string): string {
+  return `zid#${zid}#${jobType}`;
+}
+
+export function scopeForRid(rid: number, jobType: string): string {
+  return `rid#${rid}#${jobType}`;
+}
+
+/**
+ * Latest-pointer scopes a completed run flips (design §4.2 entity 4).
+ * IMPORTED runs never auto-flip: the backfill importer advances pointers
+ * explicitly under the no-clobber invariant (design §6.2 invariant 1).
+ */
+export function scopesForRun(run: RunManifest): string[] {
+  if (run.job_type === "FULL_PIPELINE") {
+    if (run.zid === null || run.zid === undefined) {
+      throw new InvalidError(`run ${run.job_id}: FULL_PIPELINE requires zid`);
+    }
+    return [scopeForZid(run.zid, run.job_type)];
+  }
+  if (run.job_type === "NARRATIVE_BATCH" || run.job_type === "SERVER_NARRATIVE") {
+    if (run.rid === null || run.rid === undefined) {
+      throw new InvalidError(`run ${run.job_id}: ${run.job_type} requires rid`);
+    }
+    return [scopeForRid(run.rid, run.job_type)];
+  }
+  if (run.job_type === "IMPORTED") {
+    return [];
+  }
+  throw new InvalidError(`run ${run.job_id}: unknown job_type ${JSON.stringify(run.job_type)}`);
+}
+
+export function logSk(seq: number): string {
+  return `${LOG_PREFIX}${String(seq).padStart(8, "0")}`;
+}
+
+/**
+ * Compose an artifact sort key from parts using the existing '#' composite
+ * convention (e.g. artifactKey('umap', 'topic', 0, 3)).
+ */
+export function artifactKey(...parts: Array<string | number>): string {
+  const strs = parts.map((p) => String(p));
+  for (const s of strs) {
+    if (!s) throw new InvalidError("artifact key parts must be non-empty");
+    if (s.includes(CHUNK_MARKER)) {
+      throw new InvalidError("artifact key parts must not contain U+007F");
+    }
+  }
+  return strs.join("#");
+}

--- a/server/src/storage/delphi/memoryStore.ts
+++ b/server/src/storage/delphi/memoryStore.ts
@@ -1,0 +1,265 @@
+/**
+ * In-memory reference implementation — twin of
+ * delphi/delphi_storage/backends/memory.py. All operations are internally
+ * synchronous (no awaits between read and write), so concurrent async
+ * callers cannot interleave inside an operation.
+ */
+import {
+  AdvanceLatestOptions,
+  AdvanceResult,
+  AlreadyExistsError,
+  BaseDelphiStore,
+  ClaimOptions,
+  ExtendLeaseOptions,
+  InvalidError,
+  LatestPointer,
+  ListRunsOptions,
+  NotFoundError,
+  RunManifest,
+  RunStatus,
+  StoreItem,
+  TERMINAL_STATUSES,
+  coerceJobType,
+  coerceRunStatus,
+  mergeManifestFields,
+  validateEnqueueable,
+  validateGenericRead,
+  validateGenericWrite,
+} from "./interface";
+import { claimOrder, nowTs, tsAddSeconds, utf8Compare, validateTs } from "./keys";
+
+interface StoredValue {
+  attributes: Record<string, unknown>;
+  blob: Buffer | null;
+}
+
+function cloneAttributes(attributes: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(attributes));
+}
+
+function cloneRun(run: RunManifest): RunManifest {
+  return JSON.parse(JSON.stringify(run));
+}
+
+export class MemoryDelphiStore extends BaseDelphiStore {
+  private kv = new Map<string, Map<string, Map<string, StoredValue>>>();
+  private runs = new Map<string, RunManifest>();
+  private latest = new Map<string, LatestPointer>();
+
+  async put(entity: string, item: StoreItem): Promise<void> {
+    validateGenericWrite(entity, item);
+    let partitions = this.kv.get(entity);
+    if (!partitions) {
+      partitions = new Map();
+      this.kv.set(entity, partitions);
+    }
+    let partition = partitions.get(item.pk);
+    if (!partition) {
+      partition = new Map();
+      partitions.set(item.pk, partition);
+    }
+    partition.set(item.sk, {
+      attributes: cloneAttributes(item.attributes),
+      blob: item.blob === null ? null : Buffer.from(item.blob),
+    });
+  }
+
+  async get(entity: string, pk: string, sk: string): Promise<StoreItem | null> {
+    validateGenericRead(entity);
+    const stored = this.kv.get(entity)?.get(pk)?.get(sk);
+    if (!stored) return null;
+    return {
+      pk,
+      sk,
+      attributes: cloneAttributes(stored.attributes),
+      blob: stored.blob === null ? null : Buffer.from(stored.blob),
+    };
+  }
+
+  private partitionItems(entity: string, pk: string): Map<string, StoredValue> {
+    return this.kv.get(entity)?.get(pk) ?? new Map();
+  }
+
+  async queryPrefix(entity: string, pk: string, skPrefix = ""): Promise<StoreItem[]> {
+    validateGenericRead(entity);
+    const partition = this.partitionItems(entity, pk);
+    const sks = Array.from(partition.keys())
+      .filter((sk) => sk.startsWith(skPrefix))
+      .sort(utf8Compare);
+    return sks.map((sk) => {
+      const stored = partition.get(sk)!;
+      return {
+        pk,
+        sk,
+        attributes: cloneAttributes(stored.attributes),
+        blob: stored.blob === null ? null : Buffer.from(stored.blob),
+      };
+    });
+  }
+
+  async queryBetween(
+    entity: string,
+    pk: string,
+    skFrom: string,
+    skTo: string
+  ): Promise<StoreItem[]> {
+    validateGenericRead(entity);
+    const partition = this.partitionItems(entity, pk);
+    const sks = Array.from(partition.keys())
+      .filter((sk) => utf8Compare(sk, skFrom) >= 0 && utf8Compare(sk, skTo) <= 0)
+      .sort(utf8Compare);
+    return sks.map((sk) => {
+      const stored = partition.get(sk)!;
+      return {
+        pk,
+        sk,
+        attributes: cloneAttributes(stored.attributes),
+        blob: stored.blob === null ? null : Buffer.from(stored.blob),
+      };
+    });
+  }
+
+  async deletePartition(entity: string, pk: string): Promise<number> {
+    validateGenericRead(entity);
+    const partitions = this.kv.get(entity);
+    const partition = partitions?.get(pk);
+    if (!partition) return 0;
+    partitions!.delete(pk);
+    return partition.size;
+  }
+
+  async enqueueRun(run: RunManifest): Promise<void> {
+    validateEnqueueable(run);
+    if (this.runs.has(run.job_id)) {
+      throw new AlreadyExistsError(`run ${JSON.stringify(run.job_id)} already exists`);
+    }
+    this.runs.set(run.job_id, cloneRun(run));
+  }
+
+  async getRun(jobId: string): Promise<RunManifest | null> {
+    const run = this.runs.get(jobId);
+    return run ? cloneRun(run) : null;
+  }
+
+  async claimNextRun(options: ClaimOptions): Promise<RunManifest | null> {
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    const queued = Array.from(this.runs.values()).filter((r) => r.status === "QUEUED");
+    if (queued.length === 0) return null;
+    queued.sort((a, b) =>
+      utf8Compare(
+        claimOrder(a.priority, a.enqueued_at, a.job_id),
+        claimOrder(b.priority, b.enqueued_at, b.job_id)
+      )
+    );
+    const run = queued[0];
+    const claimed: RunManifest = {
+      ...cloneRun(run),
+      status: "RUNNING",
+      worker_id: options.workerId,
+      started_at: at,
+      lease_expires_at: tsAddSeconds(at, options.leaseSeconds),
+      version: run.version + 1,
+    };
+    this.runs.set(run.job_id, claimed);
+    return cloneRun(claimed);
+  }
+
+  async extendLease(options: ExtendLeaseOptions): Promise<boolean> {
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    const run = this.runs.get(options.jobId);
+    if (!run || run.status !== "RUNNING" || run.worker_id !== options.workerId) {
+      return false;
+    }
+    this.runs.set(options.jobId, {
+      ...run,
+      lease_expires_at: tsAddSeconds(at, options.leaseSeconds),
+      version: run.version + 1,
+    });
+    return true;
+  }
+
+  async updateRunStatus(
+    jobId: string,
+    status: RunStatus | string,
+    options: { error?: string | null; now?: string } = {}
+  ): Promise<RunManifest> {
+    status = coerceRunStatus(status);
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    const run = this.runs.get(jobId);
+    if (!run) throw new NotFoundError(`run ${JSON.stringify(jobId)} not found`);
+    const updated: RunManifest = { ...cloneRun(run), status: status as RunStatus, version: run.version + 1 };
+    if (options.error !== undefined && options.error !== null) updated.error = options.error;
+    if ((TERMINAL_STATUSES as string[]).includes(status as string) && run.completed_at === null) {
+      updated.completed_at = at;
+    }
+    this.runs.set(jobId, updated);
+    return cloneRun(updated);
+  }
+
+  async mergeRunFields(jobId: string, fields: Record<string, unknown>): Promise<RunManifest> {
+    const run = this.runs.get(jobId);
+    if (!run) throw new NotFoundError(`run ${JSON.stringify(jobId)} not found`);
+    const merged: RunManifest = { ...mergeManifestFields(run, fields), version: run.version + 1 };
+    this.runs.set(jobId, merged);
+    return cloneRun(merged);
+  }
+
+  async advanceLatest(options: AdvanceLatestOptions): Promise<AdvanceResult> {
+    const jobType = coerceJobType(options.jobType);
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    const current = this.latest.get(options.scope);
+    if (current) {
+      if (current.job_id === options.jobId) {
+        return { advanced: false, pointer: { ...current } };
+      }
+      if (options.onlyIfAbsentOrImported && current.job_type !== "IMPORTED") {
+        return { advanced: false, pointer: { ...current } };
+      }
+    }
+    const pointer: LatestPointer = {
+      scope: options.scope,
+      job_id: options.jobId,
+      seq: current ? current.seq + 1 : 1,
+      job_type: jobType,
+      updated_at: at,
+    };
+    this.latest.set(options.scope, pointer);
+    return { advanced: true, pointer: { ...pointer } };
+  }
+
+  async getLatest(scope: string): Promise<LatestPointer | null> {
+    const pointer = this.latest.get(scope);
+    return pointer ? { ...pointer } : null;
+  }
+
+  async listRuns(options: ListRunsOptions): Promise<RunManifest[]> {
+    const hasZid = options.zid !== undefined && options.zid !== null;
+    const hasRid = options.rid !== undefined && options.rid !== null;
+    if (hasZid === hasRid) {
+      throw new InvalidError("exactly one of zid/rid is required");
+    }
+    const statusFilter =
+      options.status !== undefined && options.status !== null
+        ? coerceRunStatus(options.status)
+        : null;
+    let runs = Array.from(this.runs.values()).filter((r) =>
+      hasZid ? r.zid === options.zid : r.rid === options.rid
+    );
+    if (statusFilter !== null) {
+      runs = runs.filter((r) => r.status === statusFilter);
+    }
+    runs.sort((a, b) => {
+      const byTime = utf8Compare(b.enqueued_at, a.enqueued_at);
+      return byTime !== 0 ? byTime : utf8Compare(b.job_id, a.job_id);
+    });
+    return runs.slice(0, options.limit ?? 100).map(cloneRun);
+  }
+
+  protected async incrementLogSeq(jobId: string): Promise<number> {
+    const run = this.runs.get(jobId);
+    if (!run) throw new NotFoundError(`run ${JSON.stringify(jobId)} not found`);
+    const seq = run.log_seq + 1;
+    this.runs.set(jobId, { ...run, log_seq: seq, version: run.version + 1 });
+    return seq;
+  }
+}

--- a/server/src/storage/delphi/postgresStore.ts
+++ b/server/src/storage/delphi/postgresStore.ts
@@ -1,0 +1,479 @@
+/**
+ * PostgreSQL backend — twin of delphi/delphi_storage/backends/postgres.py.
+ * Same physical layout: one schema (default `delphi`) with `runs` (typed
+ * queue columns + JSONB manifest), `latest`, and four KV tables whose sort
+ * keys use COLLATE "C" (UTF-8 byte order, matching DynamoDB). Queue claims
+ * use FOR UPDATE SKIP LOCKED. The migration 000019 (P4) materializes the
+ * same DDL for server-managed deployments.
+ */
+import { Pool, PoolClient } from "pg";
+
+import { canonicalJsonDumps } from "./codec";
+import {
+  AdvanceLatestOptions,
+  AdvanceResult,
+  AlreadyExistsError,
+  BaseDelphiStore,
+  ClaimOptions,
+  ExtendLeaseOptions,
+  InvalidError,
+  JobType,
+  LatestPointer,
+  ListRunsOptions,
+  NotFoundError,
+  RunManifest,
+  RunStatus,
+  StorageError,
+  StoreItem,
+  TERMINAL_STATUSES,
+  coerceJobType,
+  coerceRunStatus,
+  mergeManifestFields,
+  validateEnqueueable,
+  validateGenericRead,
+  validateGenericWrite,
+} from "./interface";
+import { GENERIC_ENTITIES, claimOrder, nowTs, tsAddSeconds, validateTs } from "./keys";
+
+const IDENTIFIER_RE = /^[a-z_][a-z0-9_]{0,62}$/;
+
+const MUTATION_RETRIES = 8;
+
+export function schemaDdl(schema: string): string[] {
+  if (!IDENTIFIER_RE.test(schema)) {
+    throw new InvalidError(`schema name ${JSON.stringify(schema)} must match ${IDENTIFIER_RE}`);
+  }
+  const statements: string[] = [
+    `CREATE SCHEMA IF NOT EXISTS ${schema}`,
+    `CREATE TABLE IF NOT EXISTS ${schema}.runs (
+        job_id text PRIMARY KEY,
+        status text NOT NULL,
+        claim_order text COLLATE "C",
+        zid bigint,
+        rid bigint,
+        enqueued_at text NOT NULL,
+        version bigint NOT NULL,
+        manifest jsonb NOT NULL
+    )`,
+    `CREATE INDEX IF NOT EXISTS runs_claim_idx
+        ON ${schema}.runs (claim_order) WHERE status = 'QUEUED'`,
+    `CREATE INDEX IF NOT EXISTS runs_zid_idx ON ${schema}.runs (zid, enqueued_at)`,
+    `CREATE INDEX IF NOT EXISTS runs_rid_idx ON ${schema}.runs (rid, enqueued_at)`,
+    `CREATE TABLE IF NOT EXISTS ${schema}.latest (
+        scope text PRIMARY KEY,
+        job_id text NOT NULL,
+        seq bigint NOT NULL,
+        job_type text NOT NULL,
+        updated_at text NOT NULL
+    )`,
+  ];
+  for (const entity of GENERIC_ENTITIES) {
+    statements.push(
+      `CREATE TABLE IF NOT EXISTS ${schema}.${entity} (
+          pk text NOT NULL,
+          sk text COLLATE "C" NOT NULL,
+          attributes jsonb NOT NULL DEFAULT '{}'::jsonb,
+          blob bytea,
+          PRIMARY KEY (pk, sk)
+      )`
+    );
+  }
+  return statements;
+}
+
+export interface PostgresDelphiStoreOptions {
+  url: string;
+  schema: string;
+  poolSize?: number;
+}
+
+export class PostgresDelphiStore extends BaseDelphiStore {
+  private readonly pool: Pool;
+  readonly schema: string;
+
+  constructor(options: PostgresDelphiStoreOptions) {
+    super();
+    if (!IDENTIFIER_RE.test(options.schema)) {
+      throw new InvalidError(
+        `schema name ${JSON.stringify(options.schema)} must match ${IDENTIFIER_RE}`
+      );
+    }
+    this.schema = options.schema;
+    this.pool = new Pool({ connectionString: options.url, max: options.poolSize ?? 10 });
+  }
+
+  async ensureSchema(): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      for (const statement of schemaDdl(this.schema)) {
+        await client.query(statement);
+      }
+    } finally {
+      client.release();
+    }
+  }
+
+  async dropSchema(): Promise<void> {
+    await this.pool.query(`DROP SCHEMA IF EXISTS ${this.schema} CASCADE`);
+    await this.pool.end();
+  }
+
+  private kv(entity: string): string {
+    validateGenericRead(entity);
+    return `${this.schema}.${entity}`;
+  }
+
+  private async withTransaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await fn(client);
+      await client.query("COMMIT");
+      return result;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  // ---- generic ----
+
+  async put(entity: string, item: StoreItem): Promise<void> {
+    validateGenericWrite(entity, item);
+    await this.pool.query(
+      `INSERT INTO ${this.kv(entity)} (pk, sk, attributes, blob)
+       VALUES ($1, $2, CAST($3 AS jsonb), $4)
+       ON CONFLICT (pk, sk) DO UPDATE SET attributes = EXCLUDED.attributes, blob = EXCLUDED.blob`,
+      [item.pk, item.sk, canonicalJsonDumps(item.attributes), item.blob]
+    );
+  }
+
+  private static rowToItem(row: {
+    pk: string;
+    sk: string;
+    attributes: Record<string, unknown>;
+    blob: Buffer | null;
+  }): StoreItem {
+    return {
+      pk: row.pk,
+      sk: row.sk,
+      attributes: row.attributes,
+      blob: row.blob === null ? null : Buffer.from(row.blob),
+    };
+  }
+
+  async get(entity: string, pk: string, sk: string): Promise<StoreItem | null> {
+    const result = await this.pool.query(
+      `SELECT pk, sk, attributes, blob FROM ${this.kv(entity)} WHERE pk = $1 AND sk = $2`,
+      [pk, sk]
+    );
+    return result.rows.length ? PostgresDelphiStore.rowToItem(result.rows[0]) : null;
+  }
+
+  async queryPrefix(entity: string, pk: string, skPrefix = ""): Promise<StoreItem[]> {
+    const result = await this.pool.query(
+      `SELECT pk, sk, attributes, blob FROM ${this.kv(entity)}
+       WHERE pk = $1 AND left(sk, $2) = $3
+       ORDER BY sk COLLATE "C"`,
+      [pk, skPrefix.length, skPrefix]
+    );
+    return result.rows.map(PostgresDelphiStore.rowToItem);
+  }
+
+  async queryBetween(
+    entity: string,
+    pk: string,
+    skFrom: string,
+    skTo: string
+  ): Promise<StoreItem[]> {
+    const result = await this.pool.query(
+      `SELECT pk, sk, attributes, blob FROM ${this.kv(entity)}
+       WHERE pk = $1 AND sk >= $2 AND sk <= $3
+       ORDER BY sk COLLATE "C"`,
+      [pk, skFrom, skTo]
+    );
+    return result.rows.map(PostgresDelphiStore.rowToItem);
+  }
+
+  async deletePartition(entity: string, pk: string): Promise<number> {
+    const result = await this.pool.query(`DELETE FROM ${this.kv(entity)} WHERE pk = $1`, [pk]);
+    return result.rowCount ?? 0;
+  }
+
+  // ---- runs / queue ----
+
+  private get runsTable(): string {
+    return `${this.schema}.runs`;
+  }
+
+  private get latestTable(): string {
+    return `${this.schema}.latest`;
+  }
+
+  private runParams(run: RunManifest): unknown[] {
+    return [
+      run.job_id,
+      run.status,
+      run.status === "QUEUED" ? claimOrder(run.priority, run.enqueued_at, run.job_id) : null,
+      run.zid,
+      run.rid,
+      run.enqueued_at,
+      run.version,
+      canonicalJsonDumps(run),
+    ];
+  }
+
+  async enqueueRun(run: RunManifest): Promise<void> {
+    validateEnqueueable(run);
+    const result = await this.pool.query(
+      `INSERT INTO ${this.runsTable}
+          (job_id, status, claim_order, zid, rid, enqueued_at, version, manifest)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, CAST($8 AS jsonb))
+       ON CONFLICT (job_id) DO NOTHING`,
+      this.runParams(run)
+    );
+    if (!result.rowCount) {
+      throw new AlreadyExistsError(`run ${JSON.stringify(run.job_id)} already exists`);
+    }
+  }
+
+  async getRun(jobId: string): Promise<RunManifest | null> {
+    const result = await this.pool.query(
+      `SELECT manifest FROM ${this.runsTable} WHERE job_id = $1`,
+      [jobId]
+    );
+    return result.rows.length ? (result.rows[0].manifest as RunManifest) : null;
+  }
+
+  private async writeRun(
+    client: PoolClient,
+    run: RunManifest,
+    expectedVersion: number
+  ): Promise<boolean> {
+    const result = await client.query(
+      `UPDATE ${this.runsTable}
+       SET status = $2, claim_order = $3, version = $4, manifest = CAST($5 AS jsonb)
+       WHERE job_id = $1 AND version = $6`,
+      [
+        run.job_id,
+        run.status,
+        run.status === "QUEUED" ? claimOrder(run.priority, run.enqueued_at, run.job_id) : null,
+        run.version,
+        canonicalJsonDumps(run),
+        expectedVersion,
+      ]
+    );
+    return Boolean(result.rowCount);
+  }
+
+  async claimNextRun(options: ClaimOptions): Promise<RunManifest | null> {
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    return this.withTransaction(async (client) => {
+      const candidate = await client.query(
+        `SELECT manifest FROM ${this.runsTable}
+         WHERE status = 'QUEUED'
+         ORDER BY claim_order COLLATE "C"
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED`
+      );
+      if (!candidate.rows.length) return null;
+      const run = candidate.rows[0].manifest as RunManifest;
+      const claimed: RunManifest = {
+        ...run,
+        status: "RUNNING",
+        worker_id: options.workerId,
+        started_at: at,
+        lease_expires_at: tsAddSeconds(at, options.leaseSeconds),
+        version: run.version + 1,
+      };
+      if (!(await this.writeRun(client, claimed, run.version))) {
+        throw new StorageError(`claim of ${run.job_id} lost a race despite row lock`);
+      }
+      return claimed;
+    });
+  }
+
+  async extendLease(options: ExtendLeaseOptions): Promise<boolean> {
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    return this.withTransaction(async (client) => {
+      const result = await client.query(
+        `SELECT manifest FROM ${this.runsTable} WHERE job_id = $1 FOR UPDATE`,
+        [options.jobId]
+      );
+      if (!result.rows.length) return false;
+      const run = result.rows[0].manifest as RunManifest;
+      if (run.status !== "RUNNING" || run.worker_id !== options.workerId) return false;
+      const extended: RunManifest = {
+        ...run,
+        lease_expires_at: tsAddSeconds(at, options.leaseSeconds),
+        version: run.version + 1,
+      };
+      return this.writeRun(client, extended, run.version);
+    });
+  }
+
+  private async mutateRun(
+    jobId: string,
+    mutate: (run: RunManifest) => RunManifest
+  ): Promise<RunManifest> {
+    return this.withTransaction(async (client) => {
+      const result = await client.query(
+        `SELECT manifest FROM ${this.runsTable} WHERE job_id = $1 FOR UPDATE`,
+        [jobId]
+      );
+      if (!result.rows.length) throw new NotFoundError(`run ${JSON.stringify(jobId)} not found`);
+      const run = result.rows[0].manifest as RunManifest;
+      const updated: RunManifest = { ...mutate(run), version: run.version + 1 };
+      if (!(await this.writeRun(client, updated, run.version))) {
+        throw new StorageError(`update of ${JSON.stringify(jobId)} lost a race despite row lock`);
+      }
+      return updated;
+    });
+  }
+
+  async updateRunStatus(
+    jobId: string,
+    status: RunStatus | string,
+    options: { error?: string | null; now?: string } = {}
+  ): Promise<RunManifest> {
+    status = coerceRunStatus(status);
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    return this.mutateRun(jobId, (run) => {
+      const updated: RunManifest = { ...run, status: status as RunStatus };
+      if (options.error !== undefined && options.error !== null) updated.error = options.error;
+      if ((TERMINAL_STATUSES as string[]).includes(status as string) && run.completed_at === null) {
+        updated.completed_at = at;
+      }
+      return updated;
+    });
+  }
+
+  async mergeRunFields(jobId: string, fields: Record<string, unknown>): Promise<RunManifest> {
+    return this.mutateRun(jobId, (run) => mergeManifestFields(run, fields));
+  }
+
+  protected async incrementLogSeq(jobId: string): Promise<number> {
+    const result = await this.pool.query(
+      `UPDATE ${this.runsTable}
+       SET version = version + 1,
+           manifest = jsonb_set(
+               jsonb_set(manifest, '{log_seq}',
+                   to_jsonb(COALESCE((manifest->>'log_seq')::bigint, 0) + 1)),
+               '{version}', to_jsonb(version + 1))
+       WHERE job_id = $1
+       RETURNING (manifest->>'log_seq')::bigint AS log_seq`,
+      [jobId]
+    );
+    if (!result.rows.length) throw new NotFoundError(`run ${JSON.stringify(jobId)} not found`);
+    return Number(result.rows[0].log_seq);
+  }
+
+  // ---- latest ----
+
+  async advanceLatest(options: AdvanceLatestOptions): Promise<AdvanceResult> {
+    const jobType = coerceJobType(options.jobType);
+    const at = options.now !== undefined ? validateTs(options.now) : nowTs();
+    for (let attempt = 0; attempt < MUTATION_RETRIES; attempt++) {
+      const result = await this.withTransaction<AdvanceResult | null>(async (client) => {
+        const existing = await client.query(
+          `SELECT scope, job_id, seq, job_type, updated_at FROM ${this.latestTable}
+           WHERE scope = $1 FOR UPDATE`,
+          [options.scope]
+        );
+        if (existing.rows.length) {
+          const current = PostgresDelphiStore.rowToPointer(existing.rows[0]);
+          if (current.job_id === options.jobId) return { advanced: false, pointer: current };
+          if (options.onlyIfAbsentOrImported && current.job_type !== "IMPORTED") {
+            return { advanced: false, pointer: current };
+          }
+          const pointer: LatestPointer = {
+            scope: options.scope,
+            job_id: options.jobId,
+            seq: current.seq + 1,
+            job_type: jobType,
+            updated_at: at,
+          };
+          await client.query(
+            `UPDATE ${this.latestTable}
+             SET job_id = $2, seq = $3, job_type = $4, updated_at = $5
+             WHERE scope = $1`,
+            [pointer.scope, pointer.job_id, pointer.seq, pointer.job_type, pointer.updated_at]
+          );
+          return { advanced: true, pointer };
+        }
+        const pointer: LatestPointer = {
+          scope: options.scope,
+          job_id: options.jobId,
+          seq: 1,
+          job_type: jobType,
+          updated_at: at,
+        };
+        const inserted = await client.query(
+          `INSERT INTO ${this.latestTable} (scope, job_id, seq, job_type, updated_at)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (scope) DO NOTHING`,
+          [pointer.scope, pointer.job_id, pointer.seq, pointer.job_type, pointer.updated_at]
+        );
+        if (inserted.rowCount) return { advanced: true, pointer };
+        return null; // lost the empty-scope insert race — re-read and re-decide
+      });
+      if (result !== null) return result;
+    }
+    throw new StorageError(
+      `latest ${JSON.stringify(options.scope)}: lost ${MUTATION_RETRIES} insert races`
+    );
+  }
+
+  private static rowToPointer(row: {
+    scope: string;
+    job_id: string;
+    seq: number | string;
+    job_type: string;
+    updated_at: string;
+  }): LatestPointer {
+    return {
+      scope: row.scope,
+      job_id: row.job_id,
+      seq: Number(row.seq),
+      job_type: row.job_type as JobType,
+      updated_at: row.updated_at,
+    };
+  }
+
+  async getLatest(scope: string): Promise<LatestPointer | null> {
+    const result = await this.pool.query(
+      `SELECT scope, job_id, seq, job_type, updated_at FROM ${this.latestTable} WHERE scope = $1`,
+      [scope]
+    );
+    return result.rows.length ? PostgresDelphiStore.rowToPointer(result.rows[0]) : null;
+  }
+
+  async listRuns(options: ListRunsOptions): Promise<RunManifest[]> {
+    const hasZid = options.zid !== undefined && options.zid !== null;
+    const hasRid = options.rid !== undefined && options.rid !== null;
+    if (hasZid === hasRid) throw new InvalidError("exactly one of zid/rid is required");
+    const statusFilter =
+      options.status !== undefined && options.status !== null
+        ? coerceRunStatus(options.status)
+        : null;
+    const column = hasZid ? "zid" : "rid";
+    const value = hasZid ? options.zid : options.rid;
+    const params: unknown[] = [value];
+    let statusClause = "";
+    if (statusFilter !== null) {
+      params.push(statusFilter);
+      statusClause = ` AND status = $${params.length}`;
+    }
+    params.push(options.limit ?? 100);
+    const result = await this.pool.query(
+      `SELECT manifest FROM ${this.runsTable}
+       WHERE ${column} = $1${statusClause}
+       ORDER BY enqueued_at DESC, job_id DESC
+       LIMIT $${params.length}`,
+      params
+    );
+    return result.rows.map((row) => row.manifest as RunManifest);
+  }
+}


### PR DESCRIPTION
Stack 1 / P3 of the Storage V2 effort — the TypeScript twin of #2598, per `delphi/docs/STORAGE_V2_DESIGN.md` §3.6: the abstraction must be **two-sided**, because both the Python pipeline and the server touch the store directly.

**Stacked on #2598** (`jc/delphi-storage-v2-p2`) — it needs the conformance case files from that PR at test time (same repo checkout, no build coupling).

## What this adds

`server/src/storage/delphi/` — the TypeScript implementation of the same backend-neutral repository, kept honest by executing the **same JSON conformance case files** (`delphi/delphi_storage/conformance/cases/`) as the pytest suite:

- `errors.ts`, `keys.ts`, `codec.ts` — same wire format: canonical JSON (keys sorted by **UTF-8 byte order**, matching Python's `sort_keys`), little-endian packed float64, zstd via Node's **built-in** `zlib` zstd support (Node ≥ 22.15; no new npm dependency). The jest suite decodes zstd blobs that were encoded by Python and committed as fixtures — the cross-language pin.
- `interface.ts` — method names camelCase, **data fields snake_case** (manifests/pointers are shared wire objects written by Python and read here, and vice versa); `normalizeRunManifest` mirrors the Pydantic validation; `BaseDelphiStore` carries the shared `completeRun` (scopes derived *before* the status flip; pointer written last as the commit point; idempotent + crash-healing) and `appendLog` semantics.
- `dynamoStore.ts` — SDK v3 `DynamoDBDocumentClient` **without** `convertEmptyValues` (deliberate deviation from the older house pattern: empty strings must round-trip); optimistic-lock conditional writes on `version`; sparse `claim-index` GSI; **generation-tagged chunk rows** for blobs >300KB with the main item as the atomic commit point — the same crash-safe protocol as the Python backend (see the review fixes on #2598).
- `postgresStore.ts` — `pg` Pool, `COLLATE "C"` sort keys, `FOR UPDATE SKIP LOCKED` claims, JSONB manifests; DDL identical to the Python backend's (migration `000019` in P4 materializes it).
- `memoryStore.ts` — reference implementation (internally synchronous, so concurrent async callers can't interleave inside an op).
- `factory.ts` + `config.ts` — `DELPHI_STORAGE_BACKEND` / `DELPHI_STORAGE_TABLE_PREFIX` / `DELPHI_STORAGE_PG_SCHEMA` / `DELPHI_STORAGE_PG_URL`, env access confined to `config.ts` per the lint rule.

### Tests

- `__tests__/setup/delphi-storage-conformance.ts` — the jest case runner (twin of `runner.py`).
- Unit (no services): codec/keys pins (claim order, timestamps, scopes, canonical JSON, f64 hex, envelopes) + **all 8 shared cases** against the memory backend + Python-encoded codec fixtures. 37 tests.
- Integration (services as in CI): all cases + a `Promise.all` two-claimants-one-wins race against **real DynamoDB and PostgreSQL**. 16 tests.

## Testing

- 37 unit + 16 integration tests pass (DynamoDB local `:8002`, dockerized PG 16).
- `tsc` build clean; `eslint` clean (0 errors).
- The 12 pre-existing JWT-env unit-test failures reproduce identically on the base commit without this change (missing local JWT keys; CI provides them) — not a regression.
- TDD: test suites written first (2 suites failing on missing modules), then the implementation.

## Stack

- P1: #2597 (design doc)
- P2: #2598 (Python `delphi_storage/`)
- **P3: this PR**
- P4: DDL — `create_dynamodb_tables.py` additions + PG migration `000019` (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
