### PR TITLE
python-math #25: feat(math): small-N degenerate parity — run the real math on tiny matrices in clojure-legacy mode

### DIFF
--- a/delphi/polismath/conversation/conversation.py
+++ b/delphi/polismath/conversation/conversation.py
@@ -684,8 +684,14 @@ class Conversation:
         import numpy as np
         import pandas as pd
 
-        # Check if we have enough data
-        if self.rating_mat.shape[0] < 2 or self.rating_mat.shape[1] < 2:
+        # Check if we have enough data. Clojure runs the REAL math on any
+        # non-empty matrix — a 1x1 single-vote conversation yields center =
+        # the vote and a rank-capped zero component (every-vote step-0
+        # oracle, journal 2026-07-22) — so clojure-legacy only short-circuits
+        # on a truly EMPTY dimension; improved keeps the <2 guard.
+        tiny = self.rating_mat.shape[0] < 2 or self.rating_mat.shape[1] < 2
+        empty = self.rating_mat.shape[0] == 0 or self.rating_mat.shape[1] == 0
+        if empty or (tiny and resolve_engine_mode() != ENGINE_MODE_LEGACY):
             # Not enough data for PCA, create minimal results
             cols = max(self.rating_mat.shape[1], 1)
             self.pca = {
@@ -1793,6 +1799,14 @@ class Conversation:
             center = np.asarray(self.pca['center'], dtype=float)
             comps = np.asarray(self.pca['comps'], dtype=float)
             cmnt_proj = pca_project_cmnts(center, comps)  # Delphi sign, (n_cmts, n_comps)
+            if cmnt_proj.ndim == 2 and cmnt_proj.shape[1] < 2:
+                # comps are rank-capped (a 1-cmt conv has ONE component) but
+                # Clojure's comment-projection is always 2-row: the [pc1 pc2]
+                # destructure zero-fills the missing component
+                # (with-proj-and-extremtiy over sparsity-aware projection).
+                cmnt_proj = np.pad(
+                    cmnt_proj, ((0, 0), (0, 2 - cmnt_proj.shape[1]))
+                )
             extremity = compute_comment_extremity(cmnt_proj)
             pca_out = dict(result.get('pca', {}))
             if len(perm) == center.shape[0]:

--- a/delphi/polismath/pca_kmeans_rep/pca.py
+++ b/delphi/polismath/pca_kmeans_rep/pca.py
@@ -280,18 +280,24 @@ def pca_project_dataframe(df: pd.DataFrame,
     matrix_data_no_nan = matrix_data.copy()
     matrix_data_no_nan[nan_indices] = col_means[nan_indices[1]]
     
-    # Verify there are enough rows and columns for PCA
+    # Verify there are enough rows and columns for PCA. The powerit
+    # (clojure-legacy) path runs the REAL math on any non-empty matrix —
+    # Clojure has no small-dim guard; a 1x1 single-vote conversation yields
+    # center = the vote and a rank-capped zero component (every-vote step-0
+    # oracle). Only a truly EMPTY dimension short-circuits there; the
+    # sklearn/improved path keeps its historical <2 guard.
     n_rows, n_cols = matrix_data_no_nan.shape
     if n_rows < 2 or n_cols < 2:
-        # Create minimal PCA results with consistent shape
-        n_proj = min(n_cols, 2)
-        pca_results = {
-            'center': np.zeros(n_cols),
-            'comps': np.zeros((min(n_comps, n_cols), n_cols))
-        }
-        # Create minimal projections (all zeros)
-        proj_dict = {pid: np.zeros(n_proj) for pid in df.index}
-        return pca_results, proj_dict
+        if n_rows == 0 or n_cols == 0 or not require_powerit:
+            # Create minimal PCA results with consistent shape
+            n_proj = min(n_cols, 2)
+            pca_results = {
+                'center': np.zeros(n_cols),
+                'comps': np.zeros((min(n_comps, n_cols), n_cols))
+            }
+            # Create minimal projections (all zeros)
+            proj_dict = {pid: np.zeros(n_proj) for pid in df.index}
+            return pca_results, proj_dict
     
     # TODO(julien): try removing random_state to see if results are deterministic without it
     # (sklearn's full SVD solver is deterministic; randomized solver needs a seed).
@@ -360,6 +366,15 @@ def pca_project_dataframe(df: pd.DataFrame,
                                       start_vectors=start_vectors)
             projections = ((matrix_data_no_nan - pca_results['center'])
                            @ pca_results['comps'].T)
+            # comps are RANK-CAPPED (min(n_comps, data dim), matching
+            # Clojure's emitted comps) but projections are always 2-D:
+            # Clojure's [pc1 pc2] destructure zero-fills a missing second
+            # component (sparsity-aware-project-ptpt, pca.clj:134-157).
+            if projections.ndim == 2 and projections.shape[1] < n_comps:
+                projections = np.pad(
+                    projections,
+                    ((0, 0), (0, n_comps - projections.shape[1])),
+                )
 
         projections = np.ascontiguousarray(projections)
 

--- a/delphi/polismath/pca_kmeans_rep/repness.py
+++ b/delphi/polismath/pca_kmeans_rep/repness.py
@@ -848,9 +848,15 @@ def conv_repness(vote_matrix_df: pd.DataFrame,
         'comment_repness': []
     }
 
-    # Check if we have enough data
+    # Check if we have enough data. Clojure computes repness/consensus for
+    # ANY matrix (its best-agree guarantee produces an entry even for a
+    # single-vote 1x1 conversation; rest-stats over zero other groups fall
+    # back to the (0+1)/(0+2) prior — every-vote step-0 oracle, journal
+    # 2026-07-22). clojure-legacy therefore proceeds; improved keeps the
+    # historical <2 guard.
     if vote_matrix_df.shape[0] < 2 or vote_matrix_df.shape[1] < 2:
-        return empty_result
+        if resolve_engine_mode() != ENGINE_MODE_LEGACY:
+            return empty_result
 
     # Convert wide-format to long-format DataFrame
     # Wide: participants × comments (values = votes)

--- a/delphi/tests/test_legacy_blob_shape.py
+++ b/delphi/tests/test_legacy_blob_shape.py
@@ -475,6 +475,61 @@ def test_conv_repness_consensus_tie_break_follows_tid_order():
 
 
 # ---------------------------------------------------------------------------
+# Degenerate single-vote conversation: Clojure runs the REAL math on a 1x1
+# matrix (every-vote step-0 oracle, journal 2026-07-22 "every-vote step-0
+# diagnosis COMPLETE"): center = the vote, comps rank-capped to 1 (zero
+# vector — no variance), comment-projection zero-padded to 2 rows, repness
+# best-agree guarantee and consensus selection still produce entries.
+# Python's <2 guards must yield to the real computation in legacy mode.
+# ---------------------------------------------------------------------------
+def _tiny_conv():
+    # Built AFTER the mode fixture: the degenerate-guard behavior lives in
+    # the COMPUTE path (recompute), not just emission.
+    c = Conversation("tiny_single_vote")
+    c = c.update_votes(
+        {"votes": [{"pid": 1, "tid": 24, "vote": 1}]}, recompute=False
+    )
+    return c.recompute()
+
+
+def test_legacy_single_vote_pca_is_real(legacy):
+    d = _tiny_conv().to_dict()
+    # internal center = +1 (the vote, Delphi convention) -> emitted -1.0
+    assert d["pca"]["center"] == [-1.0]
+    # comps rank-capped to min(n_comps, n_cols) = 1; zero vector (no variance)
+    assert d["pca"]["comps"] == [[0.0]]
+    # comment-projection stays TWO rows (Clojure's [pc1 pc2] destructure
+    # zero-fills the missing component)
+    assert len(d["pca"]["comment-projection"]) == 2
+    assert d["pca"]["comment-extremity"] == [0.0]
+
+
+def test_legacy_single_vote_repness_and_consensus(legacy):
+    d = _tiny_conv().to_dict()
+    rep = d["repness"]
+    (gid,) = rep.keys()
+    (entry,) = rep[gid]
+    assert entry["tid"] == 24
+    assert entry["n-success"] == 1 and entry["n-trials"] == 1
+    assert entry["p-success"] == pytest.approx(2 / 3)      # (1+1)/(1+2)
+    assert entry["repness"] == pytest.approx(4 / 3)        # (2/3) / ((0+1)/(0+2))
+    assert entry["best-agree"] is True
+    (cons,) = d["consensus"]["agree"]
+    assert cons["tid"] == 24
+    assert cons["p-success"] == pytest.approx(2 / 3)
+    assert d["consensus"]["disagree"] == []
+
+
+def test_improved_single_vote_guards_unchanged(improved):
+    d = _tiny_conv().to_dict()
+    assert d["pca"]["center"] == [0.0]
+    assert d["repness"]["group_repness"] == {0: []} or all(
+        not v for v in d["repness"]["group_repness"].values()
+    )
+    assert d["consensus"] == {"agree": [], "disagree": []}
+
+
+# ---------------------------------------------------------------------------
 # from_dict inverse: legacy round-trip restores the internal convention.
 # ---------------------------------------------------------------------------
 def test_legacy_from_dict_unpermutes_pca_alignment(legacy):


### PR DESCRIPTION
## Why

Clojure has NO small-dimension guards: a 1x1 single-vote conversation computes center = the vote, a rank-capped zero component, a repness entry (the best-agree guarantee holds for one comment; rest-stats over zero other groups fall back to the (0+1)/(0+2) prior), and a consensus selection — pinned exactly by the vw every-vote step-0 recording (journal 2026-07-22, "every-vote step-0 diagnosis COMPLETE"). Python short-circuited to zeros/empties below 2x2, which made the every-vote battery entry diverge from step 0 (4650 of 4683 steps).

## What (legacy-gated; improved mode keeps every historical guard)

- `_compute_pca` + `pca_project_dataframe`: in clojure-legacy mode the <2 guards only fire on truly EMPTY dimensions; the powerit (power-iteration PCA) path runs at any size — comps are already rank-capped, and zero variance yields Clojure's zero vector. Projections zero-pad to 2-D (Clojure's `[pc1 pc2]` destructure zero-fills a missing second component), as does the emitted comment-projection.
- `conv_repness`: the shape<2 early return yields to the real computation.

## Testing

TDD: single-vote fixtures with exact Clojure-derived values (center -1.0, p-success 2/3, repness 4/3, best-agree), RED observed; improved-mode guards pinned unchanged.

commit-id:00d8bc52

---
**Stack**:
- #2689
- #2688
- #2687
- #2684
- #2683
- #2681
- #2680
- #2679
- #2676
- #2675
- #2674
- #2673
- #2672
- #2671
- #2670
- #2669
- #2668
- #2667
- #2666
- #2665
- #2664
- #2663
- #2659
- #2658
- #2637
- #2657
- #2656
- #2626
- #2655
- #2654
- #2653 ⬅
- #2652
- #2651
- #2650
- #2649
- #2648
- #2647
- #2646
- #2645
- #2644
- #2643
- #2642
- #2641
- #2625
- #2624
- #2623
- #2622
- #2621
- #2620
- #2640
- #2618
- #2639
- #2638
- #2615
- #2613
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*