### PR TITLE
feat(delphi): storage v2 P7a — DELPHI_WRITE_MODE + run-manifest lifecycle + per-zid purge

### DIFF
--- a/delphi/delphi_storage/manifest.py
+++ b/delphi/delphi_storage/manifest.py
@@ -1,0 +1,66 @@
+"""Run-manifest lifecycle helpers (design §4.2 entity 1, §6.1 M1).
+
+Thin, idempotent wrappers over the store's semantic ops, callable from BOTH
+the poller and run_delphi without coordination: during the migration window
+the OLD job queue remains the single master (§6.2 invariant 3) and the v2
+run row is a MIRROR that becomes the manifest as the job executes. Real v2
+claim semantics (claim_next_run with leases) activate at the enqueue flip
+(P11); until then runs are created directly in their observed state.
+"""
+
+from typing import Any, Optional, Union
+
+from delphi_storage.interface import AlreadyExists, DelphiStore, NotFound
+from delphi_storage.keys import now_ts
+from delphi_storage.models import JobType, RunManifest, RunStatus
+
+
+def ensure_run(
+    store: DelphiStore,
+    *,
+    job_id: str,
+    job_type: Union[JobType, str],
+    zid: Optional[int] = None,
+    rid: Optional[int] = None,
+    priority: int = 0,
+    config_requested: Optional[dict] = None,
+) -> RunManifest:
+    """Create the run row if absent (idempotent — poller and run_delphi may
+    both call this for the same job)."""
+    run = RunManifest(
+        job_id=job_id,
+        job_type=JobType(job_type),
+        enqueued_at=now_ts(),
+        zid=zid,
+        rid=rid,
+        priority=priority,
+        config_requested=config_requested or {},
+    )
+    try:
+        store.enqueue_run(run)
+    except AlreadyExists:
+        pass
+    existing = store.get_run(job_id)
+    if existing is None:  # belt-and-braces: enqueued or pre-existing above
+        raise NotFound(f"run {job_id!r} vanished right after ensure_run")
+    return existing
+
+
+def mark_running(store: DelphiStore, job_id: str) -> RunManifest:
+    return store.update_run_status(job_id, RunStatus.RUNNING)
+
+
+def record_input_fingerprints(
+    store: DelphiStore, job_id: str, fingerprints: dict[str, Any]
+) -> RunManifest:
+    return store.merge_run_fields(job_id, {"input_fingerprints": fingerprints})
+
+
+def mark_completed(store: DelphiStore, job_id: str) -> RunManifest:
+    """complete_run is idempotent and crash-healing; the latest pointer is
+    the commit point (flipped last)."""
+    return store.complete_run(job_id)
+
+
+def mark_failed(store: DelphiStore, job_id: str, error: Optional[str] = None) -> RunManifest:
+    return store.update_run_status(job_id, RunStatus.FAILED, error=error)

--- a/delphi/delphi_storage/purge.py
+++ b/delphi/delphi_storage/purge.py
@@ -17,3 +17,14 @@ def purge_job(store: DelphiStore, job_id: str) -> int:
     """Delete every stored item for a job across all generic entities;
     returns the number of logical items removed."""
     return sum(store.delete_partition(entity, job_id) for entity in GENERIC_ENTITIES)
+
+
+def purge_zid(store: DelphiStore, zid: int) -> dict:
+    """Per-conversation purge (the §9 GDPR path): remove the snapshot and
+    artifact partitions of EVERY run of a conversation, enumerated via the
+    run manifests (P7a). Manifests and latest pointers are retained — they
+    carry only config, counts and hashes, never vote/comment content; their
+    removal belongs to the retention machinery (P14)."""
+    runs = store.list_runs(zid=zid, limit=100000)
+    items = sum(purge_job(store, run.job_id) for run in runs)
+    return {"runs": len(runs), "items": items}

--- a/delphi/delphi_storage/write_mode.py
+++ b/delphi/delphi_storage/write_mode.py
@@ -1,0 +1,53 @@
+"""DELPHI_WRITE_MODE — the migration's writer tri-state (design §4.3, §6.1).
+
+- ``old``  — M0: only the legacy tables are written (today's behavior).
+- ``both`` — M1..M5: legacy tables exactly as today AND v2
+  runs/inputs/artifacts/latest. The whole migration window runs here; it is
+  what makes the M4 flip-back lossless (§6.2 invariant 2).
+- ``v2``   — M6+ / fresh deployments: v2 only.
+
+FAIL-LOUD when unset (locked design decision): a silently-defaulted writer
+would break invariant 2 undetected. Deployments must set it explicitly;
+example.env and the test compose file carry ``old`` so dev/test environments
+keep working. An explicit tri-state (not a boolean) so its meaning never
+inverts mid-migration.
+"""
+
+import os
+from enum import Enum
+
+from delphi_storage.interface import Invalid
+
+ENV_VAR = "DELPHI_WRITE_MODE"
+
+
+class WriteMode(str, Enum):
+    OLD = "old"
+    BOTH = "both"
+    V2 = "v2"
+
+
+def resolve_write_mode() -> WriteMode:
+    raw = os.environ.get(ENV_VAR)
+    if raw is None:
+        raise Invalid(
+            f"{ENV_VAR} is not set. This deployment must state its migration "
+            f"write mode explicitly (old|both|v2) — a silently-defaulted "
+            f"writer would undermine the flip-back guarantee "
+            f"(STORAGE_V2_DESIGN.md §4.3/§6.2). Set {ENV_VAR}=old for "
+            f"pre-migration (M0) behavior."
+        )
+    try:
+        return WriteMode(raw.strip().lower())
+    except ValueError as e:
+        raise Invalid(
+            f"{ENV_VAR}={raw!r} is not a valid write mode (expected old|both|v2)"
+        ) from e
+
+
+def v2_writes_enabled(mode: WriteMode) -> bool:
+    return mode in (WriteMode.BOTH, WriteMode.V2)
+
+
+def old_writes_enabled(mode: WriteMode) -> bool:
+    return mode in (WriteMode.OLD, WriteMode.BOTH)

