### PR TITLE
python-math #48: feat(math): vectorize legacy kmeans hot paths (item 9a)

### DIFF
--- a/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
+++ b/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
@@ -4411,3 +4411,62 @@ full battery); (b) deterministic seeded sampled PCA for extreme shapes.
 Feasibility note: dgemv-per-center keeps each element a row-dot-center
 op (same class as the scalar np.dot), so tie reproduction is plausible;
 dgemm reassociation/FMA is the hazard to test for.
+
+### Item 9a — vectorized legacy kmeans hot paths (2026-07-27/28, s7)
+
+Executed the s7 ruling above: replaced the per-pair Python `_euclidean`
+scans in `polismath/pca_kmeans_rep/legacy_kmeans.py` with per-center
+BLAS distance columns — BIT-IDENTICAL outputs (Plan A held end-to-end;
+the tie-divergence fallback was never needed).
+
+**Profile (before, cProfile at 4000x300x240k, 112.5s total)**:
+`_euclidean` 26.4M calls / 61.8s cum; `np.array_equal` 8.0M calls /
+38.9s cum (the O(n^2) `n_distinct_rows` scan); `cluster_step` 65.3s cum.
+
+**Bit-identity engineering (the empirical part)**: the s7 feasibility
+note's hazard was real but sat elsewhere than predicted — on this
+machine (numpy 1.26.4 / OpenBLAS 0.3.23 arm64) `X @ c` (dgemv)
+reassociates vs `float(np.dot(row, c))` for d>=4, and
+`einsum`/`(m*m).sum(1)` differ even at d=2; all were REJECTED. Batched
+matmul `(n,1,d)@(n,d,1)` (row norms) and `(n,1,d)@(d,1)` (cross) matched
+`np.dot` bit-for-bit on all 85 shape/scale combos probed (n=1..33422,
+d=1..783, scales 1e-8/1/1e8, C+F order), including the vw knife-edge
+pair (both distances EXACTLY 0.0) and NaN propagation — that kernel is
+the one shipped. The column combine keeps the scalar's exact order:
+`(row_norms + |c|^2) - 2.0*cross`, floor via `np.where(d2 < 0.0, 0.0,
+d2)` (NaN propagates, no maximum-clamp), then the same IEEE sqrt.
+
+**What changed** (`legacy_kmeans.py` only): new `_row_norms` +
+`_euclidean_col`; `cluster_step` folds the columns in the existing
+Clojure scan order (hash order >8 / input order <=8) with the scalar
+update rule `d <= best` (ties -> LATER cluster, NaN never wins), members
+regrouped by ascending row index == scalar append order; `most_distal`
+same inner fold + exact outer last-wins reduction (NaN-first-row sticks,
+later NaN rows skipped, last argmax otherwise); `n_distinct_rows` gains
+`bound=` (vectorized elimination passes, `array_equal(equal_nan=True)`
+semantics) so `clean_start_clusters`' `min(k, .)` is exact without
+O(n^2); `_recenter_center` index-gathers rows (same values). Scalar
+`_euclidean`, `same_clustering`, `weighted_mean` semantics untouched.
+
+**TDD**: RED confirmed (4 ImportError pins for the new functions +
+TypeError for `bound`); 11 new tests in tests/test_legacy_kmeans.py pin
+bit-equality against a VERBATIM `_scalar_d2_reference` copy of the
+pre-vectorization formula (exact `==`, random shapes incl. 1-row and
+k>n, scales 1e-8/1/1e8), the vw knife-edge exact-0.0, NaN row/center
+propagation, `cluster_step`/`most_distal` equivalence vs verbatim scalar
+reference loops (grid-tie fixtures, >8/<=8 scan, weights, k>n, NaN),
+and bounded-distinct semantics (NaN rows, -0.0==0.0).
+
+**Evidence**:
+- Full suite: 1171 passed / 22 skipped / 44 xfailed / 2 xpassed
+  (baseline 1160/22/44/2 + 11 new; zero new failures). Pyright clean on
+  both touched files.
+- Battery: `MATCH=20 DIVERGENCE=0 SKIPPED=0 ERROR=0` TWICE — once on
+  the vectorized tree (23:52) and once on the final bytes after an
+  annotation-only pyright cleanup (00:06). Bit-identity is certified,
+  not assumed.
+- Bench mid shape (8000x400x480k): cold 68.53s -> 3.58s (19x), warm
+  159.53s -> 3.77s (42x).
+- Bench FULL prod shape (33422x783x2.0M, scratch/vectorized_full.json):
+  cold 28.15s, warm 26.66s — vs the ~31 min warm tick measured s6/s7
+  (~70x). The largest prod conversation now ticks in under 30s.

