### PR TITLE
fix(math): clamp subgroup-k-smoother smoothed-k to available clusterings (#2575)

### DIFF
--- a/math/src/polismath/math/conversation.clj
+++ b/math/src/polismath/math/conversation.clj
@@ -549,13 +549,21 @@
                     ; if seen > buffer many times, switch, OW, take last smoothed
                     smoothed-k   (if (>= this-k-count count-buffer)
                                    this-k
-                                   (if smoothed-k smoothed-k this-k))]
+                                   (if smoothed-k smoothed-k this-k))
+                    ; Clamp: if smoothed-k no longer exists in THIS group's current
+                    ; subgroup clusterings (e.g. the group's base-cluster count shrank,
+                    ; lowering M), fall back to the best available k by silhouette.
+                    ; Mirrors the group-k-smoother clamp added in #2536; see issue #2575.
+                    clamped-smoothed-k
+                                 (if (contains? group-subgroup-clusterings smoothed-k)
+                                   smoothed-k
+                                   this-k)]
                 ;; We return a map of key-value pairs that look like this:
                 ;; This is maybe where we could put information about whether the last count matches for the sake of subgroups...
                 [gid
                  {:last-k       this-k
                   :last-k-count this-k-count
-                  :smoothed-k   smoothed-k}]))
+                  :smoothed-k   clamped-smoothed-k}]))
             subgroup-clusterings)))
 
       ;; This is a little different from the group version above;

--- a/math/test/conv_edge_cases_test.clj
+++ b/math/test/conv_edge_cases_test.clj
@@ -99,6 +99,56 @@
 
 
 ;; ============================================================================
+;; Bug 2b: stale smoothed-k in :subgroup-k-smoother (issue #2575)
+;;
+;; The identical bug as Bug 2, one level down. #2536 clamped smoothed-k in
+;; group-k-smoother but NOT in :subgroup-k-smoother. A group's subgroup
+;; clustering runs k-means for k in (range 2 (inc M)), where M is count-based
+;; on the group's base-cluster count. When group membership drops below a /12
+;; boundary, M falls; the carried smoothed-k can exceed M; and downstream
+;; (get group-subgroup-clusterings smoothed-k) returns nil → an empty subgroup
+;; clustering → conv-repness crash. The fix mirrors #2536: clamp the carried
+;; smoothed-k to a key that exists in THIS group's current subgroup clusterings.
+;; ============================================================================
+
+(deftest stale-subgroup-smoothed-k-is-clamped-to-available-subgroup-clusters
+  (testing "subgroup smoothed-k is clamped per group so subgroup-clusters stays non-nil"
+    ;; Simulate: a group :g0 whose previous subgroup smoothed-k was 5, but whose
+    ;; current base-cluster count only supports subgroup k=2,3 (M stepped down).
+    (let [gid :g0
+          ;; Minimal subgroup clusterings for k=2 and k=3 for this group
+          dummy-clustering-k2 [{:id 0 :members [:b1]} {:id 1 :members [:b2]}]
+          dummy-clustering-k3 [{:id 0 :members [:b1]} {:id 1 :members [:b2]} {:id 2 :members []}]
+          group-subgroup-clusterings {2 dummy-clustering-k2
+                                      3 dummy-clustering-k3}
+          subgroup-clusterings {gid group-subgroup-clusterings}
+          ;; Best available k by silhouette is 3; but buffer hasn't been exceeded,
+          ;; so the smoother preserves the (stale) old smoothed-k of 5.
+          subgroup-clusterings-silhouettes {gid {2 0.6, 3 0.8}}
+          old-smoother {:last-k 5 :last-k-count 1 :smoothed-k 5}
+          smoother-fnk (:subgroup-k-smoother conversation/small-conv-update-graph)
+          new-smoother (smoother-fnk
+                         {:conv {:subgroup-k-smoother {gid old-smoother}}
+                          :subgroup-clusterings subgroup-clusterings
+                          :subgroup-clusterings-silhouettes subgroup-clusterings-silhouettes
+                          :opts' {:group-k-buffer 4}})
+          smoothed-k (get-in new-smoother [gid :smoothed-k])
+          ;; Downstream :subgroup-clusters does exactly this lookup per group.
+          subgroup-clusters (get group-subgroup-clusterings smoothed-k)]
+
+      ;; With the current (unfixed) code, smoothed-k stays at 5 and the lookup returns nil.
+      ;; After the fix, smoothed-k should be clamped to an available k.
+      (testing "smoothed-k should be a key that exists in this group's subgroup clusterings"
+        (is (contains? group-subgroup-clusterings smoothed-k)
+            (str "smoothed-k=" smoothed-k
+                 " not in " (keys group-subgroup-clusterings))))
+
+      (testing "subgroup-clusters lookup should not be nil"
+        (is (some? subgroup-clusters)
+            "subgroup-clusters lookup must not return nil")))))
+
+
+;; ============================================================================
 ;; Bug 3 (colleague's fix): agg-bucket-votes-for-tid with unknown pids
 ;;
 ;; When base-cluster members include pids not present in the rating matrix


### PR DESCRIPTION
## Summary

Fixes #2575. PR #2536 clamped `smoothed-k` in `group-k-smoother`, but the identical bug remained one level down in `:subgroup-k-smoother` — which #2536 did not touch. This applies the same clamp to the subgroup smoother.

**Root cause** (same chain as #2536, one level down): a group's subgroup clustering runs k-means for `k ∈ (range 2 (inc M))`, where `M` is count-based on the group's base-cluster count (`M = min(max-k, 2 + ⌊#base-clusters/12⌋)`). The `:subgroup-k-smoother` carries `smoothed-k` forward across ticks (anti-flap) **without clamping to the current keys**. When a group's membership drops below a `/12` boundary, `M` falls; the carried `smoothed-k` can exceed `M`; `(get group-subgroup-clusterings smoothed-k)` returns `nil` → `(map f nil)` → `()` — an empty subgroup clustering → `conv-repness` crashes. On post-#2536 `master`, #2536's guard turns this into a *clear* `IllegalArgumentException` ("group-clusters is nil or empty"), but `conv-update` still fails — the guard makes it legible, it doesn't prevent the empty clustering.

Reported by @lgelauff, reproduced via warm-path replay across 50+ public openData conversations.

## Change

`math/src/polismath/math/conversation.clj`, `:subgroup-k-smoother` — mirror #2536's group-level clamp into the per-group `smoothed-k` computation:

```clojure
;; clamp the carried smoothed-k to a key that exists in THIS group's current clusterings
clamped-smoothed-k (if (contains? group-subgroup-clusterings smoothed-k) smoothed-k this-k)
```

`this-k` is always a valid key (chosen from the current keys); when `M` drops, the group genuinely supports fewer subclusters, so `smoothed-k` should follow it down.

## Test plan

- [x] New regression test `stale-subgroup-smoothed-k-is-clamped-to-available-subgroup-clusters` in `conv_edge_cases_test.clj`, mirroring the existing group-level `stale-smoothed-k-is-clamped-to-available-group-clusters`. Verified RED before the fix (`smoothed-k=5 not in (2 3)`, downstream lookup → nil), GREEN after.
- [x] Full math test suite: **53 tests, 150 assertions, 0 failures, 0 errors** (baseline was 52/148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
