### PR TITLE
feat(delphi): storage v2 P7b — math stage dual-write + verify_dual_write parity checker

### DIFF
--- a/delphi/docs/STORAGE_V2_IMPLEMENTATION_NOTES.md
+++ b/delphi/docs/STORAGE_V2_IMPLEMENTATION_NOTES.md
@@ -323,15 +323,31 @@ Per design §7. In order:
   manifests/pointers retained — hashes only, retention removes them in P14).
   NOTE: narrative job types are NOT mirrored yet (P7d); replays
   (--input-source) never write manifests here (P12 owns that).
-- **P7b..P7e — stage-group dual-writes** (math; umap 500s; 501/502+700s;
-  801/803), each with a `verify_dual_write` parity test:
+- **P7b — DONE** (math dual-write): `polismath/database/v2_artifacts.py`
+  builder + `run_math_pipeline.persist_math_results` seam +
+  `scripts/verify_dual_write.py`. LESSONS (all verifier-caught): legacy
+  stores only consensus.agree as `consensus_comments`; routing
+  priority/consensus default to 0 (never omitted); the participant→group
+  map is RAW-keyed (str/int mismatch ⇒ -1 on both sides — quirk parity).
+  The verifier reads both stores independently — keep it zero-shared-code
+  with the writer, that's what caught three real divergences in the first
+  draft. TWO more review-caught lessons: (a) serialize ONCE and thread the
+  dict through both writers — math_tick is time-derived inside
+  to_dynamo_dict(), so independent calls tag the two stores differently;
+  (b) resolve the write mode at the TOP of a stage's main(), not after the
+  computation, and remember stages invoked directly (tests, make process)
+  bypass run_delphi's env export. Numpy: production conv.proj values are
+  numpy arrays — sanitize (v2_artifacts._jsonable) before the codec.
+- **P7c..P7e — remaining stage-group dual-writes** (umap 500s; 801/803
+  narrative incl. numeric-rid resolution; 501/502+700s), each extending
+  verify_dual_write:
   - stages `merge_run_fields` per-stage status and `append_log`; artifacts
-    via `keys.artifact_key(...)` with the design §4.2 naming (`math#pca`,
-    `umap#assignments#<chunk>`, `priorities`, …);
-  - old-table writers to mirror: `polismath/database/dynamodb.py`
-    (DynamoDBClient, called from run_math_pipeline/conversation serializers)
-    for math; `umap_narrative/.../utils/storage.py` DynamoDBStorage for
-    umap; 501/502 extremity+priorities; 801/803 narrative sections.
+    via `keys.artifact_key(...)` with the design §4.2 naming
+    (`umap#assignments#<chunk>`, `priorities`, `narrative#<section>#<model>`, …);
+  - old-table writers to mirror: `umap_narrative/.../utils/storage.py`
+    DynamoDBStorage for umap; 501/502 extremity+priorities (Delphi_CommentExtremity,
+    CommentRouting.priority mutation → the `priorities` artifact);
+    801/803 narrative sections (Delphi_NarrativeReports).
 - **P8 — LLM recorder + EVōC seeding + config_effective**: seeding EVōC
   changes UMAP-side outputs (documented in design §4.4) — math goldens
   unaffected, but announce it; record prompts+responses as `llm#<stage>#<seq>`

--- a/delphi/polismath/database/dynamodb.py
+++ b/delphi/polismath/database/dynamodb.py
@@ -233,13 +233,17 @@ class DynamoDBClient:
         else:
             return obj
             