--- a/delphi/polismath/pca_kmeans_rep/legacy_kmeans.py
+++ b/delphi/polismath/pca_kmeans_rep/legacy_kmeans.py
@@ -35,7 +35,7 @@ authoritative; where a Clojure quirk is load-bearing it is reproduced and
 flagged in the docstring.
 """
 
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 import numpy as np
 
@@ -70,25 +70,43 @@ class _NamedData:
                 f"(got shape {self.matrix.shape} for {len(self.row_names)} names)")
         # Last-write-wins on duplicate names would corrupt lookups; Clojure's
         # index-hash also de-dups names, but our callers pass unique names.
-        self._by_name: Dict[Any, np.ndarray] = {
-            name: self.matrix[i] for i, name in enumerate(self.row_names)}
+        self._index_by_name: Dict[Any, int] = {
+            name: i for i, name in enumerate(self.row_names)}
 
     def get_row(self, name: Any) -> np.ndarray:
         """Row vector for ``name`` (Clojure ``get-row-by-name``)."""
-        return self._by_name[name]
+        return self.matrix[self._index_by_name[name]]
 
     def __contains__(self, name: Any) -> bool:
-        return name in self._by_name
+        return name in self._index_by_name
 
-    def n_distinct_rows(self) -> int:
+    def n_distinct_rows(self, bound: Optional[int] = None) -> int:
         """Count of distinct rows (Clojure ``(count (distinct (matrix/rows ...)))``
         used for ``possible-clusters``, clusters.clj:249). NaN-safe to match the
-        production first-k-distinct helper."""
-        distinct: List[np.ndarray] = []
-        for row in self.matrix:
-            if not any(np.array_equal(row, u, equal_nan=True) for u in distinct):
-                distinct.append(row)
-        return len(distinct)
+        production first-k-distinct helper.
+
+        Distinctness is first-encounter ``array_equal(..., equal_nan=True)``
+        semantics, computed as vectorized elimination passes: each pass takes
+        the first still-unmatched row and removes every row equal to it
+        (elementwise ``==`` with NaN==NaN; note ``-0.0 == 0.0``, both matching
+        ``array_equal``). Row equality is an equivalence relation, so the
+        class count is identical to the old one-row-at-a-time scan.
+
+        ``bound`` caps the count: with ``bound=b`` the scan stops once ``b``
+        distinct rows are found, so ``min(b, n_distinct_rows(bound=b)) ==
+        min(b, n_distinct_rows())`` — exactly what ``clean_start_clusters``
+        needs (``min(k, ...)``) without an O(n²) full count at 33k+ rows.
+        """
+        m = self.matrix
+        alive = np.ones(m.shape[0], dtype=bool)
+        count = 0
+        while (bound is None or count < bound) and alive.any():
+            first = int(np.argmax(alive))
+            row = m[first]
+            same = ((m == row) | (np.isnan(m) & np.isnan(row))).all(axis=1)
+            alive &= ~same
+            count += 1
+        return count
 
 
 def _euclidean(a: np.ndarray, b: np.ndarray) -> float:
@@ -115,10 +133,55 @@ def _euclidean(a: np.ndarray, b: np.ndarray) -> float:
     return float(np.sqrt(d2))
 
 
