### PR TITLE
feat(delphi): storage v2 P5 — explicit --job-id threading through all pipeline entry points

### DIFF
--- a/delphi/delphi_storage/job_id.py
+++ b/delphi/delphi_storage/job_id.py
@@ -1,0 +1,21 @@
+"""Job-id resolution for the pipeline entry points (design §4.4).
+
+Precedence: explicit CLI value > ``DELPHI_JOB_ID`` env (transition fallback —
+kept for one phase while un-migrated callers still rely on env inheritance,
+then removed) > auto-generated ``local-<uuid4>`` for dev runs.
+"""
+
+import os
+import uuid
+from typing import Optional
+
+ENV_VAR = "DELPHI_JOB_ID"
+
+
+def resolve_job_id(cli_value: Optional[str] = None) -> str:
+    if cli_value:
+        return cli_value
+    from_env = os.environ.get(ENV_VAR)
+    if from_env:
+        return from_env
+    return f"local-{uuid.uuid4()}"

--- a/delphi/polismath/run_math_pipeline.py
+++ b/delphi/polismath/run_math_pipeline.py
@@ -257,7 +257,13 @@ def main():
                         help='Maximum number of votes to process (for testing)')
     parser.add_argument('--batch-size', type=int, default=50000, 
                         help='Batch size for vote processing (default: 50000)')
+    parser.add_argument('--job-id', dest='job_id', default=None,
+                        help='Pipeline job id (Storage V2 provenance, design §4.4); defaults to DELPHI_JOB_ID env, else auto local-<uuid4>')
     args = parser.parse_args()
+
+    from delphi_storage.job_id import resolve_job_id
+    job_id = resolve_job_id(args.job_id)
+    logger.info(f"Pipeline job id: {job_id}")
 
     zid = args.zid
     start_time = time.time()

--- a/delphi/run_delphi.py
+++ b/delphi/run_delphi.py
@@ -36,6 +36,9 @@ def main():
     parser.add_argument('--include_moderation', type=bool, default=False, help='Whether or not to include moderated comments in reports. If false, moderated comments will appear.')
     parser.add_argument('--exclude_comment_selections', type=bool, default=True, help='Whether to exclude comments with selection=-1 in report_comment_selections table.')
     parser.add_argument('--region', type=str, default='us-east-1', help='AWS region')
+    parser.add_argument('--job-id', dest='job_id', default=None,
+                        help='Pipeline job id (auto local-<uuid4> when omitted; '
+                             'threaded to every stage, see docs/STORAGE_V2_DESIGN.md §4.4)')
 
     args = parser.parse_args()
 
@@ -45,6 +48,12 @@ def main():
 
     zid = args.zid
     rid = args.rid
+    from delphi_storage.job_id import resolve_job_id
+    job_id = resolve_job_id(args.job_id)
+    # Transition (design §4.4): un-migrated readers still inherit the env var;
+    # exporting here keeps them on the SAME id as the command lines below.
+    os.environ["DELPHI_JOB_ID"] = job_id
+    print(f"{YELLOW}Pipeline job id: {job_id}{NC}")
     verbose_arg = "--verbose" if args.verbose else ""
     force_arg = "--force" if args.force else ""
     # validate_arg is not used in the python script execution steps, but kept for parity with bash
@@ -56,6 +65,7 @@ def main():
         "python",
         "umap_narrative/reset_conversation.py",
         f"--zid={zid}",
+        f"--job-id={job_id}",
     ]
     # If a report ID is provided, pass it to the reset script for full cleanup
     if rid:
@@ -100,6 +110,7 @@ def main():
     math_command = [
         "python", f"{app_path}/polismath/run_math_pipeline.py",
         f"--zid={zid}",
+        f"--job-id={job_id}",
     ]
     if max_votes_arg:
         math_command.append(max_votes_arg)
@@ -120,6 +131,7 @@ def main():
         f"--zid={zid}",
         f"--include_moderation={args.include_moderation}",
         f"--exclude_comment_selections={args.exclude_comment_selections}",
+        f"--job-id={job_id}",
         "--use-ollama"
     ]
     if verbose_arg:
@@ -134,7 +146,8 @@ def main():
         "python", f"{app_path}/umap_narrative/501_calculate_comment_extremity.py",
         f"--zid={zid}",
         f"--include_moderation={args.include_moderation}",
