### PR TITLE
cost: right-size the math worker (r8g.4xlarge → r8g.2xlarge) and fix its JVM heap

### DIFF
--- a/cdk/autoscaling.ts
+++ b/cdk/autoscaling.ts
@@ -83,7 +83,8 @@ export default (
     vpc,
     launchTemplate: delphiLargeLaunchTemplate,
     // Set to 0 in the console on 2026-07-31 (c7i.8xlarge, ~$1,040/mo, was idle). Match it here so a
-    // cdk deploy does not bring it back. Large-conversation jobs route to the small class.
+    // cdk deploy does not bring it back. NOTE: delphi/scripts/job_poller.py still routes >5000-comment
+    // jobs to this class, so until that gate is removed such jobs will wait; tracked in P-004/P-003.
     minCapacity: 0,
     desiredCapacity: 0,
     maxCapacity: 3,

--- a/cdk/autoscaling.ts
+++ b/cdk/autoscaling.ts
@@ -59,7 +59,10 @@ export default (
     launchTemplate: mathWorkerLaunchTemplate,
     minCapacity: 1,
     desiredCapacity: 1,
-    maxCapacity: 5,
+    // Keep at 1: every math worker polls every conversation and holds its own actors
+    // (math/src/polismath/components/{poller,conv_man}.clj); a second instance duplicates
+    // the computation and the writes rather than sharing the load.
+    maxCapacity: 1,
     vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
     healthCheck: autoscaling.HealthCheck.ec2({ grace: cdk.Duration.minutes(2) }),
   });
@@ -79,8 +82,10 @@ export default (
   const asgDelphiLarge = new autoscaling.AutoScalingGroup(self, 'AsgDelphiLarge', {
     vpc,
     launchTemplate: delphiLargeLaunchTemplate,
-    minCapacity: 1,
-    desiredCapacity: 1,
+    // Set to 0 in the console on 2026-07-31 (c7i.8xlarge, ~$1,040/mo, was idle). Match it here so a
+    // cdk deploy does not bring it back. Large-conversation jobs route to the small class.
+    minCapacity: 0,
+    desiredCapacity: 0,
     maxCapacity: 3,
     vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
     healthCheck: autoscaling.HealthCheck.ec2({ grace: cdk.Duration.minutes(5) }),

--- a/cdk/ec2.ts
+++ b/cdk/ec2.ts
@@ -2,7 +2,10 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
 export const instanceTypeWeb = ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MEDIUM);
 export const machineImageWeb = new ec2.AmazonLinuxImage({ generation: ec2.AmazonLinuxGeneration.AMAZON_LINUX_2023 });
-export const instanceTypeMathWorker = ec2.InstanceType.of(ec2.InstanceClass.R8G, ec2.InstanceSize.XLARGE4);
+// Right-sized 2026-09: 14 days of CloudWatch showed peak 16.3 GB host memory and ~4 busy cores
+// on the previous r8g.4xlarge (128 GB / 16 vCPU). 2xlarge = 8 vCPU / 64 GB. Step to xlarge after
+// a month if peaks stay < 12 GB. See math/deps.edn for the matching JVM heap.
+export const instanceTypeMathWorker = ec2.InstanceType.of(ec2.InstanceClass.R8G, ec2.InstanceSize.XLARGE2);
 export const machineImageMathWorker = new ec2.AmazonLinuxImage({
   generation: ec2.AmazonLinuxGeneration.AMAZON_LINUX_2023,
   cpuType: ec2.AmazonLinuxCpuType.ARM_64,

--- a/math/deps.edn
+++ b/math/deps.edn
@@ -63,7 +63,11 @@
                          metasoarous/oz {:mvn/version "2.0.0-alpha5"}}
             :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
            :run
-           {:main-opts ["-m" "polismath.runner"]}
+           {:main-opts ["-m" "polismath.runner"]
+            ;; Heap for the prod worker. Sized for an r8g.2xlarge (64 GB): leaves room for the
+            ;; Datadog Java agent, JFR and page cache. Observed host peak on the old 128 GB box
+            ;; was 16.3 GB total (2026-08/09). If the instance changes, change this with it.
+            :jvm-opts ["-Xmx24g"]}
            :dev-poller
            {:extra-paths ["dev" "test"]
             :extra-deps {cider/cider-nrepl {:mvn/version "0.30.0"}}
@@ -77,7 +81,6 @@
            ;; at startup — keeps the alias self-contained on the base :deps.
            :replay
            {:main-opts ["-i" "dev/replay.clj" "-m" "replay"]}}
- ;:jvm-opts ^:replace []
- :jvm-opts ["-Xmx4g"]}
+}
  ;:mvn/repos {"twitter4j" {:url "https://twitter4j.org/maven2"}}}
   


### PR DESCRIPTION
## Why
- 14 days of CloudWatch on the current r8g.4xlarge (128 GB / 16 vCPU): host memory **avg 10.6 GB, peak 16.3 GB**; CPU **avg 6%, peak 24%** (~4 busy cores). About $700/mo for a box that is 85% empty.
- The `-Xmx4g` in `math/deps.edn` was a **top-level** `:jvm-opts` key, which tools.deps ignores (`:jvm-opts` only applies inside an alias). The JVM has been running at its default heap (¼ of RAM) all along. Credit to the independent review that caught this.

## What
| File | Change |
|---|---|
| `cdk/ec2.ts` | math worker `r8g.4xlarge` → `r8g.2xlarge` (8 vCPU / 64 GB) |
| `cdk/autoscaling.ts` | math ASG `maxCapacity` 5 → 1 (every worker polls every conversation; a second instance duplicates work, it doesn't share it). Delphi large ASG min/desired 1 → 0 to match what has been live since 2026-07-31, so `cdk deploy` can't resurrect a ~$1,040/mo idle box. |
| `math/deps.edn` | `-Xmx24g` inside the `:run` alias (sized for 64 GB with room for dd-java-agent + page cache); dead top-level key removed |

**Saves ~$350/mo.** If a month of data shows peaks under 12 GB, the next step is r8g.xlarge with `-Xmx12g` (~$525/mo total).

## Deploy notes
- After the CDK deploy, the math ASG needs an **instance refresh** to pick up the new launch template.
- The Delphi large change is a no-op in AWS today (already 0/0); it only stops drift.

## Rollback
Revert `cdk/ec2.ts` (and the heap line), instance refresh. Minutes. ASG max stays 1 either way.

## Validation
CWAgent `mem_used_percent` + EC2 CPU on the new instance for a week; the 4-hourly restart replay time; update latency on the largest active conversation. Alarm suggestion: host memory > 80%.

Part of the cost-reduction effort (Aug 2026 AWS bill $2,879 → target ~$500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s
