### PR TITLE
python-math #46: feat(delphi): large-conv tick benchmark (Phase 5) — synthesized 33k x 783 shape, cold+warm tick timing

### DIFF
--- a/delphi/.gitignore
+++ b/delphi/.gitignore
@@ -252,3 +252,9 @@ data/
 output/
 results/
 visualization_output/
+
+# Golden snapshots are LOCAL artifacts (regression_recorder.py output) —
+# evidenced via the comparer + journal, never committed (repo bloat +
+# rebase-cascade pain; the private ones under real_data/.local are already
+# ignored wholesale).
+real_data/*/golden_snapshot.json

--- a/delphi/scripts/large_conv_tick_bench.py
+++ b/delphi/scripts/large_conv_tick_bench.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Large-conversation tick benchmark (GOAL_CUTOVER_READY.md Phase 5).
+
+Times ONE full-PCA math tick at the largest prodclone conversation shape
+(33,422 participants x 783 comments, ~2.0M votes) — the pre-flip
+measurement required by CUTOVER_RUNBOOK.md risk register item 3. The
+conversation is SYNTHESIZED (seeded RNG; no real data leaves anywhere),
+sized by CLI flags so the same script smoke-tests at small shapes.
+
+Two numbers matter:
+- cold_tick_s: first-ever recompute (no warm-start state) — the
+  worst case a poller pays when it first meets a huge conv.
+- warm_tick_s: recompute after one more small vote batch — the steady
+  per-tick cost (lineage warm starts populated), which is what the
+  serial-capacity verdict rides on.
+
+Usage::
+
+    uv run python scripts/large_conv_tick_bench.py                 # full shape
+    uv run python scripts/large_conv_tick_bench.py --n-ptpts 2000 \
+        --n-cmts 200 --n-votes 120000                              # smoke
+    ... --json-out result.json                                     # machine copy
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import time
+
+import click
+import numpy as np
+
+from polismath.conversation.conversation import Conversation
+
+# Largest prodclone conv (CUTOVER_RUNBOOK.md risk item 3 / journal s6).
+DEFAULT_N_PTPTS = 33_422
+DEFAULT_N_CMTS = 783
+DEFAULT_N_VOTES = 2_000_000
+
+
+def synthesize_votes(n_ptpts: int, n_cmts: int, n_votes: int,
+                     seed: int = 42) -> list[dict]:
+    """Deterministic synthetic vote stream shaped like a real large conv.
+
+    Every participant votes on ``round(n_votes / n_ptpts)`` distinct random
+    comments (so the per-row density matches the target total), with a
+    realistic agree-heavy sign mix (55% agree / 30% disagree / 15% pass).
+    ``created`` timestamps advance one ms per vote — deterministic ordering.
+    """
+    rng = np.random.default_rng(seed)
+    per_ptpt = max(1, round(n_votes / n_ptpts))
+    votes: list[dict] = []
+    t_ms = 1_600_000_000_000
+    for pid in range(n_ptpts):
+        tids = rng.choice(n_cmts, size=min(per_ptpt, n_cmts), replace=False)
+        signs = rng.choice([1.0, -1.0, 0.0], size=len(tids), p=[0.55, 0.30, 0.15])
+        for tid, sign in zip(tids, signs):
+            t_ms += 1
+            votes.append({"pid": pid, "tid": int(tid), "vote": float(sign),
+                          "created": t_ms})
+    return votes
+
+
+def run_bench(n_ptpts: int, n_cmts: int, n_votes: int, seed: int = 42) -> dict:
+    votes = synthesize_votes(n_ptpts, n_cmts, n_votes, seed=seed)
+    n_total = len(votes)
+
+    conv = Conversation("large-conv-bench", last_updated=1)
+    t0 = time.perf_counter()
+    conv = conv.update_votes(
+        {"votes": votes, "lastVoteTimestamp": votes[-1]["created"]},
+        recompute=False)
+    ingest_s = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    conv = conv.recompute()
+    cold_tick_s = time.perf_counter() - t0
+
+    # One more tiny batch -> the steady-state warm tick (lineage warm starts
+    # for PCA/base/group all populated by the cold tick above).
+    tail = [{"pid": 0, "tid": 0, "vote": 1.0,
+             "created": votes[-1]["created"] + 1}]
+    t0 = time.perf_counter()
+    conv = conv.update_votes(
+        {"votes": tail, "lastVoteTimestamp": tail[0]["created"]},
+        recompute=False)
+    conv = conv.recompute()
+    warm_tick_s = time.perf_counter() - t0
+
+    return {
+        "n_ptpts": n_ptpts,
+        "n_cmts": n_cmts,
+        "n_votes": n_total,
+        "ingest_s": round(ingest_s, 3),
+        "cold_tick_s": round(cold_tick_s, 3),
+        "warm_tick_s": round(warm_tick_s, 3),
+        "n_groups": len(conv.group_clusters),
+        "n_base_clusters": len(conv.base_clusters),
+        "machine": platform.machine(),
+        "platform": platform.platform(),
+    }
+
+
+@click.command()
+@click.option("--n-ptpts", default=DEFAULT_N_PTPTS, show_default=True)
+@click.option("--n-cmts", default=DEFAULT_N_CMTS, show_default=True)
+@click.option("--n-votes", default=DEFAULT_N_VOTES, show_default=True)
+@click.option("--seed", default=42, show_default=True)
+@click.option("--json-out", type=click.Path(), default=None,
+              help="Also write the result JSON to this path.")
+def main(n_ptpts: int, n_cmts: int, n_votes: int, seed: int,
+         json_out: str | None) -> None:
+    """Time one cold + one warm full-PCA tick at a synthesized conv shape."""
+    result = run_bench(n_ptpts, n_cmts, n_votes, seed=seed)
+    payload = json.dumps(result, indent=2, sort_keys=True)
+    click.echo(payload)
+    if json_out:
+        with open(json_out, "w") as fh:
+            fh.write(payload + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/delphi/tests/test_large_conv_tick_bench.py
+++ b/delphi/tests/test_large_conv_tick_bench.py
@@ -1,0 +1,42 @@
+"""Unit tests for scripts/large_conv_tick_bench.py's vote synthesizer
+(the bench itself is exercised on EC2/manually — Phase 5,
+GOAL_CUTOVER_READY.md)."""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "large_conv_tick_bench.py"
+spec = importlib.util.spec_from_file_location("large_conv_tick_bench", _SCRIPT)
+bench = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bench)
+
+
+def test_synthesize_votes_shape_and_ranges():
+    votes = bench.synthesize_votes(100, 40, 2000, seed=7)
+    assert len(votes) == 100 * 20  # round(2000/100) = 20 per participant
+    pids = {v["pid"] for v in votes}
+    tids = {v["tid"] for v in votes}
+    assert pids == set(range(100))
+    assert tids <= set(range(40))
+    assert {v["vote"] for v in votes} <= {1.0, -1.0, 0.0}
+    # created strictly increases -> deterministic ordering downstream
+    created = [v["created"] for v in votes]
+    assert created == sorted(created) and len(set(created)) == len(created)
+
+
+def test_synthesize_votes_deterministic_per_seed():
+    a = bench.synthesize_votes(50, 30, 500, seed=42)
+    b = bench.synthesize_votes(50, 30, 500, seed=42)
+    c = bench.synthesize_votes(50, 30, 500, seed=43)
+    assert a == b
+    assert a != c
+
+
+def test_synthesize_votes_no_duplicate_pid_tid_pairs():
+    votes = bench.synthesize_votes(30, 25, 600, seed=1)
+    pairs = [(v["pid"], v["tid"]) for v in votes]
+    assert len(pairs) == len(set(pairs))


### PR DESCRIPTION
## What

`GOAL_CUTOVER_READY.md` Phase 5 / `CUTOVER_RUNBOOK.md` risk item 3: the pre-flip measurement tool — a benchmark answering whether the Python engine can tick the largest production-scale conversations serially before production is flipped onto it.

## How it works

Synthesizes the largest conversation shape found in prodclone (the local clone of the production database): 33,422 participants x 783 comments, ~2.0M votes — seeded RNG, no real data. It then times one COLD tick (full PCA from scratch) and one WARM tick (lineage warm starts populated — the steady per-tick cost the serial-capacity verdict rides on).

## First numbers

Smoke run at 2000 x 200 x 120k votes on an arm64 laptop: cold 6.5s, warm 14.4s — the warm tick is the expensive one at scale (the legacy kmeans warm-start path). The benchmark runs on the bench EC2 instance class via a plain clone; the dataset is synthesized on-instance.

commit-id:5747f8c9

---
**Stack**:
- #2689
- #2688
- #2687
- #2684
- #2683
- #2681
- #2680
- #2679
- #2676
- #2675 ⬅
- #2674
- #2673
- #2672
- #2671
- #2670
- #2669
- #2668
- #2667
- #2666
- #2665
- #2664
- #2663
- #2659
- #2658
- #2637
- #2657
- #2656
- #2626
- #2655
- #2654
- #2653
- #2652
- #2651
- #2650
- #2649
- #2648
- #2647
- #2646
- #2645
- #2644
- #2643
- #2642
- #2641
- #2625
- #2624
- #2623
- #2622
- #2621
- #2620
- #2640
- #2618
- #2639
- #2638
- #2615
- #2613
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*