### PR TITLE
feat(delphi): storage v2 P7c — umap 500s stage dual-write + verifier extension

### DIFF
--- a/delphi/scripts/verify_dual_write.py
+++ b/delphi/scripts/verify_dual_write.py
@@ -218,22 +218,156 @@ def verify_math_dual_write(store, job_id: str, zid, endpoint_url=None) -> dict:
     return {"ok": not mismatches, "mismatches": mismatches, "tick": tick}
 
 
+def _decoded_umap_artifacts(store, job_id: str) -> dict:
+    items = store.query_prefix("artifacts", job_id, "umap#")
+    return {item.sk: decode_payload(item.attributes, item.blob) for item in items}
+
+
+def verify_umap_dual_write(store, job_id: str, zid, endpoint_url=None) -> dict:
+    """Compare the legacy UMAP tables (conversation_id-keyed) against the
+    decoded v2 umap# artifacts of job_id. Same independence rule as the math
+    verifier: zero shared code with the writer. Compares SAME-RUN rows only
+    (EVōC cluster ids are not stable across runs)."""
+    zid = str(zid)
+    mismatches: list = []
+    artifacts = _decoded_umap_artifacts(store, job_id)
+    if not artifacts:
+        return {"ok": False, "mismatches": [f"no v2 umap artifacts for job {job_id!r}"]}
+
+    resource = _legacy_resource(endpoint_url)
+
+    def rows_of(prefix: str) -> list:
+        return [
+            row
+            for key in sorted(artifacts)
+            if key.startswith(prefix)
+            for row in artifacts[key]
+        ]
+
+    # umap#meta vs Delphi_UMAPConversationConfig
+    meta = artifacts.get("umap#meta")
+    if meta is None:
+        mismatches.append("umap#meta artifact missing")
+    else:
+        legacy_meta = resource.Table("Delphi_UMAPConversationConfig").get_item(
+            Key={"conversation_id": zid}
+        ).get("Item")
+        if not legacy_meta:
+            mismatches.append(f"no legacy Delphi_UMAPConversationConfig row for {zid}")
+        else:
+            for field in ("processed_date", "num_comments", "num_participants",
+                          "embedding_model"):
+                _compare(f"meta.{field}", meta.get(field),
+                         from_dynamo(legacy_meta.get(field)), mismatches)
+
+    # per-comment tables: embeddings and assignments
+    for prefix, table_name, fields in (
+        ("umap#embeddings#", "Delphi_CommentEmbeddings", ("embedding",)),
+        ("umap#assignments#", "Delphi_CommentHierarchicalClusterAssignments",
+         ("layer0_cluster_id", "is_outlier")),
+    ):
+        v2_rows = rows_of(prefix)
+        if not v2_rows:
+            mismatches.append(f"{prefix} artifacts missing")
+            continue
+        legacy_rows = _query_all(
+            resource.Table(table_name),
+            KeyConditionExpression=Key("conversation_id").eq(zid),
+        )
+        legacy_by_id = {
+            int(row["comment_id"]): {f: from_dynamo(row.get(f)) for f in fields}
+            for row in legacy_rows
+        }
+        v2_by_id = {
+            int(row["comment_id"]): {f: row.get(f) for f in fields}
+            for row in v2_rows
+        }
+        _compare(table_name, v2_by_id, legacy_by_id, mismatches)
+
+    # umap#graph vs Delphi_UMAPGraph (edge_id keyed)
+    v2_edges = rows_of("umap#graph#")
+    if v2_edges:
+        legacy_rows = _query_all(
+            resource.Table("Delphi_UMAPGraph"),
+            KeyConditionExpression=Key("conversation_id").eq(zid),
+        )
+        legacy_by_id = {
+            str(row["edge_id"]): {
+                "weight": from_dynamo(row.get("weight")),
+                "distance": from_dynamo(row.get("distance")),
+                "position": from_dynamo(row.get("position")),
+            }
+            for row in legacy_rows
+        }
+        v2_by_id = {
+            str(row["edge_id"]): {
+                "weight": row.get("weight"),
+                "distance": row.get("distance"),
+                "position": row.get("position"),
+            }
+            for row in v2_edges
+        }
+        _compare("umap_graph", v2_by_id, legacy_by_id, mismatches)
+    else:
+        mismatches.append("umap#graph artifacts missing")
+
+    # per-(layer,cluster) tables: keywords, features, llm topics
+    for prefix, table_name, key_field in (
+        ("umap#keywords#", "Delphi_CommentClustersStructureKeywords", "cluster_key"),
+        ("umap#features#", "Delphi_CommentClustersFeatures", "cluster_key"),
+        ("umap#topic#", "Delphi_CommentClustersLLMTopicNames", "topic_key"),
+    ):
+        v2_rows = (
+            rows_of(prefix)
+            if prefix != "umap#topic#"
+            else [artifacts[key] for key in sorted(artifacts) if key.startswith(prefix)]
+        )
+        if not v2_rows:
+            continue  # optional outputs (e.g. no LLM topics without --use-ollama)
+        legacy_rows = _query_all(
+            resource.Table(table_name),
+            KeyConditionExpression=Key("conversation_id").eq(zid),
+        )
+        legacy_by_key = {
+            str(row[key_field]): from_dynamo(
+                {k: v for k, v in row.items() if k not in ("conversation_id",)}
+            )
+            for row in legacy_rows
+        }
+        v2_by_key = {
+            str(row[key_field]): {
+                k: v for k, v in row.items() if k not in ("conversation_id",)
+            }
+            for row in v2_rows
+        }
+        _compare(table_name, v2_by_key, legacy_by_key, mismatches)
+
+    return {"ok": not mismatches, "mismatches": mismatches}
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Verify math dual-write parity")
+    parser = argparse.ArgumentParser(description="Verify dual-write parity")
     parser.add_argument("--job-id", required=True)
     parser.add_argument("--zid", required=True)
