### PR TITLE
python-math #27: feat(delphi): Q12 carve-out — pin the cold-tick PCA start to ones in both replay drivers

### DIFF
--- a/delphi/polismath/replay/driver.py
+++ b/delphi/polismath/replay/driver.py
@@ -43,6 +43,8 @@ must feed raw-DB signs (flipped); the store records which convention was used.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+
+import numpy as np
 from typing import Any, Callable
 
 from polismath.conversation.conversation import Conversation
@@ -88,6 +90,17 @@ def run_replay(
     # into wall-clock — breaking determinism. Floor to 1 (nonzero).
     base_last_updated = (dataset.votes[0].t_ms or 1) if dataset.votes else 1
     conv = Conversation(spec.dataset, last_updated=base_last_updated)
+    # Q12 pinned cold start (CLOJURE_QUIRKS.md): production Clojure draws an
+    # UNSEEDED random PCA start vector on the cold tick (rand-starting-vec,
+    # pca.clj:79-82); with a small eigengap the 100 power iterations keep a
+    # start-dependent residual, so even two Clojure runs differ. Both replay
+    # drivers pin the cold start to the ONES vector — the value both engines
+    # already pad new-comment columns with (pca.clj:46-49 / pca.py
+    # _power_iteration) — via a single-element start that padding expands to
+    # all-ones at any width. Warm ticks take the real previous comps from
+    # tick 2 on, exactly as before. Mirrors dev/replay.clj
+    # certify-cold-start-pca.
+    conv.pca = {'center': np.zeros(1), 'comps': np.array([[1.0], [1.0]])}
 
     # Cumulative latest-wins moderation value per tid across the whole replay.
     mod_state: dict[int, int] = {}

--- a/math/dev/proj_probe.clj
+++ b/math/dev/proj_probe.clj
@@ -128,4 +128,31 @@
                       winner (first (filter (fn [[_ c]] (seq (:members c))) after))]
                   (println "PHASE view-assign: pid 5 ->" (pr-str (key winner))))))))))))
 
-(apply -main *command-line-args*)
+;; Auto-run only when invoked with args (clojure -M dev/proj_probe.clj ...);
+;; library-style load-file (batch-probe callers) skips it.
+(when (seq *command-line-args*)
+  (apply -main *command-line-args*))
+
+;; Batch-mode probe (pc-revote-01 split-loop tie): replay TWO vote-count
+;; batches, then print the in-conv subset ROW ORDER and the clean-start
+;; split-loop extraction sequence with runner-up gaps.
+(defn batch-probe [csv-path cut1 cut2]
+  (let [votes (->> (replay/read-votes-csv csv-path) replay/build-dataset)
+        b1    (subvec votes 0 cut1)
+        b2    (subvec votes cut1 cut2)
+        seed  (-> (conv/new-conv)
+                  (assoc :zid 99998 :meta-tids #{}
+                         :pca replay/certify-cold-start-pca))
+        prev  (conv/conv-update seed (replay/->conv-votes b1)
+                                replay/certify-conv-opts)
+        cur   (conv/conv-update prev (replay/->conv-votes b2)
+                                replay/certify-conv-opts)
+        pnmat (nm/named-matrix (nm/rownames (:rating-mat cur)) ["x" "y"]
+                               (:proj cur))
+        inmat (nm/rowname-subset pnmat (:in-conv cur))]
+    (println "BATCH rownames-head:" (pr-str (take 20 (nm/rownames inmat))))
+    (println "BATCH rownames-tail:" (pr-str (take-last 8 (nm/rownames inmat))))
+    (println "BATCH n-clusters cur:" (count (:base-clusters cur)))
+    (doseq [c (sort-by :id (:base-clusters cur))
+            :when (> (count (:members c)) 1)]
+      (println "  multi-member cluster id=" (:id c) "members=" (pr-str (:members c))))))

--- a/math/dev/replay.clj
+++ b/math/dev/replay.clj
@@ -201,15 +201,35 @@
   {:ptpt-cutoff 1000000000
    :cmt-cutoff  1000000000})
 
