### PR TITLE
python-math #37: feat(math): mode collapse — Q15 watermark drop unconditional (item 4 parked)

### DIFF
--- a/delphi/polismath/conversation/conversation.py
+++ b/delphi/polismath/conversation/conversation.py
@@ -1440,10 +1440,10 @@ class Conversation:
         # has ONLY graph-node keys — :last-mod-timestamp is not one
         # (conversation.clj:780-820), so every votes recompute DROPS the mod
         # watermark; blobs carry lastModTimestamp only when the tick's last
-        # write was a mod-update. Improved mode keeps the persistent watermark
-        # (documented divergence). tests/test_mod_update_parity.py.
-        if resolve_engine_mode() == ENGINE_MODE_LEGACY:
-            result.last_mod_timestamp = None
+        # write was a mod-update. tests/test_mod_update_parity.py. (The
+        # former improved-mode persistent watermark is parked:
+        # POST_CUTOVER_IMPROVEMENTS.md item 4.)
+        result.last_mod_timestamp = None
 
         # Compute PCA and projections
         result._compute_pca(prev_pca=prev_pca)

--- a/delphi/tests/test_mod_update_parity.py
+++ b/delphi/tests/test_mod_update_parity.py
@@ -28,11 +28,6 @@ def legacy_mode(monkeypatch):
     monkeypatch.setenv(ENGINE_MODE_ENV_VAR, 'clojure-legacy')
 
 
-@pytest.fixture
-def improved_mode(monkeypatch):
-    monkeypatch.setenv(ENGINE_MODE_ENV_VAR, 'improved')
-
-
 def _conv(**sets):
     conv = Conversation("mod-parity-probe", last_updated=1)
     for attr, val in sets.items():
@@ -149,14 +144,6 @@ class TestWatermarkDroppedByRecompute:
         assert conv.last_mod_timestamp == 777
         conv2 = conv.update_votes(dict(self.BATCH), recompute=True)
         assert conv2.last_mod_timestamp is None
-
-    def test_watermark_persists_in_improved_mode(self, improved_mode):
-        # Documented divergence: improved mode keeps the sane persistent
-        # watermark instead of Clojure's graph-drop.
-        conv = Conversation("wm-keep", last_updated=1)
-        conv = conv.mod_update([_row(0, mod=-1, modified=777)])
-        conv2 = conv.update_votes(dict(self.BATCH), recompute=True)
-        assert conv2.last_mod_timestamp == 777
 
 
 class TestGroupVotesTallyRawMatrix:


### PR DESCRIPTION
`GOAL_CUTOVER_READY.md` Phase 2, chunk C2a of the mode collapse (removing the engine's improved-mode branches so the Clojure-faithful behavior is the only code path). Every votes recompute now drops `last_mod_timestamp` (the moderation watermark) exactly like Clojure — quirk Q15: Clojure's `conv-update` graph has no `:last-mod-timestamp` node, so the watermark never survives a votes recompute (`conversation.clj:780-820`). The former improved-mode persistent watermark is queue item 4 in `POST_CUTOVER_IMPROVEMENTS.md` (its park commit, preserving the deleted code, is minted at the end of the collapse). The improved-mode watermark test is deleted with the branch.

commit-id:4aa08bd4

---
**Stack**:
- #2689
- #2688
- #2687
- #2684
- #2683
- #2681
- #2680
- #2679
- #2676
- #2675
- #2674
- #2673
- #2672
- #2671
- #2670
- #2669
- #2668
- #2667
- #2666 ⬅
- #2665
- #2664
- #2663
- #2659
- #2658
- #2637
- #2657
- #2656
- #2626
- #2655
- #2654
- #2653
- #2652
- #2651
- #2650
- #2649
- #2648
- #2647
- #2646
- #2645
- #2644
- #2643
- #2642
- #2641
- #2625
- #2624
- #2623
- #2622
- #2621
- #2620
- #2640
- #2618
- #2639
- #2638
- #2615
- #2613
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*