--- a/delphi/docs/STORAGE_V2_IMPLEMENTATION_NOTES.md
+++ b/delphi/docs/STORAGE_V2_IMPLEMENTATION_NOTES.md
@@ -270,6 +270,15 @@ way they do.
   commit and had to be `jj split` out (filesets select what STAYS in the
   parent; the bookmark then sits on the child and must be reset with
   `jj bookmark set <name> -r <rev> --allow-backwards`).
+- **One session per workspace at a time.** Two agent sessions operating in
+  this SAME jj workspace concurrently caused an op-heads merge that folded a
+  freshly-created child commit back into its parent change (divergent
+  change, mixed P6b+P7a commit, wrong description, briefly pushed). Recovery
+  recipe that worked: `jj new <good-commit>` → `jj restore --from
+  <mixed-commit>` (child's diff becomes exactly the delta) → re-describe →
+  `jj bookmark set` both bookmarks → `jj abandon <mixed>` → push. Defensive
+  habit adopted after: verify `jj log -r @` (change id AND parent) right
+  before every describe/bookmark/push.
 - To amend an earlier PR in the stack: edit in the working copy, then
   `jj squash --into <change-id> -u 'root:"<path>"'` (descendants auto-rebase
   — safe in a single workspace), then push all moved bookmarks.
@@ -299,19 +308,30 @@ way they do.
 
 Per design §7. In order:
 
-- **P7 — manifests + dual-write** (per stage group: math; umap 500s;
-  501/502+700s; 801/803):
-  - introduce `DELPHI_WRITE_MODE=old|both|v2` (fail-loud if unset while old
-    tables exist — design §4.3) and fold `DELPHI_SNAPSHOT_INPUTS` into it;
-  - runs enqueued/claimed via the store's queue ops; stages
-    `merge_run_fields` their fingerprints (capture already returns them) and
-    `append_log`; `complete_run` flips `latest`;
-  - `scripts/verify_dual_write.py` parity test per stage group (old-table
-    rows vs v2 artifacts);
-  - per-zid purge tool (`list_runs(zid=…)` + `purge_job`) — promised in
-    P6a's PR comment;
-  - artifact keys: use `keys.artifact_key(...)` with the design §4.2 naming
-    (`math#pca`, `umap#assignments#<chunk>`, `priorities`, …).
+- **P7a — DONE** (write-mode + manifest lifecycle): `DELPHI_WRITE_MODE`
+  (`delphi_storage/write_mode.py`, fail-loud when unset; `old` wired into
+  example.env + docker-compose.test.yml; run_delphi exits 2 with a pointed
+  message, the poller mirror logs-and-continues), manifest helpers
+  (`delphi_storage/manifest.py`: ensure_run is idempotent so poller AND
+  run_delphi can both call it; the OLD queue stays the single master, v2
+  rows are mirrors until the P11 enqueue flip), poller mirror
+  (`mirror_job_claimed`/`mirror_job_finished`, module-level for testability,
+  never raise — M1: a broken v2 store must not take serving down),
+  run_delphi failure policy (both → log-and-continue on v2 failures;
+  v2 mode or explicit --snapshot-inputs → abort), capture fingerprints
+  merged into the manifest, per-zid purge (`purge_zid` + scripts/delphi_purge.py;
+  manifests/pointers retained — hashes only, retention removes them in P14).
+  NOTE: narrative job types are NOT mirrored yet (P7d); replays
+  (--input-source) never write manifests here (P12 owns that).
+- **P7b..P7e — stage-group dual-writes** (math; umap 500s; 501/502+700s;
+  801/803), each with a `verify_dual_write` parity test:
+  - stages `merge_run_fields` per-stage status and `append_log`; artifacts
+    via `keys.artifact_key(...)` with the design §4.2 naming (`math#pca`,
+    `umap#assignments#<chunk>`, `priorities`, …);
+  - old-table writers to mirror: `polismath/database/dynamodb.py`
+    (DynamoDBClient, called from run_math_pipeline/conversation serializers)
+    for math; `umap_narrative/.../utils/storage.py` DynamoDBStorage for
+    umap; 501/502 extremity+priorities; 801/803 narrative sections.
 - **P8 — LLM recorder + EVōC seeding + config_effective**: seeding EVōC
   changes UMAP-side outputs (documented in design §4.4) — math goldens
   unaffected, but announce it; record prompts+responses as `llm#<stage>#<seq>`

--- a/delphi/run_delphi.py
+++ b/delphi/run_delphi.py
@@ -25,14 +25,51 @@ def show_usage():
     print("  --validate                Run extra validation checks")
     print("  --help                    Show this help message")
 
+def _v2_mark_run_started(job_id, zid, rid):
+    """Create/mark the v2 run manifest (module-level so tests can stub it)."""
+    from delphi_storage import get_store
+    from delphi_storage.manifest import ensure_run, mark_running
+
+    store = get_store()
+    # rid is the ALPHANUMERIC public report id (r...) in this pipeline —
+    # recorded verbatim; numeric rid resolution belongs to P7d.
+    ensure_run(
+        store,
+        job_id=job_id,
+        job_type="FULL_PIPELINE",
+        zid=int(zid),
+        config_requested={"report_id": str(rid)} if rid else None,
+    )
+    mark_running(store, job_id)
+
+
+def _v2_mark_run_finished(job_id, success):
+    from delphi_storage import get_store
+    from delphi_storage.manifest import mark_completed, mark_failed
+
+    store = get_store()
+    if success:
+        mark_completed(store, job_id)
+    else:
+        mark_failed(store, job_id, error="run_delphi pipeline failed")
+
+
 def _capture_run_inputs(job_id, zid, rid):
     """Snapshot inputs into the V2 store (module-level so tests can stub it)."""
     from delphi_storage import get_store
     from delphi_storage.inputs import capture_run_inputs
 
-    fingerprints = capture_run_inputs(get_store(), job_id, zid, rid=rid)
+    store = get_store()
+    fingerprints = capture_run_inputs(store, job_id, zid, rid=rid)
     for kind, fingerprint in fingerprints.items():
         print(f"{YELLOW}Snapshotted {kind}: {fingerprint}{NC}")
+    try:
+        from delphi_storage.manifest import record_input_fingerprints
+
+        record_input_fingerprints(store, job_id, fingerprints)
+    except Exception as e:
+        # No manifest exists for a bare --snapshot-inputs run in old mode.
+        print(f"{YELLOW}Fingerprints not recorded on a manifest: {e}{NC}")
 
 
 def main():
@@ -75,22 +112,64 @@ def main():
     # validate_arg is not used in the python script execution steps, but kept for parity with bash
     # validate_arg = "--validate" if args.validate else ""
 
-    snapshot_enabled = args.snapshot_inputs or os.environ.get(
+    explicit_snapshot = args.snapshot_inputs or os.environ.get(
         "DELPHI_SNAPSHOT_INPUTS", ""
     ).lower() in ("1", "true", "yes")
-    if snapshot_enabled and args.input_source:
+    if explicit_snapshot and args.input_source:
         print(f"{RED}--snapshot-inputs and --input-source are mutually exclusive: "
               f"a run cannot both record fresh inputs and replay recorded ones.{NC}")
         sys.exit(2)
-    if snapshot_enabled:
+
+    # Migration write mode (design §4.3): explicit tri-state, fail-loud when
+    # unset. old = today's behavior; both/v2 = v2 manifest + input snapshot.
+    from delphi_storage.interface import Invalid as _StorageInvalid
+    from delphi_storage.write_mode import WriteMode, resolve_write_mode, v2_writes_enabled
+    try:
+        write_mode = resolve_write_mode()
+    except _StorageInvalid as e:
+        print(f"{RED}{e}{NC}")
+        sys.exit(2)
+
+    # Replays (--input-source) never write manifests/snapshots here — the
+    # replay harness (P12) creates its own fresh run.
+    v2_active = v2_writes_enabled(write_mode) and not args.input_source
+    v2_failures_abort = write_mode is WriteMode.V2
+
+    def _v2_finish(success):
+        if not v2_active:
+            return
+        try:
+            _v2_mark_run_finished(job_id, success)
+        except Exception as e:
+            print(f"{RED}v2 run-finish mirror failed: {e}{NC}")
+            if v2_failures_abort and success:
+                sys.exit(1)
+
+    if v2_active:
+        try:
+            _v2_mark_run_started(job_id, zid, rid)
+        except Exception as e:
+            print(f"{RED}v2 run manifest creation failed: {e}{NC}")
+            if v2_failures_abort:
+                sys.exit(1)
+
+    if explicit_snapshot or v2_active:
         print(f"{YELLOW}Snapshotting pipeline inputs for job {job_id}...{NC}")
         try:
             _capture_run_inputs(job_id, zid, rid)
+            print(f"{GREEN}Input snapshot complete.{NC}")
         except Exception as e:
-            # A run without recorded inputs defeats the point when enabled.
-            print(f"{RED}Input snapshot failed: {e}. Aborting pipeline.{NC}")
-            sys.exit(1)
-        print(f"{GREEN}Input snapshot complete.{NC}")
+            if explicit_snapshot or v2_failures_abort:
+                # A run without recorded inputs defeats the point when
+                # explicitly requested, and v2-only has no old copy to lean on.
+                print(f"{RED}Input snapshot failed: {e}. Aborting pipeline.{NC}")
+                _v2_finish(False)
+                sys.exit(1)
+            # both-mode: the old path must keep serving (design §6.1 M1);
+            # the divergence is caught by the coverage/verify tooling.
+            print(f"{RED}Input snapshot failed: {e}. Continuing (write mode 'both': "
+                  f"old path keeps serving; run is marked unreplayable by absence "
+                  f"of fingerprints).{NC}")
 
     # --- Reset all data before processing ---
     print(f"{YELLOW}Resetting all existing data for conversation {zid} before processing...{NC}")
@@ -108,6 +187,7 @@ def main():
     reset_process = subprocess.run(reset_command)
     if reset_process.returncode != 0:
         print(f"{RED}Data reset failed with exit code {reset_process.returncode}. Aborting pipeline.{NC}")
+        _v2_finish(False)
         sys.exit(reset_process.returncode)
     print(f"{GREEN}Data reset complete.{NC}")
 
@@ -117,6 +197,7 @@ def main():
     model = os.environ.get("OLLAMA_MODEL")
     if not model:
         print(f"{RED}Error: OLLAMA_MODEL environment variable not set.{NC}")
+        _v2_finish(False)
         sys.exit(1)
     print(f"{YELLOW}Using Ollama model: {model}{NC}")
 
@@ -157,6 +238,7 @@ def main():
 
     if math_exit_code != 0:
         print(f"{RED}Math pipeline failed with exit code {math_exit_code}{NC}")
+        _v2_finish(False)
         sys.exit(math_exit_code)
 
     # Run the UMAP narrative pipeline
@@ -323,6 +405,7 @@ def main():
         print(f"{RED}Pipeline failed with exit code {exit_code}{NC}")
         print("Please check logs for more details")
 
+    _v2_finish(exit_code == 0)
     sys.exit(exit_code)
 
 if __name__ == "__main__":

--- a/delphi/scripts/delphi_purge.py
+++ b/delphi/scripts/delphi_purge.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Purge Storage V2 data (design §9 GDPR path).
+
+Per job:   python scripts/delphi_purge.py --job-id <job_id>
+Per zid:   python scripts/delphi_purge.py --zid <zid>
+
+Removes snapshot (run_inputs) and artifact partitions — the payloads that
+copy votes/comments outside the source PG. Run manifests and latest pointers
+carry only config/counts/hashes and are retained (retention machinery, P14).
+Backend/config via the usual DELPHI_STORAGE_* environment variables.
+"""
+
+import argparse
+import logging
+
+from delphi_storage import get_store
+from delphi_storage.purge import purge_job, purge_zid
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Purge Delphi Storage V2 data")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--job-id", dest="job_id", help="Purge one run's stored items")
+    group.add_argument("--zid", type=int, help="Purge every run of a conversation")
+    args = parser.parse_args()
+
+    store = get_store()
+    if args.job_id:
+        deleted = purge_job(store, args.job_id)
+        logger.info(f"Purged {deleted} items for job {args.job_id}")
+    else:
+        result = purge_zid(store, args.zid)
+        logger.info(
+            f"Purged {result['items']} items across {result['runs']} runs for zid {args.zid}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/delphi/scripts/job_poller.py
+++ b/delphi/scripts/job_poller.py
@@ -400,6 +400,66 @@ def signal_handler(sig, frame):
 
 
 
+_V2_UNMIRRORED_JOB_TYPES = ('CREATE_NARRATIVE_BATCH', 'AWAITING_NARRATIVE_BATCH')
+
+
+def _get_v2_store():
+    """Module-level for testability (tests substitute a memory store)."""
+    from delphi_storage import get_store
+    return get_store()
+
+
+def _v2_mirror_enabled(job) -> bool:
+    from delphi_storage.write_mode import resolve_write_mode, v2_writes_enabled
+    if job.get('job_type') in _V2_UNMIRRORED_JOB_TYPES:
+        # Narrative manifests land with the 801/803 dual-write phase (P7d).
+        return False
+    return v2_writes_enabled(resolve_write_mode())
+
+
+def mirror_job_claimed(job) -> None:
+    """Mirror an old-queue claim into a v2 run manifest (design §6.1 M1: the
+    queue row becomes the manifest as the job executes; the OLD queue stays
+    the single master, §6.2 invariant 3). Errors are logged, never raised —
+    a broken v2 store must not take the serving path down; divergence is
+    caught by the coverage/verify tooling."""
+    try:
+        if not _v2_mirror_enabled(job):
+            return
+        from delphi_storage.manifest import ensure_run, mark_running
+        store = _get_v2_store()
+        # report_id here is the ALPHANUMERIC public report id (r...), not the
+        # numeric rid — record it verbatim; numeric rid resolution belongs to
+        # the narrative phases (P7d) whose latest scopes actually need it.
+        report_id = job.get('report_id')
+        ensure_run(
+            store,
+            job_id=job['job_id'],
+            job_type='FULL_PIPELINE',
+            zid=int(job['conversation_id']),
+            config_requested={'report_id': str(report_id)} if report_id is not None else None,
+        )
+        mark_running(store, job['job_id'])
+    except Exception as e:
+        logger.error(f"v2 manifest mirror (claim) failed for job {job.get('job_id')}: {e}")
+
+
+def mirror_job_finished(job, success: bool, error=None) -> None:
+    """Mirror the old queue's terminal decision into the v2 run manifest.
+    Same never-raise policy as mirror_job_claimed."""
+    try:
+        if not _v2_mirror_enabled(job):
+            return
+        from delphi_storage.manifest import mark_completed, mark_failed
+        store = _get_v2_store()
+        if success:
+            mark_completed(store, job['job_id'])
+        else:
+            mark_failed(store, job['job_id'], error=str(error) if error else None)
+    except Exception as e:
+        logger.error(f"v2 manifest mirror (finish) failed for job {job.get('job_id')}: {e}")
+
+
 def build_job_command(job: Dict[str, Any], app_path: str) -> list:
     """Build the stage command for a claimed job.
 
@@ -667,6 +727,7 @@ class JobProcessor:
 
     def complete_job(self, job, success, result=None, error=None):
         """Mark a job as completed or failed using optimistic locking."""
+        mirror_job_finished(job, success, error=error)
         job_id = job['job_id']
         current_version = job.get('version', 1)
         new_status = 'COMPLETED' if success else 'FAILED'
@@ -726,6 +787,7 @@ class JobProcessor:
         timeout_seconds = int(job.get('timeout_seconds', 3600))
 
         self.update_job_logs(job, {'level': 'INFO', 'message': f'Worker {self.worker_id} starting job {job_id}'})
+        mirror_job_claimed(job)
         
         try:
             # 1. Build the command

--- a/delphi/tests/test_input_snapshots.py
+++ b/delphi/tests/test_input_snapshots.py
@@ -347,6 +347,7 @@ class TestRunDelphiHook:
             "_capture_run_inputs",
             lambda job_id, zid, rid: captures.append((job_id, zid, rid)),
         )
+        monkeypatch.setenv("DELPHI_WRITE_MODE", "old")
         monkeypatch.setenv("OLLAMA_MODEL", "test-model")
         monkeypatch.setenv("DELPHI_APP_PATH", DELPHI_DIR)
         monkeypatch.delenv("DELPHI_JOB_ID", raising=False)
@@ -392,6 +393,7 @@ class TestRunDelphiHook:
             raise RuntimeError("snapshot store unreachable")
 
         monkeypatch.setattr(run_delphi, "_capture_run_inputs", boom)
+        monkeypatch.setenv("DELPHI_WRITE_MODE", "old")
         monkeypatch.setenv("OLLAMA_MODEL", "test-model")
         monkeypatch.setenv("DELPHI_APP_PATH", DELPHI_DIR)
         monkeypatch.delenv("DELPHI_JOB_ID", raising=False)

--- a/delphi/tests/test_input_source_seam.py
+++ b/delphi/tests/test_input_source_seam.py
@@ -304,6 +304,7 @@ class TestRunDelphiForwarding:
             "run",
             lambda cmd, **kw: stage_cmds.append(list(cmd)) or SimpleNamespace(returncode=0),
         )