+    parser.add_argument("--stage", choices=("math", "umap", "all"), default="all")
     parser.add_argument("--endpoint-url", default=os.environ.get("DYNAMODB_ENDPOINT"))
     args = parser.parse_args()
 
-    report = verify_math_dual_write(
-        get_store(), job_id=args.job_id, zid=args.zid, endpoint_url=args.endpoint_url
-    )
-    if report["ok"]:
-        logger.info(f"PARITY OK (tick {report.get('tick')})")
-        sys.exit(0)
-    for mismatch in report["mismatches"]:
-        logger.error(f"MISMATCH: {mismatch}")
-    sys.exit(1)
+    store = get_store()
+    ok = True
+    for stage, verify in (("math", verify_math_dual_write),
+                          ("umap", verify_umap_dual_write)):
+        if args.stage not in (stage, "all"):
+            continue
+        report = verify(store, job_id=args.job_id, zid=args.zid,
+                        endpoint_url=args.endpoint_url)
+        if report["ok"]:
+            logger.info(f"{stage.upper()} PARITY OK")
+        else:
+            ok = False
+            for mismatch in report["mismatches"]:
+                logger.error(f"{stage.upper()} MISMATCH: {mismatch}")
+    sys.exit(0 if ok else 1)
 
 
 if __name__ == "__main__":

