### PR TITLE
python-math #38: feat(math): mode collapse — Q2 prev-tick group-votes unconditional (item 5 parked)

### DIFF
--- a/delphi/polismath/conversation/conversation.py
+++ b/delphi/polismath/conversation/conversation.py
@@ -1433,7 +1433,8 @@ class Conversation:
         prev_group_k_smoother = getattr(result, 'group_k_smoother', {})
         # Q2: Clojure's :comment-priorities shadows its current-tick input
         # with (:group-votes conv) — the PREVIOUS tick's stored group-votes
-        # (conversation.clj:658). Captured here, consumed in legacy mode only.
+        # (conversation.clj:658). Captured here, consumed by
+        # _compute_comment_priorities (Q2).
         prev_group_votes = getattr(result, 'group_votes', {})
 
         # Q15: Clojure's conv-update is a plumbing-graph compile whose output
@@ -1536,15 +1537,13 @@ class Conversation:
         # every tick".
         current_group_votes = self._compute_group_votes()
         # Stored for the NEXT tick's prev capture (Clojure keeps :group-votes
-        # on the conv / in math_main) — in both modes, like self.pca.
+        # on the conv / in math_main) — like self.pca.
         self.group_votes = current_group_votes
-        if resolve_engine_mode() == ENGINE_MODE_LEGACY:
-            # Q2: previous tick's group-votes (conversation.clj:658);
-            # {} on the first tick == Clojure's nil (reduce over nothing
-            # → A/P/S all 0).
-            group_votes = prev_group_votes if prev_group_votes is not None else {}
-        else:
-            group_votes = current_group_votes
+        # Q2: comment priorities read the PREVIOUS tick's group-votes
+        # (conversation.clj:658); {} on the first tick == Clojure's nil
+        # (reduce over nothing → A/P/S all 0). (The former improved-mode
+        # current-tick read is parked: POST_CUTOVER_IMPROVEMENTS.md item 5.)
+        group_votes = prev_group_votes if prev_group_votes is not None else {}
 
         priorities: Dict[Any, float] = {}
         for tid in self.rating_mat.columns:

--- a/delphi/tests/test_priority_unmirror.py
+++ b/delphi/tests/test_priority_unmirror.py
@@ -10,8 +10,9 @@ correct behavior AND the Clojure-HEAD-parity behavior, in BOTH engine modes.
 
 Separately (CLOJURE_QUIRKS Q2): Clojure's :comment-priorities node SHADOWS
 its current-tick group-votes input with `(:group-votes conv)` — the PREVIOUS
-tick's stored value (conversation.clj:658). 'clojure-legacy' mode must do the
-same; 'improved' mode keeps the current-tick read (the sane behavior).
+tick's stored value (conversation.clj:658). The engine does the same. (The
+former improved-mode current-tick read is parked:
+POST_CUTOVER_IMPROVEMENTS.md item 5.)
 """
 
 import os
@@ -86,10 +87,6 @@ def legacy_mode(monkeypatch):
     monkeypatch.setenv(ENGINE_MODE_ENV_VAR, 'clojure-legacy')
 
 
-@pytest.fixture
-def improved_mode(monkeypatch):
-    monkeypatch.delenv(PCA_IMPL_ENV_VAR, raising=False)
-    monkeypatch.setenv(ENGINE_MODE_ENV_VAR, 'improved')
 
 
 class TestPriorityMetricUnmirrored:
@@ -147,16 +144,6 @@ class TestPrioritiesGroupVotesTick:
     def test_legacy_stores_group_votes_for_next_tick(self, legacy_mode):
         conv1 = Conversation('q2').update_votes(_bloc_votes())
         assert conv1.group_votes == conv1._compute_group_votes()
-
-    def test_improved_uses_current_tick_group_votes(self, improved_mode):
-        conv1 = Conversation('q2').update_votes(_bloc_votes())
-        conv2 = conv1.update_votes(_tick2_votes())
-        expected_curr = _expected_priorities(conv2, conv2._compute_group_votes())
-        got = {f'c{k}' if not isinstance(k, str) else k: v
-               for k, v in conv2.comment_priorities.items()}
-        for tid in expected_curr:
-            assert abs(got[tid] - expected_curr[tid]) < 1e-9
-
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
`GOAL_CUTOVER_READY.md` Phase 2, chunk C2b of the mode collapse (removing the engine's improved-mode branches so the Clojure-faithful behavior is the only code path). Comment priorities now always read the PREVIOUS tick's stored group-votes — quirk Q2 — exactly like Clojure's `:comment-priorities` node shadowing with `(:group-votes conv)` (`conversation.clj:658`); `{}` on the first tick == Clojure's nil. The former improved-mode current-tick read is queue item 5 in `POST_CUTOVER_IMPROVEMENTS.md` (its park commit, preserving the deleted code, is minted at the end of the collapse). The improved-mode priority test is deleted with the branch.

commit-id:ac5c5903

---
**Stack**:
- #2689
- #2688
- #2687
- #2684
- #2683
- #2681
- #2680
- #2679
- #2676
- #2675
- #2674
- #2673
- #2672
- #2671
- #2670
- #2669
- #2668
- #2667 ⬅
- #2666
- #2665
- #2664
- #2663
- #2659
- #2658
- #2637
- #2657
- #2656
- #2626
- #2655
- #2654
- #2653
- #2652
- #2651
- #2650
- #2649
- #2648
- #2647
- #2646
- #2645
- #2644
- #2643
- #2642
- #2641
- #2625
- #2624
- #2623
- #2622
- #2621
- #2620
- #2640
- #2618
- #2639
- #2638
- #2615
- #2613
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*