-        f"--exclude_comment_selections={args.exclude_comment_selections}"
+        f"--exclude_comment_selections={args.exclude_comment_selections}",
+        f"--job-id={job_id}"
     ]
     if verbose_arg:
         extremity_command.append(verbose_arg)
@@ -153,6 +166,7 @@ def main():
     priority_command = [
         "python", f"{app_path}/umap_narrative/502_calculate_priorities.py",
         f"--conversation_id={zid}",
+        f"--job-id={job_id}",
     ]
     if verbose_arg:
         priority_command.append(verbose_arg)
@@ -237,7 +251,8 @@ def main():
                 "python", f"{app_path}/umap_narrative/700_datamapplot_for_layer.py",
                 f"--conversation_id={zid}",
                 f"--layer={layer_id}",
-                f"--output_dir={output_dir}"
+                f"--output_dir={output_dir}",
+                f"--job-id={job_id}"
             ]
             if verbose_arg:
                 datamap_command.append(verbose_arg)

--- a/delphi/scripts/job_poller.py
+++ b/delphi/scripts/job_poller.py
@@ -399,6 +399,38 @@ def signal_handler(sig, frame):
     running = False
 
 
+
+def build_job_command(job: Dict[str, Any], app_path: str) -> list:
+    """Build the stage command for a claimed job.
+
+    The pipeline job id travels ON THE COMMAND LINE (Storage V2 design §4.4);
+    the DELPHI_JOB_ID env var set in process_job remains only as a transition
+    fallback for un-migrated readers. Note 803's --job-id is the
+    batch-tracking id (batch_job_id), a distinct concept kept as-is.
+    """
+    job_id = job['job_id']
+    job_type = job.get('job_type')
+    conversation_id = job.get('conversation_id')
+    job_config = json.loads(job.get('job_config', '{}'))
+    include_moderation = job_config.get('include_moderation', False)
+    exclude_comment_selections = job_config.get('exclude_comment_selections', True)
+    if job_type == 'CREATE_NARRATIVE_BATCH':
+        model = os.environ.get("ANTHROPIC_MODEL")
+        if not model: raise ValueError("ANTHROPIC_MODEL must be set")
+        max_batch_size = job_config.get('max_batch_size', 20)
+        cmd = ['python', f'{app_path}/umap_narrative/801_narrative_report_batch.py', f'--conversation_id={conversation_id}', f'--model={model}', f'--include_moderation={include_moderation}', f'--exclude_comment_selections={exclude_comment_selections}', f'--max-batch-size={str(max_batch_size)}', f'--job-id={job_id}']
+        if job_config.get('no_cache'): cmd.append('--no-cache')
+    elif job_type == 'AWAITING_NARRATIVE_BATCH':
+        cmd_job_id = job.get('batch_job_id', job_id)
+        cmd = ['python', f'{app_path}/umap_narrative/803_check_batch_status.py', f'--job-id={cmd_job_id}']
+    else:  # FULL_PIPELINE
+        cmd = ['python', f'{app_path}/run_delphi.py', f'--zid={conversation_id}', f'--include_moderation={include_moderation}', f'--exclude_comment_selections={exclude_comment_selections}', f'--job-id={job_id}']
+        report_id = job.get('report_id')
+        if report_id:
+            cmd.append(f'--rid={report_id}')
+    return cmd
+
+
 class JobProcessor:
     """Process jobs from the Delphi_JobQueue."""
     
@@ -697,27 +729,9 @@ class JobProcessor:
         
         try:
             # 1. Build the command
