### PR TITLE
Clojure->Python CUTOVER: Step 2 — flip to the Python engine (clean cut) [BLOCKED-ON-RULING]

### DIFF
--- a/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
+++ b/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
@@ -4510,3 +4510,108 @@ failure the 2026-07-17 memory warns about; recovered per its recipe
 (kept the trailer-matching #2683, closed #2682, deleted the stray
 bookmark+branch). A malformed `spr/edge/` bookmark from an
 empty-commit spr update was also deleted.
+
+## Session 8 (2026-07-28): CUTOVER PREP — five draft PRs, rulings recorded, stack surgery
+
+Goal (Julien): PREPARE (not execute) the cutover per
+HANDOFF_CUTOVER_EXECUTION.md, plus one addition — a final PR removing the
+Clojure tree and moving the Python math out of delphi/. NOTHING merged; no
+AWS-side change. All five PRs exist as OPEN DRAFTS:
+
+- **Step #0 = #2685** (base=stable, head=edge — the PROD DEPLOY vehicle,
+  historical convention verified: merge-commit PRs, e.g. #2596). Full
+  execution checklist in the body; merge count guidance; DO-NOT-MERGE
+  banner.
+- **Step #1 = #2686** — after_install.sh math role starts `math
+  math-python` (shadow); NEW live shadow comparer
+  (polismath/replay/shadow_compare.py + scripts/shadow_compare.py CLI,
+  31 unit tests, TDD RED->GREEN): certify/equiv acceptance on live row
+  pairs, in-sync gating via blob_total_votes, Q10 large-conv class
+  `large-conv-q10` never fails, exit codes gate Step #2 (0/1/2 =
+  clean/diverge/coverage-not-demonstrated). Julien ruling: shadow MUST
+  have comparison scripts; Step #2 gated on their success. Secrets edit
+  (polis-web-app-env-vars: MATH_PYTHON_ENV=python, MATH_CONV_CACHE_CAP)
+  documented as JULIEN-ACTION, not performed. CAUGHT: compose never
+  passed MATH_CONV_CACHE_CAP into the container — the secret edit would
+  have been silently inert; passthrough added.
+- **Step #2 = #2687 [BLOCKED-ON-RULING]** — after_install math role ->
+  `math-python` only. Body presents BOTH flip mechanisms; provisional
+  ruling (Julien 2026-07-28): Mechanism A, poller MATH_ENV->'prod' (the
+  certified seam; no server change). Rollback: env revert + `up -d math`.
+- **Step #3 = #2688** — clj `math` service removed from ALL compose files
+  (prod/dev/test); math-python promoted to default service reading
+  `MATH_ENV=${MATH_ENV:-prod}` (same var+default clj had — the
+  MATH_PYTHON_ENV indirection dies); test.yml gets a math-python
+  replacement; example.env rewritten; archive banner on math/README.
+- **Step #4 = #2689** — Clojure tree DELETED (oracle = git history;
+  restore recipe via `git archive` in math/README.md — NOT git checkout,
+  jj-colocated); delphi/polismath -> math/polismath as its own uv
+  package (delphi depends on it editable via [tool.uv.sources]; one
+  shared .venv). New polismath/paths.py kills the eight
+  `__file__.parents[2]` delphi-root derivations (test estate STAYS in
+  delphi/). Poller entry -> `python -m polismath.poller`. Docker: named
+  additional build context `mathsrc` (compose >=2.17 REQUIRED on prod
+  hosts — merge-gate checklist item). certify clj-cache check now raises
+  informative CertifyError "clj-oracle" when the oracle is absent
+  (+ pinning test). Suite: 1197 passed (baseline 1171 + 31 shadow-compare
+  + 1 oracle-error − 5 oracle-guard skips), full accounting in PR body.
+
+Also this session (Julien mid-session asks):
+- **Stack surgery**: requires_math_tree skipif guards folded DOWN out of
+  #2649 into #2647 (test_certify.py) and #2643 (test_timing_probe.py) —
+  closes the #2643-#2648 window where a delphi-only CI image fails those
+  3 tests; any `jj spr merge --count N` is now CI-safe. Verified: no
+  conflicts, trailers intact, tip tree byte-identical.
+- **Retitle**: scratch/retitle_stack.py --apply — all 52 python-math
+  stack PRs now titled `python-math #N: ...` (bottom-up merge order);
+  CUTOVER Step PRs deliberately NOT prefixed. Script's final trailer
+  check false-positived on the temporary WIP anchor (expected; all 52
+  real commits verified trailer+committer intact).
+
+OPEN RULINGS for Julien/Colin (surfaced in the session summary):
+1. Shadow (provisional, 24-48h time-boxed) vs clean cut — collapse
+   contingency written into the runbook + Step #1/#2 bodies.
+2. Flip mechanism final confirmation at Step #2 (provisional: poller
+   MATH_ENV->'prod').
+
+What's Next: reviews (independent subagents, per PR) -> apply findings ->
+Julien triggers Step #0 (stack merge + PROD DEPLOY promotion) when team
+sign-off lands.
+
+### s8 addendum: independent review round — 4 agents, all findings applied
+
+One reviewer per PR (Steps 2+3 shared). Highlights (all fixed same
+session): BLOCKER — deploy-alpha-aws.yml still built+pushed the clj math
+image (would have bricked every deploy at Step 3); MAJORs — Step 0
+rollback paths were blocked by the `Protect stable` ruleset (now a
+revert-PR flow + revert-the-revert warning) and the prod deploy needs the
+`production` env gate (team-controlled); Step 2 needed the explicit
+merge->secret->deploy ORDER (reverse = two-writer window) + the
+.env-materialization fact (secret edits reach containers only via
+deploy); shadow comparer hardened against live races (in-sync requires
+lastVoteTimestamp equality too; torn multi-table reads + malformed rows
+-> not-ready; Q10 excuses only math_main divergence); certify now serves
+CACHED pairs without the oracle tree (input-keys manifest match) and the
+equiv harness launches `python -m polismath.poller`; euro after_install
+fixed; test compose builds CPU-torch; math/.gitignore+.dockerignore; the
+oracle restore recipe no longer eats the new README. Suite after all
+fixes: 1211 green. Step PR bodies rewritten concise; "prod deploy" is a
+single team-controlled step (not in Julien's hands).
+
+### s8 addendum 2: Colin ruling — CLEAN CUT (no shadow); Step 1 folded away
+
+Colin ruled for a clean cut. Executed the runbook's collapse contingency:
+the Step 1 commit was squashed into the Step 2 flip commit (adjacent
+commits — diffs compose; the two after_install.sh edits net to exactly
+`up -d math` -> `up -d math-python`). PR #2686 closed unmerged. The flip
+PR (#2687) now carries Step 1's keepers: the MATH_CONV_CACHE_CAP compose
+passthrough, the shadow_compare tool + tests (kept as audit/dev tooling
+— its shadow-gate role is gone), and the docs. Ordering flips under
+clean cut: SECRET-FIRST is safe (nothing starts math-python until the
+flip deploys), eliminating both the two-writer window and the
+no-writer stall that shadow-then-flip had. Verification post-flip =
+rows advancing under 'prod' + no parked zids/error dumps + server
+serving fresh math (the certified evidence — battery 20/20, live
+equivalence 16/16 — replaces the soak). Step numbering keeps a
+deliberate gap (0, 2, 3, 4) to avoid renumber churn in code comments
+and docs; the flip PR body explains it.

--- a/delphi/docs/CUTOVER_RUNBOOK.md
+++ b/delphi/docs/CUTOVER_RUNBOOK.md
@@ -80,9 +80,16 @@ CLOJURE_QUIRKS.md (Q1-Q19), POST_CUTOVER_IMPROVEMENTS.md (the queue).
 
 ## Execution shape (s7 rulings + analysis — read before Step 0)
 
-**Shadow vs clean replace (analysis 2026-07-28; decision pending
-Julien):** recommended = TIME-BOXED SHADOW, 24-48h, exit checklist
-below. Rationale: it tests the only untested dimension (real prod
+**Shadow vs clean replace — FINAL RULING (Colin, 2026-07-28): CLEAN
+CUT, no shadow.** The collapse contingency below was EXECUTED the same
+day: the Step 1 shadow PR was folded into the Step 2 flip PR (#2687) —
+its keepers (MATH_CONV_CACHE_CAP compose passthrough, the
+shadow_compare comparison tool + tests, these docs) ride there; the
+shadow wiring itself (`up -d math math-python`) never ships. The shadow
+narrative below is kept for provenance. Under clean cut the safe order
+is SECRET-FIRST (set MATH_PYTHON_ENV=prod before merging: nothing
+starts math-python until the flip PR deploys, so there is no two-writer
+window at any point). Rationale: it tests the only untested dimension (real prod
 churn/concurrency/dirty data) at near-zero complexity — the service,
 env var, and compare machinery all exist; the time box kills
 shadow-limbo risk. Clean replace is defensible on the evidence
@@ -94,18 +101,44 @@ MATH_CONV_CACHE_CAP — and keep it set in ANY long-running deployment,
 not just the soak; eviction cost = the certified restart seam).
 Shadow exit checklist (agree BEFORE starting): rows advancing on all
 active zids; zero parked zids / errorconv dumps; spot-compare N active
-zids structurally identical (poller_equiv comparer on row pairs);
-large-conv divergence dismissed per risk 2/Q10.
+zids structurally identical — MECHANICAL GATE (mandated by Julien's
+ruling): `scripts/shadow_compare.py --min-matches <N>` must exit 0
+(module `polismath/replay/shadow_compare.py`; reuses the poller_equiv
+acceptance on live row pairs; only judges in-sync pairs; exit 1 =
+unexpected divergence, exit 2 = coverage not yet demonstrated);
+large-conv divergence dismissed per risk 2/Q10 (the tool classifies
+those `large-conv-q10`, never a failure). **Step #2 must NOT be merged
+until this gate passes.**
 
-**One WIP PR per step (for a future session):**
+**Collapse contingency (if Colin rules clean-cut):** close the Step #1
+PR unmerged; in the Step #2 PR, change the after_install.sh math role
+line directly from `up -d math` to `up -d math-python` (Step #1's
+intermediate `up -d math math-python` never ships); Secrets-Manager edit
+becomes MATH_PYTHON_ENV='prod' + MATH_CONV_CACHE_CAP in ONE edit; the
+shadow exit checklist is dropped (no soak), the flip gate falls back to
+the certified evidence base (battery 20/20 + live equivalence 16/16).
+shadow_compare.py stays useful POST-flip for spot-audits against
+still-standing historical clj rows (they are not deleted by the flip).
+
+**One draft PR per step (CREATED 2026-07-28, s8 — all open drafts,
+nothing merged): Step #0 = #2685, Step #1 = #2686, Step #2 = #2687,
+Step #3 = #2688, Step #4 = #2689 (the added Clojure-removal/math-move
+PR). Bodies carry the checklists, Julien-actions, and rollback notes.
+The bullet list below is the PRE-CREATION planning shape, kept for
+provenance — the PR bodies supersede it (note: the old PR-S3 bullet's
+"archive note" concern is split across #2688 + #2689).**
 - PR-S0 (promote): get the stack onto `stable` (prod deploys track
   stable, not edge — after_install.sh pulls stable).
 - PR-S1 (shadow): scripts/after_install.sh math role line →
   `up -d math math-python`; add MATH_CONV_CACHE_CAP + MATH_PYTHON_ENV
   to the SSM-sourced .env (polis-web-app-env-vars secret); exit
   checklist copied into the PR body.
-- PR-S2 (flip): ONE mechanism (ruling needed: poller MATH_ENV→'prod' vs
-  server mathEnv→'python'); revert instructions in the PR body.
+- PR-S2 (flip): ONE mechanism — PROVISIONAL RULING (Julien, 2026-07-28):
+  poller MATH_ENV→'prod' (Secrets-Manager MATH_PYTHON_ENV='prod' +
+  restart math-python; stop the clj `math` service) — the seam the
+  equivalence runs certified, no server config change, no server
+  restart. FINAL confirmation BLOCKED-ON-RULING at flip time (the PR
+  body presents both mechanisms); revert instructions in the PR body.
 - PR-S3 (decommission): remove `math` from compose + its
   after_install.sh line; archive note for the Clojure tree.
 
@@ -158,14 +191,25 @@ Verify within minutes:
 - math_main rows appearing under math_env='python' with advancing
   caching_tick;
 - no errorconv dumps / parked zids in the poller log;
-- spot-compare a few active zids' blobs vs the clojure rows (the certify
-  StepComparer acceptance; scripts/poller_equiv.py compare machinery is
-  reusable for row pairs).
+- run the live comparer: `cd delphi && uv run python
+  scripts/shadow_compare.py --json-out scratch/shadow_report.json`
+  (module polismath/replay/shadow_compare.py — certify acceptance on
+  live row pairs; judges only in-sync pairs, reports out-of-sync/
+  not-ready for retry, classifies >10k-ptpt/>5k-cmt convs
+  `large-conv-q10` per risk #2).
 
-Soak: hours-to-a-day of prod traffic. Exit = no structural divergence on
-small/mid convs; large-conv divergence understood per risk #2.
+Soak: hours-to-a-day of prod traffic. Exit = shadow_compare.py exits 0
+with `--min-matches <N>` (N = the active-zid count agreed up front) on
+repeated runs; no structural divergence on small/mid convs; large-conv
+divergence understood per risk #2. This exit gate is REQUIRED before
+Step 2 (Julien ruling 2026-07-28).
 
 ## Step 2 — flip (evening, if soak clean)
+
+GATE: `scripts/shadow_compare.py --min-matches <N>` exit 0 (see Step 1)
++ the rest of the shadow exit checklist. Mechanism per the provisional
+ruling (2026-07-28): poller MATH_ENV→'prod'; final confirmation
+BLOCKED-ON-RULING in the Step #2 PR.
 
 One env change, instantly reversible:
 - Set the python poller's MATH_ENV to the server's Config.mathEnv ('prod');

--- a/delphi/docs/HANDOFF_CUTOVER_EXECUTION.md
+++ b/delphi/docs/HANDOFF_CUTOVER_EXECUTION.md
@@ -1,5 +1,15 @@
 # HANDOFF: execute the Clojure→Python math cutover (steps 0-3 as WIP PRs)
 
+> **STATUS (2026-07-28, s8): PREP DONE; CLEAN CUT RULED.** Colin ruled
+> clean cut (no shadow) — Step 1/#2686 was folded into the flip PR and
+> closed. Open draft PRs: Step 0 = #2685 (PROD DEPLOY vehicle,
+> stable←edge), Step 2 = #2687 (flip — carries the comparison tool +
+> cache-cap fix; mechanism confirmation pending), Step 3 = #2688
+> (decommission), Step 4 = #2689 (remove Clojure tree, move Python math
+> to top-level math/ — added per Julien). Rulings in CUTOVER_RUNBOOK.md
+> "Execution shape". NOTHING merged; no AWS-side change made. Journal:
+> session 8. Julien triggers Step 0.
+
 Written 2026-07-28 at the close of s7 (GOAL_CUTOVER_READY: DONE). This is
 the ENTRY POINT for the session that ships the cutover. Read order:
 1. This file.