+        monkeypatch.setenv("DELPHI_WRITE_MODE", "old")
         monkeypatch.setenv("OLLAMA_MODEL", "test-model")
         monkeypatch.setenv("DELPHI_APP_PATH", DELPHI_DIR)
         monkeypatch.delenv("DELPHI_JOB_ID", raising=False)

--- a/delphi/tests/test_job_id_threading.py
+++ b/delphi/tests/test_job_id_threading.py
@@ -67,6 +67,7 @@ def _run_run_delphi(monkeypatch, argv):
         return SimpleNamespace(returncode=0)
 
     monkeypatch.setattr(run_delphi.subprocess, "run", fake_run)
+    monkeypatch.setenv("DELPHI_WRITE_MODE", "old")
     monkeypatch.setenv("OLLAMA_MODEL", "test-model")
     monkeypatch.setenv("DELPHI_APP_PATH", DELPHI_DIR)
     # Make the in-function `import boto3` fail so layer discovery falls back

--- a/delphi/tests/test_write_mode_manifest.py
+++ b/delphi/tests/test_write_mode_manifest.py
@@ -1,0 +1,297 @@
+"""P7a (Storage V2 design §4.3, §6.1 M0→M1): DELPHI_WRITE_MODE + the run
+manifest lifecycle mirrored from the old job queue.
+
+Contract under test:
+
+- resolve_write_mode: explicit tri-state old|both|v2 from DELPHI_WRITE_MODE,
+  FAIL-LOUD when unset (design §4.3: a silently-defaulted writer would break
+  §6.2 invariant 2 undetected). Dev/test environments set it explicitly.
+- manifest helpers (ensure_run / mark_running / record_input_fingerprints /
+  mark_completed / mark_failed) are idempotent wrappers over the store's
+  semantic ops — usable by BOTH the poller and run_delphi without
+  coordination (complete_run is already idempotent/crash-healing).
+- the poller mirrors FULL_PIPELINE jobs into v2 runs when v2 writes are
+  enabled (claim → RUNNING mirror; terminal → COMPLETED/FAILED mirror).
+  Narrative job types are deliberately NOT mirrored yet (P7d).
+- run_delphi drives capture + manifest from the write mode: old = today's
+  behavior; both = capture + manifest, v2-write failures LOG AND CONTINUE
+  (M1: the old path must keep serving; divergence is caught by coverage
+  tooling); v2 = failures ABORT (v2 is the only store). The explicit
+  --snapshot-inputs flag keeps its abort-on-failure semantics.
+- purge_zid removes every run's snapshot/artifact partitions for a
+  conversation (per-zid GDPR path, §9), via the now-existing manifests.
+"""
+
+import importlib
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from delphi_storage.backends.memory import MemoryDelphiStore
+from delphi_storage.interface import Invalid
+from delphi_storage.manifest import (
+    ensure_run,
+    mark_completed,
+    mark_failed,
+    mark_running,
+    record_input_fingerprints,
+)
+from delphi_storage.models import JobType, RunStatus, StoreItem
+from delphi_storage.purge import purge_zid
+from delphi_storage.write_mode import (
+    WriteMode,
+    old_writes_enabled,
+    resolve_write_mode,
+    v2_writes_enabled,
+)
+
+DELPHI_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if DELPHI_DIR not in sys.path:
+    sys.path.insert(0, DELPHI_DIR)
+
+
+class TestResolveWriteMode:
+    def test_unset_fails_loud(self, monkeypatch):
+        monkeypatch.delenv("DELPHI_WRITE_MODE", raising=False)
+        with pytest.raises(Invalid) as excinfo:
+            resolve_write_mode()
+        assert "DELPHI_WRITE_MODE" in str(excinfo.value)
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("old", WriteMode.OLD),
+        ("both", WriteMode.BOTH),
+        ("v2", WriteMode.V2),
+        ("BOTH", WriteMode.BOTH),  # case-insensitive
+    ])
+    def test_parses(self, monkeypatch, raw, expected):
+        monkeypatch.setenv("DELPHI_WRITE_MODE", raw)
+        assert resolve_write_mode() is expected
+
+    def test_bogus_fails(self, monkeypatch):
+        monkeypatch.setenv("DELPHI_WRITE_MODE", "new")
+        with pytest.raises(Invalid):
+            resolve_write_mode()
+
+    def test_truth_table(self):
+        assert not v2_writes_enabled(WriteMode.OLD)
+        assert v2_writes_enabled(WriteMode.BOTH)
+        assert v2_writes_enabled(WriteMode.V2)
+        assert old_writes_enabled(WriteMode.OLD)
+        assert old_writes_enabled(WriteMode.BOTH)
+        assert not old_writes_enabled(WriteMode.V2)
+
+
+class TestManifestHelpers:
+    def test_ensure_run_creates_and_is_idempotent(self):
+        store = MemoryDelphiStore()
+        run = ensure_run(store, job_id="m-1", job_type=JobType.FULL_PIPELINE, zid=7)
+        assert run.status == RunStatus.QUEUED
+        again = ensure_run(store, job_id="m-1", job_type=JobType.FULL_PIPELINE, zid=7)
+        assert again.job_id == "m-1"
+        assert store.get_run("m-1") is not None
+
+    def test_mark_running_and_fingerprints(self):
+        store = MemoryDelphiStore()
+        ensure_run(store, job_id="m-2", job_type=JobType.FULL_PIPELINE, zid=7)
+        run = mark_running(store, "m-2")
+        assert run.status == RunStatus.RUNNING
+        run = record_input_fingerprints(
+            store, "m-2", {"votes": {"sha256": "ab", "row_count": 5}}
+        )
+        assert run.input_fingerprints["votes"]["row_count"] == 5
+
+    def test_completion_flips_latest_and_is_idempotent(self):
+        store = MemoryDelphiStore()
+        ensure_run(store, job_id="m-3", job_type=JobType.FULL_PIPELINE, zid=9)
+        mark_running(store, "m-3")
+        mark_completed(store, "m-3")
+        pointer = store.get_latest("zid#9#FULL_PIPELINE")
+        assert pointer is not None and pointer.job_id == "m-3" and pointer.seq == 1
+        mark_completed(store, "m-3")  # idempotent, seq unchanged
+        assert store.get_latest("zid#9#FULL_PIPELINE").seq == 1
+
+    def test_mark_failed(self):
+        store = MemoryDelphiStore()
+        ensure_run(store, job_id="m-4", job_type=JobType.FULL_PIPELINE, zid=9)
+        run = mark_failed(store, "m-4", error="boom")
+        assert run.status == RunStatus.FAILED and run.error == "boom"
+        assert store.get_latest("zid#9#FULL_PIPELINE") is None
+
+
+class TestPollerMirror:
+    """The mirror functions are module-level in scripts.job_poller so they
+    are testable without a JobProcessor (which needs DynamoDB)."""
+
+    @pytest.fixture()
+    def poller(self, monkeypatch):
+        poller = importlib.import_module("scripts.job_poller")
+        store = MemoryDelphiStore()
+        monkeypatch.setattr(poller, "_get_v2_store", lambda: store)
+        return poller, store
+
+    def _job(self, **kw):
+        job = {"job_id": "q-1", "job_type": "FULL_PIPELINE", "conversation_id": "42"}
+        job.update(kw)
+        return job
+
+    def test_old_mode_is_a_noop(self, poller, monkeypatch):
+        module, store = poller
+        monkeypatch.setenv("DELPHI_WRITE_MODE", "old")
+        module.mirror_job_claimed(self._job())
+        assert store.get_run("q-1") is None
+
+    def test_both_mode_mirrors_claim(self, poller, monkeypatch):
+        module, store = poller
+        monkeypatch.setenv("DELPHI_WRITE_MODE", "both")
+        # report ids are ALPHANUMERIC public ids — must be recorded verbatim,
+        # never int()-coerced (a coercion failure would kill the mirror)
+        module.mirror_job_claimed(self._job(report_id="r4tykwac8thvzv35jrn53"))
+        run = store.get_run("q-1")
+        assert run is not None
+        assert run.status == RunStatus.RUNNING
+        assert run.zid == 42 and run.rid is None
+        assert run.config_requested["report_id"] == "r4tykwac8thvzv35jrn53"
+        assert run.job_type == JobType.FULL_PIPELINE
+
+    def test_finish_mirrors_completion_and_latest(self, poller, monkeypatch):
+        module, store = poller
+        monkeypatch.setenv("DELPHI_WRITE_MODE", "both")
+        module.mirror_job_claimed(self._job())
+        module.mirror_job_finished(self._job(), success=True)
+        assert store.get_run("q-1").status == RunStatus.COMPLETED
+        assert store.get_latest("zid#42#FULL_PIPELINE").job_id == "q-1"
+
+    def test_finish_mirrors_failure(self, poller, monkeypatch):
+        module, store = poller
+        monkeypatch.setenv("DELPHI_WRITE_MODE", "both")
+        module.mirror_job_claimed(self._job())
+        module.mirror_job_finished(self._job(), success=False, error="exit 1")
+        run = store.get_run("q-1")
+        assert run.status == RunStatus.FAILED and run.error == "exit 1"
+
+    def test_narrative_types_not_mirrored_yet(self, poller, monkeypatch):
+        module, store = poller
+        monkeypatch.setenv("DELPHI_WRITE_MODE", "both")
+        module.mirror_job_claimed(self._job(job_type="CREATE_NARRATIVE_BATCH"))
+        module.mirror_job_finished(
+            self._job(job_type="CREATE_NARRATIVE_BATCH"), success=True
+        )
+        assert store.get_run("q-1") is None
+
+    def test_mirror_errors_never_raise(self, poller, monkeypatch):
+        """M1 policy: the old path keeps serving; a broken v2 store must not
+        take the poller down."""
+        module, _ = poller
+        monkeypatch.setenv("DELPHI_WRITE_MODE", "both")
+
+        def broken():
+            raise RuntimeError("store unreachable")
+
+        monkeypatch.setattr(module, "_get_v2_store", broken)
+        module.mirror_job_claimed(self._job())  # must not raise
+        module.mirror_job_finished(self._job(), success=True)  # must not raise
+
+
+class TestRunDelphiWriteMode:
+    def _run(self, monkeypatch, argv, mode, capture_boom=False):
+        run_delphi = importlib.import_module("run_delphi")
+        stage_cmds, events = [], []
+        monkeypatch.setattr(
+            run_delphi.subprocess,
+            "run",
+            lambda cmd, **kw: stage_cmds.append(list(cmd)) or SimpleNamespace(returncode=0),
+        )
+
+        def capture(job_id, zid, rid):
+            if capture_boom:
+                raise RuntimeError("capture failed")
+            events.append(("capture", job_id))
+
+        monkeypatch.setattr(run_delphi, "_capture_run_inputs", capture)
+        monkeypatch.setattr(
+            run_delphi, "_v2_mark_run_started",
+            lambda job_id, zid, rid: events.append(("started", job_id)),
+        )
+        monkeypatch.setattr(
+            run_delphi, "_v2_mark_run_finished",
+            lambda job_id, success: events.append(("finished", job_id, success)),
+        )
+        if mode is None:
+            monkeypatch.delenv("DELPHI_WRITE_MODE", raising=False)
+        else:
+            monkeypatch.setenv("DELPHI_WRITE_MODE", mode)
+        monkeypatch.delenv("DELPHI_SNAPSHOT_INPUTS", raising=False)
+        monkeypatch.delenv("DELPHI_JOB_ID", raising=False)
+        monkeypatch.setenv("OLLAMA_MODEL", "test-model")
+        monkeypatch.setenv("DELPHI_APP_PATH", DELPHI_DIR)
+        monkeypatch.setitem(sys.modules, "boto3", None)
+        monkeypatch.setattr(sys, "argv", ["run_delphi.py"] + argv)
+        with pytest.raises(SystemExit) as excinfo:
+            run_delphi.main()
+        return excinfo.value.code, stage_cmds, events
+
+    def test_old_mode_no_v2_activity(self, monkeypatch):
+        code, cmds, events = self._run(monkeypatch, ["--zid=1", "--job-id=j"], "old")
+        assert code == 0 and len(cmds) == 6
+        assert events == []
+
+    def test_both_mode_captures_and_completes(self, monkeypatch):
+        code, cmds, events = self._run(monkeypatch, ["--zid=1", "--job-id=j"], "both")
+        assert code == 0 and len(cmds) == 6
+        assert ("started", "j") in events
+        assert ("capture", "j") in events
+        assert ("finished", "j", True) in events
+        assert events.index(("capture", "j")) < 3  # before stages ran
+
+    def test_both_mode_capture_failure_continues(self, monkeypatch):
+        code, cmds, events = self._run(
+            monkeypatch, ["--zid=1", "--job-id=j"], "both", capture_boom=True
+        )
+        assert code == 0
+        assert len(cmds) == 6  # stages still ran — old path keeps serving
+
+    def test_v2_mode_capture_failure_aborts(self, monkeypatch):
+        code, cmds, events = self._run(
+            monkeypatch, ["--zid=1", "--job-id=j"], "v2", capture_boom=True
+        )
+        assert code == 1
+        assert cmds == []
+
+    def test_explicit_flag_still_aborts_on_failure(self, monkeypatch):
+        code, cmds, _ = self._run(
+            monkeypatch,
+            ["--zid=1", "--job-id=j", "--snapshot-inputs"],
+            "both",
+            capture_boom=True,
+        )
+        assert code == 1
+        assert cmds == []
+
+    def test_unset_mode_fails_loud(self, monkeypatch):
+        code, cmds, _ = self._run(monkeypatch, ["--zid=1", "--job-id=j"], None)
+        assert code != 0
+        assert cmds == []
+
+
+class TestPurgeZid:
+    def test_purges_all_runs_of_a_conversation(self):
+        store = MemoryDelphiStore()
+        for i, zid in enumerate([5, 5, 6]):
+            job_id = f"p-{i}"
+            ensure_run(store, job_id=job_id, job_type=JobType.FULL_PIPELINE, zid=zid)
+            store.put(
+                "run_inputs",
+                StoreItem(pk=job_id, sk="votes", attributes={"enc": "json", "body": {}}),
+            )
+            store.put(
+                "artifacts",
+                StoreItem(pk=job_id, sk="math#pca", attributes={"enc": "json", "body": {}}),
+            )
+        result = purge_zid(store, 5)
+        assert result["runs"] == 2 and result["items"] == 4
+        assert store.query_prefix("run_inputs", "p-0") == []
+        assert store.query_prefix("artifacts", "p-1") == []
+        # the other conversation is untouched
+        assert store.query_prefix("run_inputs", "p-2") != []

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -198,6 +198,9 @@ services:
       - DATABASE_USER=${POSTGRES_USER}
       - DATABASE_PASSWORD=${POSTGRES_PASSWORD}
       # Full URL form for delphi_storage (PG-backend conformance tests).