-            job_config = json.loads(job.get('job_config', '{}'))
-            include_moderation = job_config.get('include_moderation', False)
-            exclude_comment_selections = job_config.get('exclude_comment_selections', True)
-            app_path = os.environ.get('DELPHI_APP_PATH', '/app')
-            if job_type == 'CREATE_NARRATIVE_BATCH':
-                model = os.environ.get("ANTHROPIC_MODEL")
-                if not model: raise ValueError("ANTHROPIC_MODEL must be set")
-                max_batch_size = job_config.get('max_batch_size', 20)
-                cmd = ['python', f'{app_path}/umap_narrative/801_narrative_report_batch.py', f'--conversation_id={conversation_id}', f'--model={model}', f'--include_moderation={include_moderation}', f'--exclude_comment_selections={exclude_comment_selections}', f'--max-batch-size={str(max_batch_size)}']
-                if job_config.get('no_cache'): cmd.append('--no-cache')
-            elif job_type == 'AWAITING_NARRATIVE_BATCH':
-                cmd_job_id = job.get('batch_job_id', job_id)
-                cmd = ['python', f'{app_path}/umap_narrative/803_check_batch_status.py', f'--job-id={cmd_job_id}']
-            else: # FULL_PIPELINE
-                # Base command
-                cmd = ['python', f'{app_path}/run_delphi.py', f'--zid={conversation_id}', f'--include_moderation={include_moderation}', f'--exclude_comment_selections={exclude_comment_selections}',]
-                # Check for report_id and append if it exists
-                report_id = job.get('report_id')
-                if report_id:
-                    cmd.append(f'--rid={report_id}')
-                    self.update_job_logs(job, {'level': 'INFO', 'message': f"Passing report_id {report_id} to run_delphi.py"})
+            cmd = build_job_command(job, app_path=os.environ.get('DELPHI_APP_PATH', '/app'))
+            if job.get('report_id') and job_type not in ('CREATE_NARRATIVE_BATCH', 'AWAITING_NARRATIVE_BATCH'):
+                self.update_job_logs(job, {'level': 'INFO', 'message': f"Passing report_id {job.get('report_id')} to run_delphi.py"})
 
 
             # 2. Execute the command and stream logs to prevent deadlocks

