### PR TITLE
python-math #15: feat(delphi): Clojure timing probe (Spec C)

### DIFF
--- a/delphi/scripts/clj_timing_probe.py
+++ b/delphi/scripts/clj_timing_probe.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Clojure timing probe (Spec C) — empirical runtime-vs-size measurement for
+the Clojure Mode A replay driver (``math/dev/replay.clj``), used to set the
+size cutoff for a parity-certification battery.
+
+For each requested vote-count N (capped at the dataset size), this:
+
+  1. writes a truncated votes CSV (first N data rows, header preserved) to a
+     temp dir,
+  2. writes a single-cut vote-count schedule (``{"mode": "vote-count", "at":
+     ["end"]}``, ``warm_start: chain``, ``schedule_id: probe-<N>``),
+  3. runs the Clojure driver as a subprocess (``cwd=math/``) and records
+     wall-clock seconds (subprocess only) and whether it produced a final
+     step blob.
+
+JVM startup is a fixed cost baked into every run; it is estimated from the
+smallest size probed (compute time is assumed negligible there) and used as
+the intercept ``a`` in a fitted ``runtime ~ a + b * N^k`` power-law model
+(log-log least squares on the successful runs). The fit is then inverted to
+recommend the largest N that stays within ``--budget-min`` minutes.
+
+Usage (from delphi/)::
+
+    uv run python scripts/clj_timing_probe.py probe \\
+        --votes real_data/*-vw/*-votes.csv \\
+        --sizes 500,1000,2000,4000 --budget-min 10
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Sequence
+
+import click
+import numpy as np
+
+# scripts/ -> delphi/ -> repo root
+DELPHI_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = DELPHI_ROOT.parent
+MATH_DIR = REPO_ROOT / "math"
+
+DEFAULT_SIZES = "500,1000,2000,5000"
+DEFAULT_BUDGET_MIN = 10.0
+DEFAULT_TIMEOUT_SEC = 900.0  # generous: first clojure invocation downloads maven deps
+
+
+# ---------------------------------------------------------------------------
+# Data shapes.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ProbeResult:
+    size: int
+    seconds: float | None
+    ok: bool
+    error: str | None = None
+
+
+@dataclass
+class FitResult:
+    a_est: float | None
+    b: float | None
+    k: float | None
+    n_fit_points: int
+
+
+# ---------------------------------------------------------------------------
+# Dataset discovery.
+# ---------------------------------------------------------------------------
+
+def default_votes_path() -> Path | None:
+    """First ``delphi/real_data/*-vw/*-votes.csv`` found, sorted for determinism."""
+    candidates = sorted(DELPHI_ROOT.glob("real_data/*-vw/*-votes.csv"))
+    return candidates[0] if candidates else None
+
+
+def infer_dataset_slug(votes_path: Path) -> str:
+    """Dataset slug from the export dir name, e.g. ``r6vbnh...-vw`` -> ``vw``."""
+    parent = votes_path.resolve().parent.name
+    if "-" in parent:
+        return parent.rsplit("-", 1)[-1]
+    return parent
+
+
+def count_data_rows(path: Path) -> int:
+    """Number of data rows in an export votes CSV (excludes the header)."""
+    with path.open("r", newline="") as f:
+        reader = csv.reader(f)
+        next(reader, None)
+        return sum(1 for _ in reader)
+
+
+# ---------------------------------------------------------------------------
+# Size list parsing.
+# ---------------------------------------------------------------------------
+
+def parse_sizes(spec: str, n_max: int) -> list[int]:
+    """Parse a comma-separated size list, capped at ``n_max``, deduped, ascending."""
+    sizes: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        n = int(part)
+        if n <= 0:
+            raise ValueError(f"size must be positive, got {n}")
+        sizes.add(min(n, n_max))
+    return sorted(sizes)
+
+
+# ---------------------------------------------------------------------------
+# Per-size input generation.
+# ---------------------------------------------------------------------------
+
+def truncate_votes_csv(src: Path, n: int, dest: Path) -> int:
+    """Write the header + first ``n`` data rows of ``src`` (FILE order, no
+    resort) to ``dest``. Returns the number of data rows actually written
+    (may be < n if the source has fewer rows)."""
+    with src.open("r", newline="") as fsrc, dest.open("w", newline="") as fdst:
+        reader = csv.reader(fsrc)
+        writer = csv.writer(fdst)
+        header = next(reader)
+        writer.writerow(header)
+        written = 0
+        for row in reader:
+            if written >= n:
+                break
+            writer.writerow(row)
+            written += 1
+    return written
+
+
+def build_schedule(dataset: str, size: int) -> dict:
+    """A single-cut vote-count schedule that closes the whole (truncated) file."""
+    return {
+        "dataset": dataset,
+        "schedule_id": f"probe-{size}",
+        "source": "votes-csv",
+        "cuts": {"mode": "vote-count", "at": ["end"]},
+        "moderation": "none",
+        "clojure": {"warm_start": "chain"},
+        "notes": f"clj_timing_probe size={size}",
+    }
+
+
+def write_schedule_json(schedule: dict, dest: Path) -> None:
+    dest.write_text(json.dumps(schedule))
+
+
+def find_final_blob(out_dir: Path) -> Path | None:
+    """Last ``clj/step-*.blob.json`` under ``out_dir``, or None if absent."""
+    clj_dir = out_dir / "clj"
+    if not clj_dir.is_dir():
+        return None
+    blobs = sorted(clj_dir.glob("step-*.blob.json"))
+    return blobs[-1] if blobs else None
+
+
+# ---------------------------------------------------------------------------
+# Subprocess invocation (patchable seam for tests).
+# ---------------------------------------------------------------------------
+
+def _invoke_clojure(cmd: list[str], cwd: Path, timeout: float) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd, cwd=str(cwd), capture_output=True, text=True, timeout=timeout
+    )
+
+
+InvokeFn = Callable[[list[str], Path, float], subprocess.CompletedProcess]
+
+
+def run_probe_size(
+    size: int,
+    votes_src: Path,
+    *,
+    dataset: str,
+    math_dir: Path,
+    timeout: float,
+    invoke: InvokeFn = _invoke_clojure,
+) -> ProbeResult:
+    """Truncate votes, write a schedule, run the clojure driver once, and
+    record wall-clock seconds (subprocess only) + whether a final step blob
+    was produced."""
+    with tempfile.TemporaryDirectory(prefix=f"clj-timing-{size}-") as tmp:
+        tmp_path = Path(tmp)
+        votes_path = tmp_path / "votes.csv"
+        truncate_votes_csv(votes_src, size, votes_path)
+
+        schedule = build_schedule(dataset, size)
+        schedule_path = tmp_path / "schedule.json"
+        write_schedule_json(schedule, schedule_path)
+
+        out_dir = tmp_path / "out"
+        cmd = [
+            "clojure", "-M:replay",
+            "--schedule", str(schedule_path),
+            "--votes", str(votes_path),
+            "--out", str(out_dir),
+        ]
+
+        t0 = time.perf_counter()
+        try:
+            proc = invoke(cmd, math_dir, timeout)
+        except subprocess.TimeoutExpired:
+            elapsed = time.perf_counter() - t0
+            return ProbeResult(
+                size=size, seconds=elapsed, ok=False,
+                error=f"timeout after {timeout}s",
+            )
+        except OSError as exc:
+            elapsed = time.perf_counter() - t0
+            return ProbeResult(size=size, seconds=elapsed, ok=False, error=str(exc))
+        elapsed = time.perf_counter() - t0
+
+        blob = find_final_blob(out_dir)
+        if proc.returncode != 0:
+            return ProbeResult(
+                size=size, seconds=elapsed, ok=False,
+                error=f"returncode={proc.returncode}: {proc.stderr[-500:]}",
+            )
+        if blob is None:
+            return ProbeResult(
+                size=size, seconds=elapsed, ok=False,
+                error="no final step blob produced",
+            )
+        return ProbeResult(size=size, seconds=elapsed, ok=True, error=None)
+
+
+def run_all(
+    sizes: list[int],
+    votes_src: Path,
+    *,
+    dataset: str,
+    math_dir: Path,
+    timeout: float,
+    invoke: InvokeFn = _invoke_clojure,
+) -> list[ProbeResult]:
+    """Run ``run_probe_size`` for each size, in the order given (caller sorts)."""
+    return [
+        run_probe_size(n, votes_src, dataset=dataset, math_dir=math_dir,
+                        timeout=timeout, invoke=invoke)
+        for n in sizes
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fit: runtime ~ a + b * N^k.
+# ---------------------------------------------------------------------------
+
+def fit_power_law(sizes: Sequence[int], seconds: Sequence[float]) -> FitResult:
+    """Fit ``t ~ a_est + b * N^k`` on (sizes, seconds).
+
+    ``a_est`` (the JVM-startup fixed cost) is taken directly from the
+    smallest size's wall time — compute time is assumed negligible there.
+    ``b`` and ``k`` come from a log-log least-squares fit of
+    ``log(t - a_est) ~ k * log(N) + log(b)`` over the remaining points whose
+    residual is strictly positive. Needs >= 2 such points (i.e. >= 3 sizes
+    total) or the fit is left unset (``b = k = None``).
+    """
+    if not sizes:
+        raise ValueError("fit_power_law requires at least one data point")
+    if len(sizes) != len(seconds):
+        raise ValueError("sizes and seconds must be the same length")
+
+    pairs = sorted(zip(sizes, seconds), key=lambda p: p[0])
+    sizes_sorted = [p[0] for p in pairs]
+    seconds_sorted = [p[1] for p in pairs]
+    a_est = float(seconds_sorted[0])
+
+    xs: list[float] = []
+    ys: list[float] = []
+    for n, t in zip(sizes_sorted[1:], seconds_sorted[1:]):
+        diff = t - a_est
+        if diff > 1e-9 and n > 0:
+            xs.append(math.log(n))
+            ys.append(math.log(diff))
+
+    if len(xs) < 2:
+        return FitResult(a_est=a_est, b=None, k=None, n_fit_points=len(xs))
+
+    slope, intercept = np.polyfit(xs, ys, 1)
+    k = float(slope)
+    b = float(math.exp(intercept))
+    return FitResult(a_est=a_est, b=b, k=k, n_fit_points=len(xs))
+
+
+def recommend_max_votes(fit: FitResult, budget_min: float) -> int | None:
+    """Invert ``a_est + b * N^k = budget_min * 60`` for N. None if the fit is
+    unavailable, non-increasing (k <= 0), or the fixed cost alone already
+    exceeds the budget."""
+    if fit.k is None or fit.b is None or fit.a_est is None:
+        return None
+    if fit.k <= 0 or fit.b <= 0:
+        return None
+    budget_s = budget_min * 60.0
+    target = budget_s - fit.a_est
+    if target <= 0:
+        return None
+    n = (target / fit.b) ** (1.0 / fit.k)
+    if not math.isfinite(n) or n <= 0:
+        return None
+    return int(round(n))
+
+
+# ---------------------------------------------------------------------------
+# Reporting.
+# ---------------------------------------------------------------------------
+
+def format_report_lines(
+    results: list[ProbeResult], fit: FitResult, recommended: int | None,
+    budget_min: float,
+) -> list[str]:
+    """One line per size, then a fit line, then a recommendation line."""
+    lines: list[str] = []
+    for r in results:
+        secs = "NA" if r.seconds is None else f"{r.seconds:.2f}"
+        status = "ok" if r.ok else f"fail ({r.error})"
+        lines.append(f"size={r.size} seconds={secs} status={status}")
+
+    if fit.k is not None and fit.b is not None:
+        lines.append(
+            f"fit: a_est(jvm_startup)={fit.a_est:.2f}s b={fit.b:.3e} "
+            f"k={fit.k:.3f} (n_fit_points={fit.n_fit_points})"
+        )
+    else:
+        a_str = "NA" if fit.a_est is None else f"{fit.a_est:.2f}s"
+        lines.append(f"fit: a_est(jvm_startup)={a_str} b=NA k=NA (insufficient data points)")
+
+    if recommended is not None:
+        lines.append(f"recommended_max_votes~={recommended} for budget={budget_min:g}min")
+    else:
+        lines.append(f"recommended_max_votes=NA for budget={budget_min:g}min (insufficient data)")
+
+    return lines
+
+
+def build_report(
+    *, votes_path: Path, dataset: str, dataset_size: int, budget_min: float,
+    timeout_sec: float, results: list[ProbeResult], fit: FitResult,
+    recommended: int | None,
+) -> dict:
+    return {
+        "votes_path": str(votes_path),
+        "dataset": dataset,
+        "dataset_size": dataset_size,
+        "budget_min": budget_min,
+        "timeout_sec": timeout_sec,
+        "sizes": [r.size for r in results],
+        "seconds": [r.seconds for r in results],
+        "ok": [r.ok for r in results],
+        "errors": [r.error for r in results],
+        "fit": asdict(fit),
+        "jvm_startup_estimate_sec": fit.a_est,
+        "recommended_max_votes": recommended,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+@click.group()
+def cli() -> None:
+    """Clojure timing probe (Spec C) — runtime-vs-size measurement + fit."""
+
+
+@cli.command()
+@click.option(
+    "--votes", "votes_path", type=click.Path(exists=True, path_type=Path), default=None,
+    help="Votes CSV (default: first delphi/real_data/*-vw/*-votes.csv found).",
+)
+@click.option(
+    "--sizes", default=DEFAULT_SIZES, show_default=True,
+    help="Comma-separated vote-count sizes to probe (capped at dataset size).",
+)
+@click.option(
+    "--out", "out_path", type=click.Path(path_type=Path), default=None,
+    help="Output JSON path (default: real_data/.local/replays/timing_probe.json).",
+)
+@click.option(
+    "--budget-min", type=float, default=DEFAULT_BUDGET_MIN, show_default=True,
+    help="Target wall-clock budget (minutes) used for the N extrapolation.",
+)
+@click.option(
+    "--timeout-sec", type=float, default=DEFAULT_TIMEOUT_SEC, show_default=True,
+    help="Per-run subprocess timeout (generous: first clojure invocation "
+         "downloads maven deps).",
+)
+@click.option(
+    "--dataset", default=None,
+    help="Dataset slug recorded in the schedule (default: inferred from --votes).",
+)
+def probe(votes_path, sizes, out_path, budget_min, timeout_sec, dataset) -> None:
+    """Run the Clojure driver at increasing sizes and fit a runtime model."""
+    if votes_path is None:
+        votes_path = default_votes_path()
+        if votes_path is None:
+            raise click.UsageError(
+                "no --votes given and no delphi/real_data/*-vw/*-votes.csv found"
+            )
+    votes_path = Path(votes_path)
+
+    if dataset is None:
+        dataset = infer_dataset_slug(votes_path)
+
+    if out_path is None:
+        out_path = DELPHI_ROOT / "real_data" / ".local" / "replays" / "timing_probe.json"
+    out_path = Path(out_path)
+
+    n_max = count_data_rows(votes_path)
+    size_list = parse_sizes(sizes, n_max)
+    if not size_list:
+        raise click.UsageError("no sizes to probe")
+
+    results = run_all(
+        size_list, votes_path, dataset=dataset, math_dir=MATH_DIR, timeout=timeout_sec,
+    )
+
+    ok_sizes = [r.size for r in results if r.ok]
+    ok_seconds = [r.seconds for r in results if r.ok]
+    if ok_sizes:
+        fit = fit_power_law(ok_sizes, ok_seconds)
+    else:
+        fit = FitResult(a_est=None, b=None, k=None, n_fit_points=0)
+
+    recommended = recommend_max_votes(fit, budget_min)
+
+    for line in format_report_lines(results, fit, recommended, budget_min):
+        click.echo(line)
+
+    report = build_report(
+        votes_path=votes_path, dataset=dataset, dataset_size=n_max,
+        budget_min=budget_min, timeout_sec=timeout_sec, results=results,
+        fit=fit, recommended=recommended,
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, indent=2))
+    click.echo(f"report -> {out_path}", err=True)
+
+
+if __name__ == "__main__":
+    cli()

--- a/delphi/tests/replay_harness/test_timing_probe.py
+++ b/delphi/tests/replay_harness/test_timing_probe.py
@@ -1,0 +1,450 @@
+"""Clojure timing probe (Spec C) — unit tests + one gated integration test.
+
+Unit tests mock the Clojure subprocess entirely (fast, no toolchain needed).
+The single integration test drives the REAL `clojure -M:replay` at the two
+smallest sizes; it is skipped unless `clojure` is on PATH AND
+RUN_CLJ_INTEGRATION=1 (mirrors the gating convention already used by
+math/dev/replay_smoke.sh, which is a manual smoke, not part of the fast suite).
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "clj_timing_probe.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("clj_timing_probe", _SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    # Dataclasses need their defining module registered in sys.modules (it
+    # looks itself up there to resolve field types) — exec_module alone does
+    # not register it for a dynamically-loaded file.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_module()
+
+
+# ---------------------------------------------------------------------------
+# parse_sizes
+# ---------------------------------------------------------------------------
+
+def test_parse_sizes_dedup_cap_sorted(mod):
+    sizes = mod.parse_sizes("500,1000,2000,5000,9999999", n_max=4683)
+    assert sizes == [500, 1000, 2000, 4683]  # 5000 and 9999999 both cap to n_max
+
+
+def test_parse_sizes_ascending_even_if_input_unordered(mod):
+    sizes = mod.parse_sizes("2000,500,1000", n_max=10000)
+    assert sizes == [500, 1000, 2000]
+
+
+def test_parse_sizes_rejects_non_positive(mod):
+    with pytest.raises(Exception):
+        mod.parse_sizes("0,500", n_max=1000)
+
+
+# ---------------------------------------------------------------------------
+# truncate_votes_csv
+# ---------------------------------------------------------------------------
+
+def _write_votes_csv(path: Path, n_rows: int) -> None:
+    with path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["timestamp", "datetime", "comment-id", "voter-id", "vote"])
+        for i in range(n_rows):
+            w.writerow([1700000000 + i, "some-date", i % 5, i % 7, 1 if i % 2 == 0 else -1])
+
+
+def test_truncate_votes_csv_header_preserved_and_exact_row_count(mod, tmp_path):
+    src = tmp_path / "votes.csv"
+    _write_votes_csv(src, 100)
+    dest = tmp_path / "truncated.csv"
+
+    n_written = mod.truncate_votes_csv(src, 10, dest)
+
+    assert n_written == 10
+    with dest.open() as f:
+        rows = list(csv.reader(f))
+    assert rows[0] == ["timestamp", "datetime", "comment-id", "voter-id", "vote"]
+    assert len(rows) == 11  # header + 10 data rows
+    # first N rows in FILE order (no resort).
+    assert rows[1][0] == "1700000000"
+    assert rows[10][0] == "1700000009"
+
+
+def test_truncate_votes_csv_n_greater_than_file_writes_all_rows(mod, tmp_path):
+    src = tmp_path / "votes.csv"
+    _write_votes_csv(src, 5)
+    dest = tmp_path / "truncated.csv"
+
+    n_written = mod.truncate_votes_csv(src, 1000, dest)
+
+    assert n_written == 5
+    with dest.open() as f:
+        rows = list(csv.reader(f))
+    assert len(rows) == 6
+
+
+# ---------------------------------------------------------------------------
+# count_data_rows
+# ---------------------------------------------------------------------------
+
+def test_count_data_rows_excludes_header(mod, tmp_path):
+    src = tmp_path / "votes.csv"
+    _write_votes_csv(src, 42)
+    assert mod.count_data_rows(src) == 42
+
+
+# ---------------------------------------------------------------------------
+# build_schedule
+# ---------------------------------------------------------------------------
+
+def test_build_schedule_shape(mod):
+    sched = mod.build_schedule("vw", 1234)
+    assert sched["dataset"] == "vw"
+    assert sched["schedule_id"] == "probe-1234"
+    assert sched["source"] == "votes-csv"
+    assert sched["cuts"] == {"mode": "vote-count", "at": ["end"]}
+    assert sched["moderation"] == "none"
+    assert sched["clojure"] == {"warm_start": "chain"}
+
+
+def test_write_schedule_json_roundtrips(mod, tmp_path):
+    sched = mod.build_schedule("vw", 500)
+    dest = tmp_path / "sched.json"
+    mod.write_schedule_json(sched, dest)
+    assert json.loads(dest.read_text()) == sched
+
+
+# ---------------------------------------------------------------------------
+# find_final_blob
+# ---------------------------------------------------------------------------
+
+def test_find_final_blob_none_when_absent(mod, tmp_path):
+    assert mod.find_final_blob(tmp_path / "out") is None
+
+
+def test_find_final_blob_finds_last_step(mod, tmp_path):
+    clj = tmp_path / "out" / "clj"
+    clj.mkdir(parents=True)
+    (clj / "step-000.blob.json").write_text("{}")
+    (clj / "step-001.blob.json").write_text('{"n": 1}')
+    found = mod.find_final_blob(tmp_path / "out")
+    assert found is not None
+    assert found.name == "step-001.blob.json"
+
+
+# ---------------------------------------------------------------------------
+# run_probe_size — MOCKED clojure subprocess.
+# ---------------------------------------------------------------------------
+
+def test_run_probe_size_success_writes_temp_inputs_and_reports_ok(mod, tmp_path):
+    votes_src = tmp_path / "votes.csv"
+    _write_votes_csv(votes_src, 50)
+
+    seen = {}
+
+    def fake_invoke(cmd, cwd, timeout):
+        # Locate --votes and --out among cmd args to assert shape, and
+        # simulate the clojure driver writing a final step blob.
+        seen["cmd"] = cmd
+        seen["cwd"] = cwd
+        seen["timeout"] = timeout
+        votes_arg = Path(cmd[cmd.index("--votes") + 1])
+        out_arg = Path(cmd[cmd.index("--out") + 1])
+        with votes_arg.open() as f:
+            rows = list(csv.reader(f))
+        assert len(rows) == 1 + 20  # header + 20 data rows requested below
+        clj_dir = out_arg / "clj"
+        clj_dir.mkdir(parents=True, exist_ok=True)
+        (clj_dir / "step-000.blob.json").write_text('{"n": 20}')
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    result = mod.run_probe_size(
+        20, votes_src, dataset="vw", math_dir=tmp_path, timeout=30.0, invoke=fake_invoke
+    )
+
+    assert result.ok is True
+    assert result.size == 20
+    assert result.seconds >= 0.0
+    assert result.error is None
+    assert seen["cwd"] == tmp_path
+    assert seen["timeout"] == 30.0
+    assert "-M:replay" in seen["cmd"]
+
+
+def test_run_probe_size_nonzero_returncode_is_failure(mod, tmp_path):
+    votes_src = tmp_path / "votes.csv"
+    _write_votes_csv(votes_src, 50)
+
+    def fake_invoke(cmd, cwd, timeout):
+        return subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="boom")
+
+    result = mod.run_probe_size(
+        10, votes_src, dataset="vw", math_dir=tmp_path, timeout=30.0, invoke=fake_invoke
+    )
+    assert result.ok is False
+    assert result.error is not None
+
+
+def test_run_probe_size_missing_final_blob_is_failure_even_with_returncode_zero(mod, tmp_path):
+    votes_src = tmp_path / "votes.csv"
+    _write_votes_csv(votes_src, 50)
+
+    def fake_invoke(cmd, cwd, timeout):
+        # returncode 0 but never writes a step blob.
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    result = mod.run_probe_size(
+        10, votes_src, dataset="vw", math_dir=tmp_path, timeout=30.0, invoke=fake_invoke
+    )
+    assert result.ok is False
+    assert "blob" in result.error.lower()
+
+
+def test_run_probe_size_timeout_is_failure_but_records_elapsed(mod, tmp_path):
+    votes_src = tmp_path / "votes.csv"
+    _write_votes_csv(votes_src, 50)
+
+    def fake_invoke(cmd, cwd, timeout):
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    result = mod.run_probe_size(
+        10, votes_src, dataset="vw", math_dir=tmp_path, timeout=0.01, invoke=fake_invoke
+    )
+    assert result.ok is False
+    assert result.seconds >= 0.0
+    assert "timeout" in result.error.lower()
+
+
+def test_run_all_runs_in_ascending_order(mod, tmp_path):
+    votes_src = tmp_path / "votes.csv"
+    _write_votes_csv(votes_src, 50)
+    def fake_invoke(cmd, cwd, timeout):
+        out_arg = Path(cmd[cmd.index("--out") + 1])
+        clj_dir = out_arg / "clj"
+        clj_dir.mkdir(parents=True, exist_ok=True)
+        (clj_dir / "step-000.blob.json").write_text("{}")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    results = mod.run_all(
+        [30, 10, 20], votes_src, dataset="vw", math_dir=tmp_path, timeout=30.0, invoke=fake_invoke
+    )
+    assert [r.size for r in results] == [30, 10, 20]  # run_all does not re-sort; caller must pass sorted
+
+
+# ---------------------------------------------------------------------------
+# fit_power_law — synthetic power-law recovery.
+# ---------------------------------------------------------------------------
+
+def test_fit_power_law_recovers_exponent_within_tolerance(mod):
+    """The a_est-from-smallest-run approximation is only unbiased when the
+    smallest probed N is small RELATIVE to the others (its own compute term
+    must be negligible next to the fixed cost). Using N0=10 vs 1000..8000
+    (ratio >= 100x) validates the log-log regression machinery itself,
+    isolated from that known approximation error at closely-spaced sizes."""
+    a_true = 2.0
+    b_true = 1e-9
+    k_true = 2.0
+    sizes = [10, 1000, 2000, 4000, 8000]
+    seconds = [a_true + b_true * (n ** k_true) for n in sizes]
+
+    fit = mod.fit_power_law(sizes, seconds)
+
+    assert fit.k is not None
+    assert abs(fit.k - k_true) < 0.01
+    assert abs(fit.a_est - a_true) < 0.01
+
+
+def test_fit_power_law_single_point_yields_no_fit(mod):
+    fit = mod.fit_power_law([500], [3.0])
+    assert fit.a_est == 3.0
+    assert fit.k is None
+    assert fit.b is None
+    assert fit.n_fit_points == 0
+
+
+def test_fit_power_law_empty_raises(mod):
+    with pytest.raises(ValueError):
+        mod.fit_power_law([], [])
+
+
+def test_fit_power_law_two_points_insufficient_for_regression(mod):
+    # Need >= 2 points AFTER excluding the a_est-defining smallest point,
+    # i.e. >= 3 sizes total, to fit a line.
+    fit = mod.fit_power_law([500, 1000], [3.0, 3.5])
+    assert fit.k is None
+
+
+# ---------------------------------------------------------------------------
+# recommend_max_votes
+# ---------------------------------------------------------------------------
+
+def test_recommend_max_votes_math(mod):
+    fit = mod.FitResult(a_est=2.0, b=1e-9, k=2.0, n_fit_points=3)
+    n = mod.recommend_max_votes(fit, budget_min=10.0)
+    # a + b*N^k = 600s  ->  N = ((600 - 2) / 1e-9) ** 0.5
+    expected = ((600.0 - 2.0) / 1e-9) ** 0.5
+    assert n is not None
+    assert abs(n - expected) / expected < 1e-6
+
+
+def test_recommend_max_votes_none_when_no_fit(mod):
+    fit = mod.FitResult(a_est=2.0, b=None, k=None, n_fit_points=0)
+    assert mod.recommend_max_votes(fit, budget_min=10.0) is None
+
+
+def test_recommend_max_votes_none_when_a_est_already_exceeds_budget(mod):
+    fit = mod.FitResult(a_est=1000.0, b=1e-9, k=2.0, n_fit_points=3)
+    assert mod.recommend_max_votes(fit, budget_min=1.0) is None
+
+
+# ---------------------------------------------------------------------------
+# format_report_lines — stdout line budget.
+# ---------------------------------------------------------------------------
+
+def test_format_report_lines_one_per_size_plus_fit_plus_recommendation(mod):
+    results = [
+        mod.ProbeResult(size=500, seconds=3.0, ok=True, error=None),
+        mod.ProbeResult(size=1000, seconds=4.0, ok=True, error=None),
+        mod.ProbeResult(size=2000, seconds=6.0, ok=True, error=None),
+        mod.ProbeResult(size=5000, seconds=None, ok=False, error="returncode=1"),
+    ]
+    fit = mod.fit_power_law([500, 1000, 2000], [3.0, 4.0, 6.0])
+    rec = mod.recommend_max_votes(fit, budget_min=10.0)
+
+    lines = mod.format_report_lines(results, fit, rec, budget_min=10.0)
+
+    assert len(lines) == len(results) + 2  # one per size + fit line + recommendation line
+    assert len(lines) <= 20
+
+
+def test_format_report_lines_stays_under_budget_for_many_sizes(mod):
+    results = [
+        mod.ProbeResult(size=n, seconds=float(n) / 100, ok=True, error=None)
+        for n in [500, 1000, 2000, 3000, 4000, 5000]
+    ]
+    fit = mod.fit_power_law([r.size for r in results], [r.seconds for r in results])
+    rec = mod.recommend_max_votes(fit, budget_min=10.0)
+    lines = mod.format_report_lines(results, fit, rec, budget_min=10.0)
+    assert len(lines) <= 20
+
+
+# ---------------------------------------------------------------------------
+# build_report — JSON shape.
+# ---------------------------------------------------------------------------
+
+def test_build_report_shape(mod):
+    results = [
+        mod.ProbeResult(size=500, seconds=3.0, ok=True, error=None),
+        mod.ProbeResult(size=1000, seconds=None, ok=False, error="boom"),
+    ]
+    fit = mod.FitResult(a_est=3.0, b=None, k=None, n_fit_points=0)
+    report = mod.build_report(
+        votes_path=Path("/x/votes.csv"), dataset="vw", dataset_size=1000,
+        budget_min=10.0, timeout_sec=900.0, results=results, fit=fit, recommended=None,
+    )
+    assert report["sizes"] == [500, 1000]
+    assert report["seconds"] == [3.0, None]
+    assert report["ok"] == [True, False]
+    assert report["errors"] == [None, "boom"]
+    assert report["fit"]["a_est"] == 3.0
+    assert report["recommended_max_votes"] is None
+    assert report["dataset"] == "vw"
+    assert report["dataset_size"] == 1000
+    assert "generated_at" in report
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end (mocked subprocess).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not (Path(__file__).resolve().parents[3] / "math" / "dev" / "replay.clj").exists(),
+    reason="math/ tree not present (delphi-only CI image runs from /app)",
+)
+def test_cli_probe_end_to_end_mocked(mod, tmp_path, monkeypatch):
+    votes_src = tmp_path / "votes.csv"
+    _write_votes_csv(votes_src, 200)
+    out_json = tmp_path / "report.json"
+
+    def fake_invoke(cmd, cwd, timeout):
+        out_arg = Path(cmd[cmd.index("--out") + 1])
+        clj_dir = out_arg / "clj"
+        clj_dir.mkdir(parents=True, exist_ok=True)
+        (clj_dir / "step-000.blob.json").write_text("{}")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod, "_invoke_clojure", fake_invoke)
+
+    runner = CliRunner()
+    res = runner.invoke(
+        mod.cli,
+        [
+            "probe",
+            "--votes", str(votes_src),
+            "--sizes", "50,100,150",
+            "--out", str(out_json),
+            "--budget-min", "5",
+        ],
+    )
+
+    assert res.exit_code == 0, res.output
+    lines = [l for l in res.output.splitlines() if l.strip()]
+    assert len(lines) <= 20
+    assert out_json.exists()
+    report = json.loads(out_json.read_text())
+    assert report["sizes"] == [50, 100, 150]
+    assert all(report["ok"])
+
+
+def test_cli_probe_requires_existing_votes_file(mod, tmp_path):
+    runner = CliRunner()
+    res = runner.invoke(
+        mod.cli,
+        ["probe", "--votes", str(tmp_path / "nope.csv"), "--out", str(tmp_path / "r.json")],
+    )
+    assert res.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Real integration test — gated.
+# ---------------------------------------------------------------------------
+
+_HAVE_CLJ = shutil.which("clojure") is not None
+_RUN_INTEGRATION = _HAVE_CLJ and __import__("os").environ.get("RUN_CLJ_INTEGRATION") == "1"
+
+
+@pytest.mark.skipif(
+    not _RUN_INTEGRATION,
+    reason="needs `clojure` on PATH and RUN_CLJ_INTEGRATION=1 (real subprocess, slow)",
+)
+def test_real_clojure_driver_two_smallest_sizes(mod, tmp_path):
+    votes_src = mod.default_votes_path()
+    assert votes_src is not None, "no *-vw/*-votes.csv dataset found"
+    n_max = mod.count_data_rows(votes_src)
+    sizes = mod.parse_sizes("50,100", n_max=n_max)
+
+    results = mod.run_all(
+        sizes, votes_src, dataset="vw", math_dir=mod.MATH_DIR, timeout=600.0
+    )
+
+    assert len(results) == 2
+    for r in results:
+        assert r.ok is True, f"size={r.size} failed: {r.error}"
+        assert r.seconds > 0


### PR DESCRIPTION
## What

Adds `scripts/clj_timing_probe.py` (Spec C) — a click CLI that measures how long the Clojure engine takes at increasing conversation sizes, so replay runs can be sized to a wall-clock budget. It runs the Clojure Mode A replay driver (`math/dev/replay.clj`, which replays a recorded vote schedule through the Clojure engine) at increasing vote-count sizes, records wall-clock seconds and final-blob success per size, fits runtime ~ a + b*N^k by log-log least squares (with a, the fixed JVM-startup cost, estimated from the smallest run), and recommends the largest N that stays within the wall-clock budget.

## Testing

TDD: `tests/replay_harness/test_timing_probe.py` mocks the clojure subprocess for all unit tests (CSV truncation, schedule shape, fit recovery on synthetic power-law data, recommendation math, stdout line budget, CLI end-to-end), plus one real-subprocess integration test gated on `clojure` being on PATH and `RUN_CLJ_INTEGRATION=1`.

commit-id:96c1f19e

---
**Stack**:
- #2689
- #2688
- #2687
- #2684
- #2683
- #2681
- #2680
- #2679
- #2676
- #2675
- #2674
- #2673
- #2672
- #2671
- #2670
- #2669
- #2668
- #2667
- #2666
- #2665
- #2664
- #2663
- #2659
- #2658
- #2637
- #2657
- #2656
- #2626
- #2655
- #2654
- #2653
- #2652
- #2651
- #2650
- #2649
- #2648
- #2647
- #2646
- #2645
- #2644
- #2643 ⬅
- #2642
- #2641
- #2625
- #2624
- #2623
- #2622
- #2621
- #2620
- #2640
- #2618
- #2639
- #2638
- #2615
- #2613
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*