-def weighted_mean(rows: Sequence[np.ndarray],
+def _row_norms(matrix: np.ndarray) -> np.ndarray:
+    """Per-row squared norms, BIT-EQUAL to ``float(np.dot(row, row))``.
+
+    Computed as a batched matmul ``(n,1,d) @ (n,d,1)``, which numpy evaluates
+    as one BLAS-style dot per row — empirically verified bit-identical to the
+    scalar ``np.dot`` on this machine across n=1..33422, d=1..783, scales
+    1e-8..1e8 (blas probe, journal item 9a). NOT ``einsum``/``(m*m).sum(1)``/
+    plain ``m @ c`` (dgemv): those reassociate the accumulation for d>=4 (and
+    einsum even for d=2) and differ in the last ulp — which Q11's cancellation
+    then amplifies into a changed 0.0-tie, i.e. changed cluster lineage.
+    """
+    m = np.asarray(matrix, dtype=float)
+    return np.matmul(m[:, None, :], m[:, :, None]).reshape(-1)
+
+
+def _euclidean_col(matrix: np.ndarray, center: np.ndarray,
+                   row_norms: np.ndarray) -> np.ndarray:
+    """``_euclidean(row, center)`` for every row at once — bit-identical.
+
+    Reproduces the scalar path exactly, element by element:
+
+      - cross products via the same batched-matmul-per-row kernel as
+        ``_row_norms`` (bit-equal to ``float(np.dot(row, center))``);
+      - the 3-term combine in the scalar's exact order/associativity:
+        ``(|row|² + |center|²) − 2·cross`` — left-to-right, matching
+        ``float(np.dot(av,av)) + float(np.dot(bv,bv)) - 2.0*float(...)``;
+      - the negative-residue floor as an elementwise post-combine select
+        (``np.where(d2 < 0.0, 0.0, d2)``), so NaN propagates (NaN < 0 is
+        False) exactly like the scalar ``if d2 < 0.0`` branch — never a
+        ``maximum``-style clamp;
+      - the same IEEE ``sqrt``.
+
+    The Q11 cancellation quirk (true distances ~1e-8 flooring to EXACTLY 0.0
+    and deciding tie-merges) is therefore preserved bit-for-bit; the vw
+    knife-edge pair is pinned in tests/test_legacy_kmeans.py.
+    """
+    cv = np.asarray(center, dtype=float)
+    cross = np.matmul(matrix[:, None, :], cv[:, None]).reshape(-1)
+    d2 = (row_norms + float(np.dot(cv, cv))) - 2.0 * cross
+    d2 = np.where(d2 < 0.0, 0.0, d2)
+    return np.sqrt(d2)
+
+
+def weighted_mean(rows: Union[np.ndarray, Sequence[Any]],
                   weights: Optional[Sequence[float]] = None) -> np.ndarray:
     """Mean (or weighted mean) of row vectors — Clojure ``weighted-mean``
-    (clusters.clj:89-126, matrix branch).
+    (clusters.clj:89-126, matrix branch). ``rows`` is anything
+    ``np.asarray`` turns into an (n, d) matrix: an ndarray slice (the
+    vectorized callers) or a sequence of row vectors.
 
     Clojure computes ``(count w)/(sum w) * sum_i(w_i * row_i)`` then takes the
     plain per-row mean, which algebraically equals ``sum_i(w_i row_i)/sum_i(w_i)``
@@ -208,8 +271,6 @@ def cluster_step(data: _NamedData,
     if n == 0:
         return []
     centers = [np.asarray(c['center'], dtype=float) for c in clusters]
-    members: List[List[Any]] = [[] for _ in range(n)]
-    positions: List[List[np.ndarray]] = [[] for _ in range(n)]
 
     # Assignment SCAN order: Clojure's add-to-closest iterates the
     # cleared-clusters map — ``(into {})`` of [id cluster] pairs is an
@@ -229,28 +290,34 @@ def cluster_step(data: _NamedData,
     else:
         scan = list(range(n))
 
-    for name, row in zip(data.row_names, data.matrix):
-        best_idx = scan[0]
-        best_dist = _euclidean(row, centers[scan[0]])
-        for j in scan[1:]:
-            d = _euclidean(row, centers[j])
-            # ``<=`` => ties go to the LATER cluster in scan order (Clojure
-            # min-key semantics over the map's iteration order).
-            if d <= best_dist:
-                best_dist = d
-                best_idx = j
-        members[best_idx].append(name)
-        positions[best_idx].append(row)
+    # Vectorized scan (item 9a): one bit-identical distance COLUMN per
+    # center, folded in scan order with the scalar loop's exact update rule
+    # ``d <= best`` — so ties go to the LATER cluster in scan order (Clojure
+    # min-key semantics over the map's iteration order), and a NaN distance
+    # never wins (NaN <= x is False), matching the scalar branch outcome
+    # row by row.
+    matrix = data.matrix
+    row_norms = _row_norms(matrix)
+    best_dist = _euclidean_col(matrix, centers[scan[0]], row_norms)
+    best_idx = np.full(matrix.shape[0], scan[0], dtype=np.intp)
+    for j in scan[1:]:
+        d = _euclidean_col(matrix, centers[j], row_norms)
+        upd = d <= best_dist
+        best_dist = np.where(upd, d, best_dist)
+        best_idx = np.where(upd, j, best_idx)
 
     out: List[Dict[str, Any]] = []
     for j in range(n):
-        if not members[j]:
+        rows_j = np.flatnonzero(best_idx == j)
+        if rows_j.size == 0:
             continue  # drop empty cluster
-        w = _cluster_weights(members[j], weights)
+        # Ascending row indices == the row-order append of the scalar loop.
+        members_j = [data.row_names[i] for i in rows_j]
+        w = _cluster_weights(members_j, weights)
         out.append({
             'id': clusters[j]['id'],
-            'members': members[j],
-            'center': weighted_mean(positions[j], w),
+            'members': members_j,
+            'center': weighted_mean(matrix[rows_j], w),
         })
     return out
 
@@ -269,9 +336,11 @@ def _recenter_center(data: _NamedData,
     surviving = [m for m in members if m in data]
     if not surviving:
         return None
-    rows = [data.get_row(m) for m in surviving]
+    # Gather by index in one fancy-indexing slice: identical values to the
+    # old per-name ``get_row`` list, so the mean is bit-identical.
+    idx = [data._index_by_name[m] for m in surviving]
     w = _cluster_weights(surviving, weights)
-    return weighted_mean(rows, w)
+    return weighted_mean(data.matrix[idx], w)
 
 
 def safe_recenter_clusters(data: _NamedData,
@@ -391,25 +460,42 @@ def most_distal(data: _NamedData, clusters: List[Dict[str, Any]]) -> Dict[str, A
         row in ``data`` row order.
 
     Returns ``{'dist', 'clst_id', 'id'}`` where ``id`` is the row name.
+
+    Vectorized (item 9a) with the scalar loops' exact semantics:
+
+      - inner fold over clusters uses bit-identical distance columns and the
+        update rule ``d <= near`` (NaN never wins, ties -> later cluster);
+      - the outer scalar loop ("row i wins iff ``near_dist[i] >= best``",
+        row 0 initializes) reduces to: if ``near_dist[0]`` is NaN, row 0
+        wins forever (nothing satisfies ``x >= NaN``); otherwise NaN rows
+        can never win (``NaN >= best`` is False) and among the non-NaN rows
+        a running last-wins max is exactly the LAST argmax.
     """
-    best_dist = None
-    best_clst_id = None
-    best_name = None
-    for name, row in zip(data.row_names, data.matrix):
-        # nearest cluster (ties -> later cluster)
-        near_dist = _euclidean(row, np.asarray(clusters[0]['center'], dtype=float))
-        near_id = clusters[0]['id']
-        for clst in clusters[1:]:
-            d = _euclidean(row, np.asarray(clst['center'], dtype=float))
-            if d <= near_dist:
-                near_dist = d
-                near_id = clst['id']
-        # farthest row (ties -> later row)
-        if best_dist is None or near_dist >= best_dist:
-            best_dist = near_dist
-            best_clst_id = near_id
-            best_name = name
-    return {'dist': best_dist, 'clst_id': best_clst_id, 'id': best_name}
+    matrix = data.matrix
+    n_rows = matrix.shape[0]
+    if n_rows == 0:
+        return {'dist': None, 'clst_id': None, 'id': None}
+
+    row_norms = _row_norms(matrix)
+    near_dist = _euclidean_col(
+        matrix, np.asarray(clusters[0]['center'], dtype=float), row_norms)
+    near_j = np.zeros(n_rows, dtype=np.intp)
+    for j in range(1, len(clusters)):
+        d = _euclidean_col(
+            matrix, np.asarray(clusters[j]['center'], dtype=float), row_norms)
+        upd = d <= near_dist
+        near_dist = np.where(upd, d, near_dist)
+        near_j = np.where(upd, j, near_j)
+
+    if np.isnan(near_dist[0]):
+        win = 0
+    else:
+        valid = np.flatnonzero(~np.isnan(near_dist))
+        vmax = near_dist[valid].max()
+        win = int(valid[np.flatnonzero(near_dist[valid] == vmax)[-1]])
+    return {'dist': float(near_dist[win]),
+            'clst_id': clusters[int(near_j[win])]['id'],
+            'id': data.row_names[win]}
 
 
 def clean_start_clusters(data: _NamedData,
@@ -436,7 +522,9 @@ def clean_start_clusters(data: _NamedData,
 
     clusters = safe_recenter_clusters(data, clusters, weights)
     clusters = uniqify_clusters(clusters)
-    possible = min(k, data.n_distinct_rows())
+    # ``bound=k`` stops the distinct-row scan at k classes: min(k, .) makes
+    # any count beyond k unobservable, so this is exact (and not O(n²)).
+    possible = min(k, data.n_distinct_rows(bound=k))
 
     while True:
         clusters = recenter_clusters(data, clusters, weights)

--- a/delphi/tests/test_legacy_kmeans.py
+++ b/delphi/tests/test_legacy_kmeans.py
@@ -398,3 +398,330 @@ class TestQ11DistanceCancellation:
         # Clojure: both coincident points tie at distance 0.0 to clusters 6
         # AND 8 -> min-key last-wins sends both to id 8; id 6 empties, drops.
         assert result == {7: [30], 8: [10, 20]}
+
+
+# ---------------------------------------------------------------------------
+# Item 9a: vectorized distance columns — bit-equality pins.
+#
+# The scalar _euclidean path (Q11 cancellation formula) is the semantic
+# reference: distances that cancel to EXACTLY 0.0 create ties that decide
+# cluster-id lineage, so the vectorized per-center column MUST reproduce the
+# scalar result bit for bit (==, not approx). The reference below is a
+# VERBATIM copy of the pre-vectorization formula — kept here on purpose so
+# the production code can never drift from it unnoticed.
+# ---------------------------------------------------------------------------
+
+def _scalar_d2_reference(av, bv):
+    """Verbatim copy of the scalar ``_euclidean`` d² computation: three
+    separate float(np.dot(...)) terms combined left-to-right, then the
+    elementwise negative-residue floor (if-based, so NaN propagates)."""
+    av = np.asarray(av, dtype=float)
+    bv = np.asarray(bv, dtype=float)
+    d2 = float(np.dot(av, av)) + float(np.dot(bv, bv)) - 2.0 * float(np.dot(av, bv))
+    if d2 < 0.0:
+        d2 = 0.0
+    return d2
+
+
+def _scalar_dist_reference(av, bv):
+    """sqrt of the reference d² — bitwise what ``_euclidean`` returns."""
+    return float(np.sqrt(_scalar_d2_reference(av, bv)))
+
+
+# The vw every-vote step-57 knife-edge pair (journal 2026-07-22): true
+# distance 4.66e-15, cancellation floors it to EXACTLY 0.0.
+VW_KNIFE_A = [-1.7765256006253405, 0.65139331269767860]
+VW_KNIFE_B = [-1.7765256006253405, 0.65139331269767400]
+
+
+class TestVectorizedDistanceColumnBitEquality:
+    """_euclidean_col(matrix, center, row_norms) must equal the scalar path
+    EXACTLY, element by element, on every shape — including the cancellation
+    knife-edge and NaN propagation."""
+
+    @staticmethod
+    def _assert_col_bit_equal(X, c):
+        from polismath.pca_kmeans_rep.legacy_kmeans import _euclidean_col, _row_norms
+
+        X = np.asarray(X, dtype=float)
+        col = _euclidean_col(X, np.asarray(c, dtype=float), _row_norms(X))
+        ref = np.array([_scalar_dist_reference(X[i], c) for i in range(X.shape[0])])
+        both_nan = np.isnan(col) & np.isnan(ref)
+        assert ((col == ref) | both_nan).all(), (
+            f"bit mismatch for shape {X.shape}: got {col!r} want {ref!r}")
+        return col
+
+    def test_row_norms_bit_equal_to_scalar_dot(self):
+        from polismath.pca_kmeans_rep.legacy_kmeans import _row_norms
+
+        rng = np.random.default_rng(20260727)
+        for (n, d) in [(1, 2), (3, 2), (8, 2), (100, 2), (1000, 2),
+                       (2, 1), (7, 5), (9, 7), (60, 100)]:
+            for scale in (1.0, 1e-8, 1e8):
+                X = rng.standard_normal((n, d)) * scale
+                got = _row_norms(X)
+                ref = np.array([float(np.dot(X[i], X[i])) for i in range(n)])
+                assert (got == ref).all(), (n, d, scale)
+
+    def test_random_shapes_bit_equal(self):
+        rng = np.random.default_rng(4290)
+        # Includes 1-row matrices and small-n cases (fewer rows than the
+        # cluster counts exercised in the step-level tests below).
+        for (n, d) in [(1, 2), (3, 2), (8, 2), (100, 2), (1000, 2),
+                       (2, 1), (7, 5), (9, 7), (60, 100)]:
+            for scale in (1.0, 1e-8, 1e8):
+                X = rng.standard_normal((n, d)) * scale
+                for _ in range(3):
+                    self._assert_col_bit_equal(X, rng.standard_normal(d) * scale)
+                # Center coincident with a row: self-distance must be the
+                # scalar's exact result (0.0 via the cancellation formula).
+                col = self._assert_col_bit_equal(X, X[0].copy())
+                assert col[0] == 0.0
+
+    def test_knife_edge_pair_cancels_to_exactly_zero(self):
+        X = np.array([VW_KNIFE_A, VW_KNIFE_B, [5.0, 5.0]])
+        for center in (np.array(VW_KNIFE_A), np.array(VW_KNIFE_B)):
+            col = self._assert_col_bit_equal(X, center)
+            # BOTH near-coincident rows floor to exactly 0.0 against either
+            # center — the tie that decides Q11 merge lineage.
+            assert col[0] == 0.0 and col[1] == 0.0
+
+    def test_nan_row_and_nan_center_propagate(self):
+        from polismath.pca_kmeans_rep.legacy_kmeans import _euclidean_col, _row_norms
+
+        X = np.array([[np.nan, 0.0], [1.0, 2.0]])
+        col = self._assert_col_bit_equal(X, np.array([3.0, 4.0]))
+        assert np.isnan(col[0]) and not np.isnan(col[1])
+
+        Xok = np.array([[1.0, 2.0], [3.0, 4.0]])
+        col = _euclidean_col(Xok, np.array([0.0, np.nan]), _row_norms(Xok))
+        assert np.isnan(col).all()
+
+
+class TestVectorizedClusterStepEquivalence:
+    """The vectorized assignment scan must reproduce the scalar row loop
+    EXACTLY: same members (order included), same surviving ids, bitwise-same
+    centers — under hash-scan order (>8), input order (<=8), weights, ties,
+    and k>n."""
+
+    @staticmethod
+    def _reference_cluster_step(data, clusters, weights=None):
+        # Verbatim pre-vectorization loop (distances via the scalar reference).
+        from polismath.pca_kmeans_rep.legacy_kmeans import (
+            _cluster_weights as cw, weighted_mean as wm)
+        from polismath.utils.clj_hash import clojure_hash_map_key_order
+
+        n = len(clusters)
+        if n == 0:
+            return []
+        centers = [np.asarray(c['center'], dtype=float) for c in clusters]
+        members = [[] for _ in range(n)]
+        positions = [[] for _ in range(n)]
+        if n > 8:
+            hash_pos = {cid: i for i, cid in enumerate(
+                clojure_hash_map_key_order([c['id'] for c in clusters]))}
+            scan = sorted(range(n), key=lambda j: hash_pos[clusters[j]['id']])
+        else:
+            scan = list(range(n))
+        for name, row in zip(data.row_names, data.matrix):
+            best_idx = scan[0]
+            best_dist = _scalar_dist_reference(row, centers[scan[0]])
+            for j in scan[1:]:
+                d = _scalar_dist_reference(row, centers[j])
+                if d <= best_dist:
+                    best_dist = d
+                    best_idx = j
+            members[best_idx].append(name)
+            positions[best_idx].append(row)
+        out = []
+        for j in range(n):
+            if not members[j]:
+                continue
+            out.append({'id': clusters[j]['id'], 'members': members[j],
+                        'center': wm(positions[j], cw(members[j], weights))})
+        return out
+
+    @staticmethod
+    def _assert_same(got, ref):
+        assert len(got) == len(ref)
+        for g, r in zip(got, ref):
+            assert g['id'] == r['id']
+            assert list(g['members']) == list(r['members'])
+            gc = np.asarray(g['center'], dtype=float)
+            rc = np.asarray(r['center'], dtype=float)
+            same = (gc == rc) | (np.isnan(gc) & np.isnan(rc))
+            assert gc.shape == rc.shape and same.all(), (g['id'], gc, rc)
+
+    def _random_case(self, rng, n_rows, n_clusters, weighted, grid=True):
+        # Grid-quantized coordinates make duplicate rows and row==center
+        # coincidences COMMON -> exact 0.0 ties through the cancellation
+        # formula, exercising the last-wins tie-break for real.
+        if grid:
+            vals = np.array([-1.0, -0.5, 0.0, 0.5, 1.0])
+            X = vals[rng.integers(0, len(vals), size=(n_rows, 2))]
+        else:
+            X = rng.standard_normal((n_rows, 2))
+        names = [f"p{i}" for i in range(n_rows)]
+        data = _nd(names, X)
+        centers = []
+        for _ in range(n_clusters):
+            if grid and rng.random() < 0.5 and n_rows:
+                centers.append(X[rng.integers(0, n_rows)].copy())
+            else:
+                centers.append(rng.standard_normal(2))
+        clusters = [{'id': i * 3 + 1, 'members': [], 'center': np.asarray(c)}
+                    for i, c in enumerate(centers)]
+        weights = ({nm: float(w) for nm, w in
+                    zip(names, rng.integers(1, 5, size=n_rows))}
+                   if weighted else None)
+        return data, clusters, weights
+
+    def test_matches_reference_across_fixtures(self):
+        from polismath.pca_kmeans_rep.legacy_kmeans import cluster_step
+
+        rng = np.random.default_rng(97)
+        cases = [
+            (50, 12, False, True),   # >8 clusters -> hash scan order + ties
+            (50, 12, True, True),    # ... with weights
+            (40, 5, False, True),    # <=8 clusters -> input order
+            (40, 8, True, True),     # boundary n==8
+            (5, 12, False, True),    # k > n
+            (1, 3, False, False),    # single row
+            (30, 9, False, False),   # continuous coords (no ties)
+        ]
+        for (n_rows, n_clusters, weighted, grid) in cases:
+            for _ in range(3):
+                data, clusters, weights = self._random_case(
+                    rng, n_rows, n_clusters, weighted, grid)
+                got = cluster_step(data, clusters, weights)
+                ref = self._reference_cluster_step(data, clusters, weights)
+                self._assert_same(got, ref)
+
+    def test_nan_row_follows_scalar_semantics(self):
+        # A NaN row never updates past the first scanned cluster (NaN <= x is
+        # False) -> it lands in scan[0], exactly as the scalar loop did.
+        from polismath.pca_kmeans_rep.legacy_kmeans import cluster_step
+
+        data = _nd(['a', 'nanrow'], [[0.0, 0.0], [np.nan, 1.0]])
+        clusters = [{'id': 0, 'members': [], 'center': np.array([0.0, 0.0])},
+                    {'id': 1, 'members': [], 'center': np.array([9.0, 9.0])}]
+        got = cluster_step(data, clusters)
+        ref = self._reference_cluster_step(data, clusters)
+        self._assert_same(got, ref)
+        assert 'nanrow' in got[0]['members']  # scan[0] == input position 0
+
+
+class TestVectorizedMostDistalEquivalence:
+    """most_distal must reproduce the scalar double loop exactly: inner
+    min over clusters (ties -> LATER cluster in input order), outer max over
+    rows (ties -> LATER row), NaN rows skipped — except a NaN FIRST row,
+    which the scalar loop keeps forever (nothing compares >= NaN)."""
+
+    @staticmethod
+    def _reference_most_distal(data, clusters):
+        # Verbatim pre-vectorization loop.
+        best_dist = None
+        best_clst_id = None
+        best_name = None
+        for name, row in zip(data.row_names, data.matrix):
+            near_dist = _scalar_dist_reference(
+                row, np.asarray(clusters[0]['center'], dtype=float))
+            near_id = clusters[0]['id']
+            for clst in clusters[1:]:
+                d = _scalar_dist_reference(
+                    row, np.asarray(clst['center'], dtype=float))
+                if d <= near_dist:
+                    near_dist = d
+                    near_id = clst['id']
+            if best_dist is None or near_dist >= best_dist:
+                best_dist = near_dist
+                best_clst_id = near_id
+                best_name = name
+        return {'dist': best_dist, 'clst_id': best_clst_id, 'id': best_name}
+
+    @classmethod
+    def _assert_same(cls, data, clusters):
+        from polismath.pca_kmeans_rep.legacy_kmeans import most_distal
+
+        got = most_distal(data, clusters)
+        ref = cls._reference_most_distal(data, clusters)
+        assert got['clst_id'] == ref['clst_id'] and got['id'] == ref['id'], (got, ref)
+        if ref['dist'] is None or np.isnan(ref['dist']):
+            assert got['dist'] is ref['dist'] or np.isnan(got['dist'])
+        else:
+            assert got['dist'] == ref['dist']
+        return got
+
+    def test_matches_reference_on_random_and_tied_fixtures(self):
+        rng = np.random.default_rng(1337)
+        vals = np.array([-1.0, 0.0, 1.0])
+        for n_rows, n_clusters in [(1, 1), (2, 5), (30, 3), (30, 11), (4, 9)]:
+            for _ in range(5):
+                X = vals[rng.integers(0, 3, size=(n_rows, 2))]
+                data = _nd([f"p{i}" for i in range(n_rows)], X)
+                clusters = []
+                for i in range(n_clusters):
+                    center = (X[rng.integers(0, n_rows)].copy()
+                              if rng.random() < 0.5 else rng.standard_normal(2))
+                    clusters.append({'id': i + 2, 'members': [],
+                                     'center': np.asarray(center, dtype=float)})
+                self._assert_same(data, clusters)
+
+    def test_all_rows_tie_at_zero_later_row_wins(self):
+        # Every row coincides with the single center -> all dists exactly 0.0
+        # -> outer >= keeps the LAST row.
+        data = _nd(['a', 'b', 'c'], [[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]])
+        clusters = [{'id': 5, 'members': [], 'center': np.array([1.0, 1.0])}]
+        got = self._assert_same(data, clusters)
+        assert got['id'] == 'c' and got['dist'] == 0.0
+
+    def test_nan_first_row_sticks_nan_later_row_skipped(self):
+        clusters = [{'id': 0, 'members': [], 'center': np.array([0.0, 0.0])}]
+        # NaN first row: best stays row 0 with NaN dist (scalar semantics).
+        data = _nd(['n', 'b'], [[np.nan, 0.0], [3.0, 4.0]])
+        got = self._assert_same(data, clusters)
+        assert got['id'] == 'n' and np.isnan(got['dist'])
+        # NaN NON-first row: skipped (NaN >= best is False).
+        data2 = _nd(['a', 'n', 'b'], [[1.0, 0.0], [np.nan, 0.0], [3.0, 4.0]])
+        got2 = self._assert_same(data2, clusters)
+        assert got2['id'] == 'b'
+
+
+class TestNDistinctRowsBounded:
+    """n_distinct_rows gains a ``bound`` cap so clean_start_clusters'
+    ``min(k, n_distinct)`` never pays for a full O(n²) distinct count.
+    Semantics must match the pre-vectorization scan: first-encounter
+    distinctness via array_equal(..., equal_nan=True)."""
+
+    @staticmethod
+    def _reference_n_distinct(matrix):
+        # Verbatim pre-vectorization implementation.
+        distinct = []
+        for row in np.asarray(matrix, dtype=float):
+            if not any(np.array_equal(row, u, equal_nan=True) for u in distinct):
+                distinct.append(row)
+        return len(distinct)
+
+    def test_unbounded_matches_reference_including_nan_and_negzero(self):
+        cases = [
+            [[0.0, 0.0], [0.0, 0.0], [1.0, 1.0]],
+            [[np.nan, 1.0], [np.nan, 1.0], [np.nan, 2.0]],   # NaN == NaN rows
+            [[-0.0, 1.0], [0.0, 1.0]],                        # -0.0 == 0.0
+            [[1.0, 2.0]],
+            np.zeros((0, 2)),
+        ]
+        data_rng = np.random.default_rng(7)
+        cases.append(np.array([-1.0, 0.0, 1.0])[
+            data_rng.integers(0, 3, size=(40, 2))])
+        for rows in cases:
+            m = np.asarray(rows, dtype=float)
+            nd = _NamedData(list(range(m.shape[0])), m)
+            assert nd.n_distinct_rows() == self._reference_n_distinct(m)
+
+    def test_bounded_count_saturates_like_min(self):
+        m = np.array([[0.0, 0.0], [1.0, 1.0], [0.0, 0.0], [2.0, 2.0],
+                      [3.0, 3.0], [1.0, 1.0]])  # 4 distinct
+        nd = _NamedData(list('abcdef'), m)
+        full = self._reference_n_distinct(m)
+        for k in (1, 2, 3, 4, 5, 10):
+            assert min(k, nd.n_distinct_rows(bound=k)) == min(k, full)


### PR DESCRIPTION
## What

Replace the per-pair Python `_euclidean` scans in `legacy_kmeans.py` (the quirk-for-quirk port of the Clojure engine's k-means) with per-center BLAS distance columns — BIT-IDENTICAL outputs, certified twice by the full certification battery (which replays 20 recorded dataset entries through the engine and compares against Clojure reference recordings). The bit-identity plan ("Plan A") held: no tie-break divergence appeared, so no fallback was needed.

## Why

Hot paths (cProfile at 4000 participants x 300 comments x 240k votes, 112.5s total): `_euclidean` 26.4M calls / 61.8s cumulative; `np.array_equal` 8.0M calls / 38.9s cumulative via the O(n^2) `n_distinct_rows` scan; `cluster_step` 65.3s cumulative.

## Bit-identity engineering

Empirically probed on numpy 1.26.4 / OpenBLAS 0.3.23 arm64:

- REJECTED: `X @ c` (dgemv) — it reassociates relative to `float(np.dot(row, c))` for d>=4; `einsum` and `(m*m).sum(1)` differ even at d=2. Last-ulp differences are amplified by quirk Q11 — the legacy distance formula d^2 = |a|^2+|b|^2-2ab cancels catastrophically, so near-coincident points tie at EXACTLY 0.0 — into changed 0.0-ties, i.e. changed cluster lineage.
- SHIPPED: batched matmul — `(n,1,d)@(n,d,1)` for row norms and `(n,1,d)@(d,1)` for cross products — bit-equal to `float(np.dot(...))` on all 85 probed shape/scale combos (n=1..33422, d=1..783, scales 1e-8/1/1e8, C and F memory order), including the vw dataset's knife-edge pair (both distances EXACTLY 0.0) and NaN propagation.
- The column combine keeps the scalar code's exact order and associativity: `(row_norms + |c|^2) - 2.0*cross`; the floor is `np.where(d2 < 0.0, 0.0, d2)` so NaN propagates (never a maximum-clamp); same IEEE sqrt.

## Changes (`legacy_kmeans.py` only)

- New `_row_norms` + `_euclidean_col` (bit-identical distance columns).
- `cluster_step`: the columns are folded in the existing Clojure scan order (hash order for >8 clusters, input order for <=8) with the scalar rule `d <= best` (ties go to the LATER cluster; NaN never wins); members are regrouped by ascending row index, which equals the scalar append order.
- `most_distal`: same inner fold; exact outer last-wins reduction (a NaN first row sticks; later NaN rows are skipped; otherwise last argmax).
- `n_distinct_rows(bound=)`: vectorized elimination passes with `array_equal(..., equal_nan=True)` semantics; `clean_start_clusters` passes `bound=k` so `min(k, .)` stays exact without the O(n^2) count.
- `_recenter_center`: index-gather (same values, same mean).
- `_euclidean` / `same_clustering` / `weighted_mean` semantics unchanged.

## Testing (TDD)

RED = 4 ImportError pins (`_euclidean_col` / `_row_norms`) plus a TypeError pin for the `bound` kwarg. 11 new tests: bit-equality against a VERBATIM `_scalar_d2_reference` copy of the pre-vectorization formula (exact ==), the knife-edge 0.0 case, NaN propagation, `cluster_step` / `most_distal` equivalence against verbatim scalar reference loops (grid-tie fixtures, the >8 and <=8 scan orders, weights, k>n, NaN), and bounded-distinct semantics (NaN, -0.0 == 0.0).

## Results

- Full suite: 1171 passed / 22 skipped / 44 xfailed / 2 xpassed (baseline 1160 + 11 new; zero new failures). Pyright clean.
- Battery: certify 20 entries — MATCH=20, DIVERGENCE=0, SKIPPED=0, ERROR=0 — TWICE (on the vectorized tree; final bytes after an annotation-only cleanup).
- Bench at 8000 x 400 x 480k votes: cold 68.53s → 3.58s (19x), warm 159.53s → 3.77s (42x).
- Bench at the FULL 33,422 x 783 / 2.0M-vote shape: cold 28.15s, warm 26.66s — versus ~31 min warm before (~70x); the largest production conversation now ticks in under 30 seconds.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

commit-id:52a753ee

---
**Stack**:
- #2689
- #2688
- #2687
- #2684
- #2683
- #2681
- #2680
- #2679 ⬅
- #2676
- #2675
- #2674
- #2673
- #2672
- #2671
- #2670
- #2669
- #2668
- #2667
- #2666
- #2665
- #2664
- #2663
- #2659
- #2658
- #2637
- #2657
- #2656
- #2626
- #2655
- #2654
- #2653
- #2652
- #2651
- #2650
- #2649
- #2648
- #2647
- #2646
- #2645
- #2644
- #2643
- #2642
- #2641
- #2625
- #2624
- #2623
- #2622
- #2621
- #2620
- #2640
- #2618
- #2639
- #2638
- #2615
- #2613
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*