--- a/delphi/tests/test_job_id_threading.py
+++ b/delphi/tests/test_job_id_threading.py
@@ -1,0 +1,187 @@
+"""P5 (Storage V2 design §4.4): explicit --job-id threading.
+
+The job id must flow to every stage on the COMMAND LINE — today it exists
+only as the DELPHI_JOB_ID env var set by the poller, reaching 2 of 18 tables.
+Contract under test:
+
+- resolve_job_id precedence: CLI arg > DELPHI_JOB_ID env (transition
+  fallback) > auto `local-<uuid4>`;
+- run_delphi.py accepts --job-id and passes the SAME id to all six stage
+  subprocesses (and exports it for un-migrated env readers);
+- every stage entry point accepts --job-id;
+- the poller puts --job-id on the run_delphi and 801 command lines (803
+  keeps its existing --job-id semantics: the batch-tracking id).
+"""
+
+import importlib
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from delphi_storage.job_id import resolve_job_id
+
+DELPHI_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+UMAP_DIR = os.path.join(DELPHI_DIR, "umap_narrative")
+for path in (DELPHI_DIR, UMAP_DIR):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_delphi_job_id_env():
+    """run_delphi.main() writes DELPHI_JOB_ID to the real os.environ (the
+    transition export, design §4.4) — monkeypatch can't undo out-of-band
+    writes, so restore it ourselves to keep the test session hermetic."""
+    original = os.environ.pop("DELPHI_JOB_ID", None)
+    yield
+    if original is None:
+        os.environ.pop("DELPHI_JOB_ID", None)
+    else:
+        os.environ["DELPHI_JOB_ID"] = original
+
+
+class TestResolveJobId:
+    def test_cli_wins(self, monkeypatch):
+        monkeypatch.setenv("DELPHI_JOB_ID", "env-id")
+        assert resolve_job_id("cli-id") == "cli-id"
+
+    def test_env_fallback(self, monkeypatch):
+        monkeypatch.setenv("DELPHI_JOB_ID", "env-id")
+        assert resolve_job_id(None) == "env-id"
+
+    def test_auto_local(self, monkeypatch):
+        monkeypatch.delenv("DELPHI_JOB_ID", raising=False)
+        generated = resolve_job_id(None)
+        assert generated.startswith("local-")
+        assert generated != resolve_job_id(None)
+
+
+def _run_run_delphi(monkeypatch, argv):
+    run_delphi = importlib.import_module("run_delphi")
+    recorded = []
+
+    def fake_run(cmd, **kwargs):
+        recorded.append(list(cmd))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(run_delphi.subprocess, "run", fake_run)
+    monkeypatch.setenv("OLLAMA_MODEL", "test-model")
+    monkeypatch.setenv("DELPHI_APP_PATH", DELPHI_DIR)
+    # Make the in-function `import boto3` fail so layer discovery falls back
+    # to layer 0 without touching the network.
+    monkeypatch.setitem(sys.modules, "boto3", None)
+    monkeypatch.setattr(sys, "argv", ["run_delphi.py"] + argv)
+    with pytest.raises(SystemExit) as excinfo:
+        run_delphi.main()
+    assert excinfo.value.code == 0
+    return recorded
+
+
+def _job_id_args(cmd):
+    return [arg for arg in cmd if arg.startswith("--job-id=")]
+
+
+class TestRunDelphiThreading:
+    def test_explicit_job_id_reaches_all_stages(self, monkeypatch):
+        monkeypatch.delenv("DELPHI_JOB_ID", raising=False)
+        commands = _run_run_delphi(monkeypatch, ["--zid=123", "--job-id=test-job-1"])
+        assert len(commands) == 6, [c[1] for c in commands]
+        for cmd in commands:
+            assert _job_id_args(cmd) == ["--job-id=test-job-1"], cmd
+
+    def test_auto_job_id_is_shared_across_stages(self, monkeypatch):
+        monkeypatch.delenv("DELPHI_JOB_ID", raising=False)
+        commands = _run_run_delphi(monkeypatch, ["--zid=123"])
+        ids = {arg for cmd in commands for arg in _job_id_args(cmd)}
+        assert len(ids) == 1, ids
+        (only,) = ids
+        assert only.startswith("--job-id=local-")
+        # exported for un-migrated env readers (transition, design §4.4)
+        assert os.environ.get("DELPHI_JOB_ID") == only.removeprefix("--job-id=")
+
+    def test_env_fallback_still_honored(self, monkeypatch):
+        monkeypatch.setenv("DELPHI_JOB_ID", "from-env-7")
+        commands = _run_run_delphi(monkeypatch, ["--zid=123"])
+        for cmd in commands:
+            assert _job_id_args(cmd) == ["--job-id=from-env-7"], cmd
+
+
+# (module_import_name, cli_entry_attr) — every pipeline stage entry point.
+# reset_conversation's CLI lives in cli() (main() is the worker function);
+# 801's main() is async.
+STAGE_MODULES = [
+    ("reset_conversation", "cli"),
+    ("polismath.run_math_pipeline", "main"),
+    ("run_pipeline", "main"),
+    ("501_calculate_comment_extremity", "main"),
+    ("502_calculate_priorities", "main"),
+    ("700_datamapplot_for_layer", "main"),
+    ("801_narrative_report_batch", "main"),
+]
+
+
+class TestStageParsersAcceptJobId:
+    @pytest.mark.parametrize("module_name,entry", STAGE_MODULES)
+    def test_help_mentions_job_id(self, module_name, entry, monkeypatch, capsys):
+        import asyncio
+        import inspect
+
+        module = importlib.import_module(module_name)
+        monkeypatch.setattr(sys, "argv", [f"{module_name}.py", "--help"])
+        entry_point = getattr(module, entry)
+        with pytest.raises(SystemExit) as excinfo:
+            if inspect.iscoroutinefunction(entry_point):
+                asyncio.run(entry_point())
+            else:
+                entry_point()
+        assert excinfo.value.code == 0
+        help_text = capsys.readouterr().out
+        assert "--job-id" in help_text, f"{module_name} --help lacks --job-id"
+
+    def test_run_pipeline_process_conversation_takes_job_id(self):
+        import inspect
+
+        run_pipeline = importlib.import_module("run_pipeline")
+        assert "job_id" in inspect.signature(run_pipeline.process_conversation).parameters
+
+
+class TestPollerCommands:
+    def _poller(self):
+        return importlib.import_module("scripts.job_poller")
+
+    def test_full_pipeline_command_carries_job_id(self, monkeypatch):
+        monkeypatch.setenv("DELPHI_APP_PATH", "/app")
+        poller = self._poller()
+        cmd = poller.build_job_command(
+            {"job_id": "j-123", "job_type": "FULL_PIPELINE", "conversation_id": "42"},
+            app_path="/app",
+        )
+        assert f"/app/run_delphi.py" in " ".join(cmd)
+        assert "--job-id=j-123" in cmd
+
+    def test_narrative_batch_command_carries_job_id(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_MODEL", "claude-test")
+        poller = self._poller()
+        cmd = poller.build_job_command(
+            {"job_id": "j-801", "job_type": "CREATE_NARRATIVE_BATCH", "conversation_id": "42"},
+            app_path="/app",
+        )
+        assert "801_narrative_report_batch.py" in " ".join(cmd)
+        assert "--job-id=j-801" in cmd
+
+    def test_awaiting_batch_keeps_batch_id_semantics(self):
+        poller = self._poller()
+        cmd = poller.build_job_command(
+            {
+                "job_id": "j-803",
+                "job_type": "AWAITING_NARRATIVE_BATCH",
+                "conversation_id": "42",
+                "batch_job_id": "batch-77",
+            },
+            app_path="/app",
+        )
+        assert "803_check_batch_status.py" in " ".join(cmd)
+        assert "--job-id=batch-77" in cmd
+        assert "--job-id=j-803" not in cmd

--- a/delphi/umap_narrative/501_calculate_comment_extremity.py
+++ b/delphi/umap_narrative/501_calculate_comment_extremity.py
@@ -191,7 +191,13 @@ def main():
     parser.add_argument('--verbose', action='store_true', help='Show detailed output')
     parser.add_argument('--include_moderation', type=bool, default=False, help='Whether or not to include moderated comments in reports. If false, moderated comments will appear.')
     parser.add_argument('--exclude_comment_selections', type=bool, default=True, help='Whether to exclude comments with selection=-1 in report_comment_selections table.')
+    parser.add_argument('--job-id', dest='job_id', default=None,
+                        help='Pipeline job id (Storage V2 provenance, design §4.4); defaults to DELPHI_JOB_ID env, else auto local-<uuid4>')
     args = parser.parse_args()
+
+    from delphi_storage.job_id import resolve_job_id
+    job_id = resolve_job_id(args.job_id)
+    logger.info(f"Pipeline job id: {job_id}")
     
     # Set log level based on verbosity
     if args.verbose:

--- a/delphi/umap_narrative/502_calculate_priorities.py
+++ b/delphi/umap_narrative/502_calculate_priorities.py
@@ -288,8 +288,14 @@ def main():
     )
     
     parser.add_argument('--verbose', '-v', action='store_true', help='Enable verbose logging')