--- a/delphi/tests/test_umap_dual_write.py
+++ b/delphi/tests/test_umap_dual_write.py
@@ -1,0 +1,363 @@
+"""P7c (Storage V2 design §4.2, §6.1 M1, §7): UMAP 500s stage dual-write.
+
+Contract under test:
+
+- build_* functions derive v2 artifact payloads from the SAME Pydantic model
+  lists the legacy DynamoDBStorage writes (serialize-once by construction —
+  the models carry baked datetime fields, so re-instantiating them would be
+  the math_tick trap all over again):
+  umap#meta, umap#embeddings#<chunk>, umap#graph#<chunk>,
+  umap#assignments#<chunk>, umap#keywords#<layer>, umap#features#<layer>,
+  umap#topic#<layer>#<cluster>.
+- DualWriteUmapStorage duck-types the 7 DynamoDBStorage write methods used by
+  run_pipeline: legacy write (when an inner storage is present) AND v2
+  artifact write from the same lists, per DELPHI_WRITE_MODE policy
+  (both → v2 failures logged never raised; v2 → raised; old → passthrough).
+- make_umap_storage builds the right stack for (export_dynamo, write_mode).
+- verify_umap_dual_write reads legacy tables and v2 artifacts back
+  INDEPENDENTLY and compares numerically.
+"""
+
+import os
+import sys
+
+import pytest
+
+from delphi_storage.backends.memory import MemoryDelphiStore
+from delphi_storage.codec import decode_payload
+from delphi_storage.write_mode import WriteMode
+
+DELPHI_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+UMAP_DIR = os.path.join(DELPHI_DIR, "umap_narrative")
+for path in (DELPHI_DIR, UMAP_DIR):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+from polismath_commentgraph.schemas.dynamo_models import (  # noqa: E402
+    ClusterCharacteristic,
+    ClusterLayer,
+    ClusterTopic,
+    CommentCluster,
+    CommentEmbedding,
+    ConversationMeta,
+    Coordinates,
+    Embedding,
+    EVOCParameters,
+    LLMTopicName,
+    UMAPGraphEdge,
+    UMAPParameters,
+)
+from v2_artifacts import (  # noqa: E402  (umap_narrative/v2_artifacts.py)
+    DualWriteUmapStorage,
+    build_core_umap_artifacts,
+    build_features_artifacts,
+    build_topic_artifacts,
+    make_umap_storage,
+)
+
+ZID = "42"
+
+
+def _models():
+    meta = ConversationMeta(
+        conversation_id=ZID,
+        processed_date="2026-07-07T00:00:00",
+        num_comments=3,
+        num_participants=5,
+        embedding_model="test-model",
+        umap_parameters=UMAPParameters(),
+        evoc_parameters=EVOCParameters(),
+        cluster_layers=[ClusterLayer(layer_id=0, num_clusters=2, description="test layer")],
+    )
+    embeddings = [
+        CommentEmbedding(
+            conversation_id=ZID, comment_id=i,
+            embedding=Embedding(vector=[0.1 * i, -0.2 * i], dimensions=2, model="test-model"),
+        )
+        for i in range(3)
+    ]
+    edges = [
+        UMAPGraphEdge(
+            conversation_id=ZID, edge_id=f"{i}_{i}", source_id=i, target_id=i,
+            weight=1.0, distance=0.0, position=Coordinates(x=float(i), y=-float(i)),
+        )
+        for i in range(3)
+    ]
+    clusters = [
+        CommentCluster(conversation_id=ZID, comment_id=i, layer0_cluster_id=i % 2)
+        for i in range(3)
+    ]
+    topics = [
+        ClusterTopic(
+            conversation_id=ZID, cluster_key=f"layer0_{c}", layer_id=0, cluster_id=c,
+            topic_label=f"t{c}", size=2, sample_comments=["a"],
+            centroid_coordinates=Coordinates(x=0.5, y=0.5),
+        )
+        for c in range(2)
+    ]
+    characteristics = [
+        ClusterCharacteristic(
+            conversation_id=ZID, layer_id=0, cluster_id=c, size=2,
+            top_words=["w1"], top_tfidf_scores=[0.9], sample_comments=["a"],
+        )
+        for c in range(2)
+    ]
+    llm_topics = [
+        LLMTopicName(
+            conversation_id=ZID, topic_key=f"job-x#0#{c}", layer_id=0, cluster_id=c,
+            topic_name=f"Topic {c}", model_name="llama-test",
+            created_at="2026-07-07T00:00:01",
+        )
+        for c in range(2)
+    ]
+    return meta, embeddings, edges, clusters, topics, characteristics, llm_topics
+
+
+class TestBuilders:
+    def test_core_artifact_keys_and_payloads(self):
+        meta, embeddings, edges, clusters, topics, *_ = _models()
+        artifacts = dict(
+            build_core_umap_artifacts(
+                meta, embeddings, edges, clusters, topics, chunk_size=2
+            )
+        )
+        assert set(artifacts) == {
+            "umap#meta",
+            "umap#embeddings#00000", "umap#embeddings#00001",
+            "umap#graph#00000", "umap#graph#00001",
+            "umap#assignments#00000", "umap#assignments#00001",
+            "umap#keywords#0",
+        }
+        assert artifacts["umap#meta"]["num_comments"] == 3
+        assert artifacts["umap#embeddings#00000"][0]["embedding"]["vector"] == [0.0, -0.0]
+        assert len(artifacts["umap#embeddings#00000"]) == 2
+        assert len(artifacts["umap#embeddings#00001"]) == 1
+        assert artifacts["umap#keywords#0"][0]["cluster_key"] == "layer0_0"
+
+    def test_features_and_topics_per_layer_and_cluster(self):
+        *_, characteristics, llm_topics = _models()
+        features = dict(build_features_artifacts(characteristics))
+        assert set(features) == {"umap#features#0"}
+        assert [row["cluster_id"] for row in features["umap#features#0"]] == [0, 1]
+        topics = dict(build_topic_artifacts(llm_topics))
+        assert set(topics) == {"umap#topic#0#0", "umap#topic#0#1"}
+        assert topics["umap#topic#0#1"]["topic_name"] == "Topic 1"
+        assert topics["umap#topic#0#1"]["topic_key"] == "job-x#0#1"
+
+
+class _FakeLegacy:
+    """Records calls; mimics DynamoDBStorage's result shape."""
+
+    def __init__(self):
+        self.calls = []
+
+    def _record(self, name, arg):
+        self.calls.append((name, arg))
+        return {"success": len(arg) if isinstance(arg, list) else 1, "failure": 0}
+
+    def create_conversation_meta(self, meta):
+        return self._record("meta", meta)
+
+    def batch_create_comment_embeddings(self, models):
+        return self._record("embeddings", models)
+
+    def batch_create_graph_edges(self, models):
+        return self._record("graph", models)
+
+    def batch_create_comment_clusters(self, models):
+        return self._record("clusters", models)
+
+    def batch_create_cluster_topics(self, models):
+        return self._record("topics", models)
+
+    def batch_create_cluster_characteristics(self, models):
+        return self._record("features", models)
+
+    def batch_create_llm_topic_names(self, models):
+        return self._record("llm", models)
+
+
+def _drive(storage):
+    meta, embeddings, edges, clusters, topics, characteristics, llm_topics = _models()
+    storage.create_conversation_meta(meta)
+    storage.batch_create_comment_embeddings(embeddings)
+    storage.batch_create_graph_edges(edges)
+    storage.batch_create_comment_clusters(clusters)
+    storage.batch_create_cluster_topics(topics)
+    storage.batch_create_cluster_characteristics(characteristics)
+    storage.batch_create_llm_topic_names(llm_topics)
+
+
+class TestDualWriteWrapper:
+    def test_both_mode_writes_both_sides_from_same_lists(self):
+        legacy = _FakeLegacy()
+        store = MemoryDelphiStore()
+        wrapper = DualWriteUmapStorage(
+            legacy, store=store, job_id="uj-1", write_mode=WriteMode.BOTH
+        )
+        _drive(wrapper)
+        assert [name for name, _ in legacy.calls] == [
+            "meta", "embeddings", "graph", "clusters", "topics", "features", "llm",
+        ]
+        sks = [item.sk for item in store.query_prefix("artifacts", "uj-1", "umap#")]
+        assert "umap#meta" in sks
+        assert any(sk.startswith("umap#embeddings#") for sk in sks)
+        assert "umap#keywords#0" in sks
+        assert "umap#features#0" in sks
+        assert "umap#topic#0#1" in sks
+
+    def test_v2_only_skips_legacy_and_synthesizes_results(self):
+        store = MemoryDelphiStore()
+        wrapper = DualWriteUmapStorage(
+            None, store=store, job_id="uj-2", write_mode=WriteMode.V2
+        )
+        meta, embeddings, *_ = _models()
+        result = wrapper.batch_create_comment_embeddings(embeddings)
+        assert result == {"success": 3, "failure": 0}
+        assert store.query_prefix("artifacts", "uj-2", "umap#embeddings#") != []
+
+    def test_both_mode_v2_failure_logged_not_raised(self):
+        legacy = _FakeLegacy()
+
+        class BrokenStore:
+            def put(self, *a, **k):
+                raise RuntimeError("store down")
+
+        wrapper = DualWriteUmapStorage(
+            legacy, store=BrokenStore(), job_id="uj-3", write_mode=WriteMode.BOTH
+        )
+        meta, embeddings, *_ = _models()
+        result = wrapper.batch_create_comment_embeddings(embeddings)
+        assert result["success"] == 3  # legacy result returned; no raise
+
+    def test_v2_mode_failure_raises(self):
+        class BrokenStore:
+            def put(self, *a, **k):
+                raise RuntimeError("store down")
+
+        wrapper = DualWriteUmapStorage(
+            None, store=BrokenStore(), job_id="uj-4", write_mode=WriteMode.V2
+        )
+        meta, *_ = _models()
+        with pytest.raises(RuntimeError):
+            wrapper.create_conversation_meta(meta)
+
+    def test_finalize_records_manifest_bookkeeping(self):
+        from delphi_storage.manifest import ensure_run, mark_running
+        from delphi_storage.models import JobType
+
+        store = MemoryDelphiStore()
+        ensure_run(store, job_id="uj-5", job_type=JobType.FULL_PIPELINE, zid=42)
+        mark_running(store, "uj-5")
+        wrapper = DualWriteUmapStorage(
+            None, store=store, job_id="uj-5", write_mode=WriteMode.V2
+        )
+        _drive(wrapper)
+        wrapper.finalize()
+        run = store.get_run("uj-5")
+        assert run.stage_status["umap"]["artifacts"] >= 7
+        assert store.query_prefix("artifacts", "uj-5", "log#") != []
+
+
+class TestFactory:
+    def test_old_mode_returns_plain_legacy(self, monkeypatch):
+        legacy = _FakeLegacy()
+        storage = make_umap_storage(legacy, job_id="j", write_mode=WriteMode.OLD)
+        assert storage is legacy  # zero-overhead passthrough
+
+    def test_both_mode_wraps(self):
+        legacy = _FakeLegacy()
+        store = MemoryDelphiStore()
+        storage = make_umap_storage(
+            legacy, job_id="j", write_mode=WriteMode.BOTH, store=store
+        )
+        assert isinstance(storage, DualWriteUmapStorage)
+
+    def test_v2_mode_needs_no_legacy(self):
+        store = MemoryDelphiStore()
+        storage = make_umap_storage(
+            None, job_id="j", write_mode=WriteMode.V2, store=store
+        )
+        assert isinstance(storage, DualWriteUmapStorage)
+
+
+class TestRunPipelineWiring:
+    def test_run_pipeline_uses_the_factory_and_gates_legacy(self):
+        """Source-level pin: the storage-init block routes through
+        make_umap_storage and old_writes_enabled (full e2e wiring is covered
+        by the verify test + CI)."""
+        import importlib
+
+        run_pipeline = importlib.import_module("run_pipeline")
+        import inspect
+
+        source = inspect.getsource(run_pipeline.process_conversation)
+        assert "make_umap_storage" in source
+        assert "old_writes_enabled" in source
+        assert "resolve_write_mode" in source
+
+
+class TestVerifyUmapDualWrite:
+    def _dynamo_available(self):
+        endpoint = os.environ.get("DYNAMODB_ENDPOINT", "http://localhost:8000")
+        import boto3
+        from botocore.config import Config as BotoConfig
+
+        try:
+            client = boto3.client(
+                "dynamodb", endpoint_url=endpoint, region_name="us-east-1",
+                aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", "dummy"),
+                aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", "dummy"),
+                config=BotoConfig(connect_timeout=3, read_timeout=3,
+                                  retries={"max_attempts": 0}),
+            )
+            client.list_tables(Limit=1)
+            return endpoint
+        except Exception as e:  # noqa: BLE001
+            if os.environ.get("GITHUB_ACTIONS") == "true":
+                pytest.fail(f"DynamoDB must be available in GitHub Actions: {e}")
+            pytest.skip(f"DynamoDB unavailable: {e}")
+
+    def test_verify_passes_then_catches_corruption(self, monkeypatch):
+        endpoint = self._dynamo_available()
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "dummy")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "dummy")
+        monkeypatch.setenv("DYNAMODB_ENDPOINT", endpoint)
+        import boto3
+
+        import create_dynamodb_tables as cdt
+        from polismath_commentgraph.utils.storage import DynamoDBStorage
+        from scripts.verify_dual_write import verify_umap_dual_write
+
+        resource = boto3.Session(region_name="us-east-1").resource(
+            "dynamodb", endpoint_url=endpoint
+        )
+        cdt.create_evoc_tables(resource)
+
+        legacy = DynamoDBStorage(region_name="us-east-1", endpoint_url=endpoint)
+        store = MemoryDelphiStore()
+        wrapper = DualWriteUmapStorage(
+            legacy, store=store, job_id="uvj-1", write_mode=WriteMode.BOTH
+        )
+        _drive(wrapper)
+
+        report = verify_umap_dual_write(
+            store, job_id="uvj-1", zid=ZID, endpoint_url=endpoint
+        )
+        assert report["ok"], report
+
+        # corrupt one v2 payload → must be caught
+        from delphi_storage.codec import encode_payload
+        from delphi_storage.models import StoreItem
+
+        item = store.get("artifacts", "uvj-1", "umap#meta")
+        payload = decode_payload(item.attributes, item.blob)
+        payload["num_comments"] = 999
+        enc = encode_payload(payload)
+        store.put("artifacts", StoreItem(pk="uvj-1", sk="umap#meta",
+                                         attributes=enc.meta, blob=enc.blob))
+        report = verify_umap_dual_write(
+            store, job_id="uvj-1", zid=ZID, endpoint_url=endpoint
+        )
+        assert not report["ok"]
+        assert any("meta" in mismatch for mismatch in report["mismatches"])