+      # Storage V2 write mode: tests exercise v2 paths explicitly; the
+      # environment default keeps legacy (M0) behavior.
+      - DELPHI_WRITE_MODE=${DELPHI_WRITE_MODE:-old}
       # DELPHI_STORAGE_PG_URL carries the SQLAlchemy-safe postgresql:// scheme
       # (DATABASE_URL keeps the legacy postgres:// alias for other consumers);
       # the storage backend prefers DELPHI_STORAGE_PG_URL when set.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,9 @@ services:
       - DATABASE_URL=${DATABASE_URL}
       - LOG_LEVEL=${DELPHI_LOG_LEVEL:-INFO}
       - DELPHI_DEV_OR_PROD=${DELPHI_DEV_OR_PROD:-prod}
+      # Storage V2 migration write mode (delphi/docs/STORAGE_V2_DESIGN.md §4.3).
+      # run_delphi.py fails loudly without it; compose must pass it through.
+      - DELPHI_WRITE_MODE=${DELPHI_WRITE_MODE:-old}
       # DynamoDB connection settings for local mode (will be overridden in prod)
       - DYNAMODB_ENDPOINT=${DYNAMODB_ENDPOINT}
       - POLL_INTERVAL=${POLL_INTERVAL:-2}

--- a/example.env
+++ b/example.env
@@ -153,6 +153,11 @@ SENTENCE_TRANSFORMER_MODEL=all-MiniLM-L6-v2
 # In production leave it blank.
 DYNAMODB_ENDPOINT=http://host.docker.internal:8000
 