-    
+    parser.add_argument('--job-id', dest='job_id', default=None,
+                        help='Pipeline job id (Storage V2 provenance, design §4.4); defaults to DELPHI_JOB_ID env, else auto local-<uuid4>')
+
     args = parser.parse_args()
+
+    from delphi_storage.job_id import resolve_job_id
+    job_id = resolve_job_id(args.job_id)
+    logging.info(f"Pipeline job id: {job_id}")
     
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/delphi/umap_narrative/700_datamapplot_for_layer.py
+++ b/delphi/umap_narrative/700_datamapplot_for_layer.py
@@ -534,7 +534,7 @@ def load_conversation_data_from_dynamo(zid, layer_id, dynamo_storage):
     
     return data
 
-def create_visualization(zid, layer_id, data, comment_texts, output_dir=None):
+def create_visualization(zid, layer_id, data, comment_texts, output_dir=None, job_id=None):
     """
     Create and save a visualization for a specific layer.
     
@@ -735,8 +735,9 @@ def create_visualization(zid, layer_id, data, comment_texts, output_dir=None):
             
             # Upload to S3
             try:
-                # Get job ID and report ID from environment variables
-                job_id = os.environ.get('DELPHI_JOB_ID', 'unknown')
+                # Explicit job id (design §4.4); env fallback for the
+                # transition phase, 'unknown' preserved for bare dev runs
+                job_id = job_id or os.environ.get('DELPHI_JOB_ID', 'unknown')
                 report_id = os.environ.get('DELPHI_REPORT_ID', 'unknown')
                 
                 # Create S3 key using report_id and job ID to avoid exposing ZIDs
@@ -778,7 +779,7 @@ def create_visualization(zid, layer_id, data, comment_texts, output_dir=None):
         logger.error(f"Outer traceback: {traceback.format_exc()}")
         return None
 
-def generate_visualization(zid, layer_id=0, output_dir=None, dynamo_endpoint=None):
+def generate_visualization(zid, layer_id=0, output_dir=None, dynamo_endpoint=None, job_id=None):
     """
     Generate visualization for a specific conversation and layer.
     
@@ -862,7 +863,7 @@ def generate_visualization(zid, layer_id=0, output_dir=None, dynamo_endpoint=Non
         
         # Create and save visualization
         logger.info("Creating visualization...")
-        viz_file = create_visualization(zid, layer_id, data, comment_texts, output_dir)
+        viz_file = create_visualization(zid, layer_id, data, comment_texts, output_dir, job_id=job_id)
         
         if viz_file:
             logger.info(f"Successfully generated visualization for conversation {zid}, layer {layer_id}")
@@ -889,6 +890,8 @@ def main():
                       help='Directory to save the visualization')
     parser.add_argument('--dynamo_endpoint', type=str, default=None,
                       help='DynamoDB endpoint URL')
