### PR TITLE
python-math #23: feat(delphi): replay loader resolves private datasets under real_data/.local

### DIFF
--- a/delphi/polismath/replay/real_data.py
+++ b/delphi/polismath/replay/real_data.py
@@ -23,7 +23,12 @@ REAL_DATA_ROOT = Path(__file__).resolve().parents[2] / "real_data"
 
 
 def dataset_dir(slug: str) -> Path | None:
+    """Locate a dataset directory by slug — public (``real_data/*-<slug>``)
+    first, then private (``real_data/.local/*-<slug>``, gitignored). A public
+    match wins a slug collision."""
     hits = sorted(REAL_DATA_ROOT.glob(f"*-{slug}"))
+    if not hits:
+        hits = sorted(REAL_DATA_ROOT.glob(f".local/*-{slug}"))
     return hits[0] if hits else None
 
 

--- a/delphi/scripts/certify_battery.json
+++ b/delphi/scripts/certify_battery.json
@@ -11,7 +11,7 @@
     "preset": "front-loaded",
     "n_cuts": 6,
     "engine_mode": "clojure-legacy",
-    "notes": "6 front-loaded recomputes — early-conversation warm-start stress"
+    "notes": "6 front-loaded recomputes \u2014 early-conversation warm-start stress"
   },
   {
     "dataset": "vw",
@@ -25,5 +25,46 @@
     "n_cuts": 8,
     "engine_mode": "clojure-legacy",
     "notes": "8 evenly-spaced recomputes over the full biodiversity conversation"
+  },
+  {
+    "dataset": "FLI",
+    "preset": "uniform",
+    "n_cuts": 6,
+    "engine_mode": "clojure-legacy",
+    "notes": "smallest private dataset (~91k votes) \u2014 pilot for the private-size regime; calibrates clj/py wall-clock before scheduling bg2018/pakistan/engage/bg2050"
+  },
+  {
+    "dataset": "bg2018",
+    "preset": "uniform",
+    "n_cuts": 8,
+    "engine_mode": "clojure-legacy",
+    "notes": "~226k votes; revote-rich production conversation"
+  },
+  {
+    "dataset": "pakistan",
+    "preset": "uniform",
+    "n_cuts": 8,
+    "engine_mode": "clojure-legacy",
+    "notes": "~400k votes"
+  },
+  {
+    "dataset": "engage",
+    "preset": "uniform",
+    "n_cuts": 8,
+    "engine_mode": "clojure-legacy",
+    "notes": "~443k votes"
+  },
+  {
+    "dataset": "bg2050",
+    "preset": "uniform",
+    "n_cuts": 6,
+    "engine_mode": "clojure-legacy",
+    "notes": "largest (~1.03M votes) \u2014 6 cuts to bound wall-clock"
+  },
+  {
+    "dataset": "vw",
+    "preset": "every-vote",
+    "engine_mode": "clojure-legacy",
+    "notes": "densest warm-start chain: one recompute per vote (4683 steps) \u2014 maximal sequential-seam coverage on the smallest dataset"
   }
 ]

--- a/delphi/tests/replay_harness/test_certify.py
+++ b/delphi/tests/replay_harness/test_certify.py
@@ -138,13 +138,19 @@ def test_parse_battery_entry_schedule_form_reads_base_id_from_file(tmp_path):
 
 
 def test_load_battery_starter_file_shape():
+    """The committed battery parses, keeps the four original starter entries,
+    covers the private datasets (session-3 extension), and has no duplicate
+    (dataset, schedule) pairs. Deliberately NOT pinned to an exact count —
+    the battery GROWS as the goal's coverage expands (GOAL_R1_PARITY.md)."""
     entries = cert.load_battery(CERTIFY_BATTERY_PATH)
     ids = {(e.dataset, e.schedule_id) for e in entries}
     assert ("vw", "uniform8-clojure-legacy") in ids
     assert ("vw", "front-loaded6-clojure-legacy") in ids
     assert ("vw", "single-cut-clojure-legacy") in ids
     assert ("biodiversity", "uniform8-clojure-legacy") in ids
-    assert len(entries) == 4
+    for private_ds in ("FLI", "bg2018", "pakistan", "engage", "bg2050"):
+        assert any(e.dataset == private_ds for e in entries), private_ds
+    assert len(ids) == len(entries), "duplicate (dataset, schedule) entries"
     assert all(e.engine_mode == "clojure-legacy" for e in entries)
 
 

--- a/delphi/tests/replay_harness/test_real_data_local.py
+++ b/delphi/tests/replay_harness/test_real_data_local.py
@@ -1,0 +1,39 @@
+"""dataset_dir resolves private datasets under real_data/.local/.
+
+The five private datasets live in ``real_data/.local/*-<slug>`` (gitignored);
+the public ones at ``real_data/*-<slug>``. The battery needs both
+(GOAL_R1_PARITY.md: "All real_data datasets"). Slug-only lookups keep
+report-id directory names out of code (real_data.py module doc).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from polismath.replay import real_data as rd
+
+
+@pytest.fixture()
+def fake_root(tmp_path, monkeypatch):
+    (tmp_path / "rPUBLIC-pub").mkdir()
+    (tmp_path / ".local" / "rPRIVATE-priv").mkdir(parents=True)
+    (tmp_path / ".local" / "rSHADOW-pub").mkdir()  # slug collision with public
+    monkeypatch.setattr(rd, "REAL_DATA_ROOT", tmp_path)
+    return tmp_path
+
+
+def test_public_dataset_resolves(fake_root):
+    assert rd.dataset_dir("pub") == fake_root / "rPUBLIC-pub"
+
+
+def test_local_dataset_resolves(fake_root):
+    assert rd.dataset_dir("priv") == fake_root / ".local" / "rPRIVATE-priv"
+
+
+def test_public_wins_slug_collision(fake_root):
+    # Top-level (public) match takes priority over a .local shadow.
+    assert rd.dataset_dir("pub") == fake_root / "rPUBLIC-pub"
+
+
+def test_unknown_slug_returns_none(fake_root):
+    assert rd.dataset_dir("nope") is None


### PR DESCRIPTION
`dataset_dir()` only globbed `real_data/*-<slug>`, so the five private datasets (bg2018, pakistan, engage, bg2050, FLI — slugs allowed in code per the 2026-07-05 naming policy; report-id directory names still never appear) were invisible to the replay harness and could not join the certify battery (the dataset × vote-schedule list that `scripts/certify.py` replays through both engines).

It now also searches `real_data/.local/*-<slug>`, with top-level (public) matches taking priority on a slug collision. Groundwork for extending the battery to all `real_data` datasets (`GOAL_R1_PARITY.md`, Battery section).

commit-id:a543ecf1

---
**Stack**:
- #2689
- #2688
- #2687
- #2684
- #2683
- #2681
- #2680
- #2679
- #2676
- #2675
- #2674
- #2673
- #2672
- #2671
- #2670
- #2669
- #2668
- #2667
- #2666
- #2665
- #2664
- #2663
- #2659
- #2658
- #2637
- #2657
- #2656
- #2626
- #2655
- #2654
- #2653
- #2652
- #2651 ⬅
- #2650
- #2649
- #2648
- #2647
- #2646
- #2645
- #2644
- #2643
- #2642
- #2641
- #2625
- #2624
- #2623
- #2622
- #2621
- #2620
- #2640
- #2618
- #2639
- #2638
- #2615
- #2613
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*