### PR TITLE
docs(delphi): note subgroup-k-smoother clamp for D3 port (#2575)

### DIFF
--- a/delphi/docs/PLAN_DISCREPANCY_FIXES.md
+++ b/delphi/docs/PLAN_DISCREPANCY_FIXES.md
@@ -363,6 +363,20 @@ If we discover that cold-start fixes can't be completed without warm-start testi
 2. Incremental: feed votes in batches, assert k stability
 3. Fix: Add `group_k_smoother` state with buffer=4
 
+**⚠️ Port BOTH smoother levels WITH the stale-k clamp.** Clojure has two
+k-smoothers: `group-k-smoother` AND, one level down, a per-group
+`:subgroup-k-smoother`. Both carry a `smoothed-k` forward across ticks (anti-flap)
+and both must **clamp it to a key that still exists in the current clusterings** —
+otherwise, when a group's base-cluster count drops below a `/12` boundary the
+available k-range (`M`) shrinks, the carried `smoothed-k` falls out of range, the
+`get`-by-k returns nil, and downstream `conv-repness` crashes on an empty
+clustering. Clojure fixed the group level in #2536 and the subgroup level in #2575
+(`jc/subgroup-k-smoother-clamp`): `smoothed-k = smoothed-k if (contains? clusterings
+smoothed-k) else this-k`. When porting D3, replicate the clamp at **both** levels —
+do not port the pre-#2536 unclamped logic. See `math/.../conversation.clj`
+`:group-k-smoother` / `:subgroup-k-smoother` and `math/test/conv_edge_cases_test.clj`
+for the reference tests.
+
 ---
 
 ### PR 11: Fix D12 — Comment Priorities


### PR DESCRIPTION
## Summary

Adds a porting note to the D3 (k-smoother buffer) section of `PLAN_DISCREPANCY_FIXES.md`, following the Clojure fix in #2609 (issue #2575).

When D3 is eventually ported to the Python/delphi pipeline, **both** k-smoother levels must carry the stale-`smoothed-k` clamp — the group-level `group-k-smoother` (Clojure fix #2536) **and** the per-group `:subgroup-k-smoother` (Clojure fix #2609 / #2575). Without the clamp at both levels, a group whose base-cluster count drops below a `/12` boundary can carry a `smoothed-k` that no longer exists in the current clusterings, producing an empty clustering that crashes `conv-repness`. The note points at the reference implementation and tests so this isn't re-discovered as a crash during the port.

Docs-only; no code changes.

## Related

- Clojure fix (subgroup clamp): #2609
- Issue: #2575
- Prior group-level Clojure fix: #2536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