+    parser.add_argument('--job-id', dest='job_id', default=None,
+                      help='Pipeline job id (Storage V2 provenance, design §4.4); defaults to DELPHI_JOB_ID env')
     
     args = parser.parse_args()
     
@@ -898,7 +901,8 @@ def main():
         args.conversation_id,
         layer_id=args.layer,
         output_dir=args.output_dir,
-        dynamo_endpoint=args.dynamo_endpoint
+        dynamo_endpoint=args.dynamo_endpoint,
+        job_id=args.job_id
     )
     
     if viz_file:

--- a/delphi/umap_narrative/801_narrative_report_batch.py
+++ b/delphi/umap_narrative/801_narrative_report_batch.py
@@ -1526,10 +1526,12 @@ async def main():
                         help='Specific layer numbers to process (e.g., --layers 0 1 2). If not specified, all layers will be processed.')
     parser.add_argument('--include_moderation', type=bool, default=False, help='Whether or not to include moderated comments in reports. If false, moderated comments will appear.')
     parser.add_argument('--exclude_comment_selections', type=bool, default=True, help='Whether to exclude comments with selection=-1 in report_comment_selections table.')
+    parser.add_argument('--job-id', dest='job_id', default=None,
+                        help='Pipeline job id (Storage V2 provenance, design §4.4); defaults to DELPHI_JOB_ID env; NO auto-generation here — narrative section keys embed it, so a missing id must keep failing loudly downstream')
     args = parser.parse_args()
 
-    # Get environment variables for job
-    job_id = os.environ.get('DELPHI_JOB_ID')
+    # Explicit job id (design §4.4); env fallback for the transition phase
+    job_id = args.job_id or os.environ.get('DELPHI_JOB_ID')
     report_id = os.environ.get('DELPHI_REPORT_ID')
 
     # Set up environment variables for database connections

--- a/delphi/umap_narrative/reset_conversation.py
+++ b/delphi/umap_narrative/reset_conversation.py
@@ -371,7 +371,7 @@ def main(zid: str, rid: str = None):
     
     logger.info("\nThe conversation is ready for a fresh Delphi run.")
 
-if __name__ == "__main__":
+def cli():
     parser = argparse.ArgumentParser(description="Reset Delphi data for a conversation.")
     parser.add_argument(
         '--zid', 
@@ -385,7 +385,17 @@ if __name__ == "__main__":
         required=False,
         help="The report ID (e.g., r4tykwac8thvzv35jrn53). Only needed for cleaning the Delphi_NarrativeReports table."
     )
-    
+    parser.add_argument('--job-id', dest='job_id', default=None,
+                        help="Pipeline job id (Storage V2 provenance, design §4.4); defaults to DELPHI_JOB_ID env, else auto local-<uuid4>")
+
     args = parser.parse_args()
-    
+
+    from delphi_storage.job_id import resolve_job_id
+    job_id = resolve_job_id(args.job_id)
+    logger.info(f"Pipeline job id: {job_id}")
+
     main(zid=args.zid, rid=args.rid)
+
+
+if __name__ == "__main__":
+    cli()