-    def write_conversation(self, conv) -> bool:
+    def write_conversation(self, conv, dynamo_data=None) -> bool:
         """
         Write a conversation's mathematical analysis data to DynamoDB,
         including all projections for all participants.
 
         Args:
             conv: Conversation object with math analysis data
+            dynamo_data: Optional precomputed conv.to_dynamo_dict() output.
+                The Storage V2 dual-writer passes this so the legacy and v2
+                writes share ONE serialization (math_tick is time-derived —
+                two independent calls would tag the two stores differently).
 
         Returns:
             Success status
@@ -254,8 +258,10 @@ class DynamoDBClient:
             zid = str(conv.conversation_id)
             logger.info(f"[{time.time() - start_time:.2f}s] Writing conversation {zid} to DynamoDB")
 
-            # Convert conversation to optimized DynamoDB format
-            dynamo_data = conv.to_dynamo_dict() if hasattr(conv, 'to_dynamo_dict') else None
+            # Convert conversation to optimized DynamoDB format (unless the
+            # caller already did — see the dual-write note in the docstring)
+            if dynamo_data is None:
+                dynamo_data = conv.to_dynamo_dict() if hasattr(conv, 'to_dynamo_dict') else None
 
             # Generate a math tick (version identifier)
             # Use the one from dynamo_data if available, otherwise create a new one

--- a/delphi/polismath/database/v2_artifacts.py
+++ b/delphi/polismath/database/v2_artifacts.py
@@ -1,0 +1,172 @@
+"""Storage V2 artifact builder/writer for the MATH stage (P7b, design §4.2).
+
+Derives the v2 artifacts from the SAME objects the legacy writer consumes —
+``conv.to_dynamo_dict()`` output (already Decimal-ized), ``conv.proj`` and
+``conv.group_clusters`` — so the two write paths cannot see different data.
+The parity checker (scripts/verify_dual_write.py) reads BOTH stores back
+independently, so a bug in this module's join logic surfaces there instead
+of hiding.
+
+Artifact keys (design §4.2): math#pca, math#kmeans, math#repness,
+math#routing#<chunk>, math#projections#<chunk>. Projections are logically
+chunked (per-participant rows; 18k+ participants happen in production —
+Pakistan) on top of the byte-level auto-chunking the DynamoDB backend
+already does for >300KB blobs.
+"""
+
+import logging
+from decimal import Decimal
+from typing import Any
+
+from delphi_storage.codec import encode_payload
+from delphi_storage.interface import DelphiStore, NotFound
+from delphi_storage.models import StoreItem
+
+logger = logging.getLogger(__name__)
+
+
+def _jsonable(value: Any) -> Any:
+    """Decimal AND numpy → plain JSON values, recursively. Production
+    conv.proj values are numpy arrays (the legacy writer runs _numpy_to_list
+    on them) and dynamo_data mixes Decimals with numpy scalars — the codec's
+    canonical JSON rejects both."""
+    if isinstance(value, Decimal):
+        as_int = int(value)
+        return as_int if value == as_int else float(value)
+    if hasattr(value, "tolist"):  # numpy arrays AND numpy scalars
+        return _jsonable(value.tolist())
+    if isinstance(value, dict):
+        return {key: _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+#: Participants per math#projections#<chunk> artifact (~0.1KB/row → ~500KB
+#: JSON pre-zstd at the default; the backend byte-chunker handles the rest).
+PROJECTIONS_CHUNK_SIZE = 5000
+
+#: Comments per math#routing#<chunk> artifact (usually a single chunk).
+ROUTING_CHUNK_SIZE = 5000
+
+
+def _chunked(rows: list, size: int) -> list:
+    return [rows[i : i + size] for i in range(0, max(len(rows), 1), size)]
+
+
+def _participant_groups(group_clusters) -> dict:
+    """participant -> group_id, EXACTLY as the legacy writer builds it:
+    keyed by the RAW member values with no type coercion. If conv.proj keys
+    and cluster members disagree on type (str vs int), lookups miss and the
+    row gets -1 — that is legacy behavior, reproduced deliberately so
+    verify_dual_write holds (quirk parity, see IMPLEMENTATION_NOTES §1)."""
+    mapping: dict = {}
+    for cluster in group_clusters or []:
+        group_id = cluster.get("id", 0)
+        for member in cluster.get("members", []):
+            mapping[member] = group_id
+    return mapping
+
+
+def build_math_artifacts(
+    conv,
+    dynamo_data: dict[str, Any],
+    *,
+    projections_chunk_size: int = PROJECTIONS_CHUNK_SIZE,
+    routing_chunk_size: int = ROUTING_CHUNK_SIZE,
+) -> list[tuple[str, Any]]:
+    """(artifact_key, JSON-safe payload) pairs for one math run."""
+    artifacts: list[tuple[str, Any]] = []
+
+    artifacts.append((
+        "math#pca",
+        {
+            "math_tick": _jsonable(dynamo_data.get("math_tick")),
+            "participant_count": _jsonable(dynamo_data.get("participant_count")),
+            "comment_count": _jsonable(dynamo_data.get("comment_count")),
+            "group_count": _jsonable(dynamo_data.get("group_count")),
+            "pca": _jsonable(dynamo_data.get("pca", {})),
+            "consensus": _jsonable(dynamo_data.get("consensus", {})),
+        },
+    ))
+
+    artifacts.append(("math#kmeans", _jsonable(dynamo_data.get("group_clusters", []))))
+
+    artifacts.append((
+        "math#repness",
+        _jsonable(dynamo_data.get("repness", {}).get("comment_repness", [])),
+    ))
+
+    # Routing: one row per votes_base comment, joined with priorities and
+    # group consensus — the same join the legacy writer performs (absent
+    # values stay None; the legacy rows simply omit them).
+    votes_base = dynamo_data.get("votes_base", {})
+    priorities = dynamo_data.get("comment_priorities", {})
+    group_consensus = dynamo_data.get("group_consensus", {})
+    # Defaults mirror the legacy writer: priority 0 and consensus 0 when
+    # absent (the legacy rows always carry both attributes).
+    routing_rows = [
+        {
+            "comment_id": str(comment_id),
+            "priority": _jsonable(priorities.get(comment_id, 0)),
+            "consensus_score": _jsonable(group_consensus.get(comment_id, 0)),
+            "stats": _jsonable(stats),
+        }
+        for comment_id, stats in votes_base.items()
+    ]
+    routing_rows.sort(key=lambda row: row["comment_id"])
+    for index, chunk in enumerate(_chunked(routing_rows, routing_chunk_size)):
+        artifacts.append((f"math#routing#{index:05d}", chunk))
+
+    # Projections: per-participant rows from conv.proj (NOT in dynamo_data —
+    # the legacy serializer skips them "for efficiency") + the group map.
+    participant_groups = _participant_groups(conv.group_clusters)
+    projection_rows = [
+        {
+            "participant_id": str(participant_id),
+            "coordinates": _jsonable(coordinates),
+            # raw-key lookup, -1 default — exactly the legacy semantics
+            "group_id": _jsonable(participant_groups.get(participant_id, -1)),
+        }
+        for participant_id, coordinates in conv.proj.items()
+    ]
+    projection_rows.sort(key=lambda row: row["participant_id"])
+    for index, chunk in enumerate(_chunked(projection_rows, projections_chunk_size)):
+        artifacts.append((f"math#projections#{index:05d}", chunk))
+
+    return artifacts
+
+
+def write_math_artifacts(
+    store: DelphiStore,
+    job_id: str,
+    conv,
+    dynamo_data: dict[str, Any],
+    *,
+    projections_chunk_size: int = PROJECTIONS_CHUNK_SIZE,
+) -> int:
+    """Write the math artifacts as codec envelopes under pk=job_id; record
+    math_tick_legacy on the manifest and append a log line (best-effort —
+    a standalone dev run may have no manifest row). Returns the artifact
+    count."""
+    artifacts = build_math_artifacts(
+        conv, dynamo_data, projections_chunk_size=projections_chunk_size
+    )
+    for artifact_key, payload in artifacts:
+        encoded = encode_payload(payload)
+        store.put(
+            "artifacts",
+            StoreItem(pk=job_id, sk=artifact_key, attributes=encoded.meta, blob=encoded.blob),
+        )
+    math_tick = dynamo_data.get("math_tick")
+    try:
+        if math_tick is not None:
+            store.merge_run_fields(job_id, {"math_tick_legacy": int(math_tick)})
+        store.append_log(
+            job_id, f"math stage wrote {len(artifacts)} v2 artifacts (tick {math_tick})"
+        )
+    except NotFound:
+        logger.info(
+            f"No run manifest for job {job_id!r} (standalone run) — "
+            f"artifacts written without manifest bookkeeping"
+        )
+    return len(artifacts)

--- a/delphi/polismath/run_math_pipeline.py
+++ b/delphi/polismath/run_math_pipeline.py
@@ -23,6 +23,68 @@ logger = logging.getLogger(__name__)
 from delphi_storage.inputs import VOTES_BATCH_SQL, VOTES_COUNT_SQL
 
 
+def _get_v2_store():
+    """Module-level for testability (tests substitute a memory store)."""
+    from delphi_storage import get_store
+    return get_store()
+
+
+def _export_to_legacy_dynamo(conv, dynamo_data=None):
+    """Today's unchanged legacy write path (the 6 Delphi_* math tables).
+    dynamo_data: precomputed serialization shared with the v2 writer."""
+    from polismath.database.dynamodb import DynamoDBClient
+
+    dynamodb_client = DynamoDBClient(
+        endpoint_url=os.environ.get('DYNAMODB_ENDPOINT'),
+        region_name=os.environ.get('AWS_REGION', 'us-east-1'),
+        aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID', 'dummy'),
+        aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY', 'dummy'),
+    )
+    dynamodb_client.initialize()
+    return dynamodb_client.write_conversation(conv, dynamo_data=dynamo_data)
+
+
+def persist_math_results(conv, job_id, write_mode):
+    """Mode-gated math result persistence (Storage V2 P7b, design §6.1 M1).
+
+    old  -> legacy tables only (byte-identical to pre-V2 behavior);
+    both -> legacy AND v2 artifacts; v2 failures are logged, never raised
+            (the old path must keep serving; divergence is caught by
+            scripts/verify_dual_write.py);
+    v2   -> v2 artifacts only; failures RAISE (there is no old copy).
+    Returns the legacy writer's success flag (True when legacy is skipped).
+    """
+    from delphi_storage.write_mode import old_writes_enabled, v2_writes_enabled
+
+    # ONE serialization shared by both writers: math_tick is time-derived
+    # inside to_dynamo_dict(), so two independent calls would tag the legacy
+    # tables and the v2 artifacts with DIFFERENT ticks (and verify_dual_write
+    # would be permanently red on any conversation big enough that the
+    # legacy write takes over a second).
+    dynamo_data = conv.to_dynamo_dict()
+
+    success = True
+    if old_writes_enabled(write_mode):
+        success = _export_to_legacy_dynamo(conv, dynamo_data)
+
+    if v2_writes_enabled(write_mode):
+        from delphi_storage.write_mode import WriteMode
+        from polismath.database.v2_artifacts import write_math_artifacts
+
+        try:
+            store = _get_v2_store()
+            written = write_math_artifacts(store, job_id, conv, dynamo_data)
+            logger.info(f"Wrote {written} v2 math artifacts for job {job_id}")
+        except Exception as e:
+            if write_mode is WriteMode.V2:
+                raise
+            logger.error(
+                f"v2 math artifact write failed for job {job_id} "
+                f"(write mode 'both': old path keeps serving): {e}"
+            )
+    return success
+
+
 def prepare_for_json(obj):
     import numpy as np
 
@@ -301,6 +363,12 @@ def main():
     job_id = resolve_job_id(args.job_id)
     logger.info(f"Pipeline job id: {job_id}")
 
+    # Fail fast on a misconfigured write mode — BEFORE hours of computation,
+    # not after (design §4.3 fail-loud; resolved once, used at persist time).
+    from delphi_storage.write_mode import resolve_write_mode
+    write_mode = resolve_write_mode()
+    logger.info(f"Write mode: {write_mode.value}")
+
     zid = args.zid
     start_time = time.time()
     logger.info(f"[{time.time() - start_time:.2f}s] Starting math pipeline for conversation {zid}")
@@ -440,32 +508,22 @@ def main():
         if conv.repness and 'comment_repness' in conv.repness:
             logger.info(f"Representativeness for {len(conv.repness['comment_repness'])} comments")
 
-        # Save results to DynamoDB using the DynamoDBClient, as in the Pakistan test
+        # Persist results: legacy tables and/or v2 artifacts per
+        # DELPHI_WRITE_MODE (Storage V2 P7b, design §6.1). The legacy write
+        # keeps its historical log-and-continue behavior; a v2-only write
+        # failure aborts the run (exit 1) so the poller marks it FAILED.
+        from delphi_storage.write_mode import WriteMode
         try:
-            logger.info(f"[{time.time() - start_time:.2f}s] Initializing DynamoDB client...")
-            from polismath.database.dynamodb import DynamoDBClient
-
-            # Use environment variables or sensible defaults for local/test
-            endpoint_url = os.environ.get('DYNAMODB_ENDPOINT')
-            region_name = os.environ.get('AWS_REGION', 'us-east-1')
-            aws_access_key_id = os.environ.get('AWS_ACCESS_KEY_ID', 'dummy')
-            aws_secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY', 'dummy')
-            dynamodb_client = DynamoDBClient(
-                endpoint_url=endpoint_url,
-                region_name=region_name,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key
-            )
-            dynamodb_client.initialize()
-            logger.info(f"[{time.time() - start_time:.2f}s] DynamoDB client initialized")
-            logger.info(f"[{time.time() - start_time:.2f}s] Exporting conversation to DynamoDB...")
-            success = conv.export_to_dynamodb(dynamodb_client)
-            logger.info(f"[{time.time() - start_time:.2f}s] Export to DynamoDB {'succeeded' if success else 'failed'}")
+            logger.info(f"[{time.time() - start_time:.2f}s] Persisting math results (write mode: {write_mode.value})...")
+            success = persist_math_results(conv, job_id, write_mode)
+            logger.info(f"[{time.time() - start_time:.2f}s] Math result persistence {'succeeded' if success else 'failed'}")
         except Exception as e:
-            logger.error(f"[{time.time() - start_time:.2f}s] Error exporting to DynamoDB: {e}")
+            logger.error(f"[{time.time() - start_time:.2f}s] Error persisting math results: {e}")
             import traceback
 
             traceback.print_exc()
+            if write_mode is WriteMode.V2:
+                sys.exit(1)
 
     except Exception as e:
         logger.error(f"Pipeline failed: {e}")

--- a/delphi/scripts/verify_dual_write.py
+++ b/delphi/scripts/verify_dual_write.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Dual-write parity verification (Storage V2 design §6.1 M1, §10).
+
+Reads the LEGACY Delphi_* math tables and the V2 artifacts back
+INDEPENDENTLY and compares them numerically (Decimal vs float by value,
+booleans strictly) — a bug in the dual-writer's join logic cannot hide,
+because nothing here shares code with the writer.
+
+Usage:
+    python scripts/verify_dual_write.py --job-id <job_id> --zid <zid>
+        [--endpoint-url http://localhost:8000]
+
+Exit code 0 = parity; 1 = mismatches (listed); 2 = missing data.
+Backend/config for the v2 side via the usual DELPHI_STORAGE_* env vars.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+from delphi_storage import get_store
+from delphi_storage.codec import decode_payload, from_dynamo
+from delphi_storage.conformance.runner import assert_json_equal
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _legacy_resource(endpoint_url):
+    kwargs = {"region_name": os.environ.get("AWS_REGION", "us-east-1")}
+    if endpoint_url:
+        kwargs["endpoint_url"] = endpoint_url
+        kwargs["aws_access_key_id"] = os.environ.get("AWS_ACCESS_KEY_ID", "dummy")
+        kwargs["aws_secret_access_key"] = os.environ.get("AWS_SECRET_ACCESS_KEY", "dummy")
+    return boto3.resource("dynamodb", **kwargs)
+
+
+def _decoded_artifacts(store, job_id: str) -> dict:
+    items = store.query_prefix("artifacts", job_id, "math#")
+    return {item.sk: decode_payload(item.attributes, item.blob) for item in items}
+
+
+def _query_all(table, **kwargs) -> list:
+    rows: list = []
+    while True:
+        response = table.query(**kwargs)
+        rows.extend(response.get("Items", []))
+        last = response.get("LastEvaluatedKey")
+        if not last:
+            return rows
+        kwargs["ExclusiveStartKey"] = last
+
+
+def _compare(name: str, actual, expected, mismatches: list) -> None:
+    try:
+        assert_json_equal(actual, expected)
+    except AssertionError as e:
+        mismatches.append(f"{name}: {e}")
+
+
+def verify_math_dual_write(store, job_id: str, zid, endpoint_url=None) -> dict:
+    """Compare the legacy math tables (at latest_math_tick for zid) against
+    the decoded v2 artifacts of job_id. Returns {ok, mismatches, tick}."""
+    zid = str(zid)
+    mismatches: list = []
+    artifacts = _decoded_artifacts(store, job_id)
+    if not artifacts:
+        return {"ok": False, "mismatches": [f"no v2 math artifacts for job {job_id!r}"]}
+
+    resource = _legacy_resource(endpoint_url)
+
+    config_row = resource.Table("Delphi_PCAConversationConfig").get_item(
+        Key={"zid": zid}
+    ).get("Item")
+    if not config_row:
+        return {"ok": False, "mismatches": [f"no legacy config row for zid {zid}"]}
+    tick = int(config_row["latest_math_tick"])
+    zid_tick = f"{zid}:{tick}"
+
+    # --- math#pca vs Delphi_PCAResults + config counts ---
+    pca_artifact = artifacts.get("math#pca")
+    if pca_artifact is None:
+        mismatches.append("math#pca artifact missing")
+    else:
+        _compare("pca.math_tick", pca_artifact.get("math_tick"), tick, mismatches)
+        legacy_pca = resource.Table("Delphi_PCAResults").get_item(
+            Key={"zid": zid, "math_tick": tick}
+        ).get("Item")
+        if not legacy_pca:
+            mismatches.append(f"no legacy Delphi_PCAResults row at tick {tick}")
+        else:
+            _compare("pca.pca", pca_artifact.get("pca"),
+                     from_dynamo(legacy_pca.get("pca")), mismatches)
+            # legacy stores only the AGREE list as consensus_comments; the
+            # v2 artifact keeps the full consensus dict (a superset)
+            _compare("pca.consensus.agree",
+                     (pca_artifact.get("consensus") or {}).get("agree", []),
+                     from_dynamo(legacy_pca.get("consensus_comments")), mismatches)
+            for count in ("participant_count", "comment_count", "group_count"):
+                _compare(f"pca.{count}", pca_artifact.get(count),
+                         from_dynamo(legacy_pca.get(count)), mismatches)
+
+    # --- math#kmeans vs Delphi_KMeansClusters ---
+    kmeans_artifact = artifacts.get("math#kmeans")
+    if kmeans_artifact is None:
+        mismatches.append("math#kmeans artifact missing")
+    else:
+        legacy_rows = _query_all(
+            resource.Table("Delphi_KMeansClusters"),
+            KeyConditionExpression=Key("zid_tick").eq(zid_tick),
+        )
+        legacy_groups = {
+            int(row["group_id"]): {
+                "center": from_dynamo(row.get("center")),
+                "members": from_dynamo(row.get("members")),
+            }
+            for row in legacy_rows
+        }
+        v2_groups = {
+            int(group["id"]): {"center": group.get("center"), "members": group.get("members")}
+            for group in kmeans_artifact
+        }
+        _compare("kmeans", v2_groups, legacy_groups, mismatches)
+
+    # --- math#repness vs Delphi_RepresentativeComments ---
+    repness_artifact = artifacts.get("math#repness")
+    if repness_artifact is None:
+        mismatches.append("math#repness artifact missing")
+    else:
+        group_ids = {int(entry["group_id"]) for entry in repness_artifact}
+        legacy_repness: dict = {}
+        for group_id in sorted(group_ids):
+            rows = _query_all(
+                resource.Table("Delphi_RepresentativeComments"),
+                KeyConditionExpression=Key("zid_tick_gid").eq(f"{zid_tick}:{group_id}"),
+            )
+            for row in rows:
+                legacy_repness[(group_id, str(row["comment_id"]))] = from_dynamo(
+                    row.get("repness")
+                )
+        v2_repness = {
+            (int(entry["group_id"]), str(entry["comment_id"])): entry.get("repness")
+            for entry in repness_artifact
+        }
+        _compare(
+            "repness",
+            {f"{g}:{c}": v for (g, c), v in sorted(v2_repness.items())},
+            {f"{g}:{c}": v for (g, c), v in sorted(legacy_repness.items())},
+            mismatches,
+        )
+
+    # --- math#routing#* vs Delphi_CommentRouting ---
+    routing_rows = [
+        row
+        for key in sorted(artifacts)
+        if key.startswith("math#routing#")
+        for row in artifacts[key]
+    ]
+    if routing_rows:
+        legacy_rows = _query_all(
+            resource.Table("Delphi_CommentRouting"),
+            KeyConditionExpression=Key("zid_tick").eq(zid_tick),
+        )
+        legacy_routing = {
+            str(row["comment_id"]): {
+                "stats": from_dynamo(row.get("stats")),
+                "priority": from_dynamo(row.get("priority")),
+                "consensus_score": from_dynamo(row.get("consensus_score")),
+            }
+            for row in legacy_rows
+        }
+        v2_routing = {
+            row["comment_id"]: {
+                "stats": row.get("stats"),
+                "priority": row.get("priority"),
+                "consensus_score": row.get("consensus_score"),
+            }
+            for row in routing_rows
+        }
+        _compare("routing", v2_routing, legacy_routing, mismatches)
+    else:
+        mismatches.append("math#routing artifacts missing")
+
+    # --- math#projections#* vs Delphi_PCAParticipantProjections ---
+    projection_rows = [
+        row
+        for key in sorted(artifacts)
+        if key.startswith("math#projections#")
+        for row in artifacts[key]
+    ]
+    if projection_rows:
+        legacy_rows = _query_all(
+            resource.Table("Delphi_PCAParticipantProjections"),
+            KeyConditionExpression=Key("zid_tick").eq(zid_tick),
+        )
+        legacy_projections = {
+            str(row["participant_id"]): {
+                "coordinates": from_dynamo(row.get("coordinates")),
+                "group_id": from_dynamo(row.get("group_id")),
+            }
+            for row in legacy_rows
+        }
+        v2_projections = {
+            row["participant_id"]: {
+                "coordinates": row.get("coordinates"),
+                "group_id": row.get("group_id"),
+            }
+            for row in projection_rows
+        }
+        _compare("projections", v2_projections, legacy_projections, mismatches)
+    else:
+        mismatches.append("math#projections artifacts missing")
+
+    return {"ok": not mismatches, "mismatches": mismatches, "tick": tick}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify math dual-write parity")
+    parser.add_argument("--job-id", required=True)
+    parser.add_argument("--zid", required=True)
+    parser.add_argument("--endpoint-url", default=os.environ.get("DYNAMODB_ENDPOINT"))
+    args = parser.parse_args()
+
+    report = verify_math_dual_write(
+        get_store(), job_id=args.job_id, zid=args.zid, endpoint_url=args.endpoint_url
+    )
+    if report["ok"]:
+        logger.info(f"PARITY OK (tick {report.get('tick')})")
+        sys.exit(0)
+    for mismatch in report["mismatches"]:
+        logger.error(f"MISMATCH: {mismatch}")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/delphi/tests/test_math_dual_write.py
+++ b/delphi/tests/test_math_dual_write.py
@@ -1,0 +1,336 @@
+"""P7b (Storage V2 design §4.2 artifacts, §6.1 M1, §7): MATH stage dual-write.
+
+Contract under test:
+
+- build_math_artifacts derives the v2 artifact payloads from the SAME objects
+  the legacy writer consumes (`conv.to_dynamo_dict()` output + `conv.proj` +
+  `conv.group_clusters`), converting Decimals back to floats by value:
+  math#pca, math#kmeans, math#repness, math#routing#<chunk>,
+  math#projections#<chunk> (logical chunking for the per-participant table).
+- write_math_artifacts stores them as codec envelopes under pk=job_id,
+  records math_tick_legacy on the manifest and appends a log line
+  (best-effort: a standalone run may have no manifest).
+- persist_math_results gates BOTH writers on DELPHI_WRITE_MODE:
+  old → legacy export only (byte-identical behavior); both → legacy AND v2,
+  v2 failures logged never raised; v2 → v2 only (legacy tables untouched),
+  v2 failures raise.
+- scripts/verify_dual_write.py compares the legacy table rows against the
+  decoded v2 artifacts NUMERICALLY (Decimal vs float by value) and reports
+  per-table pass/fail — it reads both sides independently, so a bug in the
+  builder's join logic cannot hide.
+"""
+
+import os
+import sys
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from delphi_storage.backends.memory import MemoryDelphiStore
+from delphi_storage.codec import decode_payload
+from delphi_storage.manifest import ensure_run, mark_running
+from delphi_storage.models import JobType
+from delphi_storage.write_mode import WriteMode
+
+DELPHI_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if DELPHI_DIR not in sys.path:
+    sys.path.insert(0, DELPHI_DIR)
+
+from polismath.database.v2_artifacts import (  # noqa: E402
+    build_math_artifacts,
+    write_math_artifacts,
+)
+from polismath.run_math_pipeline import persist_math_results  # noqa: E402
+
+
+def _fake_conv(n_participants=5):
+    """Minimal stand-in exposing exactly what the write path consumes."""
+    dynamo_data = {
+        "math_tick": 27042,
+        "participant_count": n_participants,
+        "comment_count": 3,
+        "group_count": 2,
+        "pca": {
+            "center": [Decimal("0.1"), Decimal("-0.2")],
+            "components": [[Decimal("0.5"), Decimal("0.5")],
+                           [Decimal("-0.5"), Decimal("0.5")]],
+        },
+        "consensus": {"agree": [{"tid": 1, "p-success": Decimal("0.9")}], "disagree": []},
+        "group_clusters": [
+            {"id": 0, "members": [0, 2], "center": [Decimal("1.0"), Decimal("0.0")]},
+            {"id": 1, "members": [1, 3, 4], "center": [Decimal("-1.0"), Decimal("0.0")]},
+        ],
+        "votes_base": {
+            "1": {"agree": 2, "disagree": 1, "total": 3},
+            "2": {"agree": 1, "disagree": 0, "total": 1},
+            "3": {"agree": 0, "disagree": 2, "total": 2},
+        },
+        "comment_priorities": {"1": 7, "2": 3},
+        "group_consensus": {"1": Decimal("0.75"), "3": Decimal("0.25")},
+        "repness": {
+            "comment_repness": [
+                {"group_id": 0, "comment_id": "1", "repness": Decimal("2.5")},
+                {"group_id": 1, "comment_id": "3", "repness": Decimal("1.5")},
+            ]
+        },
+    }
+    # proj keyed by the RAW member values (ints here) — the legacy group map
+    # is raw-keyed, so matching types resolve groups; mismatched types are
+    # the -1 quirk covered by its own test below.
+    proj = {i: [float(i), -float(i)] for i in range(n_participants)}
+    conv = SimpleNamespace(
+        conversation_id="42",
+        proj=proj,
+        group_clusters=dynamo_data["group_clusters"],
+        serialize_calls=0,
+    )
+
+    def to_dynamo_dict():
+        conv.serialize_calls += 1
+        return dynamo_data
+
+    conv.to_dynamo_dict = to_dynamo_dict
+    return conv, dynamo_data
+
+
+class TestBuildMathArtifacts:
+    def test_artifact_keys_and_decimal_conversion(self):
+        conv, dynamo_data = _fake_conv()
+        artifacts = dict(build_math_artifacts(conv, dynamo_data))
+        assert set(artifacts) == {
+            "math#pca",
+            "math#kmeans",
+            "math#repness",
+            "math#routing#00000",
+            "math#projections#00000",
+        }
+        pca = artifacts["math#pca"]
+        assert pca["math_tick"] == 27042
+        assert pca["pca"]["center"] == [0.1, -0.2]  # floats, not Decimals
+        assert isinstance(pca["pca"]["center"][0], float)
+        assert pca["participant_count"] == 5
+        kmeans = artifacts["math#kmeans"]
+        assert [g["id"] for g in kmeans] == [0, 1]
+        assert kmeans[0]["center"] == [1.0, 0.0]
+        repness = artifacts["math#repness"]
+        assert repness[0] == {"group_id": 0, "comment_id": "1", "repness": 2.5}
+
+    def test_routing_join_matches_legacy_semantics(self):
+        """One row per votes_base comment; priority/consensus joined with the
+        same defaults the legacy writer uses (absent → 0, never omitted)."""
+        conv, dynamo_data = _fake_conv()
+        artifacts = dict(build_math_artifacts(conv, dynamo_data))
+        routing = {row["comment_id"]: row for row in artifacts["math#routing#00000"]}
+        assert set(routing) == {"1", "2", "3"}
+        assert routing["1"]["priority"] == 7
+        assert routing["1"]["consensus_score"] == 0.75
+        assert routing["1"]["stats"] == {"agree": 2, "disagree": 1, "total": 3}
+        assert routing["2"]["consensus_score"] == 0  # legacy default, not omitted
+        assert routing["3"]["priority"] == 0  # legacy default, not omitted
+
+    def test_projections_carry_group_ids_and_chunk(self):
+        conv, dynamo_data = _fake_conv(n_participants=5)
+        artifacts = dict(build_math_artifacts(conv, dynamo_data, projections_chunk_size=2))
+        chunks = sorted(k for k in artifacts if k.startswith("math#projections#"))
+        assert chunks == [
+            "math#projections#00000",
+            "math#projections#00001",
+            "math#projections#00002",
+        ]
+        rows = [row for key in chunks for row in artifacts[key]]
+        assert len(rows) == 5
+        by_pid = {row["participant_id"]: row for row in rows}
+        assert by_pid["0"]["group_id"] == 0
+        assert by_pid["1"]["group_id"] == 1
+        assert by_pid["4"]["group_id"] == 1
+        assert by_pid["2"]["coordinates"] == [2.0, -2.0]
+
+    def test_participants_without_group_get_minus_one(self):
+        conv, dynamo_data = _fake_conv(n_participants=6)  # pid 5 in no cluster
+        artifacts = dict(build_math_artifacts(conv, dynamo_data))
+        rows = artifacts["math#projections#00000"]
+        by_pid = {row["participant_id"]: row for row in rows}
+        assert by_pid["5"]["group_id"] == -1
+
+    def test_str_int_key_mismatch_reproduces_legacy_minus_one_quirk(self):
+        """The legacy group map is raw-keyed: str proj keys never match int
+        cluster members, so every row gets -1. Quirk parity — the v2 side
+        must diverge from 'correct' exactly like the legacy side does."""
+        conv, dynamo_data = _fake_conv()
+        conv.proj = {str(pid): coords for pid, coords in conv.proj.items()}
+        artifacts = dict(build_math_artifacts(conv, dynamo_data))
+        rows = artifacts["math#projections#00000"]
+        assert all(row["group_id"] == -1 for row in rows)
+
+
+class TestNumpySafety:
+    def test_numpy_arrays_and_scalars_are_encodable(self):
+        """Production conv.proj values are numpy arrays and dynamo_data mixes
+        numpy scalars in — the builder must emit plain JSON values."""
+        np = pytest.importorskip("numpy")
+        conv, dynamo_data = _fake_conv()
+        conv.proj = {pid: np.array(coords) for pid, coords in conv.proj.items()}
+        dynamo_data["pca"]["center"] = np.array([0.1, -0.2])
+        dynamo_data["participant_count"] = np.int64(5)
+        artifacts = dict(build_math_artifacts(conv, dynamo_data))
+        pca = artifacts["math#pca"]
+        assert pca["pca"]["center"] == [0.1, -0.2]
+        assert isinstance(pca["participant_count"], int)
+        rows = artifacts["math#projections#00000"]
+        assert isinstance(rows[0]["coordinates"], list)
+        # and the codec accepts the payloads end to end
+        store = MemoryDelphiStore()
+        assert write_math_artifacts(store, "np-job", conv, dynamo_data) == 5
+
+
+class TestWriteMathArtifacts:
+    def test_writes_envelopes_and_manifest(self):
+        store = MemoryDelphiStore()
+        ensure_run(store, job_id="mj-1", job_type=JobType.FULL_PIPELINE, zid=42)
+        mark_running(store, "mj-1")
+        conv, dynamo_data = _fake_conv()
+        written = write_math_artifacts(store, "mj-1", conv, dynamo_data)
+        assert written == 5
+        items = store.query_prefix("artifacts", "mj-1", "math#")
+        assert len(items) == 5
+        pca_item = store.get("artifacts", "mj-1", "math#pca")
+        decoded = decode_payload(pca_item.attributes, pca_item.blob)
+        assert decoded["pca"]["center"] == [0.1, -0.2]
+        run = store.get_run("mj-1")
+        assert run.math_tick_legacy == 27042
+        logs = store.query_prefix("artifacts", "mj-1", "log#")
+        assert len(logs) == 1
+
+    def test_no_manifest_is_tolerated(self):
+        """Standalone dev runs may have no run row — artifacts still land."""
+        store = MemoryDelphiStore()
+        conv, dynamo_data = _fake_conv()
+        written = write_math_artifacts(store, "loose-job", conv, dynamo_data)
+        assert written == 5
+        assert store.get("artifacts", "loose-job", "math#pca") is not None
+
+
+class TestPersistModeGating:
+    def _setup(self, monkeypatch, mode):
+        conv, dynamo_data = _fake_conv()
+        calls = {"old": 0, "v2": 0}
+
+        def fake_old_export(conv_arg, dynamo_data_arg):
+            calls["old"] += 1
+            calls["old_dynamo_data"] = dynamo_data_arg
+            return True
+
+        rmp = sys.modules["polismath.run_math_pipeline"]
+        monkeypatch.setattr(rmp, "_export_to_legacy_dynamo", fake_old_export)
+
+        store = MemoryDelphiStore()
+        monkeypatch.setattr(rmp, "_get_v2_store", lambda: store)
+        return rmp, conv, calls, store
+
+    def test_old_mode_only_legacy(self, monkeypatch):
+        rmp, conv, calls, store = self._setup(monkeypatch, "old")
+        ok = persist_math_results(conv, job_id="j", write_mode=WriteMode.OLD)
+        assert ok and calls["old"] == 1
+        assert store.query_prefix("artifacts", "j", "math#") == []
+
+    def test_both_mode_writes_both(self, monkeypatch):
+        rmp, conv, calls, store = self._setup(monkeypatch, "both")
+        ok = persist_math_results(conv, job_id="j", write_mode=WriteMode.BOTH)
+        assert ok and calls["old"] == 1
+        assert len(store.query_prefix("artifacts", "j", "math#")) == 5
+
+    def test_single_serialization_shared_by_both_writers(self, monkeypatch):
+        """math_tick is time-derived inside to_dynamo_dict — TWO independent
+        calls would tag the legacy tables and v2 artifacts with different
+        ticks and turn verify_dual_write permanently red on real runs."""
+        rmp, conv, calls, store = self._setup(monkeypatch, "both")
+        persist_math_results(conv, job_id="j", write_mode=WriteMode.BOTH)
+        assert conv.serialize_calls == 1
+        # and the very same dict object reached the legacy writer
+        pca_item = store.get("artifacts", "j", "math#pca")
+        assert calls["old_dynamo_data"]["math_tick"] == 27042
+
+    def test_both_mode_v2_failure_is_swallowed(self, monkeypatch):
+        rmp, conv, calls, store = self._setup(monkeypatch, "both")
+
+        def boom():
+            raise RuntimeError("v2 store down")
+
+        monkeypatch.setattr(rmp, "_get_v2_store", boom)
+        ok = persist_math_results(conv, job_id="j", write_mode=WriteMode.BOTH)
+        assert ok and calls["old"] == 1  # old path served
+
+    def test_v2_mode_skips_legacy_and_raises_on_failure(self, monkeypatch):
+        rmp, conv, calls, store = self._setup(monkeypatch, "v2")
+        ok = persist_math_results(conv, job_id="j", write_mode=WriteMode.V2)
+        assert ok and calls["old"] == 0
+        assert len(store.query_prefix("artifacts", "j", "math#")) == 5
+
+        def boom():
+            raise RuntimeError("v2 store down")
+
+        monkeypatch.setattr(rmp, "_get_v2_store", boom)
+        with pytest.raises(RuntimeError):
+            persist_math_results(conv, job_id="j2", write_mode=WriteMode.V2)
+
+
+class TestVerifyDualWrite:
+    """End-to-end parity: legacy tables written by the REAL DynamoDBClient vs
+    v2 artifacts — compared by the independent verifier."""
+
+    def _dynamo_available(self):
+        endpoint = os.environ.get("DYNAMODB_ENDPOINT", "http://localhost:8000")
+        import boto3
+        from botocore.config import Config as BotoConfig
+
+        try:
+            client = boto3.client(
+                "dynamodb", endpoint_url=endpoint, region_name="us-east-1",
+                aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", "dummy"),
+                aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", "dummy"),
+                config=BotoConfig(connect_timeout=3, read_timeout=3,
+                                  retries={"max_attempts": 0}),
+            )
+            client.list_tables(Limit=1)
+            return endpoint
+        except Exception as e:  # noqa: BLE001
+            if os.environ.get("GITHUB_ACTIONS") == "true":
+                pytest.fail(f"DynamoDB must be available in GitHub Actions: {e}")
+            pytest.skip(f"DynamoDB unavailable: {e}")
+
+    def test_verify_passes_then_catches_corruption(self, monkeypatch):
+        endpoint = self._dynamo_available()
+        from polismath.database.dynamodb import DynamoDBClient
+        from scripts.verify_dual_write import verify_math_dual_write
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "dummy")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "dummy")
+        conv, dynamo_data = _fake_conv()
+        client = DynamoDBClient(endpoint_url=endpoint, region_name="us-east-1")
+        client.initialize()
+        assert client.write_conversation(conv) is True
+
+        store = MemoryDelphiStore()
+        write_math_artifacts(store, "vj-1", conv, dynamo_data)
+
+        report = verify_math_dual_write(
+            store, job_id="vj-1", zid=42, endpoint_url=endpoint
+        )
+        assert report["ok"], report
+
+        # corrupt one v2 value → the verifier must catch it
+        from delphi_storage.models import StoreItem
+        from delphi_storage.codec import encode_payload
+
+        payloads = dict(build_math_artifacts(conv, dynamo_data))
+        pca = payloads["math#pca"]
+        pca["pca"]["center"][0] = 999.0
+        enc = encode_payload(pca)
+        store.put("artifacts", StoreItem(pk="vj-1", sk="math#pca",
+                                         attributes=enc.meta, blob=enc.blob))
+        report = verify_math_dual_write(
+            store, job_id="vj-1", zid=42, endpoint_url=endpoint
+        )
+        assert not report["ok"]
+        assert any("pca" in mismatch for mismatch in report["mismatches"])

--- a/delphi/tests/test_math_pipeline_runs_e2e.py
+++ b/delphi/tests/test_math_pipeline_runs_e2e.py
@@ -146,6 +146,7 @@ def mock_moderation_data():
 
 @mock.patch('psycopg2.connect')
 def test_run_math_pipeline_e2e(mock_connect, dynamodb_resource, mock_comments_data, mock_votes_data, mock_moderation_data):
+    os.environ.setdefault("DELPHI_WRITE_MODE", "old")  # P7b: math persistence is mode-gated
     """
     Runs the entire math pipeline script, mocking all database calls
     and checking DynamoDB for results.


