### PR TITLE
python-math #24: feat(delphi): Q10 carve-out — pin large-conv cutoffs to certify the deterministic full-PCA path

### DIFF
--- a/delphi/polismath/replay/certify.py
+++ b/delphi/polismath/replay/certify.py
@@ -90,7 +90,11 @@ def default_ledger_path() -> Path:
 # ---------------------------------------------------------------------------
 ACCEPTANCE_EXCLUDED_KEYS = frozenset({"subgroup-clusters", "subgroup-votes", "subgroup-repness"})
 ACCEPTANCE_KEYS = PREP_MAIN_KEYS - ACCEPTANCE_EXCLUDED_KEYS
-ACCEPTANCE_NOTICE = "subgroup-* keys excluded from acceptance (CLOJURE_QUIRKS.md Q7)"
+ACCEPTANCE_NOTICE = (
+    "subgroup-* keys excluded from acceptance (CLOJURE_QUIRKS.md Q7); "
+    "large-conv mini-batch PCA disabled in the clj driver — full-PCA path "
+    "certified at every size (Q10)"
+)
 
 
 def project_acceptance(blob: dict[str, Any]) -> dict[str, Any]:

--- a/math/dev/replay.clj
+++ b/math/dev/replay.clj
@@ -190,15 +190,31 @@
 ;; One full replay pass: seed → reduce conv-update, keeping conv per step.
 ;; ---------------------------------------------------------------------------
 
+;; Q10 carve-out (CLOJURE_QUIRKS.md): conv-update's large-conv dispatch
+;; (n-ptpts > 10000 OR n-cmts > 5000, conversation.clj:784-815) runs
+;; mini-batch partial-pca on an UNSEEDED random row sample — no
+;; deterministic reference exists on that path, even between two Clojure
+;; runs. Certification pins both cutoffs huge so every step takes the
+;; deterministic full-PCA (small-conv) path at any size. Logged per run
+;; here and by certify.py's acceptance notice.
+(def certify-conv-opts
+  {:ptpt-cutoff 1000000000
+   :cmt-cutoff  1000000000})
+
 (defn run-once
   "Returns a vector of [step conv-after-update] pairs, one per cut slot.
-  The reduce threading the conv IS the implicit warm-start chain."
+  The reduce threading the conv IS the implicit warm-start chain.
+  conv-update runs with certify-conv-opts (Q10 full-PCA carve-out)."
   [zid meta-tids steps]
+  (binding [*out* *err*]
+    (println "Q10 carve-out: large-conv mini-batch PCA disabled"
+             "(ptpt/cmt cutoffs pinned to 10^9; full PCA at every size)"))
   (let [seed (-> (conv/new-conv) (assoc :zid zid :meta-tids (set meta-tids)))]
     (loop [conv seed [s & more] steps acc []]
       (if (nil? s)
         acc
-        (let [conv' (conv/conv-update conv (->conv-votes (:votes s)))]
+        (let [conv' (conv/conv-update conv (->conv-votes (:votes s))
+                                      certify-conv-opts)]
           (recur conv' more (conj acc [s conv'])))))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Quirk Q10 (`delphi/docs/CLOJURE_QUIRKS.md`): Clojure's `conv-update` switches to mini-batch partial-pca on an UNSEEDED Mersenne-Twister row sample when n-ptpts > 10000 or n-cmts > 5000 (conversation.clj:757-815) — so large conversations are not reproducible, and no deterministic reference exists on that path, not even between two Clojure runs. This is the root cause of the pakistan/engage/bg2050 mid-chain battery divergences, verified to switch at exactly the first divergent step on all three.

## What

The replay driver now passes `{:ptpt-cutoff :cmt-cutoff}` = 10^9 into `conv-update`, so certification exercises the deterministic full-PCA path at every size (a `math/dev/` change only — no math sources touched), and `certify.py`'s acceptance notice logs the carve-out on every run, like Q7's (the subgroup carve-out). Python keeps full PCA at all sizes — no change needed there.

commit-id:7c20f8e1

---
**Stack**:
- #2689
- #2688
- #2687
- #2684
- #2683
- #2681
- #2680
- #2679
- #2676
- #2675
- #2674
- #2673
- #2672
- #2671
- #2670
- #2669
- #2668
- #2667
- #2666
- #2665
- #2664
- #2663
- #2659
- #2658
- #2637
- #2657
- #2656
- #2626
- #2655
- #2654
- #2653
- #2652 ⬅
- #2651
- #2650
- #2649
- #2648
- #2647
- #2646
- #2645
- #2644
- #2643
- #2642
- #2641
- #2625
- #2624
- #2623
- #2622
- #2621
- #2620
- #2640
- #2618
- #2639
- #2638
- #2615
- #2613
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*