--- a/delphi/polismath/replay/shadow_compare.py
+++ b/delphi/polismath/replay/shadow_compare.py
@@ -1,0 +1,373 @@
+"""Live shadow-soak comparer for the Clojure→Python math cutover (Step #1).
+
+Compares math rows between two live math_envs in the SAME database — the
+Clojure engine's rows (``math_env='prod'``) vs the Python poller's shadow
+rows (``math_env='python'``) — using the same acceptance surface as the
+certify battery and the poller-equivalence harness:
+
+- ``math_main``      → certify's acceptance-projecting comparer
+  (:func:`polismath.replay.certify._acceptance_projecting_comparer` —
+  subgroup-* excluded per Q7, structural identity + declared float
+  tolerances);
+- ``math_bidtopid``  → EXACT (:func:`polismath.replay.poller_equiv.compare_bidtopid`,
+  modulo the documented pid int/str normalization);
+- ``math_ptptstats`` → structural + tolerant
+  (:func:`polismath.replay.poller_equiv._ptptstats_comparer`).
+
+Unlike the replay harness there is NO batch gating: the two engines poll the
+live vote stream independently, so at any instant a zid's row pair may
+reflect different vote watermarks. Pairs are only judged when IN SYNC (equal
+:func:`polismath.replay.poller_equiv.blob_total_votes`); out-of-sync pairs
+are reported and retried on the next run, never counted as divergence.
+
+Large conversations — ``n`` > 10000 participants OR ``n-cmts`` > 5000
+comments, the Clojure large-conv dispatch cutoffs (conversation.clj:784-815)
+— are EXPECTED to diverge: Clojure's mini-batch PCA path is unseeded-random
+there (Q10, CLOJURE_QUIRKS.md — not even self-consistent between two Clojure
+runs), while Python runs deterministic full PCA at every size (documented
+improvement, same blob shape). Their divergences classify as
+``large-conv-q10`` and never fail the run (CUTOVER_RUNBOOK.md risk #2).
+
+Exit-code semantics (this is the Step 2 gate — runbook "Shadow exit
+checklist"): 0 = no unexpected divergence (and ``--min-matches`` satisfied);
+1 = at least one UNEXPECTED divergence; 2 = clean but fewer full MATCH zids
+than ``--min-matches`` demands (coverage not yet demonstrated — keep
+soaking / re-run once engines sync). NOTE: click also exits 2 on a CLI
+usage error — gate scripts must require exit 0, never distinguish 1 vs 2.
+
+CLI wrapper: ``delphi/scripts/shadow_compare.py``.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Mapping, Sequence
+
+import sqlalchemy as sa
+
+from polismath.replay import poller_equiv as pe
+from polismath.replay.certify import _acceptance_projecting_comparer
+from polismath.replay.stepcompare import StepComparer
+
+# Clojure's large-conv dispatch cutoffs — STRICTLY-GREATER comparisons
+# (conversation.clj:784-815: n-ptpts > 10000 OR n-cmts > 5000).
+LARGE_CONV_PTPT_CUTOFF = 10_000
+LARGE_CONV_CMT_CUTOFF = 5_000
+
+TABLES = ("math_main", "math_bidtopid", "math_ptptstats")
+
+SYNC_IN_SYNC = "in-sync"
+SYNC_OUT_OF_SYNC = "out-of-sync"
+SYNC_NOT_READY = "not-ready"
+
+VERDICT_MATCH = "match"
+VERDICT_DIVERGE = "diverge"
+VERDICT_LARGE_CONV_Q10 = "large-conv-q10"
+VERDICT_OUT_OF_SYNC = "out-of-sync"
+VERDICT_NOT_READY = "not-ready"
+VERDICT_MISSING = "missing"
+VERDICT_PARTIAL = "partial"
+
+# Verdicts that MAY fail a run (see aggregate); everything else is
+# expected/transient and only ever reported.
+_FAILING_VERDICTS = (VERDICT_DIVERGE,)
+
+PairMap = Mapping[str, tuple[dict[str, Any] | None, dict[str, Any] | None]]
+
+
+def is_large_conv(blob: Mapping[str, Any]) -> bool:
+    """Q10 classification from the blob's own ``n``/``n-cmts`` keys.
+    Missing/malformed keys count as small — a blob too degenerate to carry
+    its size cannot be excused as a large conv."""
+    n = blob.get("n")
+    n_cmts = blob.get("n-cmts")
+    return (isinstance(n, (int, float)) and n > LARGE_CONV_PTPT_CUTOFF) or (
+        isinstance(n_cmts, (int, float)) and n_cmts > LARGE_CONV_CMT_CUTOFF
+    )
+
+
+def sync_state(blob_a: Mapping[str, Any], blob_b: Mapping[str, Any]) -> str:
+    """Whether the two engines have processed the same cumulative vote set.
+    ``blob_total_votes`` returns None when a blob can't be judged yet —
+    treated as not-ready, never as zero (see its docstring).
+
+    Equal totals alone can hide a REVOTE-only watermark delta (a revote
+    overwrites its (pid, tid) cell, never inflating the total), which would
+    surface as a false small-conv divergence. When BOTH blobs carry
+    ``lastVoteTimestamp`` it must match too; if either omits it, vote-total
+    equality remains the only (best-effort) signal."""
+    va = pe.blob_total_votes(dict(blob_a))
+    vb = pe.blob_total_votes(dict(blob_b))
+    if va is None or vb is None:
+        return SYNC_NOT_READY
+    if va != vb:
+        return SYNC_OUT_OF_SYNC
+    la = blob_a.get("lastVoteTimestamp")
+    lb = blob_b.get("lastVoteTimestamp")
+    if la is not None and lb is not None and la != lb:
+        return SYNC_OUT_OF_SYNC
+    return SYNC_IN_SYNC
+
+
+def _tick_summary(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "caching_tick": row.get("caching_tick"),
+        "math_tick": row.get("math_tick"),
+        "last_vote_timestamp": row.get("last_vote_timestamp"),
+        "modified": row.get("modified"),
+    }
+
+
+def classify_pair(
+    zid: int,
+    pair: PairMap,
+    math_envs: tuple[str, str],
+    *,
+    math_main_comparer: StepComparer | None = None,
+    ptptstats_comparer: StepComparer | None = None,
+) -> dict[str, Any]:
+    """One zid's verdict over the three math tables (same table semantics as
+    :func:`polismath.replay.poller_equiv.compare_batch`, applied to live row
+    pairs instead of snapshot stores)."""
+    env_a, env_b = math_envs
+    main_a, main_b = pair.get("math_main", (None, None))
+    if main_a is None or main_b is None:
+        return {
+            "zid": zid,
+            "verdict": VERDICT_MISSING,
+            "missing": [e for e, r in ((env_a, main_a), (env_b, main_b)) if r is None],
+        }
+
+    blob_a, blob_b = main_a.get("data"), main_b.get("data")
+    if not isinstance(blob_a, Mapping) or not isinstance(blob_b, Mapping):
+        # Dirty live data (NULL / non-JSON-object column) must be survivable
+        # — report and retry, never crash the soak tool.
+        return {
+            "zid": zid,
+            "verdict": VERDICT_NOT_READY,
+            "reason": "malformed-data",
+            "malformed": [
+                e for e, b in ((env_a, blob_a), (env_b, blob_b))
+                if not isinstance(b, Mapping)
+            ],
+        }
+
+    torn = _torn_tables(pair, math_envs)
+    if torn:
+        # Each engine mints ONE math_tick per write cycle shared across the
+        # three tables (math_writer.py write cycle; mirrors conv_man.clj) —
+        # a side table on a different tick than its own env's math_main is
+        # a torn read (the six SELECTs are not one snapshot): retry, don't
+        # false-diverge.
+        return {
+            "zid": zid,
+            "verdict": VERDICT_NOT_READY,
+            "reason": "torn-read",
+            "torn": torn,
+        }
+
+    base = {
+        "zid": zid,
+        "ticks": {env_a: _tick_summary(main_a), env_b: _tick_summary(main_b)},
+        "votes": {
+            env_a: pe.blob_total_votes(blob_a),
+            env_b: pe.blob_total_votes(blob_b),
+        },
+    }
+
+    state = sync_state(blob_a, blob_b)
+    if state == SYNC_NOT_READY:
+        return {**base, "verdict": VERDICT_NOT_READY}
+    if state == SYNC_OUT_OF_SYNC:
+        return {**base, "verdict": VERDICT_OUT_OF_SYNC}
+
+    large = is_large_conv(blob_a) or is_large_conv(blob_b)
+    tables: dict[str, Any] = {}
+
+    main_cmp = math_main_comparer or _acceptance_projecting_comparer()
+    step = main_cmp.compare_step(blob_a, blob_b, zid)
+    tables["math_main"] = {
+        "match": step["match"],
+        "n_divergences": step["n_divergences"],
+        "families": step["families"],
+    }
+
+    bid_a, bid_b = pair.get("math_bidtopid", (None, None))
+    if bid_a is None or bid_b is None:
+        tables["math_bidtopid"] = {
+            "match": None,
+            "reason": "missing-row",
+            "missing": [e for e, r in ((env_a, bid_a), (env_b, bid_b)) if r is None],
+        }
+    else:
+        cmp_bid = pe.compare_bidtopid(bid_a["data"], bid_b["data"])
+        # Drop the (potentially huge) normalized payloads from the verdict;
+        # a diverging soak run re-fetches them for debugging anyway.
+        tables["math_bidtopid"] = {"match": cmp_bid["match"]}
+
+    ppt_a, ppt_b = pair.get("math_ptptstats", (None, None))
+    if ppt_a is None or ppt_b is None:
+        tables["math_ptptstats"] = {
+            "match": None,
+            "reason": "missing-row",
+            "missing": [e for e, r in ((env_a, ppt_a), (env_b, ppt_b)) if r is None],
+        }
+    else:
+        cmp_ppt = ptptstats_comparer or pe._ptptstats_comparer()
+        step_ppt = cmp_ppt.compare_step(ppt_a["data"], ppt_b["data"], zid)
+        tables["math_ptptstats"] = {
+            "match": step_ppt["match"],
+            "n_divergences": step_ppt["n_divergences"],
+            "families": step_ppt["families"],
+        }
+
+    diverged = any(t.get("match") is False for t in tables.values())
+    partial = any(t.get("match") is None for t in tables.values())
+    if diverged:
+        # Q10 (unseeded-random clj mini-batch PCA) can only be the cause
+        # when math_main ITSELF diverges — a side-table-only divergence on
+        # a large conv is a genuine defect, never excused.
+        main_diverged = tables["math_main"].get("match") is False
+        verdict = VERDICT_LARGE_CONV_Q10 if (large and main_diverged) else VERDICT_DIVERGE
+    elif partial:
+        verdict = VERDICT_PARTIAL
+    else:
+        verdict = VERDICT_MATCH
+    return {**base, "verdict": verdict, "large_conv": large, "tables": tables}
+
+
+def _torn_tables(pair: PairMap, math_envs: tuple[str, str]) -> list[dict[str, Any]]:
+    """Side tables whose ``math_tick`` disagrees with their own env's
+    math_main row (both rows present and both ticks known)."""
+    torn: list[dict[str, Any]] = []
+    mains = pair.get("math_main", (None, None))
+    for idx, env in enumerate(math_envs):
+        main_row = mains[idx]
+        main_tick = main_row.get("math_tick") if main_row is not None else None
+        if main_tick is None:
+            continue
+        for table in ("math_bidtopid", "math_ptptstats"):
+            row = pair.get(table, (None, None))[idx]
+            tick = row.get("math_tick") if row is not None else None
+            if tick is not None and tick != main_tick:
+                torn.append(
+                    {"env": env, "table": table, "math_tick": tick, "main_tick": main_tick}
+                )
+    return torn
+
+
+def aggregate(
+    verdicts: Sequence[Mapping[str, Any]], *, min_matches: int = 0
+) -> dict[str, Any]:
+    """Run summary + exit code. Only UNEXPECTED divergence (``diverge``)
+    fails outright (exit 1). ``min_matches`` unmet — with no divergence —
+    exits 2: the soak hasn't yet DEMONSTRATED coverage, which is different
+    from having demonstrated a defect."""
+    counts = Counter(v["verdict"] for v in verdicts)
+    n_matches = counts.get(VERDICT_MATCH, 0)
+    if any(counts.get(v) for v in _FAILING_VERDICTS):
+        exit_code = 1
+    elif n_matches < min_matches:
+        exit_code = 2
+    else:
+        exit_code = 0
+    return {
+        "counts": dict(counts),
+        "n_zids": len(verdicts),
+        "n_matches": n_matches,
+        "min_matches": min_matches,
+        "exit_code": exit_code,
+    }
+
+
+def discover_zids(
+    conn: Any, math_envs: tuple[str, str], *, limit: int | None = None
+) -> list[int]:
+    """zids carrying a math_main row in EITHER env (a row missing on one
+    side is itself a finding — see ``classify_pair``'s missing verdict),
+    most recently modified first."""
+    text = (
+        "SELECT zid, MAX(modified) AS last_modified FROM math_main "
+        "WHERE math_env IN (:env_a, :env_b) "
+        "GROUP BY zid ORDER BY last_modified DESC"
+    )
+    params: dict[str, Any] = {"env_a": math_envs[0], "env_b": math_envs[1]}
+    if limit is not None:
+        text += " LIMIT :limit"
+        params["limit"] = limit
+    result = conn.execute(sa.text(text), params)
+    return [int(row["zid"]) for row in result.mappings().all()]
+
+
+def fetch_pair(conn: Any, zid: int, math_envs: tuple[str, str]) -> dict[str, Any]:
+    """The ``{table: (row_a, row_b)}`` mapping for one zid."""
+    env_a, env_b = math_envs
+    return {
+        table: (
+            pe.fetch_math_row(conn, table, zid, env_a),
+            pe.fetch_math_row(conn, table, zid, env_b),
+        )
+        for table in TABLES
+    }
+
+
+def run(
+    conn: Any,
+    *,
+    math_envs: tuple[str, str] = ("prod", "python"),
+    zids: Sequence[int] | None = None,
+    limit: int | None = 50,
+    min_matches: int = 0,
+) -> dict[str, Any]:
+    """One soak-compare pass: discover (or take) zids, fetch each pair,
+    classify, aggregate. Read-only — never writes to the database."""
+    if zids is None:
+        zids = discover_zids(conn, math_envs, limit=limit)
+    verdicts = [
+        classify_pair(zid, fetch_pair(conn, zid, math_envs), math_envs)
+        for zid in zids
+    ]
+    return {
+        "math_envs": list(math_envs),
+        "verdicts": verdicts,
+        "summary": aggregate(verdicts, min_matches=min_matches),
+    }
+
+
+def render_lines(report: Mapping[str, Any], *, max_lines: int = 200) -> list[str]:
+    """Human-readable soak report (one line per zid + a summary line)."""
+    env_a, env_b = report["math_envs"]
+    lines: list[str] = []
+    for v in report["verdicts"][:max_lines]:
+        zid = v["zid"]
+        verdict = v["verdict"].upper()
+        if v["verdict"] == VERDICT_MISSING:
+            lines.append(f"zid {zid}: {verdict} (no row for: {', '.join(v['missing'])})")
+            continue
+        votes = v.get("votes", {})
+        ticks = v.get("ticks", {})
+        detail = (
+            f"votes {env_a}={votes.get(env_a)} {env_b}={votes.get(env_b)}, "
+            f"caching_tick {env_a}={ticks.get(env_a, {}).get('caching_tick')} "
+            f"{env_b}={ticks.get(env_b, {}).get('caching_tick')}"
+        )
+        if v["verdict"] in (VERDICT_DIVERGE, VERDICT_LARGE_CONV_Q10):
+            n_div = sum(
+                t.get("n_divergences", 0) or 0 for t in v.get("tables", {}).values()
+            )
+            suffix = " — EXPECTED (Q10 unseeded-random clj large-conv path)" if (
+                v["verdict"] == VERDICT_LARGE_CONV_Q10
+            ) else ""
+            lines.append(f"zid {zid}: {verdict} ({n_div} divergences; {detail}){suffix}")
+        else:
+            lines.append(f"zid {zid}: {verdict} ({detail})")
+    n_hidden = len(report["verdicts"]) - min(len(report["verdicts"]), max_lines)
+    if n_hidden:
+        lines.append(f"... {n_hidden} more zids (see --json-out for the full report)")
+    s = report["summary"]
+    counts = ", ".join(f"{k}={n}" for k, n in sorted(s["counts"].items())) or "no zids"
+    lines.append(
+        f"summary: {counts}; matches {s['n_matches']}/{s['min_matches']} required"
+        f" -> exit {s['exit_code']}"
+    )
+    return lines

--- a/delphi/scripts/shadow_compare.py
+++ b/delphi/scripts/shadow_compare.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Shadow-soak comparer CLI — Clojure→Python math cutover Step #1.
+
+Compares the Clojure engine's live math rows (``math_env='prod'``) against
+the Python poller's shadow rows (``math_env='python'``) in the SAME
+database, with the same acceptance surface as the certify battery /
+poller-equivalence harness. Read-only. See
+``polismath/replay/shadow_compare.py`` (the logic + full semantics) and
+``delphi/docs/CUTOVER_RUNBOOK.md`` "Step 1 — shadow in prod".
+
+Typical soak usage (math host, or anywhere with DB access)::
+
+    cd delphi && uv run python scripts/shadow_compare.py \\
+        --min-matches 5 --json-out scratch/shadow_report.json
+
+Exit codes (the Step #2 gate): 0 = clean (no unexpected divergence AND
+``--min-matches`` full-MATCH zids demonstrated); 1 = at least one
+UNEXPECTED divergence (a small/mid conv differs while in sync — investigate
+before any flip); 2 = clean so far but coverage not yet demonstrated
+(fewer than ``--min-matches`` matches — keep soaking, re-run).
+
+Large convs (>10k ptpts or >5k comments) are reported as
+``large-conv-q10`` and never fail the run: the Clojure baseline there is
+unseeded-random (Q10, CLOJURE_QUIRKS.md) — expected, not a defect.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+import sqlalchemy as sa
+
+from polismath.replay import shadow_compare as sc
+from polismath.replay.poller_equiv import _url_with_scheme
+
+
+def _parse_zids(value: str | None) -> list[int] | None:
+    if not value:
+        return None
+    try:
+        return [int(z) for z in value.split(",") if z.strip()]
+    except ValueError:
+        raise click.BadParameter(
+            f"--zids must be a comma-separated list of integers, got {value!r}"
+        )
+
+
+@click.command()
+@click.option(
+    "--database-url",
+    envvar="DATABASE_URL",
+    required=True,
+    help="Postgres connection URL (defaults to $DATABASE_URL).",
+)
+@click.option(
+    "--clj-env", default="prod", show_default=True,
+    help="math_env the Clojure engine writes under.",
+)
+@click.option(
+    "--py-env", default="python", show_default=True,
+    help="math_env the Python shadow poller writes under (MATH_PYTHON_ENV).",
+)
+@click.option(
+    "--zids", default=None, callback=lambda ctx, param, value: _parse_zids(value),
+    help="Comma-separated zids to compare (default: discover every zid with "
+         "a math_main row in either env, most recently modified first).",
+)
+@click.option(
+    "--limit", type=int, default=50, show_default=True,
+    help="Max zids when discovering (ignored with --zids).",
+)
+@click.option(
+    "--min-matches", type=int, default=0, show_default=True,
+    help="Fail (exit 2) unless at least this many zids fully MATCH — makes "
+         "the runbook's 'spot-compare N active zids' gate mechanical.",
+)
+@click.option(
+    "--json-out", type=click.Path(dir_okay=False, path_type=Path), default=None,
+    help="Also write the full report as JSON.",
+)
+def main(database_url, clj_env, py_env, zids, limit, min_matches, json_out):
+    """One read-only compare pass over live clj-vs-python shadow rows."""
+    engine = sa.create_engine(_url_with_scheme(database_url, "postgresql+psycopg2"))
+    with engine.connect() as conn:
+        report = sc.run(
+            conn,
+            math_envs=(clj_env, py_env),
+            zids=zids,
+            limit=limit,
+            min_matches=min_matches,
+        )
+    for line in sc.render_lines(report):
+        click.echo(line)
+    if json_out is not None:
+        json_out.write_text(json.dumps(report, indent=2, default=str))
+        click.echo(f"full report: {json_out}")
+    sys.exit(report["summary"]["exit_code"])
+
+
+if __name__ == "__main__":
+    main()

--- a/delphi/tests/replay_harness/test_shadow_compare.py
+++ b/delphi/tests/replay_harness/test_shadow_compare.py
@@ -1,0 +1,580 @@
+"""Unit tests for the live shadow-soak comparer (cutover Step #1 —
+CUTOVER_RUNBOOK.md "Step 1 — shadow in prod").
+
+NO live Postgres required: every test is pure-Python or drives
+:func:`polismath.replay.shadow_compare.run` against a fake connection double
+(the ``_FakeConn``/``_SequenceConn`` pattern from
+``test_poller_equiv_seed.py`` / ``test_poller_equiv_compare.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from polismath.replay import shadow_compare as sc
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / doubles.
+# --------------------------------------------------------------------------- #
+def _blob(
+    *, n: int = 2, n_cmts: int = 2, votes: dict[str, int] | None = None,
+    comp0: float = 1.0, last_vote_ts: int = 1000,
+) -> dict[str, Any]:
+    """A minimal math_main-shaped blob (prep-main key spelling — mirrors
+    ``test_poller_equiv_compare.py``'s ``_math_main_blob`` helper) carrying
+    the keys the shadow comparer reads: ``n``/``n-cmts`` (Q10 large-conv
+    cutoffs) and ``user-vote-counts`` (sync detection)."""
+    return {
+        "zid": 1,
+        "n": n,
+        "n-cmts": n_cmts,
+        "in-conv": [1, 2],
+        "tids": [0, 1],
+        "pca": {"center": [0.1, 0.2], "comps": [[comp0, 0.0], [0.0, 1.0]]},
+        "base-clusters": {
+            "id": [0, 1], "x": [0.1, -0.1], "y": [0.2, -0.2],
+            "count": [1, 2], "members": [[1], [2, 3]],
+        },
+        "repness": {},
+        "lastVoteTimestamp": last_vote_ts,
+        "user-vote-counts": votes if votes is not None else {"1": 3},
+    }
+
+
+def _row(data: dict[str, Any], *, env: str = "e", tick: int = 1) -> dict[str, Any]:
+    """A math-table row shape (what :func:`pe.fetch_math_row` returns)."""
+    return {
+        "zid": 1, "math_env": env, "data": data,
+        "last_vote_timestamp": data.get("lastVoteTimestamp", 1000),
+        "caching_tick": tick, "math_tick": tick, "modified": 123,
+    }
+
+
+def _bidtopid(groups: list[list[int]] | None = None) -> dict[str, Any]:
+    return {"zid": 1, "bidToPid": groups if groups is not None else [[1], [2, 3]]}
+
+
+def _ptptstats(centricness: list[float] | None = None) -> dict[str, Any]:
+    return {
+        "zid": 1,
+        "ptptstats": {
+            "pid": [1, 2],
+            "centricness": centricness if centricness is not None else [0.5, 0.6],
+        },
+        "lastVoteTimestamp": 1000,
+    }
+
+
+def _pair(
+    blob_a: dict[str, Any] | None,
+    blob_b: dict[str, Any] | None,
+    *,
+    bid_a: dict[str, Any] | None = None,
+    bid_b: dict[str, Any] | None = None,
+    ppt_a: dict[str, Any] | None = None,
+    ppt_b: dict[str, Any] | None = None,
+    tick_a: int = 1,
+    tick_b: int = 1,
+) -> dict[str, tuple[dict[str, Any] | None, dict[str, Any] | None]]:
+    """Build the ``{table: (row_a, row_b)}`` mapping ``classify_pair`` takes.
+    ``None`` for any blob/side-table argument means "row absent in that
+    env". Side tables share their env's main ``math_tick`` (one tick per
+    write cycle — the coherent, non-torn state)."""
+    return {
+        "math_main": (
+            _row(blob_a, env="prod", tick=tick_a) if blob_a is not None else None,
+            _row(blob_b, env="python", tick=tick_b) if blob_b is not None else None,
+        ),
+        "math_bidtopid": (
+            _row(bid_a, env="prod", tick=tick_a) if bid_a is not None else None,
+            _row(bid_b, env="python", tick=tick_b) if bid_b is not None else None,
+        ),
+        "math_ptptstats": (
+            _row(ppt_a, env="prod", tick=tick_a) if ppt_a is not None else None,
+            _row(ppt_b, env="python", tick=tick_b) if ppt_b is not None else None,
+        ),
+    }
+
+
+def _matching_pair(**kwargs: Any) -> dict[str, Any]:
+    """An in-sync, fully matching three-table pair."""
+    return _pair(
+        _blob(), _blob(),
+        bid_a=_bidtopid(), bid_b=_bidtopid(),
+        ppt_a=_ptptstats(), ppt_b=_ptptstats(),
+        **kwargs,
+    )
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = [r for r in (rows or []) if r is not None]
+
+    def mappings(self):
+        return self
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+class _PairConn:
+    """Serves :func:`pe.fetch_math_row` queries from a
+    ``{(table, zid, math_env): row}`` mapping, and zid-discovery queries
+    (recognized by their GROUP BY) from a canned row list."""
+
+    def __init__(self, rows, discover_rows=None):
+        self.rows = dict(rows)
+        self.discover_rows = list(discover_rows or [])
+        self.calls: list[tuple[str, dict]] = []
+
+    def execute(self, stmt, params=None):
+        text = str(stmt)
+        params = dict(params or {})
+        self.calls.append((text, params))
+        if "GROUP BY" in text:
+            return _FakeResult(self.discover_rows)
+        table = text.split("FROM ", 1)[1].split()[0]
+        return _FakeResult([self.rows.get((table, params["zid"], params["math_env"]))])
+
+
+# --------------------------------------------------------------------------- #
+# is_large_conv — the Q10 cutoffs are STRICTLY-GREATER (conversation.clj:
+# 784-815 dispatches to large-conv-update when n-ptpts > 10000 OR
+# n-cmts > 5000).
+# --------------------------------------------------------------------------- #
+class TestIsLargeConv:
+    def test_small_conv(self):
+        assert sc.is_large_conv(_blob(n=100, n_cmts=50)) is False
+
+    def test_exactly_at_cutoffs_is_not_large(self):
+        assert sc.is_large_conv(_blob(n=10_000, n_cmts=5_000)) is False
+
+    def test_ptpt_cutoff_exceeded(self):
+        assert sc.is_large_conv(_blob(n=10_001, n_cmts=50)) is True
+
+    def test_cmt_cutoff_exceeded(self):
+        assert sc.is_large_conv(_blob(n=100, n_cmts=5_001)) is True
+
+    def test_missing_size_keys_is_not_large(self):
+        assert sc.is_large_conv({}) is False
+
+
+# --------------------------------------------------------------------------- #
+# sync_state — live rows are only judged when both engines have processed
+# the same cumulative vote set (blob_total_votes equality).
+# --------------------------------------------------------------------------- #
+class TestSyncState:
+    def test_equal_vote_totals_in_sync(self):
+        a = _blob(votes={"1": 5, "2": 3})
+        b = _blob(votes={"1": 4, "2": 4})  # same TOTAL (8), split differently
+        assert sc.sync_state(a, b) == sc.SYNC_IN_SYNC
+
+    def test_different_totals_out_of_sync(self):
+        assert (
+            sc.sync_state(_blob(votes={"1": 5}), _blob(votes={"1": 4}))
+            == sc.SYNC_OUT_OF_SYNC
+        )
+
+    def test_missing_counts_not_ready(self):
+        blob = _blob()
+        del blob["user-vote-counts"]
+        assert sc.sync_state(blob, _blob()) == sc.SYNC_NOT_READY
+
+    def test_equal_totals_different_last_vote_ts_out_of_sync(self):
+        """Revote-only watermark delta: totals equal (revotes overwrite
+        cells), lastVoteTimestamp differs — must NOT be judged in-sync."""
+        assert (
+            sc.sync_state(_blob(last_vote_ts=1000), _blob(last_vote_ts=2000))
+            == sc.SYNC_OUT_OF_SYNC
+        )
+
+    def test_missing_last_vote_ts_falls_back_to_totals(self):
+        blob = _blob()
+        del blob["lastVoteTimestamp"]
+        assert sc.sync_state(blob, _blob()) == sc.SYNC_IN_SYNC
+
+
+# --------------------------------------------------------------------------- #
+# classify_pair — one zid's three-table verdict.
+# --------------------------------------------------------------------------- #
+class TestClassifyPair:
+    ENVS = ("prod", "python")
+
+    def test_identical_in_sync_pair_matches(self):
+        v = sc.classify_pair(1, _matching_pair(), self.ENVS)
+        assert v["verdict"] == sc.VERDICT_MATCH
+        assert v["tables"]["math_main"]["match"] is True
+        assert v["tables"]["math_bidtopid"]["match"] is True
+        assert v["tables"]["math_ptptstats"]["match"] is True
+
+    def test_in_sync_math_main_divergence(self):
+        pair = _pair(
+            _blob(comp0=1.0), _blob(comp0=5.0),
+            bid_a=_bidtopid(), bid_b=_bidtopid(),
+            ppt_a=_ptptstats(), ppt_b=_ptptstats(),
+        )
+        v = sc.classify_pair(1, pair, self.ENVS)
+        assert v["verdict"] == sc.VERDICT_DIVERGE
+        assert v["tables"]["math_main"]["match"] is False
+        assert v["tables"]["math_main"]["n_divergences"] > 0
+
+    def test_large_conv_divergence_is_expected_q10(self):
+        pair = _pair(
+            _blob(n=20_000, comp0=1.0), _blob(n=20_000, comp0=5.0),
+            bid_a=_bidtopid(), bid_b=_bidtopid(),
+            ppt_a=_ptptstats(), ppt_b=_ptptstats(),
+        )
+        v = sc.classify_pair(1, pair, self.ENVS)
+        assert v["verdict"] == sc.VERDICT_LARGE_CONV_Q10
+        assert v["large_conv"] is True
+
+    def test_large_conv_match_is_still_match(self):
+        pair = _pair(
+            _blob(n=20_000), _blob(n=20_000),
+            bid_a=_bidtopid(), bid_b=_bidtopid(),
+            ppt_a=_ptptstats(), ppt_b=_ptptstats(),
+        )
+        v = sc.classify_pair(1, pair, self.ENVS)
+        assert v["verdict"] == sc.VERDICT_MATCH
+
+    def test_bidtopid_divergence_diverges(self):
+        pair = _pair(
+            _blob(), _blob(),
+            bid_a=_bidtopid([[1], [2, 3]]), bid_b=_bidtopid([[1, 2], [3]]),
+            ppt_a=_ptptstats(), ppt_b=_ptptstats(),
+        )
+        v = sc.classify_pair(1, pair, self.ENVS)
+        assert v["verdict"] == sc.VERDICT_DIVERGE
+        assert v["tables"]["math_bidtopid"]["match"] is False
+
+    def test_bidtopid_pid_str_int_normalization_still_matches(self):
+        pair = _pair(
+            _blob(), _blob(),
+            bid_a=_bidtopid([[1], [2, 3]]),
+            bid_b={"zid": 1, "bidToPid": [["1"], ["3", "2"]]},
+            ppt_a=_ptptstats(), ppt_b=_ptptstats(),
+        )
+        v = sc.classify_pair(1, pair, self.ENVS)
+        assert v["verdict"] == sc.VERDICT_MATCH
+
+    def test_missing_python_math_main_row(self):
+        v = sc.classify_pair(1, _pair(_blob(), None), self.ENVS)
+        assert v["verdict"] == sc.VERDICT_MISSING
+        assert v["missing"] == ["python"]
+
+    def test_out_of_sync_pair_skips_table_compare(self):
+        pair = _pair(_blob(votes={"1": 9}), _blob(votes={"1": 5}))
+        v = sc.classify_pair(1, pair, self.ENVS)
+        assert v["verdict"] == sc.VERDICT_OUT_OF_SYNC
+        assert "tables" not in v
+        assert v["votes"] == {"prod": 9, "python": 5}
+
+    def test_not_ready_pair(self):
+        blob = _blob()
+        del blob["user-vote-counts"]
+        v = sc.classify_pair(1, _pair(blob, _blob()), self.ENVS)
+        assert v["verdict"] == sc.VERDICT_NOT_READY
+
+    def test_missing_side_table_is_partial_not_diverge(self):
+        pair = _pair(
+            _blob(), _blob(),
+            bid_a=_bidtopid(), bid_b=None,
+            ppt_a=_ptptstats(), ppt_b=_ptptstats(),
+        )
+        v = sc.classify_pair(1, pair, self.ENVS)
+        assert v["verdict"] == sc.VERDICT_PARTIAL
+        assert v["tables"]["math_bidtopid"]["match"] is None
+        assert v["tables"]["math_bidtopid"]["missing"] == ["python"]
+
+    def test_ticks_and_votes_reported_on_judged_pairs(self):
+        v = sc.classify_pair(1, _matching_pair(tick_a=45, tick_b=44), self.ENVS)
+        assert v["ticks"]["prod"]["caching_tick"] == 45
+        assert v["ticks"]["python"]["caching_tick"] == 44
+        assert v["votes"] == {"prod": 3, "python": 3}
+
+    def test_both_math_main_rows_missing(self):
+        v = sc.classify_pair(1, _pair(None, None), self.ENVS)
+        assert v["verdict"] == sc.VERDICT_MISSING
+        assert v["missing"] == ["prod", "python"]
+
+    def test_malformed_data_column_is_not_ready_not_crash(self):
+        pair = _pair(_blob(), _blob())
+        main_a, main_b = pair["math_main"]
+        main_b = dict(main_b)
+        main_b["data"] = None  # NULL jsonb / dirty live data
+        pair["math_main"] = (main_a, main_b)
+        v = sc.classify_pair(1, pair, self.ENVS)
+        assert v["verdict"] == sc.VERDICT_NOT_READY
+        assert v["reason"] == "malformed-data"
+        assert v["malformed"] == ["python"]
+
+    def test_torn_side_table_is_not_ready(self):
+        """A side table one write-cycle behind its own env's math_main
+        (independent SELECTs, no snapshot) must retry, not false-diverge."""
+        pair = _matching_pair(tick_a=2, tick_b=2)
+        bid_a, bid_b = pair["math_bidtopid"]
+        stale = dict(bid_b)
+        stale["math_tick"] = 1
+        pair["math_bidtopid"] = (bid_a, stale)
+        v = sc.classify_pair(1, pair, self.ENVS)
+        assert v["verdict"] == sc.VERDICT_NOT_READY
+        assert v["reason"] == "torn-read"
+        assert v["torn"] == [
+            {"env": "python", "table": "math_bidtopid", "math_tick": 1, "main_tick": 2}
+        ]
+
+    def test_ptptstats_divergence_diverges(self):
+        pair = _pair(
+            _blob(), _blob(),
+            bid_a=_bidtopid(), bid_b=_bidtopid(),
+            ppt_a=_ptptstats([0.5, 0.6]), ppt_b=_ptptstats([0.9, 0.1]),
+        )
+        v = sc.classify_pair(1, pair, self.ENVS)
+        assert v["verdict"] == sc.VERDICT_DIVERGE
+        assert v["tables"]["math_ptptstats"]["match"] is False
+
+    def test_large_conv_side_table_only_divergence_is_not_excused(self):
+        """Q10 can only explain a math_main divergence — a side-table-only
+        divergence on a large conv is a genuine defect."""
+        pair = _pair(
+            _blob(n=20_000), _blob(n=20_000),
+            bid_a=_bidtopid([[1], [2, 3]]), bid_b=_bidtopid([[1, 2], [3]]),
+            ppt_a=_ptptstats(), ppt_b=_ptptstats(),
+        )
+        v = sc.classify_pair(1, pair, self.ENVS)
+        assert v["verdict"] == sc.VERDICT_DIVERGE
+
+
+# --------------------------------------------------------------------------- #
+# aggregate — exit-code semantics gate Step #2 (runbook: shadow exit
+# checklist). Only UNEXPECTED divergence fails; out-of-sync / not-ready /
+# large-conv-Q10 never do; --min-matches makes the "spot-compare N active
+# zids" checklist item mechanically checkable.
+# --------------------------------------------------------------------------- #
+class TestAggregate:
+    def _verdict(self, verdict: str, zid: int = 1) -> dict[str, Any]:
+        return {"zid": zid, "verdict": verdict}
+
+    def test_all_match_exits_zero(self):
+        summary = sc.aggregate([self._verdict(sc.VERDICT_MATCH)])
+        assert summary["exit_code"] == 0
+        assert summary["counts"] == {sc.VERDICT_MATCH: 1}
+
+    def test_any_diverge_exits_one(self):
+        summary = sc.aggregate(
+            [self._verdict(sc.VERDICT_MATCH), self._verdict(sc.VERDICT_DIVERGE, 2)]
+        )
+        assert summary["exit_code"] == 1
+
+    def test_expected_families_do_not_fail(self):
+        summary = sc.aggregate([
+            self._verdict(sc.VERDICT_MATCH),
+            self._verdict(sc.VERDICT_LARGE_CONV_Q10, 2),
+            self._verdict(sc.VERDICT_OUT_OF_SYNC, 3),
+            self._verdict(sc.VERDICT_NOT_READY, 4),
+            self._verdict(sc.VERDICT_PARTIAL, 5),
+            self._verdict(sc.VERDICT_MISSING, 6),
+        ])
+        assert summary["exit_code"] == 0
+
+    def test_min_matches_unmet_exits_two(self):
+        summary = sc.aggregate(
+            [self._verdict(sc.VERDICT_MATCH), self._verdict(sc.VERDICT_OUT_OF_SYNC, 2)],
+            min_matches=2,
+        )
+        assert summary["exit_code"] == 2
+
+    def test_diverge_beats_min_matches(self):
+        summary = sc.aggregate(
+            [self._verdict(sc.VERDICT_DIVERGE)], min_matches=5,
+        )
+        assert summary["exit_code"] == 1
+
+    def test_no_zids_with_min_matches_exits_two(self):
+        """Day-zero soak state: nothing to compare yet is NOT a pass."""
+        summary = sc.aggregate([], min_matches=1)
+        assert summary["exit_code"] == 2
+        assert summary["n_zids"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# run — orchestration over a live connection (faked here).
+# --------------------------------------------------------------------------- #
+class TestRun:
+    def _conn_for(self, zid: int) -> _PairConn:
+        rows = {}
+        for table, data in (
+            ("math_main", _blob()),
+            ("math_bidtopid", _bidtopid()),
+            ("math_ptptstats", _ptptstats()),
+        ):
+            for env in ("prod", "python"):
+                row = _row(data, env=env)
+                row["zid"] = zid
+                rows[(table, zid, env)] = row
+        return _PairConn(rows, discover_rows=[{"zid": zid}])
+
+    def test_run_with_explicit_zids(self):
+        report = sc.run(self._conn_for(7), zids=[7])
+        assert [v["zid"] for v in report["verdicts"]] == [7]
+        assert report["verdicts"][0]["verdict"] == sc.VERDICT_MATCH
+        assert report["summary"]["exit_code"] == 0
+        assert report["math_envs"] == ["prod", "python"]
+
+    def test_run_discovers_zids_when_not_given(self):
+        report = sc.run(self._conn_for(7))
+        assert [v["zid"] for v in report["verdicts"]] == [7]
+
+    def test_run_missing_pair_row(self):
+        conn = self._conn_for(7)
+        del conn.rows[("math_main", 7, "python")]
+        report = sc.run(conn, zids=[7])
+        assert report["verdicts"][0]["verdict"] == sc.VERDICT_MISSING
+        assert report["summary"]["exit_code"] == 0  # missing != diverge
+
+    def test_run_custom_envs(self):
+        rows = {}
+        for table, data in (
+            ("math_main", _blob()),
+            ("math_bidtopid", _bidtopid()),
+            ("math_ptptstats", _ptptstats()),
+        ):
+            for env in ("clj-ref", "py-shadow"):
+                rows[(table, 3, env)] = _row(data, env=env)
+        report = sc.run(
+            _PairConn(rows), zids=[3], math_envs=("clj-ref", "py-shadow"),
+        )
+        assert report["verdicts"][0]["verdict"] == sc.VERDICT_MATCH
+
+
+# --------------------------------------------------------------------------- #
+# discover_zids — most-recently-modified first, either env qualifies.
+# --------------------------------------------------------------------------- #
+class TestDiscoverZids:
+    def test_returns_zids_in_query_order(self):
+        conn = _PairConn({}, discover_rows=[{"zid": 5}, {"zid": 3}])
+        assert sc.discover_zids(conn, ("prod", "python")) == [5, 3]
+
+    def test_limit_is_forwarded(self):
+        conn = _PairConn({}, discover_rows=[{"zid": 5}])
+        sc.discover_zids(conn, ("prod", "python"), limit=10)
+        text, params = conn.calls[-1]
+        assert "LIMIT" in text.upper()
+        assert params.get("limit") == 10
+
+
+# --------------------------------------------------------------------------- #
+# render_lines — human-readable soak report.
+# --------------------------------------------------------------------------- #
+class TestRenderLines:
+    def test_lines_carry_verdicts_and_summary(self):
+        report = sc.run(TestRun()._conn_for(7), zids=[7])
+        lines = sc.render_lines(report)
+        joined = "\n".join(lines)
+        assert "zid 7" in joined
+        assert "MATCH" in joined.upper()
+        assert "exit 0" in joined
+
+    def test_diverge_and_q10_lines(self):
+        envs = ("prod", "python")
+        diverge = sc.classify_pair(
+            1,
+            _pair(_blob(comp0=1.0), _blob(comp0=5.0),
+                  bid_a=_bidtopid(), bid_b=_bidtopid(),
+                  ppt_a=_ptptstats(), ppt_b=_ptptstats()),
+            envs,
+        )
+        q10 = sc.classify_pair(
+            2,
+            _pair(_blob(n=20_000, comp0=1.0), _blob(n=20_000, comp0=5.0),
+                  bid_a=_bidtopid(), bid_b=_bidtopid(),
+                  ppt_a=_ptptstats(), ppt_b=_ptptstats()),
+            envs,
+        )
+        report = {
+            "math_envs": list(envs),
+            "verdicts": [diverge, q10],
+            "summary": sc.aggregate([diverge, q10]),
+        }
+        joined = "\n".join(sc.render_lines(report))
+        assert "divergences" in joined
+        assert "EXPECTED" in joined  # the Q10 suffix
+        assert "exit 1" in joined
+
+    def test_max_lines_truncation(self):
+        verdicts = [{"zid": z, "verdict": sc.VERDICT_MISSING, "missing": ["python"]}
+                    for z in range(5)]
+        report = {
+            "math_envs": ["prod", "python"],
+            "verdicts": verdicts,
+            "summary": sc.aggregate(verdicts),
+        }
+        lines = sc.render_lines(report, max_lines=2)
+        joined = "\n".join(lines)
+        assert "3 more zids" in joined
+
+
+class TestCli:
+    def _load_cli(self):
+        import importlib.util
+
+        path = Path(__file__).resolve().parents[2] / "scripts" / "shadow_compare.py"
+        spec = importlib.util.spec_from_file_location("shadow_compare_cli", path)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_bad_zids_is_a_usage_error(self):
+        from click.testing import CliRunner
+
+        mod = self._load_cli()
+        res = CliRunner().invoke(
+            mod.main, ["--database-url", "postgresql://x/y", "--zids", "1,abc"]
+        )
+        assert res.exit_code == 2
+        assert "--zids" in res.output
+
+    def test_cli_passes_options_through_and_writes_json(self, monkeypatch, tmp_path):
+        from click.testing import CliRunner
+
+        mod = self._load_cli()
+
+        class _Eng:
+            def connect(self):
+                return self
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        seen: dict[str, Any] = {}
+
+        def fake_run(conn, **kwargs):
+            seen.update(kwargs)
+            return {
+                "math_envs": ["prod", "python"],
+                "verdicts": [],
+                "summary": {"counts": {}, "n_zids": 0, "n_matches": 0,
+                            "min_matches": 0, "exit_code": 0},
+            }
+
+        monkeypatch.setattr(mod.sa, "create_engine", lambda url: _Eng())
+        monkeypatch.setattr(mod.sc, "run", fake_run)
+        out = tmp_path / "report.json"
+        res = CliRunner().invoke(
+            mod.main,
+            ["--database-url", "postgresql://x/y", "--zids", "5,7",
+             "--min-matches", "3", "--json-out", str(out)],
+        )
+        assert res.exit_code == 0
+        assert seen["zids"] == [5, 7]
+        assert seen["min_matches"] == 3
+        assert out.exists()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,6 +179,10 @@ services:
       # Error dump dir + retry cap (dump -> retry -> park circuit breaker).
       - MATH_POLLER_DUMP_DIR=${MATH_POLLER_DUMP_DIR:-scratch/errorconv}
       - MATH_POLLER_RETRY_CAP=${MATH_POLLER_RETRY_CAP:-1}
+      # Conv-cache LRU cap (0 = unlimited). MUST be >0 for any long-running
+      # deployment — the cache never evicts by default and grows toward the
+      # container memory limit below (eviction = the certified restart seam).
+      - MATH_CONV_CACHE_CAP=${MATH_CONV_CACHE_CAP:-0}
     networks:
       - "polis-net"
     extra_hosts:

--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -104,8 +104,19 @@ if [ "$SERVICE_FROM_FILE" == "server" ]; then
   echo "Starting docker-compose up for 'server', 'nginx-proxy', and 'client-participation-alpha' services"
   sudo /usr/local/bin/docker-compose up -d server nginx-proxy client-participation-alpha --build --force-recreate
 elif [ "$SERVICE_FROM_FILE" == "math" ]; then
-  echo "Starting docker-compose up for 'math' service"
-  sudo /usr/local/bin/docker-compose up -d math --build --force-recreate
+  # Cutover Step 2 (flip, clean cut): the Python math poller is THE math
+  # engine. Its MATH_ENV comes from the instance .env, which THIS SCRIPT
+  # rewrites from the polis-web-app-env-vars secret on every deploy (key
+  # MATH_PYTHON_ENV, 'prod' post-flip) — container restarts do NOT pick
+  # up secret edits. The Clojure `math` service is deliberately NOT
+  # started anymore: two writers must never share a math_env. Its
+  # definition stays in docker-compose.yml until Step 3, so an emergency
+  # manual restart is `docker-compose up -d math` — but only AFTER
+  # taking the poller off 'prod'; the normal rollback is revert-this-PR
+  # + redeploy. Compose profiles gate DEV only; prod starts services BY
+  # NAME here.
+  echo "Starting docker-compose up for 'math-python' service (cutover Step 2)"
+  sudo /usr/local/bin/docker-compose up -d math-python --build --force-recreate
 elif [ "$SERVICE_FROM_FILE" == "delphi" ]; then
   echo "Starting docker-compose up for 'delphi' service"
   echo "Fetching Ollama Service URL for Delphi..."


### PR DESCRIPTION
THE FLIP, clean-cut style: deploys stop starting the Clojure engine and the Python engine takes over writing the rows the server reads — in one motion, with no shadow period. **Colin ruled clean cut (2026-07-28)**; the formerly-planned Step 1 shadow PR (#2686) was folded into this one and closed, which is why the step numbering skips 1.

**DO NOT MERGE until:** Julien confirms the mechanism below (provisional choice 2026-07-28: option A) and gives the go.

## Background, in one paragraph

Every math result row is keyed by (conversation, `math_env`), and the server only reads rows whose `math_env` matches its setting (`prod`). Today the Clojure engine writes those rows. The Python engine is certified equivalent (replay battery: 20/20 dataset pairs match bit-for-bit; live side-by-side runs against the real Clojure container: 16/16 batches identical) — that evidence base is what replaces a shadow soak.

## What's in this PR

- `scripts/after_install.sh` (the script every deploy runs): the math host goes from `up -d math` to `up -d math-python` — one line; deploys now start the Python engine instead of the Clojure one. The Clojure service definition STAYS in the compose file until Step 3, so an emergency manual restart of it remains a one-liner.
- `docker-compose.yml`: actually pass `MATH_CONV_CACHE_CAP` into the container — the setting was documented but never reached the poller, so it would have been silently ignored.
- **A comparison tool** (`polismath/replay/shadow_compare.py` + CLI, 44 unit tests): diffs two engines' result rows with the certification's tolerance rules, guarding against false alarms (only judges pairs at the same vote watermark; retries mid-write or corrupted rows; knows that very large conversations legitimately differ — quirk Q10, the Clojure engine's unseeded random sampling). Built as the shadow gate; kept as audit/dev tooling since it survived review with 44 tests and remains the standard way to compare any two `math_env`s.
- `CUTOVER_RUNBOOK.md` + journal: Colin's ruling recorded; the shadow sections marked historical.

## The flip, in order

1. **First** (Julien, in AWS): add to the secret `polis-web-app-env-vars` (us-east-1): `MATH_PYTHON_ENV=prod` and `MATH_CONV_CACHE_CAP=64`. This is SAFE to do first under clean cut: nothing anywhere starts `math-python` until this PR deploys, so no two engines can ever write the same rows.
2. Merge this PR, get it onto `stable`, deploy the math host. The deploy stops all containers, copies the secret to the instance's `.env` fresh, and starts only `math-python` — which reads `MATH_ENV=prod` and takes over. The only gap is the deploy's own restart blip.

(The cache-cap setting limits how many conversations the poller keeps in memory — it never evicts by default; 64 is a starting value.)

**A fact that bites:** changing the secret does NOTHING to already-running containers — only a deploy rewrites the instance's `.env`. Manual equivalent: edit `/opt/polis/polis/.env` on the host, then `docker-compose up -d --force-recreate math-python`; a plain restart keeps the old values.

## Confirm after the flip

Result rows advancing under `math_env='prod'` with fresh `caching_tick`; no conversations parked as failing, no error dumps in the poller log; the server keeps serving fresh math (it polls every ~2.5s); comment routing gets priorities; participant responses include group assignments.

## The two possible mechanisms (final ruling needed)

**Option A (provisional choice, recommended)** — point the PYTHON ENGINE at the server's rows (the secret change above). No server change, no server restart; exactly the handover certified in the side-by-side runs.

**Option B** — point the SERVER at the python rows instead. Provisionally rejected: touches the serving path twice (flip and rollback); that handover was never certified; and `MATH_ENV` is one shared setting read by both the server and the Clojure engine, so flipping it server-side would drag the Clojure engine's write-target along — doing B cleanly needs a new server-only setting plus a server code change.

## Rollback

1. Revert this PR and redeploy the math host — the script starts `math` (Clojure) again and `math-python` stops.
2. Also set `MATH_PYTHON_ENV` back to `python` in the secret (hygiene — it only matters if the flip script ever deploys again).

The Clojure engine resumes from the rows as they are; the row format the Python engine wrote is certified identical, so nothing needs cleaning.

Series: Step 0 = #2685, Step 3 = #2688, Step 4 = #2689 (Step 1 was the shadow — dropped). Nothing merges without Julien's explicit go.

commit-id:ae5fdde0

---
**Stack**:
- #2689
- #2688
- #2687 ⬅
- #2684
- #2683
- #2681
- #2680
- #2679
- #2676
- #2675
- #2674
- #2673
- #2672
- #2671
- #2670
- #2669
- #2668
- #2667
- #2666
- #2665
- #2664
- #2663
- #2659
- #2658
- #2637
- #2657
- #2656
- #2626
- #2655
- #2654
- #2653
- #2652
- #2651
- #2650
- #2649
- #2648
- #2647
- #2646
- #2645
- #2644
- #2643
- #2642
- #2641
- #2625
- #2624
- #2623
- #2622
- #2621
- #2620
- #2640
- #2618
- #2639
- #2638
- #2615
- #2613
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*