+;; Q12 carve-out (CLOJURE_QUIRKS.md): the COLD-tick PCA start vector is
+;; unseeded-random in production (rand-starting-vec, pca.clj:79-82 — the
+;; original author's own "should really throw a [seeded] random number
+;; generator in here... XXX" comment) — with a small eigengap, 100 power
+;; iterations don't fully converge and the residual start-dependence makes
+;; even two Clojure runs differ. Certification pins the cold start to the
+;; ONES vector — the same value power-iteration pads new-comment columns
+;; with (pca.clj:46-49) — by seeding the conv with single-element [1.0]
+;; comps that the padding expands to all-ones at any width. Warm ticks are
+;; untouched (real previous comps take over from tick 2). The Python replay
+;; driver pins the same start.
+(def certify-cold-start-pca
+  {:comps [[1.0] [1.0]]})
+
 (defn run-once
   "Returns a vector of [step conv-after-update] pairs, one per cut slot.
   The reduce threading the conv IS the implicit warm-start chain.
-  conv-update runs with certify-conv-opts (Q10 full-PCA carve-out)."
+  conv-update runs with certify-conv-opts (Q10 full-PCA carve-out) and the
+  seed conv carries certify-cold-start-pca (Q12 pinned cold start)."
   [zid meta-tids steps]
   (binding [*out* *err*]
     (println "Q10 carve-out: large-conv mini-batch PCA disabled"
-             "(ptpt/cmt cutoffs pinned to 10^9; full PCA at every size)"))
-  (let [seed (-> (conv/new-conv) (assoc :zid zid :meta-tids (set meta-tids)))]
+             "(ptpt/cmt cutoffs pinned to 10^9; full PCA at every size)")
+    (println "Q12 carve-out: cold-tick PCA start pinned to ones"
+             "(production start is unseeded-random)"))
+  (let [seed (-> (conv/new-conv)
+                 (assoc :zid zid
+                        :meta-tids (set meta-tids)
+                        :pca certify-cold-start-pca))]
     (loop [conv seed [s & more] steps acc []]
       (if (nil? s)
         acc


### PR DESCRIPTION
## Why

Quirk Q12: production Clojure draws an UNSEEDED random start vector for PCA power iteration on the cold tick — a conversation's first math update, where there is no previous result to warm-start from (`rand-starting-vec`, `pca.clj:79-82`, complete with the original author's own comment: "should really throw a [seeded] random number generator in the equation here... XXX"). With a small eigengap, the fixed 100 power iterations do not fully converge, so a start-dependent residual survives into the output (~4e-4 on the `pc-smallmix-01` battery entry at step 0). Even two Clojure runs differ on cold ticks — no deterministic reference exists to certify against.

## What

Both replay drivers (the Clojure and Python harness programs that feed a recorded vote schedule through their respective engines) now pin the cold start to the ONES vector — the exact value power iteration already pads new-comment columns with (`pca.clj:46-49` / `pca.py` `_power_iteration`). The pin works by seeding the conversation with a single-element `[1.0]` start vector that the existing padding expands to any width (`dev/replay.clj` `certify-cold-start-pca`; `polismath/replay/driver.py`). Warm ticks are untouched: from tick 2 on they take the real previous components exactly as before. The pin is logged per run, and the quirk is ledgered as Q12 in `CLOJURE_QUIRKS.md`.

## Battery effect

In the certification battery (recorded real-conversation vote schedules replayed through both engines and compared step by step):

- `pc-smallmix-01` and `pc-midmix-01` went DIVERGENCE -> MATCH.
- `pc-revote-01`'s step 0 cleared (its remaining residual from step 1 on comes from split-loop extraction order on tie-dense 15-comment geometry, diagnosed separately).
- 14/15 MATCH with the five prodclone extractions (datasets extracted from the production-database clone) in the battery.

commit-id:6b40e1bf

---
**Stack**:
- #2689
- #2688
- #2687
- #2684
- #2683
- #2681
- #2680
- #2679
- #2676
- #2675
- #2674
- #2673
- #2672
- #2671
- #2670
- #2669
- #2668
- #2667
- #2666
- #2665
- #2664
- #2663
- #2659
- #2658
- #2637
- #2657
- #2656
- #2626
- #2655 ⬅
- #2654
- #2653
- #2652
- #2651
- #2650
- #2649
- #2648
- #2647
- #2646
- #2645
- #2644
- #2643
- #2642
- #2641
- #2625
- #2624
- #2623
- #2622
- #2621
- #2620
- #2640
- #2618
- #2639
- #2638
- #2615
- #2613
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*