--- a/delphi/umap_narrative/run_pipeline.py
+++ b/delphi/umap_narrative/run_pipeline.py
@@ -1398,6 +1398,12 @@ def process_conversation(
     job_id = resolve_job_id(job_id)
     logger.info(f"Using job_id: {job_id} for this pipeline run.")
 
+    # Migration write mode, resolved up front (fail fast on misconfiguration
+    # — design §4.3; stages invoked directly bypass run_delphi's env export).
+    from delphi_storage.write_mode import old_writes_enabled, resolve_write_mode
+    write_mode = resolve_write_mode()
+    logger.info(f"Write mode: {write_mode.value}")
+
     conversation_id = str(zid)
     conversation_name = metadata.get("conversation_name", f"Conversation {zid}")
 
@@ -1406,16 +1412,27 @@ def process_conversation(
         process_comments(comments, conversation_id)
     )
 
-    # Initialize DynamoDB storage if requested
+    # Initialize storage if requested: the legacy DynamoDBStorage (old/both
+    # write modes) wrapped by the v2 dual-writer (both/v2) — the wrapper
+    # duck-types the seven write methods below, so every call site feeds the
+    # SAME model lists to both stores (Storage V2 P7c, design §6.1 M1).
     dynamo_storage = None
     if export_dynamo:
-        # Use endpoint from environment if available
-        raw_endpoint = os.environ.get("DYNAMODB_ENDPOINT")
-        endpoint_url = raw_endpoint if raw_endpoint and raw_endpoint.strip() else None
-        logger.info(f"Using DynamoDB endpoint from environment: {endpoint_url}")
-        region = os.environ.get("AWS_REGION", "us-east-1")
+        legacy_storage = None
+        if old_writes_enabled(write_mode):
+            # Use endpoint from environment if available
+            raw_endpoint = os.environ.get("DYNAMODB_ENDPOINT")
+            endpoint_url = raw_endpoint if raw_endpoint and raw_endpoint.strip() else None
+            logger.info(f"Using DynamoDB endpoint from environment: {endpoint_url}")
+            region = os.environ.get("AWS_REGION", "us-east-1")
 
-        dynamo_storage = DynamoDBStorage(region_name=region, endpoint_url=endpoint_url)
+            legacy_storage = DynamoDBStorage(region_name=region, endpoint_url=endpoint_url)
+
+        from v2_artifacts import make_umap_storage
+
+        dynamo_storage = make_umap_storage(
+            legacy_storage, job_id=job_id, write_mode=write_mode
+        )
 
         # Store basic data in DynamoDB
         logger.info(
@@ -1486,6 +1503,10 @@ def process_conversation(
         dynamo_storage=dynamo_storage,
         job_id=job_id,  # Pass job_id
     )
+
+    # Record the umap stage on the v2 run manifest (no-op for plain legacy)
+    if dynamo_storage is not None and hasattr(dynamo_storage, "finalize"):
+        dynamo_storage.finalize()
 
     # Save metadata
     with open(os.path.join(output_dir, f"{conversation_id}_metadata.json"), "w") as f:

--- a/delphi/umap_narrative/v2_artifacts.py
+++ b/delphi/umap_narrative/v2_artifacts.py
@@ -1,0 +1,284 @@
+"""Storage V2 artifact builder/writer for the UMAP 500s stage (P7c, design
+§4.2). Twin of polismath/database/v2_artifacts.py for the umap side.
+
+The dual-write seam is a duck-typed WRAPPER over the legacy DynamoDBStorage:
+run_pipeline calls the same seven write methods it always has, and the
+wrapper feeds the SAME already-materialized Pydantic model lists to both the
+legacy tables and the v2 artifact store. That guarantees the serialize-once
+invariant (P7b lesson: the models carry baked datetime fields —
+ConversationMeta.processed_date, LLMTopicName.created_at — so
+re-instantiating them for a second write path would tag the two stores
+differently, exactly the math_tick trap).
+
+Artifact keys (design §4.2): umap#meta, umap#embeddings#<chunk>,
+umap#graph#<chunk>, umap#assignments#<chunk>, umap#keywords#<layer>,
+umap#features#<layer>, umap#topic#<layer>#<cluster>.
+"""
+
+import json
+import logging
+from typing import Any, Optional
+
+from delphi_storage.codec import encode_payload
+from delphi_storage.interface import DelphiStore, NotFound
+from delphi_storage.models import StoreItem
+from delphi_storage.write_mode import WriteMode
+from polismath.database.v2_artifacts import _jsonable
+
+logger = logging.getLogger(__name__)
+
+#: Rows per chunk artifact. Embeddings rows are the fat ones (vector of
+#: hundreds of floats); graph/assignments rows are small. The backend
+#: byte-chunks any blob >300KB regardless — these bounds keep individual
+#: artifacts readable.
+EMBEDDINGS_CHUNK_SIZE = 500
+GRAPH_CHUNK_SIZE = 5000
+ASSIGNMENTS_CHUNK_SIZE = 5000
+
+
+def _chunked(rows: list, size: int) -> list:
+    return [rows[i : i + size] for i in range(0, max(len(rows), 1), size)]
+
+
+def _model_payload(model) -> dict:
+    """The SAME serialization the legacy path uses (storage.py):
+    model_dump_json with the Pydantic-v1 fallback — pre-Decimal values."""
+    try:
+        raw = model.model_dump_json()
+    except AttributeError:  # pydantic v1 models
+        raw = model.json()
+    return _jsonable(json.loads(raw))
+
+
+def _model_payloads(models) -> list:
+    return [_model_payload(model) for model in models]
+
+
+def build_core_umap_artifacts(
+    meta,
+    embedding_models,
+    edge_models,
+    cluster_models,
+    topic_models,
+    *,
+    chunk_size: Optional[int] = None,
+) -> list:
+    """(artifact_key, payload) pairs for the five core 500s outputs.
+    chunk_size overrides all three chunk sizes (tests); production uses the
+    per-kind defaults."""
+    artifacts: list = []
+    artifacts.append(("umap#meta", _model_payload(meta)))
+
+    for index, chunk in enumerate(
+        _chunked(_model_payloads(embedding_models), chunk_size or EMBEDDINGS_CHUNK_SIZE)
+    ):
+        artifacts.append((f"umap#embeddings#{index:05d}", chunk))
+    for index, chunk in enumerate(
+        _chunked(_model_payloads(edge_models), chunk_size or GRAPH_CHUNK_SIZE)
+    ):
+        artifacts.append((f"umap#graph#{index:05d}", chunk))
+    for index, chunk in enumerate(
+        _chunked(_model_payloads(cluster_models), chunk_size or ASSIGNMENTS_CHUNK_SIZE)
+    ):
+        artifacts.append((f"umap#assignments#{index:05d}", chunk))
+
+    by_layer: dict = {}
+    for payload in _model_payloads(topic_models):
+        by_layer.setdefault(payload.get("layer_id"), []).append(payload)
+    for layer_id in sorted(by_layer):
+        rows = sorted(by_layer[layer_id], key=lambda row: row.get("cluster_id", 0))
+        artifacts.append((f"umap#keywords#{layer_id}", rows))
+    return artifacts
+
+
+def build_features_artifacts(characteristic_models) -> list:
+    """umap#features#<layer> — one artifact per layer."""
+    by_layer: dict = {}
+    for payload in _model_payloads(characteristic_models):
+        by_layer.setdefault(payload.get("layer_id"), []).append(payload)
+    return [
+        (
+            f"umap#features#{layer_id}",
+            sorted(by_layer[layer_id], key=lambda row: row.get("cluster_id", 0)),
+        )
+        for layer_id in sorted(by_layer)
+    ]
+
+
+def build_topic_artifacts(llm_topic_models) -> list:
+    """umap#topic#<layer>#<cluster> — one artifact per LLM topic name."""
+    return [
+        (f"umap#topic#{payload.get('layer_id')}#{payload.get('cluster_id')}", payload)
+        for payload in _model_payloads(llm_topic_models)
+    ]
+
+
+class DualWriteUmapStorage:
+    """Duck-typed stand-in for DynamoDBStorage's seven write methods used by
+    run_pipeline (and ONLY those — anything else raises loudly). Writes the
+    legacy tables through the wrapped storage (when present) and the v2
+    artifacts from the same model lists, per DELPHI_WRITE_MODE policy:
+    both → v2 failures logged, never raised (old path keeps serving);
+    v2 → raised (there is no old copy)."""
+
+    def __init__(
+        self,
+        legacy_storage,
+        *,
+        store: DelphiStore,
+        job_id: str,
+        write_mode: WriteMode,
+    ) -> None:
+        self._legacy = legacy_storage
+        self._store = store
+        self._job_id = job_id
+        self._write_mode = write_mode
+        self._artifact_count = 0
+
+    # ---- v2 side ----
+
+    def _write_artifacts(self, artifacts) -> None:
+        try:
+            for artifact_key, payload in artifacts:
+                encoded = encode_payload(payload)
+                self._store.put(
+                    "artifacts",
+                    StoreItem(
+                        pk=self._job_id,
+                        sk=artifact_key,
+                        attributes=encoded.meta,
+                        blob=encoded.blob,
+                    ),
+                )
+                self._artifact_count += 1
+        except Exception as e:
+            if self._write_mode is WriteMode.V2:
+                raise
+            logger.error(
+                f"v2 umap artifact write failed for job {self._job_id} "
+                f"(write mode 'both': old path keeps serving): {e}"
+            )
+
+    def _result(self, legacy_result, models) -> dict:
+        if legacy_result is not None:
+            return legacy_result
+        count = len(models) if isinstance(models, list) else 1
+        return {"success": count, "failure": 0}
+
+    # ---- the seven legacy write methods, same signatures ----
+
+    def create_conversation_meta(self, meta):
+        legacy_result = (
+            self._legacy.create_conversation_meta(meta) if self._legacy else None
+        )
+        self._write_artifacts([("umap#meta", _model_payload(meta))])
+        return self._result(legacy_result, meta)
+
+    def batch_create_comment_embeddings(self, models):
+        legacy_result = (
+            self._legacy.batch_create_comment_embeddings(models) if self._legacy else None
+        )
+        self._write_artifacts(
+            (f"umap#embeddings#{i:05d}", chunk)
+            for i, chunk in enumerate(
+                _chunked(_model_payloads(models), EMBEDDINGS_CHUNK_SIZE)
+            )
+        )
+        return self._result(legacy_result, models)
+
+    def batch_create_graph_edges(self, models):
+        legacy_result = (
+            self._legacy.batch_create_graph_edges(models) if self._legacy else None
+        )
+        self._write_artifacts(
+            (f"umap#graph#{i:05d}", chunk)
+            for i, chunk in enumerate(_chunked(_model_payloads(models), GRAPH_CHUNK_SIZE))
+        )
+        return self._result(legacy_result, models)
+
+    def batch_create_comment_clusters(self, models):
+        legacy_result = (
+            self._legacy.batch_create_comment_clusters(models) if self._legacy else None
+        )
+        self._write_artifacts(
+            (f"umap#assignments#{i:05d}", chunk)
+            for i, chunk in enumerate(
+                _chunked(_model_payloads(models), ASSIGNMENTS_CHUNK_SIZE)
+            )
+        )
+        return self._result(legacy_result, models)
+
+    def batch_create_cluster_topics(self, models):
+        legacy_result = (
+            self._legacy.batch_create_cluster_topics(models) if self._legacy else None
+        )
+        by_layer: dict = {}
+        for payload in _model_payloads(models):
+            by_layer.setdefault(payload.get("layer_id"), []).append(payload)
+        self._write_artifacts(
+            (
+                f"umap#keywords#{layer_id}",
+                sorted(by_layer[layer_id], key=lambda row: row.get("cluster_id", 0)),
+            )
+            for layer_id in sorted(by_layer)
+        )
+        return self._result(legacy_result, models)
+
+    def batch_create_cluster_characteristics(self, models):
+        legacy_result = (
+            self._legacy.batch_create_cluster_characteristics(models)
+            if self._legacy
+            else None
+        )
+        self._write_artifacts(build_features_artifacts(models))
+        return self._result(legacy_result, models)
+
+    def batch_create_llm_topic_names(self, models):
+        legacy_result = (
+            self._legacy.batch_create_llm_topic_names(models) if self._legacy else None
+        )
+        self._write_artifacts(build_topic_artifacts(models))
+        return self._result(legacy_result, models)
+
+    # ---- manifest bookkeeping ----
+
+    def finalize(self) -> None:
+        """Record stage status + a log line on the run manifest (best-effort:
+        standalone runs may have no manifest row)."""
+        try:
+            self._store.merge_run_fields(
+                self._job_id, {"stage_status": {"umap": {"artifacts": self._artifact_count}}}
+            )
+            self._store.append_log(
+                self._job_id, f"umap stage wrote {self._artifact_count} v2 artifacts"
+            )
+        except NotFound:
+            logger.info(
+                f"No run manifest for job {self._job_id!r} (standalone run) — "
+                f"umap artifacts written without manifest bookkeeping"
+            )
+        except Exception as e:
+            if self._write_mode is WriteMode.V2:
+                raise
+            logger.error(f"umap manifest bookkeeping failed for {self._job_id}: {e}")
+
+
+def make_umap_storage(
+    legacy_storage,
+    *,
+    job_id: str,
+    write_mode: WriteMode,
+    store: Optional[DelphiStore] = None,
+):
+    """The storage stack for (legacy_storage, write_mode): plain legacy in
+    old mode (zero overhead, byte-identical behavior), the dual-write wrapper
+    otherwise. `store` defaults to the configured v2 store."""
+    if write_mode is WriteMode.OLD:
+        return legacy_storage
+    if store is None:
+        from delphi_storage import get_store
+
+        store = get_store()
+    return DualWriteUmapStorage(
+        legacy_storage, store=store, job_id=job_id, write_mode=write_mode
+    )


### PR DESCRIPTION
Stack 2 / P7c of the Storage V2 effort (design in #2597, §4.2 + §6.1 M1 + §7): the **UMAP 500s stage-group dual-write** — all seven stage outputs become v2 artifacts alongside the legacy tables, gated by `DELPHI_WRITE_MODE`, with the verifier extended to cover them.

**Stacked on #2605** (`jc/delphi-storage-v2-p7b`).

## The seam: a duck-typed wrapper, not seven edits

Unlike math (one funnel), the 500s stage writes through **seven** `DynamoDBStorage` method calls. The seam is `DualWriteUmapStorage` (`umap_narrative/v2_artifacts.py`): it duck-types exactly those seven methods, so **all seven call sites in `run_pipeline.py` are untouched** — the wrapper feeds the *same already-materialized Pydantic model lists* to the legacy tables and the v2 artifact store.

That makes the P7b serialize-once lesson hold **by construction**: the models carry baked `datetime.now()` fields (`ConversationMeta.processed_date`, `LLMTopicName.created_at`); re-instantiating them for a second write path would tag the two stores differently — the math_tick trap all over again.

Artifact keys per design §4.2: `umap#meta`, `umap#embeddings#<chunk>` (500/chunk — the fat vector rows), `umap#graph#<chunk>`, `umap#assignments#<chunk>` (5000/chunk), `umap#keywords#<layer>`, `umap#features#<layer>`, `umap#topic#<layer>#<cluster>` (the job-id-versioned LLM names; note the legacy model silently drops its `job_id` kwarg — only `topic_key` carries it, mirrored as-is).

- `make_umap_storage`: `old` mode returns the **plain** legacy storage (zero overhead, byte-identical); `both`/`v2` return the wrapper (v2-only runs with no legacy inner).
- Failure policy: `both` → v2 failures logged, never raised; `v2` → raised.
- `finalize()` records `stage_status.umap` + a log line on the run manifest (best-effort for manifest-less standalone runs).
- `run_pipeline.py`: write mode resolved **up front** (fail-fast — before `process_comments` and all writes, per the P7b lesson); the legacy client is constructed only when old writes are enabled.

## Verifier extension

`verify_umap_dual_write` in `scripts/verify_dual_write.py` — independent reads of the seven `conversation_id`-keyed legacy tables vs the decoded `umap#` artifacts, numeric-tolerant. **Same-run comparisons only**: EVōC cluster ids are not stable across runs (unseeded until P8), but both writers consume the same in-memory arrays within a run, so parity holds by construction. CLI gains `--stage math|umap|all`.

## Testing (TDD — 12 tests written first, RED on missing module)

Builders (chunking, per-layer grouping, per-cluster topic keys) from real Pydantic models; wrapper semantics (same-list dual writes, v2-only synthesis of the legacy result shape, both failure policies, manifest finalize); factory matrix; a source-level wiring pin on `process_conversation`; and an end-to-end parity test against real DynamoDB local — legacy write via the **real** `DynamoDBStorage` (tables created by the real `create_evoc_tables`), verify passes; corrupt `umap#meta`, verify catches it.

Full suite: **493 passed, 60 skipped, 58 xfailed** (5 pre-existing DynamoDB-unavailable errors unchanged). Golden snapshots ran and passed — write-side only.

## Stack

- P1 #2597 … P7a #2604 · P7b #2605
- **P7c: this PR**
- Next: P7d — 801/803 narrative dual-write (`narrative#<section>#<model>` artifacts, manifest mirroring for the narrative job types, numeric-rid resolution), then P7e 501/502/700 (`priorities` artifact kills the in-place mutation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