--- a/delphi/umap_narrative/run_pipeline.py
+++ b/delphi/umap_narrative/run_pipeline.py
@@ -1324,7 +1324,8 @@ def create_enhanced_multilayer_index(
 
 
 def process_conversation(
-    zid, export_dynamo=True, use_ollama=False, include_moderation=False, exclude_comment_selections=True
+    zid, export_dynamo=True, use_ollama=False, include_moderation=False, exclude_comment_selections=True,
+    job_id=None,
 ):
     """
     Main function to process a conversation and generate visualizations.
@@ -1373,9 +1374,10 @@ def process_conversation(
         finally:
             postgres_client.shutdown()
 
-    # Generate a job_id for this pipeline run
-    # If DELPHI_JOB_ID is set (e.g., by a calling script like run_delphi.py), use that.
-    job_id = os.environ.get("DELPHI_JOB_ID", f"pipeline_run_{uuid.uuid4()}")
+    # Job id for this pipeline run: explicit arg > DELPHI_JOB_ID env
+    # (transition fallback, design §4.4) > auto local-<uuid4>.
+    from delphi_storage.job_id import resolve_job_id
+    job_id = resolve_job_id(job_id)
     logger.info(f"Using job_id: {job_id} for this pipeline run.")
 
     conversation_id = str(zid)
@@ -1523,6 +1525,12 @@ def main():
         default=True,
         help="Whether to exclude comments with selection=-1 in report_comment_selections table.",
     )
+    parser.add_argument(
+        "--job-id",
+        dest="job_id",
+        default=None,
+        help="Pipeline job id (Storage V2 provenance, design §4.4); defaults to DELPHI_JOB_ID env, else auto local-<uuid4>",
+    )
 
     args = parser.parse_args()
 
@@ -1596,6 +1604,7 @@ def main():
             use_ollama=args.use_ollama,
             include_moderation=args.include_moderation,
             exclude_comment_selections=args.exclude_comment_selections,
+            job_id=args.job_id,
         )
 
 


### PR DESCRIPTION
Stack 2 / P5 of the Storage V2 effort (design in #2597, §4.4): the pipeline job id now travels **on the command line** through every entry point, replacing the env-var-only propagation that reached 2 of 18 tables (§3.2). This is the provenance foundation P6 (input snapshots) and P7 (manifests + dual-write) build on.

**Stacked on #2600** (`jc/delphi-storage-v2-p4`).

## What this changes

- **`delphi_storage/job_id.py`** — `resolve_job_id`: explicit CLI value > `DELPHI_JOB_ID` env (kept as a transition fallback for one phase, per §4.4) > auto `local-<uuid4>` for dev runs.
- **`run_delphi.py`** — gains `--job-id`, resolves once, exports `DELPHI_JOB_ID` so un-migrated env readers inherit the *same* id as the command lines, and appends `--job-id=<id>` to all six stage subprocesses (reset, math, umap 500s, 501, 502, 700 per layer).
- **`scripts/job_poller.py`** — command construction extracted into a module-level `build_job_command()` (now unit-testable); `FULL_PIPELINE` and `CREATE_NARRATIVE_BATCH` commands carry `--job-id=<queue job_id>`; the env export stays during the transition. **803's existing `--job-id` is untouched** — it's the batch-tracking id (`batch_job_id`), a distinct concept, documented as such.
- **Stage entry points** now all accept `--job-id`:
  - `reset_conversation.py` — CLI moved from the `__main__` block into `cli()` (`main()` stays the worker function; behavior unchanged);
  - `polismath/run_math_pipeline.py` — arg + log only, **no math-logic change** (golden suite ran and passed);
  - `run_pipeline.py` — threaded into `process_conversation(job_id=…)`, replacing the env read buried at the call depth; the auto-id prefix for bare dev runs changes `pipeline_run_<uuid>` → `local-<uuid>`;
  - `501` / `502` — arg + log (consumed from P7 on);
  - `700_datamapplot_for_layer.py` — threaded down to the S3-key builder (`'unknown'` fallback preserved for bare dev runs);
  - `801_narrative_report_batch.py` — arg > env, deliberately **no auto-generation**: narrative section keys embed the id, so a missing one must keep failing loudly downstream.

## Testing (TDD — tests first, 1 collection error RED)

`tests/test_job_id_threading.py`:
- `resolve_job_id` precedence (CLI / env / auto-distinct);
- `run_delphi.py` passes one shared id to **all six** stage commands (explicit, auto-generated, and env-fallback variants), and exports it;
- every stage entry point's `--help` advertises `--job-id` (real argparse, incl. the async 801 main);
- `process_conversation` exposes the `job_id` parameter;
- `build_job_command` for all three job types (`FULL_PIPELINE`/801 carry the queue job id; 803 keeps `batch_job_id` semantics).

Full suite: **424 passed, 30 skipped, 58 xfailed** (5 pre-existing DynamoDB-unavailable errors unchanged). Golden snapshots ran and passed — math outputs untouched.

## Stack

- P1 #2597 · P2 #2598 · P3 #2599 · P4 #2600 (Stack 1, Foundation)
- **P5: this PR** — Stack 2 (provenance plumbing) begins
- Next: P6 input snapshots (capture-only, then `--input-source` seam; golden-invariant), P7 manifests + dual-write, P8 LLM recorder + EVōC seeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
