### PR TITLE
python-math #18: feat(delphi): prodclone extractor — feature-filtered dataset export (Spec B)

### DIFF
--- a/delphi/polismath/replay/prodclone.py
+++ b/delphi/polismath/replay/prodclone.py
@@ -1,0 +1,546 @@
+"""Prodclone extractor — pull feature-classified real conversations out of a
+"prodclone" Postgres database (a clone of the production polis DB) into the
+replay-dataset export format, for Clojure↔Python math parity certification.
+
+See ``delphi/scripts/prodclone_extract.py`` for the CLI. This module holds
+the PURE building blocks (SQL builders, feature classifiers, CSV row
+formatters, slug minting, path-safety guard, prodclone_map merge-update) plus
+the thin DB-facing helpers that wire them together. The pure functions are
+unit-tested without a database; ``fetch_*``/``run_survey``/``run_extract``
+need a live connection and are covered by ONE integration test.
+
+CRITICAL privacy rules (see delphi/tests/test_prodclone_extract.py and the
+project CLAUDE.md for the full policy):
+
+- Output goes ONLY under ``<real_data_root>/.local/`` — :func:`assert_under_local`
+  is the hard guard; every write path routes through it.
+- Minted slugs are neutral (``pc-<feature>-<NN>``); the on-disk directory
+  prefix is a salted hash of the zid (:func:`fake_report_prefix`), never the
+  real report id.
+- The slug→zid mapping lives ONLY in ``prodclone_map.json`` (merge-update,
+  never clobber — see :func:`merge_prodclone_map`).
+- Comment text is REDACTED in the export (``comment-body`` column present but
+  always empty) — the math pipeline never reads it.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+# ---------------------------------------------------------------------------
+# Feature classes + thresholds (module constants — the single source of truth
+# for both the classifier and the prodclone_map.json "filters" audit trail).
+# ---------------------------------------------------------------------------
+
+FEATURES: tuple[str, ...] = (
+    "modheavy", "revote", "banned", "meta", "zerovote", "smallmix", "midmix",
+)
+
+MODHEAVY_MIN_FRAC = 0.20
+"""A conversation qualifies as modheavy when >=20% of its comments are
+moderated-out (comments.mod = -1)."""
+
+REVOTE_MIN_FRAC = 0.10
+"""A conversation qualifies as revote-heavy when >=10% of its votes are
+revotes (a later occurrence of an already-seen (pid, tid) pair)."""
+
+SMALL_MAX_VOTES = 5_000
+"""Upper bound (inclusive) of the 'small' conversation size class."""
+
+MEDIUM_MAX_VOTES = 50_000
+"""Upper bound (inclusive) of the 'medium' conversation size class."""
+
+FAKE_PREFIX_SALT = "polis-prodclone-extract-v1"
+"""Fixed salt for :func:`fake_report_prefix`. Not a secret — it just keeps the
+fake report-id prefix from being a trivial function of the zid alone; the
+real zid↔slug mapping lives only in prodclone_map.json."""
+
+_FAKE_PREFIX_HEX_LEN = 12
+
+_SLUG_RE_TEMPLATE = r"^pc-{feature}-(\d+)$"
+
+
+def _thresholds() -> dict[str, Any]:
+    """Snapshot of the threshold constants, for the prodclone_map.json audit
+    trail (so a future reader can see what filters produced a given slug
+    without re-reading this module's source)."""
+    return {
+        "modheavy_min_frac": MODHEAVY_MIN_FRAC,
+        "revote_min_frac": REVOTE_MIN_FRAC,
+        "small_max_votes": SMALL_MAX_VOTES,
+        "medium_max_votes": MEDIUM_MAX_VOTES,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SQL builders — pure string construction, no DB required to test.
+# ---------------------------------------------------------------------------
+
+
+def sql_conversation_stats() -> str:
+    """One aggregate query, one row per conversation, covering every stat the
+    feature classifiers need. No zid parameter — the caller filters/classifies
+    in Python (keeps the classifier pure and DB-independent)."""
+    return """
+        SELECT
+            c.zid AS zid,
+            COALESCE(v.n_votes, 0) AS n_votes,
+            COALESCE(v.n_revotes, 0) AS n_revotes,
+            COALESCE(p.n_ptpts, 0) AS n_ptpts,
+            COALESCE(cm.n_comments, 0) AS n_comments,
+            COALESCE(cm.n_mod_out, 0) AS n_mod_out,
+            COALESCE(cm.has_meta, false) AS has_meta,
+            COALESCE(b.has_banned_voter, false) AS has_banned_voter
+        FROM conversations c
+        LEFT JOIN (
+            SELECT zid,
+                   COUNT(*) AS n_votes,
+                   COUNT(*) - COUNT(DISTINCT (pid, tid)) AS n_revotes
+            FROM votes
+            GROUP BY zid
+        ) v ON v.zid = c.zid
+        LEFT JOIN (
+            SELECT zid, COUNT(*) AS n_ptpts
+            FROM participants
+            GROUP BY zid
+        ) p ON p.zid = c.zid
+        LEFT JOIN (
+            SELECT zid,
+                   COUNT(*) AS n_comments,
+                   COUNT(*) FILTER (WHERE mod = -1) AS n_mod_out,
+                   BOOL_OR(is_meta) AS has_meta
+            FROM comments
+            GROUP BY zid
+        ) cm ON cm.zid = c.zid
+        LEFT JOIN (
+            SELECT DISTINCT v2.zid, true AS has_banned_voter
+            FROM votes v2
+            JOIN participants pp ON pp.zid = v2.zid AND pp.pid = v2.pid
+            WHERE pp.mod = -1
+        ) b ON b.zid = c.zid
+    """
+
+
+def sql_votes_export() -> str:
+    """FULL revote history for one conversation, ordered by created ASC with
+    a ``ctid`` tiebreak for deterministic chronological ordering on ties
+    (mirrors the ``ORDER BY created ASC, ctid ASC`` convention already used
+    elsewhere in this codebase, e.g. tests/test_generator_vote_copy.py). No
+    dedup — every row survives."""
+    return """
+        SELECT tid, pid, vote, created
+        FROM votes
+        WHERE zid = %s
+        ORDER BY created ASC, ctid ASC
+    """
+
+
+def sql_comments_export() -> str:
+    return """
+        SELECT tid, pid, created, mod
+        FROM comments
+        WHERE zid = %s
+        ORDER BY tid ASC
+    """
+
+
+def sql_comment_vote_counts() -> str:
+    """Agrees/disagrees per comment, counted over ALL vote rows (including
+    revotes) — mirrors server/src/report.ts's sendCommentSummary, which
+    increments per raw vote row with no dedup."""
+    return """
+        SELECT tid,
+               COUNT(*) FILTER (WHERE vote = -1) AS agrees,
+               COUNT(*) FILTER (WHERE vote = 1) AS disagrees
+        FROM votes
+        WHERE zid = %s
+        GROUP BY tid
+    """
+
+
+# ---------------------------------------------------------------------------
+# Feature classifiers — pure functions over aggregate stats dicts.
+# ---------------------------------------------------------------------------
+
+
+def classify_conversation(stats: dict[str, Any]) -> dict[str, float | None]:
+    """Classify one conversation's aggregate stats against every feature
+    class. Returns ``{feature: metric_or_None}`` — ``None`` means the
+    conversation does not qualify for that feature; a float is the
+    "suitability" metric used to sort candidates within the class.
+
+    ``stats`` keys: zid, n_votes, n_ptpts, n_comments, n_mod_out, n_revotes,
+    has_banned_voter, has_meta (see :func:`sql_conversation_stats`).
+    """
+    n_votes = stats["n_votes"]
+    n_comments = stats["n_comments"]
+    n_mod_out = stats["n_mod_out"]
+    n_revotes = stats["n_revotes"]
+    n_ptpts = stats["n_ptpts"]
+    has_banned_voter = bool(stats["has_banned_voter"])
+    has_meta = bool(stats["has_meta"])
+
+    mod_frac = (n_mod_out / n_comments) if n_comments else 0.0
+    revote_frac = (n_revotes / n_votes) if n_votes else 0.0
+
+    is_modheavy = n_comments > 0 and mod_frac >= MODHEAVY_MIN_FRAC
+    is_revote = n_votes > 0 and revote_frac >= REVOTE_MIN_FRAC
+    is_banned = has_banned_voter
+    is_meta = has_meta
+    is_zerovote = n_votes == 0
+
+    # "unremarkable" = none of the other interesting features apply — the
+    # smallmix/midmix classes exist for plain volume coverage, not to
+    # double-count conversations that are already interesting for another
+    # reason.
+    is_unremarkable = not (is_modheavy or is_revote or is_banned or is_meta)
+    is_smallmix = is_unremarkable and 0 < n_votes <= SMALL_MAX_VOTES
+    is_midmix = (
+        is_unremarkable and SMALL_MAX_VOTES < n_votes <= MEDIUM_MAX_VOTES
+    )
+
+    return {
+        "modheavy": mod_frac if is_modheavy else None,
+        "revote": revote_frac if is_revote else None,
+        # Banned/meta are presence classes (no natural fraction) — use
+        # n_votes/n_comments as a "more data is more useful" tiebreak metric.
+        "banned": float(n_votes) if is_banned else None,
+        "meta": float(n_comments) if is_meta else None,
+        # zerovote's metric is n_ptpts; survey_candidates sorts it ASCENDING
+        # (fewest participants = the simplest, cleanest zero-vote exemplar).
+        "zerovote": float(n_ptpts) if is_zerovote else None,
+        "smallmix": float(n_votes) if is_smallmix else None,
+        "midmix": float(n_votes) if is_midmix else None,
+    }
+
+
+# Features whose candidate list is sorted ascending by metric (simplest
+# exemplar first) rather than the default descending (most-pronounced /
+# most-data first).
+_ASCENDING_FEATURES = frozenset({"zerovote"})
+
+
+def survey_candidates(rows: Iterable[dict[str, Any]], limit: int) -> dict[str, list[dict[str, Any]]]:
+    """Classify + sort + truncate a list of per-conversation stats rows.
+
+    Returns ``{feature: [{zid, n_votes, n_ptpts, n_comments, metric}, ...]}``
+    with every list already sorted by suitability and capped at ``limit``.
+    No topic/description/text ever touches this function — only the numeric
+    columns the spec allows in survey output.
+    """
+    rows = list(rows)
+    result: dict[str, list[dict[str, Any]]] = {f: [] for f in FEATURES}
+    for stats in rows:
+        metrics = classify_conversation(stats)
+        for feature, metric in metrics.items():
+            if metric is None:
+                continue
+            result[feature].append({
+                "zid": stats["zid"],
+                "n_votes": stats["n_votes"],
+                "n_ptpts": stats["n_ptpts"],
+                "n_comments": stats["n_comments"],
+                "metric": metric,
+            })
+    for feature in FEATURES:
+        reverse = feature not in _ASCENDING_FEATURES
+        result[feature].sort(key=lambda c: c["metric"], reverse=reverse)
+        result[feature] = result[feature][:limit]
+    return result
+
+
+def size_class_counts(rows: Iterable[dict[str, Any]]) -> dict[str, int]:
+    """Counts of conversations by vote-count size bucket (informational —
+    printed alongside the per-feature survey, independent of feature class)."""
+    small = medium = large = 0
+    for stats in rows:
+        n = stats["n_votes"]
+        if n <= SMALL_MAX_VOTES:
+            small += 1
+        elif n <= MEDIUM_MAX_VOTES:
+            medium += 1
+        else:
+            large += 1
+    return {"small": small, "medium": medium, "large": large}
+
+
+# ---------------------------------------------------------------------------
+# Slug minting + fake report-id prefix.
+# ---------------------------------------------------------------------------
+
+
+def next_free_slug(feature: str, existing_slugs: Iterable[str]) -> str:
+    """Mint the next free ``pc-<feature>-NN`` slug — the smallest 2-digit
+    (or wider, once >99) number not already used for this feature."""
+    pattern = re.compile(_SLUG_RE_TEMPLATE.format(feature=re.escape(feature)))
+    used: set[int] = set()
+    for slug in existing_slugs:
+        m = pattern.match(slug)
+        if m:
+            used.add(int(m.group(1)))
+    n = 1
+    while n in used:
+        n += 1
+    width = 2 if n < 100 else len(str(n))
+    return f"pc-{feature}-{n:0{width}d}"
+
+
+def fake_report_prefix(zid: int, salt: str = FAKE_PREFIX_SALT) -> str:
+    """Deterministic, non-reversible-looking stand-in for a real report id.
+
+    NEVER a function of the zid alone in an obviously-invertible way, and
+    NEVER the actual report id — the true zid↔slug mapping is recorded only
+    in prodclone_map.json (gitignored)."""
+    digest = hashlib.sha256(f"{salt}:{zid}".encode("utf-8")).hexdigest()
+    return f"pcx{digest[:_FAKE_PREFIX_HEX_LEN]}"
+
+
+# ---------------------------------------------------------------------------
+# Path-safety guard — the hard privacy constraint.
+# ---------------------------------------------------------------------------
+
+
+def assert_under_local(path: Path, root: Path) -> Path:
+    """Resolve ``path`` and assert it lives inside ``<root>/.local/``.
+
+    Raises ``ValueError`` for anything else — including the real_data root
+    itself, sibling directories, and ``..`` traversal escapes. This is the
+    ONE guard every write path in this module routes through; never bypass
+    it, even when the caller "knows" the path is safe (belt-and-braces)."""
+    local_root = (root / ".local").resolve()
+    resolved = path.resolve()
+    if resolved != local_root and local_root not in resolved.parents:
+        raise ValueError(
+            f"refusing to write outside {local_root} (.local): {resolved}"
+        )
+    return resolved
+
+
+def compute_extract_dir(out_root: Path, prefix: str, slug: str) -> Path:
+    """Compute (but do not create) the extraction target directory, confined
+    to ``<out_root>/.local/`` by construction and re-verified defensively via
+    :func:`assert_under_local`."""
+    candidate = out_root / ".local" / f"{prefix}-{slug}"
+    return assert_under_local(candidate, out_root)
+
+
+# ---------------------------------------------------------------------------
+# CSV row formatters — mirror server/src/report.ts's export format.
+# ---------------------------------------------------------------------------
+
+
+def format_export_datetime(created_ms: int) -> str:
+    """Human-readable rendering of a created-ms timestamp. Not parsed by any
+    loader (only the numeric "timestamp" column is) — the format here just
+    visually mirrors the JS ``Date.toString()`` shape seen in existing export
+    samples, e.g. 'Tue Nov 19 2024 15:06:00 GMT+0000 (Coordinated Universal Time)'."""
+    import time
+
+    return time.strftime(
+        "%a %b %d %Y %H:%M:%S GMT+0000 (Coordinated Universal Time)",
+        time.gmtime(created_ms / 1000),
+    )
+
+
+def format_votes_rows(raw_rows: Iterable[dict[str, Any]]) -> list[dict[str, str]]:
+    """``raw_rows``: dicts with keys tid, pid, vote (RAW db sign), created (ms).
+    Returns export-format row dicts, one per input row, in the SAME order —
+    no sorting, no dedup (full revote history survives verbatim). The vote
+    sign is flipped (raw AGREE=-1 -> export +1), mirroring the production
+    export's ``String(-row.vote)``."""
+    out = []
+    for row in raw_rows:
+        created = row["created"]
+        out.append({
+            "timestamp": str(created // 1000),
+            "datetime": format_export_datetime(created),
+            "comment-id": str(row["tid"]),
+            "voter-id": str(row["pid"]),
+            "vote": str(-row["vote"]),
+        })
+    return out
+
+
+def format_comments_rows(
+    raw_rows: Iterable[dict[str, Any]],
+    vote_counts: dict[int, tuple[int, int]],
+) -> list[dict[str, str]]:
+    """``raw_rows``: dicts with keys tid, pid, created, mod.
+    ``vote_counts``: {tid: (agrees, disagrees)}, counted over ALL vote rows
+    (see :func:`sql_comment_vote_counts`); missing tids default to (0, 0).
+
+    ``comment-body`` is ALWAYS the empty string — comment text is redacted
+    per the privacy rules; the column is present (mirroring the export
+    format) but never populated."""
+    out = []
+    for row in raw_rows:
+        agrees, disagrees = vote_counts.get(row["tid"], (0, 0))
+        created = row["created"]
+        out.append({
+            "timestamp": str(created // 1000),
+            "datetime": format_export_datetime(created),
+            "comment-id": str(row["tid"]),
+            "author-id": str(row["pid"]),
+            "agrees": str(agrees),
+            "disagrees": str(disagrees),
+            "moderated": str(row["mod"]),
+            "comment-body": "",
+        })
+    return out
+
+
+_VOTES_FIELDNAMES = ["timestamp", "datetime", "comment-id", "voter-id", "vote"]
+_COMMENTS_FIELDNAMES = [
+    "timestamp", "datetime", "comment-id", "author-id",
+    "agrees", "disagrees", "moderated", "comment-body",
+]
+
+
+def write_votes_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=_VOTES_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_comments_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=_COMMENTS_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+# ---------------------------------------------------------------------------
+# prodclone_map.json — merge-update, never clobber.
+# ---------------------------------------------------------------------------
+
+
+def merge_prodclone_map(
+    existing: dict[str, Any], slug: str, entry: dict[str, Any]
+) -> dict[str, Any]:
+    """Return a NEW dict: ``existing`` with ``slug: entry`` set/overwritten.
+    Does not mutate ``existing`` — callers read-modify-write the JSON file
+    with this as the pure "modify" step, so a crash between read and write
+    never partially corrupts the in-memory map."""
+    merged = dict(existing)
+    merged[slug] = entry
+    return merged
+
+
+def load_prodclone_map(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def save_prodclone_map(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# DB-facing helpers — need a live psycopg2 connection.
+# ---------------------------------------------------------------------------
+
+
+def _rows_as_dicts(cur) -> list[dict[str, Any]]:
+    columns = [d[0] for d in cur.description]
+    return [dict(zip(columns, row)) for row in cur.fetchall()]
+
+
+def fetch_conversation_stats(conn) -> list[dict[str, Any]]:
+    """Run :func:`sql_conversation_stats` and return one dict per conversation."""
+    with conn.cursor() as cur:
+        cur.execute(sql_conversation_stats())
+        return _rows_as_dicts(cur)
+
+
+def fetch_votes(conn, zid: int) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(sql_votes_export(), (zid,))
+        return _rows_as_dicts(cur)
+
+
+def fetch_comments(conn, zid: int) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(sql_comments_export(), (zid,))
+        return _rows_as_dicts(cur)
+
+
+def fetch_comment_vote_counts(conn, zid: int) -> dict[int, tuple[int, int]]:
+    with conn.cursor() as cur:
+        cur.execute(sql_comment_vote_counts(), (zid,))
+        return {row["tid"]: (row["agrees"], row["disagrees"]) for row in _rows_as_dicts(cur)}
+
+
+def run_survey(conn, limit: int) -> dict[str, Any]:
+    """Fetch stats for every conversation, classify, and return the full
+    survey result (candidates per feature + size-class counts + the
+    threshold constants used, for the audit-trail JSON)."""
+    from datetime import datetime, timezone
+
+    stats = fetch_conversation_stats(conn)
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "n_conversations": len(stats),
+        "size_classes": {
+            "small_max_votes": SMALL_MAX_VOTES,
+            "medium_max_votes": MEDIUM_MAX_VOTES,
+            "counts": size_class_counts(stats),
+        },
+        "thresholds": _thresholds(),
+        "candidates": survey_candidates(stats, limit=limit),
+    }
+
+
+def run_extract(
+    conn, *, zid: int, feature: str, out_root: Path, map_path: Path | None = None,
+) -> dict[str, Any]:
+    """Extract one conversation's votes + comments into
+    ``<out_root>/.local/<fake-prefix>-<slug>/`` and merge-update
+    prodclone_map.json. Returns ``{slug, dir, entry}``.
+
+    ``map_path`` defaults to ``<out_root>/.local/prodclone_map.json``.
+    """
+    if feature not in FEATURES:
+        raise ValueError(f"unknown feature {feature!r}; must be one of {FEATURES}")
+    if map_path is None:
+        map_path = out_root / ".local" / "prodclone_map.json"
+
+    existing_map = load_prodclone_map(map_path)
+    slug = next_free_slug(feature, existing_map.keys())
+    prefix = fake_report_prefix(zid)
+    target_dir = compute_extract_dir(out_root, prefix, slug)
+
+    votes_raw = fetch_votes(conn, zid)
+    comments_raw = fetch_comments(conn, zid)
+    vote_counts = fetch_comment_vote_counts(conn, zid)
+
+    votes_rows = format_votes_rows(votes_raw)
+    comments_rows = format_comments_rows(comments_raw, vote_counts)
+
+    dir_name = target_dir.name  # "<prefix>-<slug>"
+    write_votes_csv(target_dir / f"{dir_name}-votes.csv", votes_rows)
+    write_comments_csv(target_dir / f"{dir_name}-comments.csv", comments_rows)
+
+    from datetime import datetime, timezone
+
+    entry = {
+        "zid": zid,
+        "feature": feature,
+        "extracted_at": datetime.now(timezone.utc).isoformat(),
+        "n_votes": len(votes_rows),
+        "n_comments": len(comments_rows),
+        "filters": _thresholds(),
+    }
+    merged_map = merge_prodclone_map(existing_map, slug, entry)
+    save_prodclone_map(map_path, merged_map)
+
+    return {"slug": slug, "dir": str(target_dir), "entry": entry}

--- a/delphi/scripts/prodclone_extract.py
+++ b/delphi/scripts/prodclone_extract.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Prodclone extractor CLI — pull feature-classified real conversations out of
+a "prodclone" Postgres database (a clone of the production polis DB) into the
+replay-dataset export format, for Clojure↔Python math parity certification.
+
+See ``delphi/polismath/replay/prodclone.py`` for the pure building blocks
+(SQL builders, feature classifiers, CSV formatters, slug minting, the
+path-safety guard). This script is a thin click CLI wiring those together
+with a live psycopg2 connection — mirrors the style of
+``scripts/replay_driver.py``.
+
+CRITICAL privacy rules — see the pure module's docstring and
+delphi/tests/test_prodclone_extract.py for the full policy. In short:
+output goes ONLY under ``<out-root>/.local/``, slugs are neutral, the
+directory prefix is a salted hash (never the real report id), the slug→zid
+mapping lives ONLY in prodclone_map.json, and comment text is redacted.
+
+Usage (from delphi/)::
+
+    # Survey the prodclone DB for candidate conversations per feature class:
+    uv run python scripts/prodclone_extract.py survey \\
+        --database-url postgresql://user:pass@host:5432/prodclone
+
+    # Extract one conversation for a feature class:
+    uv run python scripts/prodclone_extract.py extract \\
+        --database-url postgresql://user:pass@host:5432/prodclone \\
+        --zid 12345 --feature modheavy
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+import psycopg2
+
+from polismath.replay import prodclone as pc
+from polismath.replay.real_data import REAL_DATA_ROOT
+
+DEFAULT_SURVEY_OUT = REAL_DATA_ROOT / ".local" / "prodclone_survey.json"
+
+
+@click.group()
+def cli() -> None:
+    """Prodclone extractor — survey + extract feature-classified conversations."""
+
+
+def _print_survey(result: dict) -> None:
+    sc = result["size_classes"]
+    counts = sc["counts"]
+    click.echo(
+        f"size classes (n={result['n_conversations']}): "
+        f"small(<={sc['small_max_votes']} votes)={counts['small']}  "
+        f"medium(<={sc['medium_max_votes']} votes)={counts['medium']}  "
+        f"large={counts['large']}"
+    )
+    for feature in pc.FEATURES:
+        candidates = result["candidates"][feature]
+        click.echo(f"[{feature}] {len(candidates)} candidate(s)")
+        for c in candidates:
+            click.echo(
+                f"  zid={c['zid']} n_votes={c['n_votes']} n_ptpts={c['n_ptpts']} "
+                f"n_comments={c['n_comments']} metric={c['metric']:.3f}"
+            )
+
+
+@cli.command()
+@click.option("--database-url", required=True,
+              help="Postgres connection URL for the prodclone database.")
+@click.option("--limit", type=int, default=3, show_default=True,
+              help="Max candidates listed per feature class.")
+@click.option("--out", "out_path", type=click.Path(path_type=Path), default=None,
+              help=f"Full survey JSON path (default: {DEFAULT_SURVEY_OUT}).")
+def survey(database_url: str, limit: int, out_path: Path | None) -> None:
+    """Survey the prodclone DB: candidate conversations per feature class,
+    no topics/text — just zid, n_votes, n_ptpts, n_comments, metric."""
+    out_path = out_path or DEFAULT_SURVEY_OUT
+    # The survey JSON contains raw zids — same containment rule as extract:
+    # refuse any destination outside real_data/.local/ (review finding,
+    # 2026-07-22: --out could previously bypass the guard).
+    out_path = pc.assert_under_local(out_path, REAL_DATA_ROOT)
+    conn = psycopg2.connect(database_url)
+    try:
+        result = pc.run_survey(conn, limit=limit)
+    finally:
+        conn.close()
+
+    _print_survey(result)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    click.echo(f"full survey -> {out_path}")
+
+
+@cli.command()
+@click.option("--database-url", required=True,
+              help="Postgres connection URL for the prodclone database.")
+@click.option("--zid", type=int, required=True, help="Conversation zid to extract.")
+@click.option("--feature", type=click.Choice(pc.FEATURES), required=True,
+              help="Feature class this extraction is for (mints the next free slug).")
+@click.option("--out-root", type=click.Path(path_type=Path), default=None,
+              help="real_data root — a .local/ subdir is created beneath it "
+                   f"(default: {REAL_DATA_ROOT}).")
+def extract(database_url: str, zid: int, feature: str, out_root: Path | None) -> None:
+    """Mint the next free slug for FEATURE and export ZID's votes (full
+    revote history) + comments (text redacted) into
+    <out-root>/.local/<fake-prefix>-<slug>/, then merge-update
+    prodclone_map.json."""
+    out_root = out_root or REAL_DATA_ROOT
+    conn = psycopg2.connect(database_url)
+    try:
+        result = pc.run_extract(conn, zid=zid, feature=feature, out_root=out_root)
+    finally:
+        conn.close()
+
+    entry = result["entry"]
+    click.echo(f"slug={result['slug']}")
+    click.echo(
+        f"wrote {entry['n_votes']} votes, {entry['n_comments']} comments -> {result['dir']}"
+    )
+    click.echo(f"prodclone_map.json updated ({out_root / '.local' / 'prodclone_map.json'})")
+
+
+if __name__ == "__main__":
+    cli()

--- a/delphi/tests/test_prodclone_extract.py
+++ b/delphi/tests/test_prodclone_extract.py
@@ -1,0 +1,739 @@
+"""Tests for the prodclone extractor (delphi/scripts/prodclone_extract.py +
+delphi/polismath/replay/prodclone.py).
+
+Unit tests exercise the PURE building blocks (SQL builders, feature
+classifiers, CSV row formatters, slug minting, path-safety guard, map
+merging) with synthetic in-memory data — no database required.
+
+ONE integration test spins up a temp Postgres (via the existing
+``require_polis_postgres`` fixture from tests/conftest.py — self-skips if
+docker/a service is unavailable), seeds ~30 synthetic rows covering every
+feature class, and round-trips survey → extract → ``load_export_votes``.
+
+Privacy: no real zids/report-ids/vote content appear anywhere here — every
+seeded zid/pid/tid/vote below is synthetic, invented for this test only.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from polismath.replay import prodclone as pc
+
+_CLI_PATH = Path(__file__).resolve().parents[1] / "scripts" / "prodclone_extract.py"
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location("prodclone_extract_cli", _CLI_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# classify_conversation — pure feature classifiers
+# ---------------------------------------------------------------------------
+
+
+def _stats(**overrides) -> dict:
+    base = dict(
+        zid=1,
+        n_votes=1000,
+        n_ptpts=50,
+        n_comments=40,
+        n_mod_out=0,
+        n_revotes=0,
+        has_banned_voter=False,
+        has_meta=False,
+    )
+    base.update(overrides)
+    return base
+
+
+def test_classify_modheavy_qualifies_at_threshold():
+    stats = _stats(n_comments=100, n_mod_out=20)  # exactly 20%
+    result = pc.classify_conversation(stats)
+    assert result["modheavy"] == pytest.approx(0.20)
+
+
+def test_classify_modheavy_below_threshold_excluded():
+    stats = _stats(n_comments=100, n_mod_out=19)  # 19% < 20%
+    result = pc.classify_conversation(stats)
+    assert result["modheavy"] is None
+
+
+def test_classify_modheavy_zero_comments_excluded():
+    stats = _stats(n_comments=0, n_mod_out=0)
+    result = pc.classify_conversation(stats)
+    assert result["modheavy"] is None
+
+
+def test_classify_revote_qualifies_at_threshold():
+    stats = _stats(n_votes=1000, n_revotes=100)  # exactly 10%
+    result = pc.classify_conversation(stats)
+    assert result["revote"] == pytest.approx(0.10)
+
+
+def test_classify_revote_below_threshold_excluded():
+    stats = _stats(n_votes=1000, n_revotes=99)
+    result = pc.classify_conversation(stats)
+    assert result["revote"] is None
+
+
+def test_classify_banned_qualifies():
+    stats = _stats(has_banned_voter=True)
+    result = pc.classify_conversation(stats)
+    assert result["banned"] == pytest.approx(float(stats["n_votes"]))
+
+
+def test_classify_banned_absent_excluded():
+    stats = _stats(has_banned_voter=False)
+    result = pc.classify_conversation(stats)
+    assert result["banned"] is None
+
+
+def test_classify_meta_qualifies():
+    stats = _stats(has_meta=True)
+    result = pc.classify_conversation(stats)
+    assert result["meta"] == pytest.approx(float(stats["n_comments"]))
+
+
+def test_classify_meta_absent_excluded():
+    stats = _stats(has_meta=False)
+    result = pc.classify_conversation(stats)
+    assert result["meta"] is None
+
+
+def test_classify_zerovote_qualifies():
+    stats = _stats(n_votes=0, n_ptpts=3)
+    result = pc.classify_conversation(stats)
+    assert result["zerovote"] == pytest.approx(3.0)
+
+
+def test_classify_zerovote_excluded_when_votes_present():
+    stats = _stats(n_votes=1)
+    result = pc.classify_conversation(stats)
+    assert result["zerovote"] is None
+
+
+def test_classify_smallmix_qualifies_when_unremarkable_and_small():
+    stats = _stats(n_votes=3000, n_comments=40, n_mod_out=0, n_revotes=0,
+                    has_banned_voter=False, has_meta=False)
+    result = pc.classify_conversation(stats)
+    assert result["smallmix"] == pytest.approx(3000.0)
+    assert result["midmix"] is None
+
+
+def test_classify_midmix_qualifies_when_unremarkable_and_medium():
+    stats = _stats(n_votes=30_000, n_comments=40)
+    result = pc.classify_conversation(stats)
+    assert result["midmix"] == pytest.approx(30_000.0)
+    assert result["smallmix"] is None
+
+
+def test_classify_smallmix_excluded_at_zero_votes():
+    """zerovote and smallmix are mutually exclusive (smallmix requires > 0)."""
+    stats = _stats(n_votes=0)
+    result = pc.classify_conversation(stats)
+    assert result["smallmix"] is None
+    assert result["midmix"] is None
+
+
+def test_classify_smallmix_excluded_above_size_bound():
+    stats = _stats(n_votes=200_000)
+    result = pc.classify_conversation(stats)
+    assert result["smallmix"] is None
+    assert result["midmix"] is None
+
+
+def test_classify_unremarkable_excludes_modheavy_from_smallmix():
+    """A small conversation that is ALSO modheavy must not double-count as
+    smallmix — 'unremarkable' means none of the other features apply."""
+    stats = _stats(n_votes=3000, n_comments=100, n_mod_out=25)  # 25% mod-out
+    result = pc.classify_conversation(stats)
+    assert result["modheavy"] is not None
+    assert result["smallmix"] is None
+
+
+def test_classify_unremarkable_excludes_banned_from_midmix():
+    stats = _stats(n_votes=30_000, has_banned_voter=True)
+    result = pc.classify_conversation(stats)
+    assert result["banned"] is not None
+    assert result["midmix"] is None
+
+
+# ---------------------------------------------------------------------------
+# survey_candidates — sorting + per-class limit
+# ---------------------------------------------------------------------------
+
+
+def test_survey_candidates_sorts_descending_by_metric_and_limits():
+    rows = [
+        _stats(zid=1, n_comments=100, n_mod_out=20),  # 0.20
+        _stats(zid=2, n_comments=100, n_mod_out=80),  # 0.80
+        _stats(zid=3, n_comments=100, n_mod_out=50),  # 0.50
+        _stats(zid=4, n_comments=100, n_mod_out=19),  # excluded
+    ]
+    result = pc.survey_candidates(rows, limit=2)
+    modheavy = result["modheavy"]
+    assert [c["zid"] for c in modheavy] == [2, 3]
+    assert modheavy[0]["metric"] == pytest.approx(0.80)
+    # Row columns required by the spec (no topic/text).
+    for c in modheavy:
+        assert set(c) >= {"zid", "n_votes", "n_ptpts", "n_comments", "metric"}
+
+
+def test_survey_candidates_zerovote_sorts_ascending_by_ptpts():
+    """zerovote favors the simplest (fewest-participant) exemplar first."""
+    rows = [
+        _stats(zid=1, n_votes=0, n_ptpts=9),
+        _stats(zid=2, n_votes=0, n_ptpts=1),
+        _stats(zid=3, n_votes=0, n_ptpts=5),
+    ]
+    result = pc.survey_candidates(rows, limit=10)
+    assert [c["zid"] for c in result["zerovote"]] == [2, 3, 1]
+
+
+def test_survey_candidates_covers_all_feature_classes():
+    rows = [_stats(zid=1)]
+    result = pc.survey_candidates(rows, limit=5)
+    assert set(result) == set(pc.FEATURES)
+
+
+def test_size_class_counts():
+    rows = [
+        _stats(zid=1, n_votes=100),      # small
+        _stats(zid=2, n_votes=5000),     # small (boundary, inclusive)
+        _stats(zid=3, n_votes=5001),     # medium
+        _stats(zid=4, n_votes=50_000),   # medium (boundary, inclusive)
+        _stats(zid=5, n_votes=50_001),   # large
+    ]
+    counts = pc.size_class_counts(rows)
+    assert counts["small"] == 2
+    assert counts["medium"] == 2
+    assert counts["large"] == 1
+
+
+# ---------------------------------------------------------------------------
+# next_free_slug — pure slug minting
+# ---------------------------------------------------------------------------
+
+
+def test_next_free_slug_first_ever():
+    assert pc.next_free_slug("modheavy", []) == "pc-modheavy-01"
+
+
+def test_next_free_slug_fills_gap():
+    existing = ["pc-modheavy-01", "pc-modheavy-03"]
+    assert pc.next_free_slug("modheavy", existing) == "pc-modheavy-02"
+
+
+def test_next_free_slug_ignores_other_features():
+    existing = ["pc-revote-01", "pc-revote-02"]
+    assert pc.next_free_slug("modheavy", existing) == "pc-modheavy-01"
+
+
+def test_next_free_slug_is_neutral():
+    """Minted slugs must never leak feature-unrelated identifying info."""
+    slug = pc.next_free_slug("banned", [])
+    assert re.fullmatch(r"pc-banned-\d\d", slug)
+
+
+# ---------------------------------------------------------------------------
+# fake_report_prefix — salted hash, no zid leak
+# ---------------------------------------------------------------------------
+
+
+def test_fake_report_prefix_deterministic():
+    assert pc.fake_report_prefix(424242) == pc.fake_report_prefix(424242)
+
+
+def test_fake_report_prefix_differs_across_zids():
+    assert pc.fake_report_prefix(1) != pc.fake_report_prefix(2)
+
+
+def test_fake_report_prefix_format_and_no_literal_zid():
+    zid = 13579
+    prefix = pc.fake_report_prefix(zid)
+    assert prefix.startswith("pcx")
+    assert re.fullmatch(r"pcx[0-9a-f]+", prefix)
+    assert str(zid) not in prefix
+
+
+# ---------------------------------------------------------------------------
+# assert_under_local — path-safety guard
+# ---------------------------------------------------------------------------
+
+
+def test_assert_under_local_accepts_path_inside(tmp_path):
+    target = tmp_path / ".local" / "pcxabc-pc-modheavy-01"
+    result = pc.assert_under_local(target, tmp_path)
+    assert result == target.resolve()
+
+
+def test_assert_under_local_rejects_path_outside_dot_local(tmp_path):
+    """The core path-safety requirement: writing anywhere that is NOT under
+    <root>/.local/ must raise, even if it's still under the real_data root."""
+    bad = tmp_path / "not_local" / "pcxabc-pc-modheavy-01"
+    with pytest.raises(ValueError):
+        pc.assert_under_local(bad, tmp_path)
+
+
+def test_assert_under_local_rejects_traversal_escape(tmp_path):
+    bad = tmp_path / ".local" / ".." / ".." / "evil"
+    with pytest.raises(ValueError):
+        pc.assert_under_local(bad, tmp_path)
+
+
+def test_compute_extract_dir_confines_to_local(tmp_path):
+    target = pc.compute_extract_dir(tmp_path, "pcxabc123", "pc-modheavy-01")
+    assert target == (tmp_path / ".local" / "pcxabc123-pc-modheavy-01").resolve()
+
+
+# ---------------------------------------------------------------------------
+# CSV row formatters — mirror the export format (server/src/report.ts)
+# ---------------------------------------------------------------------------
+
+
+def test_format_votes_rows_flips_sign_and_maps_columns():
+    raw = [{"tid": 7, "pid": 3, "vote": -1, "created": 1_700_000_000_123}]
+    rows = pc.format_votes_rows(raw)
+    assert len(rows) == 1
+    row = rows[0]
+    assert set(row) == {"timestamp", "datetime", "comment-id", "voter-id", "vote"}
+    assert row["timestamp"] == "1700000000"
+    assert row["comment-id"] == "7"
+    assert row["voter-id"] == "3"
+    assert row["vote"] == "1"  # raw -1 (agree) flips to export +1
+
+
+def test_format_votes_rows_preserves_all_rows_no_dedup():
+    """Full revote history: two rows for the same (pid, tid) must both survive."""
+    raw = [
+        {"tid": 1, "pid": 1, "vote": -1, "created": 100_000},
+        {"tid": 1, "pid": 1, "vote": 1, "created": 200_000},
+    ]
+    rows = pc.format_votes_rows(raw)
+    assert len(rows) == 2
+    assert rows[0]["vote"] == "1"
+    assert rows[1]["vote"] == "-1"
+
+
+def test_format_votes_rows_preserves_input_order():
+    raw = [
+        {"tid": 2, "pid": 1, "vote": 0, "created": 300},
+        {"tid": 1, "pid": 1, "vote": 0, "created": 100},
+    ]
+    rows = pc.format_votes_rows(raw)
+    assert [r["comment-id"] for r in rows] == ["2", "1"]
+
+
+def test_format_comments_rows_redacts_text():
+    raw = [{"tid": 5, "pid": 2, "created": 1_700_000_000_000, "mod": 1}]
+    rows = pc.format_comments_rows(raw, vote_counts={})
+    row = rows[0]
+    assert row["comment-body"] == ""
+    assert set(row) == {
+        "timestamp", "datetime", "comment-id", "author-id",
+        "agrees", "disagrees", "moderated", "comment-body",
+    }
+
+
+def test_format_comments_rows_counts_agrees_disagrees():
+    raw = [{"tid": 5, "pid": 2, "created": 0, "mod": 0}]
+    rows = pc.format_comments_rows(raw, vote_counts={5: (7, 3)})
+    row = rows[0]
+    assert row["agrees"] == "7"
+    assert row["disagrees"] == "3"
+
+
+def test_format_comments_rows_default_zero_votes():
+    raw = [{"tid": 9, "pid": 2, "created": 0, "mod": -1}]
+    rows = pc.format_comments_rows(raw, vote_counts={})
+    row = rows[0]
+    assert row["agrees"] == "0"
+    assert row["disagrees"] == "0"
+    assert row["moderated"] == "-1"
+
+
+# ---------------------------------------------------------------------------
+# CSV writers — round-trip through csv.DictReader
+# ---------------------------------------------------------------------------
+
+
+def test_write_votes_csv_round_trips(tmp_path):
+    raw = [
+        {"tid": 1, "pid": 1, "vote": -1, "created": 1_700_000_000_000},
+        {"tid": 2, "pid": 1, "vote": 1, "created": 1_700_000_001_000},
+    ]
+    path = tmp_path / "votes.csv"
+    pc.write_votes_csv(path, pc.format_votes_rows(raw))
+    with open(path, newline="") as fh:
+        reader = csv.DictReader(fh)
+        assert reader.fieldnames == [
+            "timestamp", "datetime", "comment-id", "voter-id", "vote",
+        ]
+        got = list(reader)
+    assert len(got) == 2
+    assert got[0]["vote"] == "1"
+
+
+def test_write_comments_csv_round_trips(tmp_path):
+    raw = [{"tid": 1, "pid": 1, "created": 1_700_000_000_000, "mod": 1}]
+    path = tmp_path / "comments.csv"
+    pc.write_comments_csv(path, pc.format_comments_rows(raw, vote_counts={1: (2, 1)}))
+    with open(path, newline="") as fh:
+        reader = csv.DictReader(fh)
+        assert reader.fieldnames == [
+            "timestamp", "datetime", "comment-id", "author-id",
+            "agrees", "disagrees", "moderated", "comment-body",
+        ]
+        got = list(reader)
+    assert got[0]["comment-body"] == ""
+    assert got[0]["agrees"] == "2"
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring — click commands, DB access faked out (no real Postgres needed).
+# ---------------------------------------------------------------------------
+
+
+class _FakeConn:
+    def close(self):
+        pass
+
+
+def test_survey_cli_prints_compactly_and_writes_json(tmp_path, monkeypatch):
+    mod = _load_cli_module()
+    monkeypatch.setattr(mod.psycopg2, "connect", lambda url: _FakeConn())
+
+    stats_rows = [
+        _stats(zid=1, n_comments=100, n_mod_out=30),  # modheavy
+        _stats(zid=2, n_votes=0, n_ptpts=2),           # zerovote
+    ]
+    monkeypatch.setattr(mod.pc, "fetch_conversation_stats", lambda conn: stats_rows)
+
+    # survey --out is containment-guarded like extract (raw zids in the JSON),
+    # so the test destination must live under <REAL_DATA_ROOT>/.local/.
+    monkeypatch.setattr(mod, "REAL_DATA_ROOT", tmp_path)
+    out_path = tmp_path / ".local" / "survey.json"
+    runner = CliRunner()
+    res = runner.invoke(
+        mod.cli,
+        ["survey", "--database-url", "postgresql://fake", "--limit", "2",
+         "--out", str(out_path)],
+    )
+    assert res.exit_code == 0, res.output
+    assert "[modheavy]" in res.output
+    assert "[zerovote]" in res.output
+    lines = [l for l in res.output.splitlines() if l.strip()]
+    assert len(lines) <= 40
+
+    data = json.loads(out_path.read_text())
+    assert data["n_conversations"] == 2
+    assert any(c["zid"] == 1 for c in data["candidates"]["modheavy"])
+    assert any(c["zid"] == 2 for c in data["candidates"]["zerovote"])
+    # No topic/description/text anywhere in the survey output.
+    dumped = json.dumps(data)
+    for forbidden in ("topic", "description", "txt", "comment-body"):
+        assert forbidden not in dumped
+
+
+def test_extract_cli_writes_files_and_updates_map(tmp_path, monkeypatch):
+    mod = _load_cli_module()
+    monkeypatch.setattr(mod.psycopg2, "connect", lambda url: _FakeConn())
+
+    votes_raw = [
+        {"tid": 1, "pid": 1, "vote": -1, "created": 1_700_000_000_000},
+        {"tid": 1, "pid": 1, "vote": 1, "created": 1_700_000_001_000},
+    ]
+    comments_raw = [{"tid": 1, "pid": 1, "created": 1_700_000_000_000, "mod": 0}]
+    monkeypatch.setattr(mod.pc, "fetch_votes", lambda conn, zid: votes_raw)
+    monkeypatch.setattr(mod.pc, "fetch_comments", lambda conn, zid: comments_raw)
+    monkeypatch.setattr(mod.pc, "fetch_comment_vote_counts", lambda conn, zid: {1: (1, 1)})
+
+    out_root = tmp_path / "real_data_root"
+    runner = CliRunner()
+    res = runner.invoke(
+        mod.cli,
+        ["extract", "--database-url", "postgresql://fake", "--zid", "555",
+         "--feature", "meta", "--out-root", str(out_root)],
+    )
+    assert res.exit_code == 0, res.output
+    assert "slug=pc-meta-01" in res.output
+
+    map_path = out_root / ".local" / "prodclone_map.json"
+    saved_map = json.loads(map_path.read_text())
+    assert saved_map["pc-meta-01"]["zid"] == 555
+    assert saved_map["pc-meta-01"]["feature"] == "meta"
+
+    extracted_dirs = list((out_root / ".local").glob("pcx*-pc-meta-01"))
+    assert len(extracted_dirs) == 1
+    votes_csvs = list(extracted_dirs[0].glob("*-votes.csv"))
+    assert len(votes_csvs) == 1
+    with open(votes_csvs[0], newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 2  # full revote history, no dedup
+
+
+def test_extract_cli_rejects_unknown_feature(tmp_path, monkeypatch):
+    mod = _load_cli_module()
+    monkeypatch.setattr(mod.psycopg2, "connect", lambda url: _FakeConn())
+    runner = CliRunner()
+    res = runner.invoke(
+        mod.cli,
+        ["extract", "--database-url", "postgresql://fake", "--zid", "1",
+         "--feature", "not-a-real-feature", "--out-root", str(tmp_path)],
+    )
+    assert res.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# merge_prodclone_map — merge-update, never clobber
+# ---------------------------------------------------------------------------
+
+
+def test_merge_prodclone_map_adds_new_slug():
+    existing = {"pc-modheavy-01": {"zid": 1}}
+    merged = pc.merge_prodclone_map(existing, "pc-revote-01", {"zid": 2})
+    assert merged["pc-modheavy-01"] == {"zid": 1}
+    assert merged["pc-revote-01"] == {"zid": 2}
+
+
+def test_merge_prodclone_map_does_not_mutate_input():
+    existing = {"pc-modheavy-01": {"zid": 1}}
+    pc.merge_prodclone_map(existing, "pc-revote-01", {"zid": 2})
+    assert "pc-revote-01" not in existing
+
+
+def test_merge_prodclone_map_overwrites_same_slug():
+    existing = {"pc-modheavy-01": {"zid": 1, "n_votes": 10}}
+    merged = pc.merge_prodclone_map(existing, "pc-modheavy-01", {"zid": 1, "n_votes": 99})
+    assert merged["pc-modheavy-01"]["n_votes"] == 99
+
+
+# ---------------------------------------------------------------------------
+# SQL builders — pure string construction (no DB), sanity-checked shape
+# ---------------------------------------------------------------------------
+
+
+def test_sql_conversation_stats_mentions_expected_tables():
+    sql = pc.sql_conversation_stats()
+    lowered = sql.lower()
+    for table in ("conversations", "votes", "participants", "comments"):
+        assert table in lowered
+
+
+def test_sql_votes_export_orders_by_created_then_tiebreak():
+    sql = pc.sql_votes_export()
+    lowered = sql.lower()
+    assert "order by" in lowered
+    assert "created" in lowered
+    assert "%s" in sql  # zid placeholder
+
+
+def test_sql_comments_export_has_zid_placeholder():
+    sql = pc.sql_comments_export()
+    assert "%s" in sql
+
+
+def test_sql_comment_vote_counts_has_zid_placeholder():
+    sql = pc.sql_comment_vote_counts()
+    assert "%s" in sql
+
+
+# ---------------------------------------------------------------------------
+# Integration test — real Postgres schema, survey + extract round trip
+# ---------------------------------------------------------------------------
+
+
+def _seed(cur, zid, uid_start, *, votes, comments, participants, banned_pids=()):
+    """Seed one synthetic conversation.
+
+    Assumes the CALLER has already run ``SET session_replication_role =
+    replica`` on this session — that suppresses FK-enforcement triggers (so we
+    don't need real ``users`` rows) and the ``tid_auto`` trigger (so our
+    explicit tid values are kept verbatim instead of being reassigned).
+    Mirrors the pattern in tests/poller/test_integration_postgres.py.
+
+    votes: list of (pid, tid, vote_sign, created_ms)  [raw DB sign]
+    comments: list of (tid, pid, created_ms, mod, is_meta)
+    participants: list of pid
+    """
+    cur.execute(
+        "INSERT INTO conversations (zid, topic, description) VALUES (%s, %s, %s)",
+        (zid, "t", "d"),
+    )
+    uid = uid_start
+    for pid in participants:
+        mod = -1 if pid in banned_pids else 0
+        cur.execute(
+            "INSERT INTO participants (zid, pid, uid, mod) VALUES (%s, %s, %s, %s)",
+            (zid, pid, uid + pid, mod),
+        )
+    for tid, pid, created, mod, is_meta in comments:
+        cur.execute(
+            "INSERT INTO comments (zid, tid, pid, uid, created, txt, mod, is_meta) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+            (zid, tid, pid, uid + pid, created, f"synthetic comment {zid}-{tid}",
+             mod, is_meta),
+        )
+    for pid, tid, vote, created in votes:
+        cur.execute(
+            "INSERT INTO votes (zid, pid, tid, vote, created) VALUES (%s, %s, %s, %s, %s)",
+            (zid, pid, tid, vote, created),
+        )
+
+
+@pytest.mark.integration
+def test_survey_and_extract_round_trip(tmp_path, monkeypatch):
+    from tests.conftest import require_polis_postgres
+
+    with require_polis_postgres() as url:
+        import psycopg2
+
+        conn = psycopg2.connect(url)
+        conn.autocommit = True
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SET session_replication_role = replica")
+                # zid 1: modheavy — 3/10 comments moderated-out (30% >= 20%).
+                _seed(
+                    cur, zid=101_001, uid_start=1,
+                    participants=[0, 1, 2, 3],
+                    comments=[(t, 0, 1000 + t, (-1 if t < 3 else 0), False)
+                              for t in range(10)],
+                    votes=[(p, t, -1, 2000 + p * 10 + t)
+                           for p in range(1, 4) for t in range(10)],
+                )
+                # zid 2: revote-heavy — 2 of 10 distinct pairs revoted (>=10%).
+                base_votes = [(p, t, -1, 3000 + p * 10 + t)
+                              for p in range(2) for t in range(5)]
+                revotes = [(0, 0, 1, 3999), (0, 1, 1, 3998)]
+                _seed(
+                    cur, zid=101_002, uid_start=100,
+                    participants=[0, 1],
+                    comments=[(t, 0, 3000 + t, 0, False) for t in range(5)],
+                    votes=base_votes + revotes,
+                )
+                # zid 3: banned voter cast a vote.
+                _seed(
+                    cur, zid=101_003, uid_start=200,
+                    participants=[0, 1],
+                    banned_pids=[1],
+                    comments=[(0, 0, 4000, 0, False)],
+                    votes=[(0, 0, -1, 4001), (1, 0, 1, 4002)],
+                )
+                # zid 4: has a meta comment.
+                _seed(
+                    cur, zid=101_004, uid_start=300,
+                    participants=[0],
+                    comments=[(0, 0, 5000, 0, True)],
+                    votes=[(0, 0, -1, 5001)],
+                )
+                # zid 5: zerovote.
+                _seed(
+                    cur, zid=101_005, uid_start=400,
+                    participants=[0, 1],
+                    comments=[(0, 0, 6000, 0, False)],
+                    votes=[],
+                )
+                # zid 6: unremarkable small (smallmix).
+                _seed(
+                    cur, zid=101_006, uid_start=500,
+                    participants=[0, 1],
+                    comments=[(0, 0, 7000, 0, False)],
+                    votes=[(0, 0, -1, 7001), (1, 0, 1, 7002)],
+                )
+
+            stats = pc.fetch_conversation_stats(conn)
+            our_zids = {101_001, 101_002, 101_003, 101_004, 101_005, 101_006}
+            our_stats = [s for s in stats if s["zid"] in our_zids]
+            assert len(our_stats) == 6
+
+            survey = pc.survey_candidates(our_stats, limit=10)
+            assert 101_001 in {c["zid"] for c in survey["modheavy"]}
+            assert 101_002 in {c["zid"] for c in survey["revote"]}
+            assert 101_003 in {c["zid"] for c in survey["banned"]}
+            assert 101_004 in {c["zid"] for c in survey["meta"]}
+            assert 101_005 in {c["zid"] for c in survey["zerovote"]}
+            assert 101_006 in {c["zid"] for c in survey["smallmix"]}
+
+            # --- extract zid 101_006 (smallmix) and verify with load_export_votes ---
+            out_root = tmp_path / "real_data_root"
+            map_path = out_root / ".local" / "prodclone_map.json"
+            result = pc.run_extract(
+                conn, zid=101_006, feature="smallmix",
+                out_root=out_root, map_path=map_path,
+            )
+            slug = result["slug"]
+            extracted_dir = Path(result["dir"])
+            assert extracted_dir.exists()
+            assert extracted_dir.is_relative_to((out_root / ".local").resolve())
+
+            votes_csv = next(extracted_dir.glob("*-votes.csv"))
+            comments_csv = next(extracted_dir.glob("*-comments.csv"))
+            with open(votes_csv, newline="") as fh:
+                vote_rows = list(csv.DictReader(fh))
+            assert len(vote_rows) == 2
+            with open(comments_csv, newline="") as fh:
+                comment_rows = list(csv.DictReader(fh))
+            assert comment_rows[0]["comment-body"] == ""
+
+            # prodclone_map.json — merge-update, never clobber.
+            assert map_path.exists()
+            saved_map = json.loads(map_path.read_text())
+            assert slug in saved_map
+            assert saved_map[slug]["zid"] == 101_006
+            assert saved_map[slug]["feature"] == "smallmix"
+
+            # A second extraction (different feature) must not clobber the map.
+            result2 = pc.run_extract(
+                conn, zid=101_005, feature="zerovote",
+                out_root=out_root, map_path=map_path,
+            )
+            saved_map2 = json.loads(map_path.read_text())
+            assert slug in saved_map2  # still there
+            assert result2["slug"] in saved_map2
+
+            # --- verify parseability via the real loader (monkeypatch its
+            # search root at the .local dir, per the spec's suggested escape
+            # hatch — load_export_votes globs REAL_DATA_ROOT non-recursively).
+            from polismath.replay import real_data as real_data_mod
+
+            monkeypatch.setattr(
+                real_data_mod, "REAL_DATA_ROOT", (out_root / ".local").resolve()
+            )
+            ds = real_data_mod.load_export_votes(slug)
+            assert ds.n == 2
+        finally:
+            conn.close()
+
+
+def test_extract_path_safety_guard_direct(tmp_path):
+    """Spec-mandated path-safety test: a target outside .local must raise."""
+    with pytest.raises(ValueError):
+        pc.assert_under_local(tmp_path / "real_data" / "oops", tmp_path)
+
+
+def test_survey_cli_refuses_out_path_outside_local(tmp_path, monkeypatch):
+    """survey --out is guarded like extract: the survey JSON carries raw
+    zids, so a destination outside <REAL_DATA_ROOT>/.local/ must be refused
+    BEFORE anything runs (review finding, 2026-07-22)."""
+    mod = _load_cli_module()
+    monkeypatch.setattr(mod, "REAL_DATA_ROOT", tmp_path)
+    runner = CliRunner()
+    res = runner.invoke(
+        mod.cli,
+        ["survey", "--database-url", "postgresql://fake",
+         "--out", str(tmp_path / "leak.json")],
+    )
+    assert res.exit_code != 0
+    assert not (tmp_path / "leak.json").exists()


### PR DESCRIPTION
## What

Adds a prodclone extractor (Spec B) — a tool that exports feature-filtered private test datasets from a production database clone into the replay-data format. Built by a Sonnet agent from SPEC_B: `scripts/prodclone_extract.py` (click CLI with `survey` and `extract` commands) over `polismath/replay/prodclone.py` (pure SQL builders, feature classifiers, CSV writers, slug minting, path-safety guard).

## Privacy invariants (reviewed)

- The output path is resolved and asserted to live under `real_data/.local/` (refuses anything else).
- The directory prefix is a salted sha256 of the zid (the internal conversation id), never a real report id.
- The comment-body column is present but ALWAYS empty (text redacted — the math pipeline never reads it).
- The slug-to-zid map lives only in `.local/prodclone_map.json` (merge-updated).

The export mirrors the public dataset byte-layout: votes carry the full revote history (`ORDER BY created, ctid` — no dedup); comment agrees/disagrees are counted over all vote rows the way `report.ts` does.

## Feature classes

modheavy / revote / banned (voters with `participants.mod = -1`) / meta / zerovote / smallmix / midmix (unremarkable-volume coverage).

## Testing

52 passed — pure-function units (no DB) plus one integration test on the repo's `require_polis_postgres` throwaway-Postgres fixture, round-tripping survey → extract → `load_export_votes`. TDD (RED commit first in the agent's clone).

commit-id:9f45b733

---
**Stack**:
- #2689
- #2688
- #2687
- #2684
- #2683
- #2681
- #2680
- #2679
- #2676
- #2675
- #2674
- #2673
- #2672
- #2671
- #2670
- #2669
- #2668
- #2667
- #2666
- #2665
- #2664
- #2663
- #2659
- #2658
- #2637
- #2657
- #2656
- #2626
- #2655
- #2654
- #2653
- #2652
- #2651
- #2650
- #2649
- #2648
- #2647
- #2646 ⬅
- #2645
- #2644
- #2643
- #2642
- #2641
- #2625
- #2624
- #2623
- #2622
- #2621
- #2620
- #2640
- #2618
- #2639
- #2638
- #2615
- #2613
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*