### PR DESCRIPTION
Stack 2 / P7b of the Storage V2 effort (design in #2597, §4.2 artifacts + §6.1 M1 + §7): the **math stage-group dual-write** — math results become v2 artifacts alongside the legacy `Delphi_*` tables, gated by `DELPHI_WRITE_MODE`, with the design's `verify_dual_write` parity gate.

**Stacked on #2604** (`jc/delphi-storage-v2-p7a`).

## What this adds

### Artifact builder (`polismath/database/v2_artifacts.py`)
Derives the v2 payloads from the **same objects the legacy writer consumes** (`conv.to_dynamo_dict()` output, `conv.proj`, `conv.group_clusters`), converting Decimals back to floats by value. Keys per design §4.2: `math#pca` (carrying the **full** consensus dict — legacy keeps only the agree list), `math#kmeans`, `math#repness`, `math#routing#<chunk>`, `math#projections#<chunk>` (logical chunks of 5000 participants — 18k+ happen in production — layered on the backend's byte-level auto-chunking).

**Legacy quirks reproduced deliberately**, each pinned by a test:
- routing `priority`/`consensus_score` default to `0` (the legacy rows always carry both attributes);
- the participant→group map is **raw-keyed** exactly like the legacy writer — a str/int key-type mismatch yields `group_id: -1` on *both* sides rather than being "fixed" on one.

### The persistence seam (`run_math_pipeline.py::persist_math_results`)
`old` → legacy export only (the previous write block extracted verbatim into `_export_to_legacy_dynamo`; behavior unchanged, including its historical log-and-continue). `both` → legacy AND v2; v2 failures are logged, never raised (M1: the old path keeps serving). `v2` → v2 only; failures exit 1 so the poller marks the run FAILED.

### The parity gate (`scripts/verify_dual_write.py`)
Reads the legacy tables (at `latest_math_tick`) and the decoded v2 artifacts back **independently** — zero shared code with the writer — and compares numerically (Decimal vs float by value). CLI: `--job-id/--zid/--endpoint-url`, exit 0/1.

**It proved itself during development**: the first builder draft failed verification with three real divergences (the consensus agree-list subset, the routing defaults, the raw-keyed group map) — exactly the class of bug it exists to catch, found before any reviewer saw the code.

## Testing (TDD — 12 tests written first, RED on missing modules)

Builder payloads/joins/chunking/quirk-parity; envelope round-trip + `math_tick_legacy` manifest bookkeeping (tolerant of manifest-less standalone runs); mode gating incl. both failure policies; and an end-to-end parity test against real DynamoDB local — legacy write via the **real** `DynamoDBClient`, verify passes; corrupt one v2 value, verify catches it (skip-locally / fail-in-CI convention).

Full suite: **480 passed, 59 skipped, 58 xfailed** (5 pre-existing DynamoDB-unavailable errors unchanged). **Golden snapshots ran and passed** — write-side only, math outputs untouched.

## Stack

- P1 #2597 · P2 #2598 · P3 #2599 · P4 #2600 (Stack 1) · P5 #2601 · P6a #2602 · P6b #2603 · P7a #2604
- **P7b: this PR**
- Next: P7c — umap 500s dual-write (DynamoDBStorage mirror), then P7d 801/803 narrative (+ numeric-rid resolution), P7e 501/502/700

🤖 Generated with [Claude Code](https://claude.com/claude-code)