+# Storage V2 migration write mode (delphi/docs/STORAGE_V2_DESIGN.md §4.3).
+# REQUIRED — writers fail loudly when unset. old = legacy tables only (M0);
+# both = legacy AND v2 (the M1-M5 migration window); v2 = v2 only (M6+/fresh).
+DELPHI_WRITE_MODE=old
+
 
 ###### OLLAMA #####
 OLLAMA_HOST=http://host.docker.internal:11434


### PR DESCRIPTION
Stack 2 / P7a of the Storage V2 effort (design in #2597, §4.3 + §6.1 M0→M1 + §6.2): the **manifest half of P7** — every pipeline job leaves a v2 run manifest when v2 writes are enabled. The stage-group dual-writes (math, umap 500s, 501/502/700s, 801/803) follow as P7b–P7e, each with its `verify_dual_write` parity test.

**Stacked on #2603** (`jc/delphi-storage-v2-p6b`).

## What this adds

### `DELPHI_WRITE_MODE` (`delphi_storage/write_mode.py`)
The locked tri-state from the design: `old` (M0, today's behavior) / `both` (the whole M1–M5 window — what makes the M4 flip-back lossless per §6.2 invariant 2) / `v2` (M6+/fresh deployments). **Fail-loud when unset** — a silently-defaulted writer would undermine the flip-back guarantee undetected. `example.env` and `docker-compose.test.yml` carry `old`, so dev/test environments keep working; `run_delphi.py` exits 2 with a pointed message when unset, the poller mirror logs per-job instead of taking the worker down.

### Run-manifest lifecycle (`delphi_storage/manifest.py`)
Idempotent helpers (`ensure_run`, `mark_running`, `record_input_fingerprints`, `mark_completed`, `mark_failed`) over the store's semantic ops. Idempotence is the coordination story: the poller AND `run_delphi.py` can both drive the same run without stepping on each other (`complete_run` was already idempotent/crash-healing from P2).

### Poller mirror (`scripts/job_poller.py`)
`mirror_job_claimed` / `mirror_job_finished` — module-level (testable without a `JobProcessor`). The **old queue remains the single master** (§6.2 invariant 3): v2 run rows are mirrors that become manifests as jobs execute; real v2 claim semantics activate at the enqueue flip (P11). `complete_job` is the single funnel for every terminal path (success/failure/timeout/critical), so one hook covers them all. Mirror errors are **logged, never raised** — M1 requires the old serving path to survive a broken v2 store; divergence is caught by the coverage/verify tooling. Narrative job types are deliberately not mirrored yet (P7d).

### `run_delphi.py` write-mode behavior
- `old`: exactly today's behavior (explicit `--snapshot-inputs` still works, with its abort-on-failure semantics).
- `both`/`v2`: manifest created + marked RUNNING, inputs snapshotted, fingerprints merged into the manifest, and COMPLETED/FAILED marked at every exit path.
- Failure policy: `both` → **log-and-continue** (the old path keeps serving; an unreplayable run is visible as missing fingerprints); `v2` → **abort** (there is no old copy to lean on).
- Replays (`--input-source`) never write manifests here — the replay harness (P12) creates its own fresh run with `replay_of`.

### Per-zid purge (completes the §9 GDPR path promised in #2602)
`purge_zid` (`delphi_storage/purge.py`) + `scripts/delphi_purge.py --zid N | --job-id X`: enumerates a conversation's runs via the now-existing manifests and removes every snapshot/artifact partition. Manifests and latest pointers are retained — they carry only config/counts/hashes, never vote/comment content; the retention machinery (P14) removes them.

## Testing (TDD — 23 tests written first, RED on missing modules)

`tests/test_write_mode_manifest.py`: write-mode parsing / fail-loud / truth table; manifest-helper idempotence incl. the latest-pointer flip staying at seq 1 on double completion; the poller mirror across modes and job types incl. the never-raise policy; the `run_delphi` mode matrix (`old`/`both`/`v2` × capture success/failure, explicit-flag abort, unset-mode fail-loud with zero stages run); per-zid purge isolation. Existing `run_delphi`-invoking suites updated for the now-required mode env.

Full suite: **469 passed, 58 skipped, 58 xfailed** (5 pre-existing DynamoDB-unavailable errors unchanged). Golden snapshots ran and passed.

## Stack

- P1 #2597 · P2 #2598 · P3 #2599 · P4 #2600 (Stack 1) · P5 #2601 · P6a #2602 · P6b #2603
- **P7a: this PR**
- Next: P7b — math stage dual-write (`math#pca`/`math#kmeans`/`math#repness`/… artifacts + `verify_dual_write`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
