### PR TITLE
cost: turn off the Ollama GPU stack (flag-gated); topic naming via Anthropic Batch API

### DIFF
--- a/cdk/autoscaling.ts
+++ b/cdk/autoscaling.ts
@@ -10,30 +10,37 @@ export default (
   self: Construct,
   vpc: cdk.aws_ec2.Vpc,
   instanceRole: cdk.aws_iam.Role,
-  ollamaLaunchTemplate: cdk.aws_ec2.LaunchTemplate,
+  ollamaLaunchTemplate: cdk.aws_ec2.LaunchTemplate | undefined,
   logGroup: cdk.aws_logs.LogGroup,
-  fileSystem: cdk.aws_efs.FileSystem,
+  fileSystem: cdk.aws_efs.FileSystem | undefined,
   webLaunchTemplate: cdk.aws_ec2.LaunchTemplate,
   mathWorkerLaunchTemplate: cdk.aws_ec2.LaunchTemplate,
   delphiSmallLaunchTemplate: cdk.aws_ec2.LaunchTemplate,
   delphiLargeLaunchTemplate: cdk.aws_ec2.LaunchTemplate,
   ollamaNamespace: string,
-  alarmTopic: cdk.aws_sns.Topic
+  alarmTopic: cdk.aws_sns.Topic,
+  enableOllama: boolean = false
 ) => {
   const commonAsgProps = { vpc, role: instanceRole };
 
-  // Ollama ASG
-  const asgOllama = new autoscaling.AutoScalingGroup(self, 'AsgOllama', {
-    vpc,
-    launchTemplate: ollamaLaunchTemplate,
-    minCapacity: 1,
-    maxCapacity: 3,
-    desiredCapacity: 1,
-    vpcSubnets: { subnetGroupName: 'PrivateWithEgress' },
-    healthCheck: autoscaling.HealthCheck.ec2({ grace: cdk.Duration.minutes(10) }),
-  });
-  asgOllama.node.addDependency(logGroup);
-  asgOllama.node.addDependency(fileSystem); // Ensure EFS is ready before instances start
+  // Ollama ASG (only when the GPU stack is enabled)
+  let asgOllama: autoscaling.AutoScalingGroup | undefined;
+  if (enableOllama) {
+    if (!ollamaLaunchTemplate || !fileSystem) {
+      throw new Error('enableOllama is true but ollamaLaunchTemplate/fileSystem were not provided to createAutoScalingAndAlarms');
+    }
+    asgOllama = new autoscaling.AutoScalingGroup(self, 'AsgOllama', {
+      vpc,
+      launchTemplate: ollamaLaunchTemplate,
+      minCapacity: 1,
+      maxCapacity: 3,
+      desiredCapacity: 1,
+      vpcSubnets: { subnetGroupName: 'PrivateWithEgress' },
+      healthCheck: autoscaling.HealthCheck.ec2({ grace: cdk.Duration.minutes(10) }),
+    });
+    asgOllama.node.addDependency(logGroup);
+    asgOllama.node.addDependency(fileSystem); // Ensure EFS is ready before instances start
+  }
 
   // Web ASG
   const asgWeb = new autoscaling.AutoScalingGroup(self, 'Asg', {
@@ -126,21 +133,23 @@ export default (
   const delphiSmallCpuMetric = createDelphiCpuScaling(asgDelphiSmall, 'DelphiSmall', 60); // Target 60% CPU
   const delphiLargeCpuMetric = createDelphiCpuScaling(asgDelphiLarge, 'DelphiLarge', 60); // Target 60% CPU
 
-  // Add Ollama GPU Scaling Policy
-  const ollamaGpuMetric = new cloudwatch.Metric({
-    namespace: ollamaNamespace, // Custom namespace from CW Agent config
-    metricName: 'utilization_gpu', // GPU utilization metric name from CW Agent config
-    dimensionsMap: { AutoScalingGroupName: asgOllama.autoScalingGroupName },
-    statistic: 'Average',
-    period: cdk.Duration.minutes(1),
-  });
-  asgOllama.scaleToTrackMetric('OllamaGpuScaling', {
-    metric: ollamaGpuMetric,
-    targetValue: 75,
-    cooldown: cdk.Duration.minutes(5), // Prevent flapping
-    disableScaleIn: false, // Allow scaling down
-    estimatedInstanceWarmup: cdk.Duration.minutes(5), // Time until instance contributes metrics meaningfully
-  });
+  // Add Ollama GPU Scaling Policy (only when the GPU stack is enabled)
+  if (enableOllama && asgOllama) {
+    const ollamaGpuMetric = new cloudwatch.Metric({
+      namespace: ollamaNamespace, // Custom namespace from CW Agent config
+      metricName: 'utilization_gpu', // GPU utilization metric name from CW Agent config
+      dimensionsMap: { AutoScalingGroupName: asgOllama.autoScalingGroupName },
+      statistic: 'Average',
+      period: cdk.Duration.minutes(1),
+    });
+    asgOllama.scaleToTrackMetric('OllamaGpuScaling', {
+      metric: ollamaGpuMetric,
+      targetValue: 75,
+      cooldown: cdk.Duration.minutes(5), // Prevent flapping
+      disableScaleIn: false, // Allow scaling down
+      estimatedInstanceWarmup: cdk.Duration.minutes(5), // Time until instance contributes metrics meaningfully
+    });
+  }
 
   return {
     asgOllama,

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,6 +6,7 @@ import * as path from 'path'; // Use * as path
 interface ExtendedStackProps extends cdk.StackProps {
   domainName?: string; // Make optional since we're not using it initially
   enableSSHAccess: boolean;
+  enableOllama: boolean; // Gate the (temporarily retired) Ollama GPU stack
   envFile: string;
   branch: string; // Make required
   sshAllowedIpRange?: string; // Optional, but required if enableSSHAccess is true
@@ -30,6 +31,10 @@ const props: ExtendedStackProps = {
   },
   domainName: process.env.CDK_DOMAIN_NAME,
   enableSSHAccess: parseBoolean(process.env.CDK_SSH_ACCESS),
+  // The Ollama GPU stack (ASG/GPU launch template/EFS/NLB/secret) is off by
+  // default. Set CDK_ENABLE_OLLAMA=true to recreate it (pair with
+  // LLM_PROVIDER=ollama in the app env for a self-hosted LLM).
+  enableOllama: parseBoolean(process.env.CDK_ENABLE_OLLAMA),
   envFile: resolvedEnvFilePath,
   branch: process.env.CDK_BRANCH || 'edge', // Provide a default branch
   sshAllowedIpRange: process.env.CDK_SSH_ALLOWED_IP_RANGE,

--- a/cdk/launchTemplates.ts
+++ b/cdk/launchTemplates.ts
@@ -8,7 +8,7 @@ export default (
   logGroup: cdk.aws_logs.LogGroup,
   ollamaNamespace: string,
   ollamaModelDirectory: string,
-  fileSystem: cdk.aws_efs.FileSystem,
+  fileSystem: cdk.aws_efs.FileSystem | undefined,
   machineImageWeb: ec2.IMachineImage,
   instanceTypeWeb: ec2.InstanceType,
   webSecurityGroup: ec2.ISecurityGroup,
@@ -25,10 +25,11 @@ export default (
   instanceTypeDelphiLarge: ec2.InstanceType,
   delphiSecurityGroup: ec2.ISecurityGroup,
   delphiLargeKeyPair: ec2.IKeyPair | undefined,
-  machineImageOllama: ec2.IMachineImage,
-  instanceTypeOllama: ec2.InstanceType,
+  machineImageOllama: ec2.IMachineImage | undefined,
+  instanceTypeOllama: ec2.InstanceType | undefined,
   ollamaKeyPair: ec2.IKeyPair | undefined,
-  ollamaSecurityGroup: ec2.ISecurityGroup
+  ollamaSecurityGroup: ec2.ISecurityGroup | undefined,
+  enableOllama: boolean = false
 ) => {
   const usrdata = (CLOUDWATCH_LOG_GROUP_NAME: string, service: string, instanceSize?: string) => {
     let ld: ec2.UserData;
@@ -99,9 +100,11 @@ EOF`,
     return ld;
   };
   
-  const ollamaUsrData = ec2.UserData.forLinux();
 // Define path for CloudWatch Agent config
 // --- CloudWatch Agent Config Asset ---
+// NOTE: this asset is shared by EVERY tier's user data (see usrdata() above),
+// not just Ollama, so it is created unconditionally even when the Ollama stack
+// is gated off.
 const cwAgentConfigAsset = new s3_assets.Asset(self, 'CwAgentConfigAsset', {
   path: 'config/amazon-cloudwatch-agent.json' // Adjust path relative to cdk project root
 });
@@ -110,59 +113,56 @@ const cwAgentConfigAsset = new s3_assets.Asset(self, 'CwAgentConfigAsset', {
 cwAgentConfigAsset.grantRead(instanceRole);
 const cwAgentConfigPath = '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json';
 const cwAgentTempPath = '/tmp/amazon-cloudwatch-agent.json'; // Temporary download location
-const efsDnsName = `${fileSystem.fileSystemId}.efs.${cdk.Stack.of(self).region}.${cdk.Stack.of(self).urlSuffix}`;
 
-// Add commands to the Ollama UserData
-ollamaUsrData.addCommands(
-  // Spread the base user data commands
-  ...usrdata(logGroup.logGroupName, "ollama").render().split('\n').filter(line => line.trim() !== ''),
+// --- Ollama user data (only when the GPU stack is enabled) ---
+let ollamaUsrData: ec2.UserData | undefined;
+if (enableOllama) {
+  if (!fileSystem) {
+    throw new Error('enableOllama is true but no EFS fileSystem was provided to configureLaunchTemplates');
+  }
+  const efsDnsName = `${fileSystem.fileSystemId}.efs.${cdk.Stack.of(self).region}.${cdk.Stack.of(self).urlSuffix}`;
+  ollamaUsrData = ec2.UserData.forLinux();
+  ollamaUsrData.addCommands(
+    // Spread the base user data commands
+    ...usrdata(logGroup.logGroupName, "ollama").render().split('\n').filter(line => line.trim() !== ''),
 
-  // Install EFS utilities
-  'echo "Installing EFS utilities for Ollama..."',
-  'sudo dnf install -y amazon-efs-utils nfs-utils',
+    // Install EFS utilities
+    'echo "Installing EFS utilities for Ollama..."',
+    'sudo dnf install -y amazon-efs-utils nfs-utils',
 
-  // Start Ollama-specific setup
-  'echo "Starting Ollama specific setup..."',
+    // Start Ollama-specific setup
+    'echo "Starting Ollama specific setup..."',
 
-  // NOTE: the CloudWatch agent's config download and `systemctl start` used to
-  // live here. They now run in the shared usrdata() above, for every tier, so
-  // this block would be a duplicate. The GPU metrics are unaffected: the same
-  // config file carries the nvidia_gpu section.
+    // --- Mount EFS using standard NFSv4.1 ---
+    `echo "Mounting EFS filesystem using NFSv4.1 and DNS Name: ${efsDnsName}"...`,
+    `sudo mkdir -p ${ollamaModelDirectory}`,
+    `sudo mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport ${efsDnsName}:/ ${ollamaModelDirectory}`,
+    `echo "${efsDnsName}:/ ${ollamaModelDirectory} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,_netdev 0 0" | sudo tee -a /etc/fstab`,
+    `sudo chown ec2-user:ec2-user ${ollamaModelDirectory}`,
+    'echo "EFS mounted successfully."',
 
-  // --- Mount EFS using standard NFSv4.1 ---
-  // Use the manually constructed EFS DNS name
-  `echo "Mounting EFS filesystem using NFSv4.1 and DNS Name: ${efsDnsName}"...`, // Use variable here
-  `sudo mkdir -p ${ollamaModelDirectory}`, // Ensure mount point exists
-  // Standard NFS mount command with recommended options for EFS
-  `sudo mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport ${efsDnsName}:/ ${ollamaModelDirectory}`, // Use variable here
-  // Update fstab to use NFS4 and the DNS name for persistence
-  `echo "${efsDnsName}:/ ${ollamaModelDirectory} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,_netdev 0 0" | sudo tee -a /etc/fstab`, // Use variable here
-  // Set ownership for the application user
-  `sudo chown ec2-user:ec2-user ${ollamaModelDirectory}`,
-  'echo "EFS mounted successfully."',
+    // --- Start Ollama container ---
+    'echo "Starting Ollama container..."',
+    'sudo docker run -d --name ollama \\',
+    '  --gpus all \\',
+    '  -p 0.0.0.0:11434:11434 \\',
+    `  -v ${ollamaModelDirectory}:/root/.ollama \\`,
+    '  --restart unless-stopped \\',
+    '  ollama/ollama serve',
 
-  // --- Start Ollama container ---
-  'echo "Starting Ollama container..."',
-  'sudo docker run -d --name ollama \\',
-  '  --gpus all \\',
-  '  -p 0.0.0.0:11434:11434 \\',
-  `  -v ${ollamaModelDirectory}:/root/.ollama \\`,
-  '  --restart unless-stopped \\',
-  '  ollama/ollama serve',
+    // --- Pull initial model in background ---
+    '(',
+    '  echo "Waiting for Ollama service (background task)..."',
+    '  sleep 60',
+    '  echo "Pulling default Ollama model (llama3.1:8b) in background..."',
+    '  sudo docker exec ollama ollama pull llama3.1:8b || echo "Failed to pull default model initially, may need manual pull later."',
+    '  echo "Background model pull task finished."',
+    ') &',
+    'disown',
+    'echo "Ollama setup script finished."'
+  );
+}
 
-  // --- Pull initial model in background ---
-  '(',
-  '  echo "Waiting for Ollama service (background task)..."',
-  '  sleep 60',
-  '  echo "Pulling default Ollama model (llama3.1:8b) in background..."',
-  '  sudo docker exec ollama ollama pull llama3.1:8b || echo "Failed to pull default model initially, may need manual pull later."',
-  '  echo "Background model pull task finished."',
-  ') &',
-  'disown',
-  'echo "Ollama setup script finished."'
-); // End of ollamaUsrData.addCommands
-  
-  
   // --- Launch Templates
   const webLaunchTemplate = new ec2.LaunchTemplate(self, 'WebLaunchTemplate', {
     machineImage: machineImageWeb,
@@ -223,24 +223,27 @@ ollamaUsrData.addCommands(
       },
     ],
   });
-  // Ollama Launch Template
-  const ollamaLaunchTemplate = new ec2.LaunchTemplate(self, 'OllamaLaunchTemplate', {
-    machineImage: machineImageOllama,
-    userData: ollamaUsrData,
-    instanceType: instanceTypeOllama,
-    securityGroup: ollamaSecurityGroup,
-    keyPair: ollamaKeyPair,
-    role: instanceRole,
-    blockDevices: [
-      {
-        deviceName: '/dev/xvda', // Adjust if needed for DLAMI
-        volume: ec2.BlockDeviceVolume.ebs(100, {
-          volumeType: ec2.EbsDeviceVolumeType.GP3,
-          deleteOnTermination: true,
-        }),
-      },
-    ],
-  });
+  // Ollama Launch Template (only when the GPU stack is enabled)
+  let ollamaLaunchTemplate: ec2.LaunchTemplate | undefined;
+  if (enableOllama) {
+    ollamaLaunchTemplate = new ec2.LaunchTemplate(self, 'OllamaLaunchTemplate', {
+      machineImage: machineImageOllama,
+      userData: ollamaUsrData,
+      instanceType: instanceTypeOllama,
+      securityGroup: ollamaSecurityGroup,
+      keyPair: ollamaKeyPair,
+      role: instanceRole,
+      blockDevices: [
+        {
+          deviceName: '/dev/xvda', // Adjust if needed for DLAMI
+          volume: ec2.BlockDeviceVolume.ebs(100, {
+            volumeType: ec2.EbsDeviceVolumeType.GP3,
+            deleteOnTermination: true,
+          }),
+        },
+      ],
+    });
+  }
 
   return {
     webLaunchTemplate,

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -41,6 +41,7 @@ import { ImportWorkerService } from './import-worker-service';
 
 interface PolisStackProps extends cdk.StackProps {
   enableSSHAccess?: boolean; // Make optional, default to false
+  enableOllama?: boolean; // Gate the Ollama GPU stack (default false)
   envFile: string;
   branch?: string;
   sshAllowedIpRange?: string; // Add a property for SSH access control
@@ -56,6 +57,12 @@ export class CdkStack extends cdk.Stack {
     super(scope, id, props);
 
     const defaultSSHRange = '0.0.0.0/0';
+    // The Ollama GPU stack is temporarily retired to cut cost. Everything it
+    // needs (ASG, GPU launch template, EFS, internal NLB, service-URL secret,
+    // SG rules and outputs) is gated behind this flag (CDK_ENABLE_OLLAMA). The
+    // self-hosted-LLM feature stays supported: flip the flag and set
+    // LLM_PROVIDER=ollama to bring it all back.
+    const enableOllama = props.enableOllama ?? false;
     const ollamaPort = 11434;
     const ollamaModelDirectory = '/efs/ollama-models';
     const ollamaNamespace = 'OllamaMetrics'; // Custom namespace for GPU metrics
@@ -85,18 +92,22 @@ export class CdkStack extends cdk.Stack {
       efsSecurityGroup,
     } = createSecurityGroups(vpc, this);
 
-    // Allow Delphi -> Ollama
-    ollamaSecurityGroup.addIngressRule(
-      ec2.Peer.ipv4(vpc.vpcCidrBlock), // Allows traffic from any private IP within the VPC
-      ec2.Port.tcp(ollamaPort),
-      `Allow NLB traffic on ${ollamaPort} from VPC`
-    );
-    // Allow Ollama -> EFS
-    efsSecurityGroup.addIngressRule(
-      ollamaSecurityGroup,
-      ec2.Port.tcp(2049), // NFS port
-      'Allow NFS from Ollama instances'
-    );
+    // Ollama/EFS ingress rules (only when the GPU stack is enabled). The empty
+    // security groups themselves are left in place (harmless, no rules).
+    if (enableOllama) {
+      // Allow Delphi -> Ollama
+      ollamaSecurityGroup.addIngressRule(
+        ec2.Peer.ipv4(vpc.vpcCidrBlock), // Allows traffic from any private IP within the VPC
+        ec2.Port.tcp(ollamaPort),
+        `Allow NLB traffic on ${ollamaPort} from VPC`
+      );
+      // Allow Ollama -> EFS
+      efsSecurityGroup.addIngressRule(
+        ollamaSecurityGroup,
+        ec2.Port.tcp(2049), // NFS port
+        'Allow NFS from Ollama instances'
+      );
+    }
 
     // Conditional SSH Access
     if (props.enableSSHAccess) {
@@ -104,7 +115,9 @@ export class CdkStack extends cdk.Stack {
       webSecurityGroup.addIngressRule(sshPeer, ec2.Port.tcp(22), 'Allow SSH access');
       mathWorkerSecurityGroup.addIngressRule(sshPeer, ec2.Port.tcp(22), 'Allow SSH access');
       delphiSecurityGroup.addIngressRule(sshPeer, ec2.Port.tcp(22), 'Allow SSH access');
-      ollamaSecurityGroup.addIngressRule(sshPeer, ec2.Port.tcp(22), 'Allow SSH access');
+      if (enableOllama) {
+        ollamaSecurityGroup.addIngressRule(sshPeer, ec2.Port.tcp(22), 'Allow SSH access');
+      }
     }
 
     webSecurityGroup.addIngressRule(ec2.Peer.ipv4(props.sshAllowedIpRange || defaultSSHRange), ec2.Port.tcp(22), 'Allow SSH'); // Control SSH separately
@@ -123,7 +136,7 @@ export class CdkStack extends cdk.Stack {
     const mathWorkerKeyPair = getKeyPair('MathWorkerKeyPair', props.mathWorkerKeyPairName);
     const delphiSmallKeyPair = getKeyPair('DelphiSmallKeyPair', props.delphiSmallKeyPairName);
     const delphiLargeKeyPair = getKeyPair('DelphiLargeKeyPair', props.delphiLargeKeyPairName);
-    const ollamaKeyPair = getKeyPair('OllamaKeyPair', props.ollamaKeyPairName);
+    const ollamaKeyPair = enableOllama ? getKeyPair('OllamaKeyPair', props.ollamaKeyPairName) : undefined;
 
     const { instanceRole, codeDeployRole, dbBackupLambdaRole } = createRoles(this);
 
@@ -142,35 +155,38 @@ export class CdkStack extends cdk.Stack {
     // Create DB and related resources
     const { dbSubnetGroup, db, dbSecretArnParam, dbHostParam, dbPortParam } = createDBResources(this, vpc);
 
-    // --- EFS for Ollama Models
-    const fileSystemPolicyDocument = new iam.PolicyDocument({
-      statements: [
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: [
-            "elasticfilesystem:ClientMount",
-            "elasticfilesystem:ClientWrite",
-            "elasticfilesystem:ClientRootAccess",
-          ],
-          principals: [new iam.AnyPrincipal()],
-          resources: ["*"], // Applies to the filesystem this policy is attached to
-          conditions: {
-            Bool: { "elasticfilesystem:AccessedViaMountTarget": "true" }
-          }
-        })
-      ]
-    });
-    const fileSystem = new efs.FileSystem(this, 'OllamaModelFileSystem', {
-      vpc,
-      encrypted: true,
-      lifecyclePolicy: efs.LifecyclePolicy.AFTER_14_DAYS,
-      performanceMode: efs.PerformanceMode.GENERAL_PURPOSE,
-      throughputMode: efs.ThroughputMode.ELASTIC,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
-      securityGroup: efsSecurityGroup,
-      vpcSubnets: { subnetGroupName: 'PrivateWithEgress' },
-      fileSystemPolicy: fileSystemPolicyDocument,
-    });
+    // --- EFS for Ollama Models (only when the GPU stack is enabled)
+    let fileSystem: efs.FileSystem | undefined;
+    if (enableOllama) {
+      const fileSystemPolicyDocument = new iam.PolicyDocument({
+        statements: [
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: [
+              "elasticfilesystem:ClientMount",
+              "elasticfilesystem:ClientWrite",
+              "elasticfilesystem:ClientRootAccess",
+            ],
+            principals: [new iam.AnyPrincipal()],
+            resources: ["*"], // Applies to the filesystem this policy is attached to
+            conditions: {
+              Bool: { "elasticfilesystem:AccessedViaMountTarget": "true" }
+            }
+          })
+        ]
+      });
+      fileSystem = new efs.FileSystem(this, 'OllamaModelFileSystem', {
+        vpc,
+        encrypted: true,
+        lifecyclePolicy: efs.LifecyclePolicy.AFTER_14_DAYS,
+        performanceMode: efs.PerformanceMode.GENERAL_PURPOSE,
+        throughputMode: efs.ThroughputMode.ELASTIC,
+        removalPolicy: cdk.RemovalPolicy.RETAIN,
+        securityGroup: efsSecurityGroup,
+        vpcSubnets: { subnetGroupName: 'PrivateWithEgress' },
+        fileSystemPolicy: fileSystemPolicyDocument,
+      });
+    }
 
     // launch templates
     const {
@@ -203,7 +219,8 @@ export class CdkStack extends cdk.Stack {
       machineImageOllama,
       instanceTypeOllama,
       ollamaKeyPair,
-      ollamaSecurityGroup
+      ollamaSecurityGroup,
+      enableOllama
     );
 
     // Auto Scaling Groups and alarms
@@ -226,7 +243,8 @@ export class CdkStack extends cdk.Stack {
       delphiSmallLaunchTemplate,
       delphiLargeLaunchTemplate,
       ollamaNamespace,
-      alarmTopic
+      alarmTopic,
+      enableOllama
     );
 
     // --- DEPLOY STUFF
@@ -244,41 +262,49 @@ export class CdkStack extends cdk.Stack {
       codeDeployRole
     );
 
-    // --- Ollama Network Load Balancer (Internal, in Private+Egress)
-    const ollamaNlb = new elbv2.NetworkLoadBalancer(this, 'OllamaNlb', {
-      vpc,
-      internetFacing: false, // Internal only
-      crossZoneEnabled: true,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
-    });
-    const ollamaListener = ollamaNlb.addListener('OllamaListener', {
-      port: ollamaPort,
-      protocol: elbv2.Protocol.TCP,
-    });
-    const ollamaTargetGroup = new elbv2.NetworkTargetGroup(this, 'OllamaTargetGroup', {
-      vpc,
-      port: ollamaPort,
-      protocol: elbv2.Protocol.TCP,
-      targetType: elbv2.TargetType.INSTANCE,
-      targets: [asgOllama],
-      healthCheck: {
+    // --- Ollama Network Load Balancer + service-URL secret (only when enabled)
+    let ollamaNlb: elbv2.NetworkLoadBalancer | undefined;
+    let ollamaServiceSecret: secretsmanager.Secret | undefined;
+    if (enableOllama) {
+      if (!asgOllama) {
+        throw new Error('enableOllama is true but asgOllama was not created');
+      }
+      // Internal, in Private+Egress
+      ollamaNlb = new elbv2.NetworkLoadBalancer(this, 'OllamaNlb', {
+        vpc,
+        internetFacing: false, // Internal only
+        crossZoneEnabled: true,
+        vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+      });
+      const ollamaListener = ollamaNlb.addListener('OllamaListener', {
+        port: ollamaPort,
         protocol: elbv2.Protocol.TCP,
-        interval: cdk.Duration.seconds(30),
-        healthyThresholdCount: 2,
-        unhealthyThresholdCount: 2,
-      },
-      deregistrationDelay: cdk.Duration.seconds(60),
-    });
-    ollamaListener.addTargetGroups('OllamaTg', ollamaTargetGroup);
+      });
+      const ollamaTargetGroup = new elbv2.NetworkTargetGroup(this, 'OllamaTargetGroup', {
+        vpc,
+        port: ollamaPort,
+        protocol: elbv2.Protocol.TCP,
+        targetType: elbv2.TargetType.INSTANCE,
+        targets: [asgOllama],
+        healthCheck: {
+          protocol: elbv2.Protocol.TCP,
+          interval: cdk.Duration.seconds(30),
+          healthyThresholdCount: 2,
+          unhealthyThresholdCount: 2,
+        },
+        deregistrationDelay: cdk.Duration.seconds(60),
+      });
+      ollamaListener.addTargetGroups('OllamaTg', ollamaTargetGroup);
 
-    // Secret for Ollama NLB endpoint
-    const ollamaServiceSecret = new secretsmanager.Secret(this, 'OllamaServiceSecret', {
-      secretName: '/polis/ollama-service-url',
-      description: 'URL for the internal Ollama service endpoint (NLB)',
-      // Store the NLB DNS name and port
-      secretStringValue: cdk.SecretValue.unsafePlainText(`http://${ollamaNlb.loadBalancerDnsName}:${ollamaPort}`),
-    });
-    ollamaServiceSecret.grantRead(instanceRole);
+      // Secret for Ollama NLB endpoint
+      ollamaServiceSecret = new secretsmanager.Secret(this, 'OllamaServiceSecret', {
+        secretName: '/polis/ollama-service-url',
+        description: 'URL for the internal Ollama service endpoint (NLB)',
+        // Store the NLB DNS name and port
+        secretStringValue: cdk.SecretValue.unsafePlainText(`http://${ollamaNlb.loadBalancerDnsName}:${ollamaPort}`),
+      });
+      ollamaServiceSecret.grantRead(instanceRole);
+    }
 
     // --- DB Access Rules
     db.connections.allowFrom(asgWeb, ec2.Port.tcp(5432), 'Allow database access from web ASG');
@@ -371,8 +397,10 @@ export class CdkStack extends cdk.Stack {
 
     // --- Outputs
     new cdk.CfnOutput(this, 'LoadBalancerDNS', { value: lb.loadBalancerDnsName, description: 'Public DNS name of the Application Load Balancer' });
-    new cdk.CfnOutput(this, 'OllamaNlbDnsName', { value: ollamaNlb.loadBalancerDnsName, description: 'Internal DNS Name for the Ollama Network Load Balancer'});
-    new cdk.CfnOutput(this, 'OllamaServiceSecretArn', { value: ollamaServiceSecret.secretArn, description: 'ARN of the Secret containing the Ollama service URL' });
-    new cdk.CfnOutput(this, 'EfsFileSystemId', { value: fileSystem.fileSystemId, description: 'ID of the EFS File System for Ollama models' });
+    if (enableOllama && ollamaNlb && ollamaServiceSecret && fileSystem) {
+      new cdk.CfnOutput(this, 'OllamaNlbDnsName', { value: ollamaNlb.loadBalancerDnsName, description: 'Internal DNS Name for the Ollama Network Load Balancer'});
+      new cdk.CfnOutput(this, 'OllamaServiceSecretArn', { value: ollamaServiceSecret.secretArn, description: 'ARN of the Secret containing the Ollama service URL' });
+      new cdk.CfnOutput(this, 'EfsFileSystemId', { value: fileSystem.fileSystemId, description: 'ID of the EFS File System for Ollama models' });
+    }
   }
 }

--- a/cdk/secrets.ts
+++ b/cdk/secrets.ts
@@ -12,8 +12,8 @@ export default (
   asgMathWorker: cdk.aws_autoscaling.AutoScalingGroup,
   asgDelphiSmall: cdk.aws_autoscaling.AutoScalingGroup,
   asgDelphiLarge: cdk.aws_autoscaling.AutoScalingGroup,
-  asgOllama: cdk.aws_autoscaling.AutoScalingGroup,
-  fileSystem: cdk.aws_efs.FileSystem
+  asgOllama: cdk.aws_autoscaling.AutoScalingGroup | undefined,
+  fileSystem: cdk.aws_efs.FileSystem | undefined
 ) => {
   const webAppEnvVarsSecret = new secretsmanager.Secret(self, 'WebAppEnvVarsSecret', {
     secretName: 'polis-web-app-env-vars',
@@ -38,13 +38,18 @@ export default (
   const addSecretDependency = (asg: autoscaling.IAutoScalingGroup) => asg.node.addDependency(webAppEnvVarsSecret);
 
   // Apply common dependencies to all ASGs
-  [asgWeb, asgMathWorker, asgDelphiSmall, asgDelphiLarge, asgOllama].forEach(asg => {
+  [asgWeb, asgMathWorker, asgDelphiSmall, asgDelphiLarge].forEach(asg => {
     addLogDependency(asg);
     addSecretDependency(asg);
-    // Only add DB dependency if the service needs it
-    if (asg !== asgOllama) {
-      addDbDependency(asg);
-    }
+    addDbDependency(asg);
   });
-  asgOllama.node.addDependency(fileSystem);
+
+  // Ollama dependencies (only when the GPU stack is enabled)
+  if (asgOllama) {
+    addLogDependency(asgOllama);
+    addSecretDependency(asgOllama);
+    if (fileSystem) {
+      asgOllama.node.addDependency(fileSystem);
+    }
+  }
 }

--- a/delphi/README.md
+++ b/delphi/README.md
@@ -58,3 +58,34 @@ This is a Python implementation of the mathematical components of the [Pol.is](h
 - Uses DynamoDB for storing intermediate and final results
 - Generates interactive and static visualizations for conversations
 - Stores visualizations in S3-compatible storage (see [S3_STORAGE.md](S3_STORAGE.md) for details)
+
+## Topic-cluster naming (LLM provider)
+
+Topic-cluster labels (the short 3–5 word names for each cluster) are generated
+by an LLM. The provider is selected with environment variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `LLM_PROVIDER` | `anthropic` | `anthropic` (Batch API) or `ollama` (self-hosted GPU) |
+| `ANTHROPIC_TOPIC_MODEL` | `claude-haiku-4-5-20251001` | Anthropic model; falls back to `ANTHROPIC_MODEL` |
+| `ANTHROPIC_API_KEY` | — | Required when `LLM_PROVIDER=anthropic` |
+| `TOPIC_BATCH_MAX_WAIT_SECONDS` | `1800` | Max wait for a naming batch before falling back to generic labels |
+| `OLLAMA_MODEL` / `OLLAMA_HOST` | `llama3.1:8b` / `http://ollama:11434` | Only used when `LLM_PROVIDER=ollama` |
+
+**Anthropic (default):** all cluster prompts for a layer are submitted as one
+Anthropic Message Batch and polled until complete. Naming never crashes the
+pipeline — a failed request falls back to a generic `Topic N` label, and a
+wholesale failure falls back to conventional keyword labels.
+
+Enable topic naming with `run_pipeline.py --name-topics` (the deprecated
+`--use-ollama` flag still works and forces `LLM_PROVIDER=ollama`).
+
+**Re-enabling the self-hosted Ollama GPU stack:** the GPU infrastructure is
+turned off by default to save cost, but the self-hosted LLM path remains
+supported. To bring it back:
+
+1. Deploy the CDK stack with `CDK_ENABLE_OLLAMA=true` (recreates the ASG, GPU
+   launch template, EFS, internal NLB and the `/polis/ollama-service-url`
+   secret — the EFS model volume is `RETAIN`, so the model file survives).
+2. Set `LLM_PROVIDER=ollama` (plus `OLLAMA_MODEL` / `OLLAMA_HOST`) in the
+   Delphi environment.

--- a/delphi/example.env
+++ b/delphi/example.env
@@ -5,9 +5,18 @@ PORT=8080
 LOG_LEVEL=INFO
 MATH_ENV=dev
 
-# LLM configuration
-# Default is ollama (alternative: anthropic)
-LLM_PROVIDER=ollama
+# LLM configuration (used for topic-cluster naming)
+# Provider: anthropic (default, via the Batch API) or ollama (self-hosted GPU).
+LLM_PROVIDER=anthropic
+# Anthropic topic-naming model. Resolution order:
+#   ANTHROPIC_TOPIC_MODEL -> ANTHROPIC_MODEL -> claude-haiku-4-5-20251001
+ANTHROPIC_TOPIC_MODEL=claude-haiku-4-5-20251001
+# ANTHROPIC_API_KEY is required when LLM_PROVIDER=anthropic (set it, do not commit it).
+# Max seconds to wait for a naming batch before falling back to generic labels.
+TOPIC_BATCH_MAX_WAIT_SECONDS=1800
+#
+# Ollama (only used when LLM_PROVIDER=ollama; the GPU infra is off by default,
+# re-enable it in CDK with CDK_ENABLE_OLLAMA=true).
 # Default is llama3.1:8b - other options: llama3, gemma:7b, mistral, mixtral, etc.
 OLLAMA_MODEL=llama3.1:8b
 # For local development, use localhost

--- a/delphi/run_delphi.py
+++ b/delphi/run_delphi.py
@@ -70,18 +70,27 @@ def main():
 
     print(f"{GREEN}Processing conversation {zid}...{NC}")
 
-    # Set model
-    model = os.environ.get("OLLAMA_MODEL")
-    if not model:
-        print(f"{RED}Error: OLLAMA_MODEL environment variable not set.{NC}")
-        sys.exit(1)
-    print(f"{YELLOW}Using Ollama model: {model}{NC}")
+    # Select the topic-naming provider. Default is Anthropic (via the Batch API);
+    # OLLAMA_MODEL / OLLAMA_HOST are only required for a self-hosted Ollama setup.
+    llm_provider = os.environ.get("LLM_PROVIDER", "anthropic").lower()
+    if llm_provider == "ollama":
+        model = os.environ.get("OLLAMA_MODEL")
+        if not model:
+            print(f"{RED}Error: LLM_PROVIDER=ollama but OLLAMA_MODEL is not set.{NC}")
+            sys.exit(1)
+        os.environ["OLLAMA_HOST"] = os.environ.get("OLLAMA_HOST", "http://ollama:11434")
+        print(f"{YELLOW}Using Ollama model: {model} at {os.environ['OLLAMA_HOST']}{NC}")
+    else:
+        topic_model = (
+            os.environ.get("ANTHROPIC_TOPIC_MODEL")
+            or os.environ.get("ANTHROPIC_MODEL")
+            or "claude-haiku-4-5-20251001"
+        )
+        print(f"{YELLOW}Using {llm_provider} topic model: {topic_model}{NC}")
 
     # Set up environment for the pipeline
     app_path = os.environ.get('DELPHI_APP_PATH', '/app')
     os.environ["PYTHONPATH"] = f"{app_path}:{os.environ.get('PYTHONPATH', '')}"
-    os.environ["OLLAMA_HOST"] = os.environ.get("OLLAMA_HOST", "http://ollama:11434")
-    # OLLAMA_MODEL is already set and checked
     max_votes = os.environ.get("MAX_VOTES")
     max_votes_arg = f"--max-votes={max_votes}" if max_votes else ""
     if max_votes:
@@ -120,7 +129,7 @@ def main():
         f"--zid={zid}",
         f"--include_moderation={args.include_moderation}",
         f"--exclude_comment_selections={args.exclude_comment_selections}",
-        "--use-ollama"
+        "--name-topics"
     ]
     if verbose_arg:
         umap_command.append(verbose_arg)

--- a/delphi/scripts/job_poller.py
+++ b/delphi/scripts/job_poller.py
@@ -765,6 +765,23 @@ class JobProcessor:
             self.complete_job(job, False, error=f"Critical poller error: {str(e)}")
 
 
+def should_process_job(instance_type: str, job_actual_size: str) -> bool:
+    """
+    Decide whether a worker of the given instance type should process a job of
+    the given size.
+
+    The dedicated "large" worker ASG is scaled to zero, so the normal/default
+    worker class now processes ALL job sizes. "large" remains an opt-in,
+    large-only class (set INSTANCE_SIZE=large) for anyone who re-enables that
+    ASG; "dev" processes anything. get_job_actual_size is still consulted for
+    logging/visibility.
+    """
+    if instance_type == "large":
+        return job_actual_size == "large"
+    # 'default', 'small', 'dev' and anything else: process every size.
+    return True
+
+
 def poll_and_process(processor: JobProcessor, interval: int = 10):
     """The main loop for a worker thread."""
     logger.info(f"Worker {processor.worker_id} starting job polling...")
@@ -782,19 +799,8 @@ def poll_and_process(processor: JobProcessor, interval: int = 10):
                 else:
                     job_actual_size = "normal"
 
-                can_process = False
                 instance_type = processor.instance_type
-
-                if instance_type == "large":
-                    # A large instance ONLY processes large jobs.
-                    can_process = job_actual_size == "large"
-                else:  # This covers 'small' and the 'default' type.
-                    # Small/default instances ONLY process normal-sized jobs.
-                    can_process = job_actual_size == "normal"
-
-                if instance_type == "dev":
-                    # Dev instances can process any job size.
-                    can_process = True
+                can_process = should_process_job(instance_type, job_actual_size)
 
                 if not can_process:
                     logger.info(f"Worker instance type '{instance_type}' cannot process job '{job_to_process['job_id']}' of size '{job_actual_size}'. Skipping for now.")

--- a/delphi/tests/topic_naming/test_job_routing.py
+++ b/delphi/tests/topic_naming/test_job_routing.py
@@ -1,0 +1,28 @@
+"""
+Unit tests for job-size routing in the Delphi job poller.
+
+The dedicated "large" worker ASG is at zero, so the normal/default class must
+process ALL job sizes; "large" stays an opt-in large-only class.
+"""
+
+from scripts.job_poller import should_process_job
+
+
+def test_default_processes_all_sizes():
+    assert should_process_job("default", "normal") is True
+    assert should_process_job("default", "large") is True
+
+
+def test_small_processes_all_sizes():
+    assert should_process_job("small", "normal") is True
+    assert should_process_job("small", "large") is True
+
+
+def test_dev_processes_all_sizes():
+    assert should_process_job("dev", "normal") is True
+    assert should_process_job("dev", "large") is True
+
+
+def test_large_is_large_only():
+    assert should_process_job("large", "large") is True
+    assert should_process_job("large", "normal") is False

--- a/delphi/tests/topic_naming/test_model_provider_batch.py
+++ b/delphi/tests/topic_naming/test_model_provider_batch.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for the Anthropic Message Batches helpers on AnthropicProvider.
+
+The HTTP layer (``requests``) is fully mocked, so no network access or API key
+is needed. These cover the create -> poll -> results flow and result parsing.
+"""
+
+import json
+from unittest import mock
+
+import pytest
+
+from umap_narrative.llm_factory_constructor.model_provider import (
+    AnthropicProvider,
+    get_model_provider,
+)
+
+
+class FakeResponse:
+    def __init__(self, *, json_data=None, text=None, status_code=200):
+        self._json = json_data
+        self.text = text if text is not None else ""
+        self.status_code = status_code
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise AssertionError(f"HTTP {self.status_code}")
+
+
+def make_provider():
+    return AnthropicProvider(model_name="claude-haiku-4-5-20251001", api_key="sk-test")
+
+
+def test_provider_supports_batching():
+    assert make_provider().supports_batching is True
+
+
+def test_get_batch_responses_posts_to_batches_endpoint():
+    provider = make_provider()
+    captured = {}
+
+    def fake_post(url, headers=None, json=None):
+        captured["url"] = url
+        captured["json"] = json
+        return FakeResponse(json_data={"id": "batch_123", "processing_status": "in_progress"})
+
+    batch_requests = [
+        {"custom_id": "layer0_cluster0", "params": {"messages": [{"role": "user", "content": "p0"}], "max_tokens": 64}},
+        {"custom_id": "layer0_cluster1", "params": {"messages": [{"role": "user", "content": "p1"}], "max_tokens": 64}},
+    ]
+
+    with mock.patch("umap_narrative.llm_factory_constructor.model_provider.requests.post", side_effect=fake_post):
+        result = provider.get_batch_responses(batch_requests)
+
+    # Correct (plural) endpoint, not the singular ".../batch".
+    assert captured["url"] == "https://api.anthropic.com/v1/messages/batches"
+    # One request per cluster, each with a custom_id and the model injected.
+    reqs = captured["json"]["requests"]
+    assert [r["custom_id"] for r in reqs] == ["layer0_cluster0", "layer0_cluster1"]
+    assert all(r["params"]["model"] == "claude-haiku-4-5-20251001" for r in reqs)
+    assert result["id"] == "batch_123"
+
+
+def test_get_batch_responses_without_api_key_returns_error():
+    provider = AnthropicProvider(model_name="claude-haiku-4-5-20251001", api_key=None)
+    provider.api_key = None
+    result = provider.get_batch_responses([{"custom_id": "a", "params": {}}])
+    assert "error" in result
+
+
+def test_poll_batch_polls_until_ended():
+    provider = make_provider()
+    responses = [
+        {"processing_status": "in_progress", "request_counts": {"processing": 2}},
+        {"processing_status": "in_progress", "request_counts": {"processing": 1}},
+        {"processing_status": "ended", "results_url": "https://x/results", "request_counts": {"succeeded": 2}},
+    ]
+    calls = {"n": 0}
+
+    def fake_get(url, headers=None):
+        r = responses[calls["n"]]
+        calls["n"] += 1
+        return FakeResponse(json_data=r)
+
+    slept = []
+    with mock.patch("umap_narrative.llm_factory_constructor.model_provider.requests.get", side_effect=fake_get):
+        final = provider.poll_batch("batch_123", initial_interval=1, sleep=slept.append)
+
+    assert final["processing_status"] == "ended"
+    assert final["results_url"] == "https://x/results"
+    assert calls["n"] == 3
+    # Backoff doubled between the two waits (1s then 2s).
+    assert slept == [1, 2]
+
+
+def test_poll_batch_times_out():
+    provider = make_provider()
+
+    def fake_get(url, headers=None):
+        return FakeResponse(json_data={"processing_status": "in_progress"})
+
+    # Fake clock that jumps past the deadline on the first check.
+    clock = {"t": 0.0}
+
+    def fake_now():
+        clock["t"] += 10_000
+        return clock["t"]
+
+    with mock.patch("umap_narrative.llm_factory_constructor.model_provider.requests.get", side_effect=fake_get):
+        with pytest.raises(TimeoutError):
+            provider.poll_batch("batch_123", max_wait_seconds=1, sleep=lambda s: None, now=fake_now)
+
+
+def test_get_batch_results_parses_jsonl():
+    provider = make_provider()
+    lines = [
+        json.dumps({"custom_id": "layer0_cluster0", "result": {"type": "succeeded", "message": {"content": [{"type": "text", "text": "\"Traffic Safety\""}]}}}),
+        "",  # blank line ignored
+        json.dumps({"custom_id": "layer0_cluster1", "result": {"type": "errored", "error": {"type": "invalid_request"}}}),
+    ]
+
+    def fake_get(url, headers=None):
+        assert url == "https://x/results"
+        return FakeResponse(text="\n".join(lines))
+
+    with mock.patch("umap_narrative.llm_factory_constructor.model_provider.requests.get", side_effect=fake_get):
+        records = provider.get_batch_results({"results_url": "https://x/results"})
+
+    assert len(records) == 2
+    assert records[0]["custom_id"] == "layer0_cluster0"
+
+
+def test_extract_text_from_result():
+    ok = {"result": {"type": "succeeded", "message": {"content": [{"type": "text", "text": "hello"}]}}}
+    errored = {"result": {"type": "errored", "error": {}}}
+    refused = {"result": {"type": "succeeded", "message": {"stop_reason": "refusal", "content": []}}}
+    assert AnthropicProvider.extract_text_from_result(ok) == "hello"
+    assert AnthropicProvider.extract_text_from_result(errored) is None
+    assert AnthropicProvider.extract_text_from_result(refused) is None
+
+
+def test_factory_selects_ollama_and_anthropic(monkeypatch):
+    monkeypatch.setenv("OLLAMA_MODEL", "llama3.1:8b")
+    ollama = get_model_provider("ollama")
+    assert ollama.supports_batching is False
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    anthropic = get_model_provider("anthropic", "claude-haiku-4-5-20251001")
+    assert anthropic.supports_batching is True

--- a/delphi/tests/topic_naming/test_topic_naming.py
+++ b/delphi/tests/topic_naming/test_topic_naming.py
@@ -1,0 +1,264 @@
+"""
+Unit tests for provider-agnostic topic naming.
+
+The provider factory is mocked with fake providers so no network or API key is
+needed. Covers: batch request construction (one custom_id per cluster), mapping
+results back to the right clusters, partial failures, the label cleanup, the
+ollama (non-batch) path, and conventional fallback.
+"""
+
+import numpy as np
+import pytest
+
+from umap_narrative import topic_naming
+from umap_narrative.topic_naming import (
+    build_topic_prompt,
+    clean_topic_name,
+    generate_cluster_topic_labels,
+    resolve_model_name,
+    resolve_provider_type,
+    select_representative_comments,
+)
+
+
+# --- provider resolution ---------------------------------------------------
+
+def test_resolve_provider_default_anthropic(monkeypatch):
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    assert resolve_provider_type() == "anthropic"
+
+
+def test_resolve_provider_env(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "OLLAMA")
+    assert resolve_provider_type() == "ollama"
+
+
+def test_resolve_model_precedence(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_TOPIC_MODEL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
+    assert resolve_model_name("anthropic") == topic_naming.DEFAULT_ANTHROPIC_TOPIC_MODEL
+    monkeypatch.setenv("ANTHROPIC_MODEL", "claude-x")
+    assert resolve_model_name("anthropic") == "claude-x"
+    monkeypatch.setenv("ANTHROPIC_TOPIC_MODEL", "claude-topic")
+    assert resolve_model_name("anthropic") == "claude-topic"
+
+
+# --- cleanup ---------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ('"Traffic Safety"', "Traffic Safety"),
+        ("Topic label: Housing Costs", "Housing Costs"),
+        ("1_2: Public Transit", "Public Transit"),
+        ("- **Climate Policy**", "Climate Policy"),
+        ("First line here\nsecond line", "First line here"),
+    ],
+)
+def test_clean_topic_name(raw, expected):
+    assert clean_topic_name(raw, "fallback") == expected
+
+
+def test_clean_topic_name_empty_uses_fallback():
+    assert clean_topic_name("   ", "Topic 3") == "Topic 3"
+    assert clean_topic_name("", "Topic 3") == "Topic 3"
+
+
+def test_build_prompt_caps_at_five_comments():
+    prompt = build_topic_prompt([f"c{i}" for i in range(10)])
+    assert "1. c0" in prompt and "5. c4" in prompt
+    assert "6. c5" not in prompt
+
+
+# --- representative comment selection --------------------------------------
+
+def test_select_representative_uses_centroid():
+    layer = np.array([0, 0, 0, 0, 0, 1])
+    document_map = np.array(
+        [[0, 0], [0.1, 0], [10, 10], [11, 11], [12, 12], [0, 0]], dtype=float
+    )
+    comments = [f"c{i}" for i in range(6)]
+    chosen = select_representative_comments(0, layer, comments, document_map, limit=2)
+    # The two closest to the cluster-0 centroid should be selected.
+    assert set(chosen).issubset(set(comments[:5]))
+    assert len(chosen) == 2
+
+
+def test_select_representative_no_map_takes_first():
+    layer = np.array([0, 0, 0, 1])
+    comments = ["a", "b", "c", "d"]
+    assert select_representative_comments(0, layer, comments, None, limit=2) == ["a", "b"]
+
+
+# --- fake providers --------------------------------------------------------
+
+class FakeAnthropicProvider:
+    supports_batching = True
+
+    def __init__(self, results, model_name="claude-haiku-4-5-20251001", fail_create=False):
+        self.model_name = model_name
+        self._results = results
+        self._fail_create = fail_create
+        self.created_requests = None
+
+    def get_batch_responses(self, batch_requests):
+        self.created_requests = batch_requests
+        if self._fail_create:
+            return {"error": "boom"}
+        return {"id": "batch_1", "processing_status": "in_progress"}
+
+    def poll_batch(self, batch_id, max_wait_seconds=1800, sleep=None):
+        return {"processing_status": "ended", "results_url": "https://x"}
+
+    def get_batch_results(self, batch):
+        return self._results
+
+    @staticmethod
+    def extract_text_from_result(record):
+        from umap_narrative.llm_factory_constructor.model_provider import AnthropicProvider
+        return AnthropicProvider.extract_text_from_result(record)
+
+
+class FakeOllamaProvider:
+    supports_batching = False
+
+    def __init__(self, mapping, model_name="llama3.1:8b"):
+        self.model_name = model_name
+        self._mapping = mapping
+        self.prompts_seen = []
+
+    def get_response(self, system_message, user_message):
+        self.prompts_seen.append(user_message)
+        # Return based on which cluster's prompt this is.
+        for key, val in self._mapping.items():
+            if key in user_message:
+                return val
+        return "Generic"
+
+
+def _characteristics(ids):
+    return {i: {"top_words": [f"w{i}"], "sample_comments": [f"sample {i}"]} for i in ids}
+
+
+# --- batch path ------------------------------------------------------------
+
+def test_batch_path_maps_results_to_clusters(monkeypatch):
+    # Two clusters; results returned out of order.
+    results = [
+        {"custom_id": "layer0_cluster1", "result": {"type": "succeeded", "message": {"content": [{"type": "text", "text": '"Housing"'}]}}},
+        {"custom_id": "layer0_cluster0", "result": {"type": "succeeded", "message": {"content": [{"type": "text", "text": '"Traffic"'}]}}},
+    ]
+    provider = FakeAnthropicProvider(results)
+    monkeypatch.setattr(topic_naming, "get_model_provider", lambda *a, **k: provider)
+
+    layer = np.array([0, 0, 1, 1])
+    comments = ["a", "b", "c", "d"]
+    labels = generate_cluster_topic_labels(
+        _characteristics([0, 1]),
+        comment_texts=comments,
+        layer=layer,
+        layer_idx=0,
+        name_topics=True,
+    )
+
+    # One request per cluster, custom_id per cluster.
+    assert {r["custom_id"] for r in provider.created_requests} == {"layer0_cluster0", "layer0_cluster1"}
+    # Correct mapping despite out-of-order results, with layer_cluster prefix.
+    assert labels[0] == "0_0: Traffic"
+    assert labels[1] == "0_1: Housing"
+
+
+def test_batch_partial_failure_uses_fallback_label(monkeypatch):
+    results = [
+        {"custom_id": "layer0_cluster0", "result": {"type": "succeeded", "message": {"content": [{"type": "text", "text": "Good Label"}]}}},
+        {"custom_id": "layer0_cluster1", "result": {"type": "errored", "error": {"type": "server_error"}}},
+        # cluster 2 missing entirely from results.
+    ]
+    provider = FakeAnthropicProvider(results)
+    monkeypatch.setattr(topic_naming, "get_model_provider", lambda *a, **k: provider)
+
+    layer = np.array([0, 1, 2])
+    labels = generate_cluster_topic_labels(
+        _characteristics([0, 1, 2]),
+        comment_texts=["a", "b", "c"],
+        layer=layer,
+        layer_idx=0,
+        name_topics=True,
+    )
+    assert labels[0] == "0_0: Good Label"
+    assert labels[1] == "0_1: Topic 1"   # errored -> fallback
+    assert labels[2] == "0_2: Topic 2"   # missing -> fallback
+
+
+def test_batch_creation_failure_falls_back_to_conventional(monkeypatch):
+    provider = FakeAnthropicProvider([], fail_create=True)
+    monkeypatch.setattr(topic_naming, "get_model_provider", lambda *a, **k: provider)
+
+    labels = generate_cluster_topic_labels(
+        _characteristics([0]),
+        comment_texts=["a"],
+        layer=np.array([0]),
+        layer_idx=0,
+        name_topics=True,
+    )
+    # Conventional fallback: keyword-based, no "0_0:" prefix.
+    assert "Keywords" in labels[0]
+
+
+# --- ollama path -----------------------------------------------------------
+
+def test_ollama_path_selected_and_sequential(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    provider = FakeOllamaProvider({"sampleA": "\"Label A\""})
+    captured = {}
+
+    def fake_factory(provider_type, model_name):
+        captured["provider_type"] = provider_type
+        return provider
+
+    monkeypatch.setattr(topic_naming, "get_model_provider", fake_factory)
+
+    # Comment text 'sampleA' distinguishes cluster 0's prompt.
+    layer = np.array([0])
+    labels = generate_cluster_topic_labels(
+        _characteristics([0]),
+        comment_texts=["sampleA text"],
+        layer=layer,
+        layer_idx=0,
+        name_topics=True,
+    )
+    assert captured["provider_type"] == "ollama"
+    assert labels[0] == "0_0: Label A"
+    assert provider.prompts_seen  # went through the one-by-one path
+
+
+def test_use_ollama_alias_forces_ollama(monkeypatch):
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    provider = FakeOllamaProvider({})
+    captured = {}
+
+    def fake_factory(provider_type, model_name):
+        captured["provider_type"] = provider_type
+        return provider
+
+    monkeypatch.setattr(topic_naming, "get_model_provider", fake_factory)
+    generate_cluster_topic_labels(
+        _characteristics([0]),
+        comment_texts=["x"],
+        layer=np.array([0]),
+        layer_idx=0,
+        use_ollama=True,  # deprecated alias
+    )
+    assert captured["provider_type"] == "ollama"
+
+
+# --- naming disabled -------------------------------------------------------
+
+def test_name_topics_false_returns_conventional():
+    labels = generate_cluster_topic_labels(
+        _characteristics([0, 1]),
+        comment_texts=["a", "b"],
+        layer=np.array([0, 1]),
+        name_topics=False,
+    )
+    assert all("Keywords" in v for v in labels.values())

--- a/delphi/umap_narrative/llm_factory_constructor/model_provider.py
+++ b/delphi/umap_narrative/llm_factory_constructor/model_provider.py
@@ -9,8 +9,9 @@ allowing for easy configuration and switching between model providers.
 import os
 import json
 import logging
+import time
 import requests
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Callable
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -98,7 +99,12 @@ def _check_response_for_issues(response_json: dict, model_name: Optional[str]) -
 
 class ModelProvider:
     """Base class for model providers."""
-    
+
+    # Whether this provider can process many prompts in a single asynchronous
+    # batch call. Subclasses that support the Anthropic Message Batches API set
+    # this to True; the default (e.g. Ollama) processes prompts one-by-one.
+    supports_batching: bool = False
+
     def get_response(self, system_message: str, user_message: str) -> str:
         """
         Get a response from the model.
@@ -245,6 +251,14 @@ class OllamaProvider(ModelProvider):
 class AnthropicProvider(ModelProvider):
     """Provider for Anthropic Claude models."""
 
+    # Anthropic supports the Message Batches API.
+    supports_batching: bool = True
+
+    # Base URL for the Message Batches API. NOTE the trailing "batches" (plural):
+    # the endpoint is POST/GET /v1/messages/batches[/{id}]. An earlier version of
+    # this file posted to the singular ".../batch", which does not exist (404).
+    BATCH_API_URL = "https://api.anthropic.com/v1/messages/batches"
+
     def __init__(self, model_name: Optional[str] = None, api_key: Optional[str] = None):
         """
         Initialize the Anthropic provider.
@@ -369,101 +383,155 @@ class AnthropicProvider(ModelProvider):
                 ]
             })
     
+    def _batch_headers(self) -> Dict[str, str]:
+        return {
+            "x-api-key": self.api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }
+
     def get_batch_responses(self, batch_requests: List[Dict[str, Any]]) -> Dict[str, Any]:
         """
-        Submit a batch of requests to the Anthropic Batch API.
-        
+        Create a batch on the Anthropic Message Batches API.
+
         Args:
-            batch_requests: List of request objects, each containing:
-                - system: System message
-                - messages: List of message objects
-                - max_tokens: Maximum tokens for response
-                - metadata: Dictionary with request metadata
-                
+            batch_requests: List of request objects already in Batch API shape,
+                each a dict with:
+                - "custom_id": stable string used to correlate the result back to
+                  the caller (results come back in arbitrary order).
+                - "params": a Messages API params dict (model, messages,
+                  max_tokens, ...). If "model" is omitted, this provider's
+                  model_name is injected.
+
         Returns:
-            Dictionary with batch job metadata
+            The created batch object as returned by the API (contains "id",
+            "processing_status", and later "results_url"), or a dict with an
+            "error" key on failure.
+
+        Note: the server-side "fallbacks" param (used for claude-fable-5 refusal
+        recovery in the non-batch path) is rejected by the Batch API and must not
+        be added here — a refused item comes back with stop_reason "refusal".
         """
         if not self.api_key:
             logger.error("No Anthropic API key provided for batch requests")
             return {"error": "API key missing"}
-        
+
+        formatted_requests = []
+        for req in batch_requests:
+            params = dict(req.get("params", {}))
+            params.setdefault("model", self.model_name)
+            formatted_requests.append(
+                {"custom_id": req["custom_id"], "params": params}
+            )
+
         try:
-            logger.info(f"Submitting batch of {len(batch_requests)} requests to Anthropic API")
-            
-            # Use Anthropic Batch API endpoint
-            headers = {
-                "x-api-key": self.api_key,
-                "anthropic-version": "2023-06-01",
-                "content-type": "application/json"
-            }
-            
-            # Format requests for Batch API
-            # Note: the server-side "fallbacks" param (used for claude-fable-5
-            # refusal recovery elsewhere in this file) is rejected by the Batch
-            # API and must not be added here — a refused batch item just comes
-            # back with stop_reason "refusal" and needs to be resubmitted
-            # separately via the non-batch path.
-            formatted_requests = []
-            for i, request in enumerate(batch_requests):
-                req = {
-                    "model": self.model_name,
-                    "system": request.get("system", ""),
-                    "messages": request.get("messages", []),
-                    "max_tokens": request.get("max_tokens", 8000),
-                    "output_config": {"effort": "medium"}
-                }
-                
-                # Add request ID (for correlation on response)
-                req["request_id"] = f"req_{i}"
-                
-                formatted_requests.append(req)
-            
-            # Check if Batch API is available
-            try:
-                # Make a request to the Batch API endpoint
-                batch_request_data = {
-                    "requests": formatted_requests
-                }
-                
-                response = requests.post(
-                    "https://api.anthropic.com/v1/messages/batch",
-                    headers=headers,
-                    json=batch_request_data
-                )
-                
-                # Check if the response indicates Batch API is not available
-                if response.status_code == 404:
-                    logger.warning("Anthropic Batch API endpoint not found (404). Falling back to sequential processing.")
-                    return {"error": "Batch API not available", "fallback": "sequential"}
-                
-                # Raise for other errors
-                response.raise_for_status()
-                
-                # Get response data
-                response_data = response.json()
-                logger.info(f"Batch submitted successfully. Batch ID: {response_data.get('batch_id')}")
-                
-                # Add metadata mapping
-                response_data["request_metadata"] = {f"req_{i}": request.get("metadata", {}) for i, request in enumerate(batch_requests)}
-                
-                return response_data
-                
-            except requests.exceptions.HTTPError as e:
-                if e.response is not None and e.response.status_code == 404:
-                    logger.warning("Anthropic Batch API endpoint not found (404). Falling back to sequential processing.")
-                    return {"error": "Batch API not available", "fallback": "sequential"}
-                else:
-                    logger.error(f"HTTP error using Anthropic Batch API: {str(e)}")
-                    return {"error": f"HTTP error: {str(e)}"}
-                    
-            except Exception as e:
-                logger.error(f"Error using Anthropic Batch API: {str(e)}")
-                return {"error": str(e)}
-                
+            logger.info(
+                f"Submitting batch of {len(formatted_requests)} requests to "
+                f"{self.BATCH_API_URL}"
+            )
+            response = requests.post(
+                self.BATCH_API_URL,
+                headers=self._batch_headers(),
+                json={"requests": formatted_requests},
+            )
+            response.raise_for_status()
+            data = response.json()
+            logger.info(
+                f"Batch submitted successfully. Batch ID: {data.get('id')} "
+                f"status: {data.get('processing_status')}"
+            )
+            return data
         except Exception as e:
-            logger.error(f"Error preparing batch request: {str(e)}")
+            logger.error(f"Error using Anthropic Batch API: {str(e)}")
             return {"error": str(e)}
-    
+
+    def retrieve_batch(self, batch_id: str) -> Dict[str, Any]:
+        """Fetch the current state of a batch (GET /v1/messages/batches/{id})."""
+        response = requests.get(
+            f"{self.BATCH_API_URL}/{batch_id}",
+            headers=self._batch_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def poll_batch(
+        self,
+        batch_id: str,
+        max_wait_seconds: float = 1800.0,
+        initial_interval: float = 5.0,
+        max_interval: float = 60.0,
+        sleep: Callable[[float], None] = time.sleep,
+        now: Callable[[], float] = time.monotonic,
+    ) -> Dict[str, Any]:
+        """
+        Poll a batch until its processing_status is "ended", with exponential
+        backoff. Raises TimeoutError if the batch does not end within
+        max_wait_seconds.
+
+        Returns the final (ended) batch object, which carries "results_url".
+        """
+        deadline = now() + max_wait_seconds
+        interval = initial_interval
+        while True:
+            batch = self.retrieve_batch(batch_id)
+            status = batch.get("processing_status")
+            if status == "ended":
+                return batch
+            remaining = deadline - now()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Batch {batch_id} did not complete within {max_wait_seconds}s "
+                    f"(last status: {status})"
+                )
+            counts = batch.get("request_counts", {})
+            logger.info(
+                f"Batch {batch_id} status={status} counts={counts}; "
+                f"sleeping {min(interval, remaining):.0f}s"
+            )
+            sleep(min(interval, remaining))
+            interval = min(interval * 2, max_interval)
+
+    def get_batch_results(self, batch: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        Download and parse the JSONL results of an ended batch.
+
+        Args:
+            batch: an ended batch object (must contain "results_url").
+
+        Returns:
+            A list of result records, each a dict with "custom_id" and "result".
+        """
+        results_url = batch.get("results_url")
+        if not results_url:
+            raise ValueError("Batch has no results_url; is it ended?")
+        response = requests.get(results_url, headers=self._batch_headers())
+        response.raise_for_status()
+        records = []
+        for line in response.text.splitlines():
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+        return records
+
+    @staticmethod
+    def extract_text_from_result(record: Dict[str, Any]) -> Optional[str]:
+        """
+        Pull the assistant text out of a single batch result record.
+
+        Returns None if the request did not succeed (errored/canceled/expired/
+        refusal) or produced no text block.
+        """
+        result = record.get("result", {})
+        if result.get("type") != "succeeded":
+            return None
+        message = result.get("message", {})
+        if message.get("stop_reason") == "refusal":
+            return None
+        content = message.get("content", [])
+        text_blocks = [b.get("text", "") for b in content if b.get("type") == "text"]
+        return text_blocks[0] if text_blocks else None
+
+
     def list_available_models(self) -> List[str]:
         """
         List available Claude models.
@@ -612,7 +680,13 @@ def get_model_provider(provider_type: Optional[str] = None, model_name: Optional
     else:
         # Default to Ollama
         model_name = model_name or os.environ.get("OLLAMA_MODEL", "llama3")
-        endpoint = os.environ.get("OLLAMA_ENDPOINT", "http://localhost:11434")
+        # Honor OLLAMA_HOST (used by the ollama client and the rest of Delphi),
+        # falling back to the older OLLAMA_ENDPOINT name.
+        endpoint = (
+            os.environ.get("OLLAMA_HOST")
+            or os.environ.get("OLLAMA_ENDPOINT")
+            or "http://localhost:11434"
+        )
         logger.info(f"Using Ollama provider with model: {model_name} at {endpoint}")
         return OllamaProvider(model_name=model_name, endpoint=endpoint)
 

--- a/delphi/umap_narrative/run_pipeline.py
+++ b/delphi/umap_narrative/run_pipeline.py
@@ -24,6 +24,11 @@ from polismath_commentgraph.utils.converter import DataConverter
 # Import from local modules
 from polismath_commentgraph.utils.storage import DynamoDBStorage, PostgresClient
 from sentence_transformers import SentenceTransformer
+from umap_narrative.topic_naming import (
+    generate_cluster_topic_labels,
+    resolve_model_name,
+    resolve_provider_type,
+)
 from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
 from umap import UMAP
 
@@ -274,235 +279,6 @@ def characterize_comment_clusters(cluster_layer, comment_texts):
         }
 
     return cluster_characteristics
-
-
-def generate_cluster_topic_labels(
-    cluster_characteristics,
-    comment_texts=None,
-    layer=None,
-    layer_idx=0,
-    conversation_name=None,
-    use_ollama=False,
-    document_map=None,
-):
-    """
-    Generate topic labels for clusters based on their characteristics.
-
-    Args:
-        cluster_characteristics: Dictionary with cluster characterizations
-        comment_texts: List of comment text strings (used for Ollama naming)
-        layer: Cluster assignments for the current layer (used for Ollama naming)
-        layer_idx: Index of the current layer
-        conversation_name: Name of the conversation (used for Ollama naming)
-        use_ollama: Whether to use Ollama for topic naming
-        document_map: 2D UMAP coordinates for selecting representative comments
-
-    Returns:
-        cluster_labels: Dictionary mapping cluster IDs to topic labels
-    """
-    cluster_labels = {}
-
-    # Check for Anthropic API key
-    anthropic_api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not anthropic_api_key:
-        warning_message = (
-            "⚠️ ANTHROPIC_API_KEY not set. LLM-based narrative reports will be skipped."
-        )
-        logger.warning(warning_message)
-        # Print to stdout directly for better visibility in Docker logs
-        print(f"\033[0;33m{warning_message}\033[0m")
-        print(
-            "To generate narrative reports, set the ANTHROPIC_API_KEY environment variable."
-        )
-
-    # Check if we should use Ollama
-    if use_ollama and comment_texts is not None and layer is not None:
-        try:
-            import ollama
-
-            logger.info("Using Ollama for cluster naming")
-
-            # Function to get topic labels via Ollama
-            def get_topic_name(comments):
-                prompt = (
-                    "Read these comments and provide ONLY ONE short topic label (3–5 words) "
-                    "that captures their combined essence. Do not give one topic per comment. "
-                    "Do not include explanations, introductions, or multiple outputs. "
-                    "Reply with exactly one topic label, in quotation marks, on a single line.\n\n"
-                    "Comments:\n"
-                )
-                for j, comment in enumerate(
-                    comments[:5]
-                ):  # Use 5 pseudo-random comments as examples
-                    prompt += f"{j + 1}. {comment}\n"
-
-                try:
-                    # Get model name from environment variable or use default
-                    model_name = os.environ.get("OLLAMA_MODEL", "llama3.1:8b")
-                    logger.info(f"Using Ollama model from environment: {model_name}")
-                    response = ollama.chat(
-                        model=model_name, messages=[{"role": "user", "content": prompt}]
-                    )
-
-                    # Extract just the topic name with more thorough cleaning
-                    raw_response = response["message"]["content"].strip()
-
-                    # Clean up various prefixes - extended list from 600_generate_llm_topic_names.py
-                    prefixes_to_remove = [
-                        "Here is the list of topic labels:",
-                        "Here is the list of topic labels",
-                        "Here are the topic labels:",
-                        "Here are the topic labels",
-                        "Here is the topic label:",
-                        "Here is the topic label",
-                        "The topic label is:",
-                        "The topic label is",
-                        "Topic label:",
-                        "Here is a concise topic label:",
-                        "Here's a concise topic label:",
-                        "Concise topic label:",
-                        "Topic name:",
-                        "Topic name",
-                        "Topic:",
-                        "Label:",
-                        "Label",
-                    ]
-
-                    # First, check if there's already a layer_cluster prefix (like "1_2:") and remove it
-                    import re
-
-                    layer_prefix_match = re.match(r"^\d+_\d+:\s*", raw_response)
-                    if layer_prefix_match:
-                        raw_response = raw_response[layer_prefix_match.end() :]
-
-                    for prefix in prefixes_to_remove:
-                        if raw_response.startswith(prefix):
-                            raw_response = raw_response.replace(prefix, "", 1)
-
-                    # Strip all whitespace including newlines BEFORE splitting
-                    raw_response = raw_response.strip()
-
-                    # Get just the first line, as we only want the label
-                    topic = raw_response.split("\n")[0].strip()
-
-                    # Remove quotes if they're present (handle both double and single quotes)
-                    topic = topic.strip("\"'")
-
-                    # Remove common formats like "1. Topic Name" or "- Topic Name"
-                    if topic.startswith("1. ") or topic.startswith("- "):
-                        topic = topic[3:].strip()
-
-                    # Remove asterisks and other markdown formatting
-                    topic = topic.replace("*", "")
-
-                    # Check if we ended up with empty string after all the cleaning
-                    if not topic or not topic.strip():
-                        logger.warning(
-                            f"Empty topic name after cleaning for cluster - original response: '{raw_response}'"
-                        )
-                        return f"Topic {len(comments)}"  # Fallback
-                    if len(topic) > 50:  # If it's too long, truncate
-                        topic = topic[:50] + "..."
-                    return topic
-                except Exception as e:
-                    logger.error(f"Error generating topic with Ollama: {e}")
-                    return f"Topic {len(comments)}"
-
-            # Generate labels using Ollama
-            for cluster_id in cluster_characteristics.keys():
-                if cluster_id < 0:  # Skip noise points
-                    continue
-
-                # Get comments for this cluster
-                cluster_indices = np.where(layer == cluster_id)[0]
-
-                # Select the 5 most representative comments (closest to centroid)
-                if len(cluster_indices) > 5 and document_map is not None:
-                    # Calculate centroid of the cluster in document_map space
-                    centroid = np.mean(document_map[cluster_indices], axis=0)
-
-                    # Calculate distance from each comment to the centroid
-                    distances = np.sqrt(
-                        np.sum((document_map[cluster_indices] - centroid) ** 2, axis=1)
-                    )
-
-                    # Get indices of the 5 comments closest to centroid
-                    closest_indices = np.argsort(distances)[:5]
-                    selected_indices = cluster_indices[closest_indices].tolist()
-
-                    logger.info(
-                        f"Selected {len(selected_indices)} most representative comments "
-                        f"for layer {layer_idx}, cluster {cluster_id} "
-                        f"(distances: {distances[closest_indices]})"
-                    )
-                else:
-                    # If 5 or fewer comments, use all of them
-                    selected_indices = cluster_indices.tolist()
-
-                selected_comments = [comment_texts[i] for i in selected_indices]
-
-                # Get topic name
-                topic_name = get_topic_name(
-                    selected_comments,
-                )
-                # Add layer_cluster prefix to ensure uniqueness
-                # Use the passed layer_idx parameter, not the layer array
-                logger.info(
-                    f"DEBUG: Creating prefix for layer_idx={layer_idx}, cluster_id={cluster_id}, topic='{topic_name}'"
-                )
-                # Strip quotes again in case they were added back somehow
-                cleaned_topic_name = topic_name.strip().strip("\"'")
-                prefixed_topic_name = (
-                    f"{layer_idx}_{cluster_id}: {cleaned_topic_name}"
-                    if cleaned_topic_name
-                    else f"{layer_idx}_{cluster_id}:"
-                )
-                logger.info(f"DEBUG: Final prefixed name: '{prefixed_topic_name}'")
-                cluster_labels[cluster_id] = prefixed_topic_name
-
-                # Sleep briefly to avoid rate limiting
-                time.sleep(0.5)
-
-            logger.info(f"Generated {len(cluster_labels)} topic names using Ollama")
-            return cluster_labels
-
-        except ImportError:
-            logger.error("Ollama not installed. Using conventional topic naming.")
-            # Fall back to conventional naming
-        except Exception as e:
-            logger.error(f"Error using Ollama: {e}")
-            # Fall back to conventional naming
-
-    # Conventional topic naming (fallback or when Ollama is not requested)
-    for cluster_id, characteristics in cluster_characteristics.items():
-        top_words = characteristics.get("top_words", [])
-        sample_comments = characteristics.get("sample_comments", [])
-
-        label_parts = []
-
-        # Add top words
-        if len(top_words) > 0:
-            label_parts.append("Keywords: " + ", ".join(top_words[:5]))
-
-        # Add first sample comment (shortened)
-        if len(sample_comments) > 0:
-            first_comment = sample_comments[0]
-            if len(first_comment) > 50:
-                first_comment = first_comment[:47] + "..."
-            label_parts.append("Example: " + first_comment)
-
-        # Create the final label
-        if label_parts:
-            label = " | ".join(label_parts)
-            # Truncate if too long
-            if len(label) > 50:
-                label = label[:47] + "..."
-        else:
-            label = f"Topic {cluster_id}"
-
-        cluster_labels[cluster_id] = label
-
-    return cluster_labels
 
 
 def create_comment_hover_info(cluster_layer, cluster_characteristics, comment_texts):
@@ -1049,7 +825,7 @@ def process_layers_and_create_visualizations(
     cluster_layers,
     comment_texts,
     output_dir,
-    use_ollama=False,
+    name_topics=False,
     dynamo_storage=None,
     job_id=None,  # Added job_id
 ):
@@ -1063,7 +839,8 @@ def process_layers_and_create_visualizations(
         cluster_layers: Cluster assignments for each layer
         comment_texts: List of comment text strings
         output_dir: Directory to save visualizations
-        use_ollama: Whether to use Ollama for topic naming (deprecated, will be moved to separate script)
+        name_topics: Whether to generate LLM topic labels (provider chosen by
+            LLM_PROVIDER; default anthropic via the Batch API)
         dynamo_storage: Optional DynamoDBStorage object for storing in DynamoDB
         job_id: Job ID for this run
     """
@@ -1088,20 +865,22 @@ def process_layers_and_create_visualizations(
         layer_data=layer_data,
     )
 
-    # If Ollama is requested, warn that this is deprecated
-    if use_ollama:
-        logger.warning(
-            "Ollama topic naming is moving to a separate process to improve reliability. "
-            "Use the new update_with_ollama.py script to update topic names with LLM after processing."
+    # If topic naming is requested, generate LLM topic labels.
+    if name_topics:
+        provider_type = resolve_provider_type()
+        topic_model = resolve_model_name(provider_type)
+        logger.info(
+            f"Generating LLM topic names with provider={provider_type} "
+            f"model={topic_model}"
         )
 
-        # For backward compatibility, still run with Ollama if requested
         for layer_idx, cluster_layer in enumerate(cluster_layers):
             characteristics = layer_data[layer_idx]["characteristics"]
 
-            # Generate topic labels with Ollama
+            # Generate topic labels via the configured provider (Anthropic batch
+            # by default; Ollama one-by-one when LLM_PROVIDER=ollama).
             logger.info(
-                f"Generating LLM topic names for layer {layer_idx} with Ollama..."
+                f"Generating LLM topic names for layer {layer_idx}..."
             )
             cluster_labels = generate_cluster_topic_labels(
                 characteristics,
@@ -1109,7 +888,7 @@ def process_layers_and_create_visualizations(
                 layer=cluster_layer,
                 layer_idx=layer_idx,
                 conversation_name=conversation_name,
-                use_ollama=True,
+                name_topics=True,
                 document_map=document_map,
             )
 
@@ -1128,13 +907,13 @@ def process_layers_and_create_visualizations(
                 logger.info(
                     f"Storing LLM topic names for layer {layer_idx} in DynamoDB..."
                 )
-                # Get model name from environment variable or use default
-                model_name = os.environ.get("OLLAMA_MODEL", "llama3.1:8b")
+                # Record the model that actually produced these labels.
+                model_name = topic_model
                 llm_topic_models = DataConverter.batch_convert_llm_topic_names(
                     conversation_id,
                     cluster_labels,
                     layer_idx,
-                    model_name=model_name,  # Model used by Ollama
+                    model_name=model_name,  # Model used for topic naming
                     job_id=job_id,  # Pass job_id
                 )
                 result = dynamo_storage.batch_create_llm_topic_names(llm_topic_models)
@@ -1324,7 +1103,7 @@ def create_enhanced_multilayer_index(
 
 
 def process_conversation(
-    zid, export_dynamo=True, use_ollama=False, include_moderation=False, exclude_comment_selections=True
+    zid, export_dynamo=True, name_topics=False, include_moderation=False, exclude_comment_selections=True
 ):
     """
     Main function to process a conversation and generate visualizations.
@@ -1332,7 +1111,7 @@ def process_conversation(
     Args:
         zid: Conversation ID
         export_dynamo: Whether to export results to DynamoDB
-        use_ollama: Whether to use Ollama for topic naming
+        name_topics: Whether to generate LLM topic labels (provider via LLM_PROVIDER)
         include_moderation: Whether to filter out moderated comments (mod == -1)
         exclude_comment_selections: Whether to exclude comments that have selection == -1
             in report_comment_selections table (for any report in this conversation)
@@ -1462,7 +1241,7 @@ def process_conversation(
         cluster_layers,
         comment_texts,
         output_dir,
-        use_ollama=use_ollama,
+        name_topics=name_topics,
         dynamo_storage=dynamo_storage,
         job_id=job_id,  # Pass job_id
     )
@@ -1509,7 +1288,14 @@ def main():
         help="Use mock data instead of connecting to PostgreSQL",
     )
     parser.add_argument(
-        "--use-ollama", action="store_true", help="Use Ollama for topic naming"
+        "--name-topics",
+        action="store_true",
+        help="Generate LLM topic labels (provider via LLM_PROVIDER; default anthropic batch)",
+    )
+    parser.add_argument(
+        "--use-ollama",
+        action="store_true",
+        help="Deprecated alias for --name-topics that forces LLM_PROVIDER=ollama",
     )
     parser.add_argument(
         "--include_moderation",
@@ -1535,9 +1321,20 @@ def main():
         db_password=args.db_password,
     )
 
-    # Log Ollama usage
+    # Resolve topic-naming request. --use-ollama is a deprecated alias that both
+    # enables naming and forces the ollama provider.
     if args.use_ollama:
-        logger.info("Ollama will be used for topic naming")
+        logger.warning(
+            "--use-ollama is deprecated; use --name-topics with LLM_PROVIDER=ollama. "
+            "Forcing LLM_PROVIDER=ollama for this run."
+        )
+        os.environ["LLM_PROVIDER"] = "ollama"
+    name_topics = args.name_topics or args.use_ollama
+    if name_topics:
+        logger.info(
+            f"Topic naming enabled (provider={resolve_provider_type()}, "
+            f"model={resolve_model_name(resolve_provider_type())})"
+        )
 
     # Process conversation
     if args.use_mock_data:
@@ -1586,14 +1383,14 @@ def main():
             cluster_layers,
             comment_texts,
             output_dir,
-            use_ollama=args.use_ollama,
+            name_topics=name_topics,
         )
     else:
         # Process with real data from PostgreSQL
         process_conversation(
             args.zid,
             export_dynamo=not args.no_dynamo,
-            use_ollama=args.use_ollama,
+            name_topics=name_topics,
             include_moderation=args.include_moderation,
             exclude_comment_selections=args.exclude_comment_selections,
         )

--- a/delphi/umap_narrative/topic_naming.py
+++ b/delphi/umap_narrative/topic_naming.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""
+Provider-agnostic topic-cluster naming for the UMAP narrative pipeline.
+
+This module is deliberately kept free of the heavy scientific imports used by
+``run_pipeline.py`` (torch, sentence-transformers, umap, datamapplot) so the
+naming logic can be unit-tested without them. It depends only on ``numpy`` (for
+representative-comment selection) and the LLM provider factory.
+
+Two naming strategies are supported:
+
+* **Anthropic (default)** — all cluster prompts for a layer are collected and
+  submitted as a *single* Message Batch; the pipeline polls until the batch
+  ends and maps each result back to its cluster by ``custom_id``.
+* **Ollama (self-hosted)** — prompts are sent one-by-one, exactly as before.
+
+Provider selection:
+
+* ``LLM_PROVIDER`` env var (default ``anthropic``).
+* Anthropic model: ``ANTHROPIC_TOPIC_MODEL`` -> ``ANTHROPIC_MODEL`` ->
+  ``DEFAULT_ANTHROPIC_TOPIC_MODEL``.
+* Ollama model/host: ``OLLAMA_MODEL`` / ``OLLAMA_HOST`` (as before).
+
+Naming failures never crash the pipeline: an individual failed request falls
+back to a generic ``Topic N`` label, and a wholesale failure falls back to the
+conventional keyword-based labels.
+"""
+
+import logging
+import os
+import re
+from typing import Callable, Dict, List, Optional
+
+import numpy as np
+
+from umap_narrative.llm_factory_constructor.model_provider import get_model_provider
+
+logger = logging.getLogger(__name__)
+
+# Default Anthropic model for topic labels. Overridable via ANTHROPIC_TOPIC_MODEL
+# (or ANTHROPIC_MODEL). Kept small/cheap — labels are 3–5 words.
+DEFAULT_ANTHROPIC_TOPIC_MODEL = "claude-haiku-4-5-20251001"
+
+# Small cap: labels are a few words. Leaves headroom above the visible text.
+TOPIC_MAX_TOKENS = 64
+
+# Prefixes an LLM sometimes prepends to a label; stripped during cleanup.
+_PREFIXES_TO_REMOVE = [
+    "Here is the list of topic labels:",
+    "Here is the list of topic labels",
+    "Here are the topic labels:",
+    "Here are the topic labels",
+    "Here is the topic label:",
+    "Here is the topic label",
+    "The topic label is:",
+    "The topic label is",
+    "Topic label:",
+    "Here is a concise topic label:",
+    "Here's a concise topic label:",
+    "Concise topic label:",
+    "Topic name:",
+    "Topic name",
+    "Topic:",
+    "Label:",
+    "Label",
+]
+
+
+def resolve_provider_type(provider_type: Optional[str] = None) -> str:
+    """Resolve the provider type from arg -> LLM_PROVIDER env -> 'anthropic'."""
+    return (provider_type or os.environ.get("LLM_PROVIDER") or "anthropic").lower()
+
+
+def resolve_model_name(provider_type: str) -> Optional[str]:
+    """Resolve the model name for the given provider from the environment."""
+    if provider_type == "anthropic":
+        return (
+            os.environ.get("ANTHROPIC_TOPIC_MODEL")
+            or os.environ.get("ANTHROPIC_MODEL")
+            or DEFAULT_ANTHROPIC_TOPIC_MODEL
+        )
+    return os.environ.get("OLLAMA_MODEL", "llama3.1:8b")
+
+
+def build_topic_prompt(comments: List[str]) -> str:
+    """Build the single-label topic-naming prompt for a set of comments."""
+    prompt = (
+        "Read these comments and provide ONLY ONE short topic label (3–5 words) "
+        "that captures their combined essence. Do not give one topic per comment. "
+        "Do not include explanations, introductions, or multiple outputs. "
+        "Reply with exactly one topic label, in quotation marks, on a single line.\n\n"
+        "Comments:\n"
+    )
+    for j, comment in enumerate(comments[:5]):
+        prompt += f"{j + 1}. {comment}\n"
+    return prompt
+
+
+def clean_topic_name(raw_response: str, fallback: str) -> str:
+    """
+    Clean an LLM topic label: strip layer/cluster prefixes, boilerplate
+    prefixes, quotes, list markers and markdown; truncate if too long. Returns
+    ``fallback`` if the cleaned string is empty.
+    """
+    if not raw_response:
+        return fallback
+
+    raw_response = raw_response.strip()
+
+    # Remove an accidental "1_2:" layer_cluster prefix if the model echoed one.
+    layer_prefix_match = re.match(r"^\d+_\d+:\s*", raw_response)
+    if layer_prefix_match:
+        raw_response = raw_response[layer_prefix_match.end():]
+
+    for prefix in _PREFIXES_TO_REMOVE:
+        if raw_response.startswith(prefix):
+            raw_response = raw_response.replace(prefix, "", 1)
+
+    raw_response = raw_response.strip()
+
+    # Only the first line is the label.
+    topic = raw_response.split("\n")[0].strip()
+
+    # Strip surrounding quotes (single or double).
+    topic = topic.strip("\"'")
+
+    # Remove list markers like "1. Topic" or "- Topic".
+    if topic.startswith("1. ") or topic.startswith("- "):
+        topic = topic[3:].strip()
+
+    # Drop markdown emphasis.
+    topic = topic.replace("*", "")
+
+    if not topic or not topic.strip():
+        logger.warning(
+            f"Empty topic name after cleaning - original response: '{raw_response}'"
+        )
+        return fallback
+
+    if len(topic) > 50:
+        topic = topic[:50] + "..."
+
+    return topic
+
+
+def select_representative_comments(
+    cluster_id: int,
+    layer,
+    comment_texts: List[str],
+    document_map=None,
+    limit: int = 5,
+) -> List[str]:
+    """
+    Pick up to ``limit`` comments that best represent a cluster: the ones
+    closest to the cluster centroid in 2D document-map space when available,
+    otherwise the first ``limit`` members.
+    """
+    cluster_indices = np.where(np.asarray(layer) == cluster_id)[0]
+
+    if len(cluster_indices) > limit and document_map is not None:
+        centroid = np.mean(document_map[cluster_indices], axis=0)
+        distances = np.sqrt(
+            np.sum((document_map[cluster_indices] - centroid) ** 2, axis=1)
+        )
+        closest = np.argsort(distances)[:limit]
+        selected_indices = cluster_indices[closest].tolist()
+    else:
+        selected_indices = cluster_indices.tolist()[:limit]
+
+    return [comment_texts[i] for i in selected_indices]
+
+
+def _prefixed(layer_idx: int, cluster_id: int, cleaned: str) -> str:
+    """Apply the unique ``layer_cluster:`` prefix used throughout the pipeline."""
+    cleaned = cleaned.strip().strip("\"'")
+    if cleaned:
+        return f"{layer_idx}_{cluster_id}: {cleaned}"
+    return f"{layer_idx}_{cluster_id}:"
+
+
+def _conventional_labels(cluster_characteristics) -> Dict[int, str]:
+    """Keyword/example based labels — the non-LLM fallback."""
+    labels: Dict[int, str] = {}
+    for cluster_id, characteristics in cluster_characteristics.items():
+        top_words = characteristics.get("top_words", [])
+        sample_comments = characteristics.get("sample_comments", [])
+        label_parts = []
+        if len(top_words) > 0:
+            label_parts.append("Keywords: " + ", ".join(top_words[:5]))
+        if len(sample_comments) > 0:
+            first_comment = sample_comments[0]
+            if len(first_comment) > 50:
+                first_comment = first_comment[:47] + "..."
+            label_parts.append("Example: " + first_comment)
+        if label_parts:
+            label = " | ".join(label_parts)
+            if len(label) > 50:
+                label = label[:47] + "..."
+        else:
+            label = f"Topic {cluster_id}"
+        labels[cluster_id] = label
+    return labels
+
+
+def _cluster_prompts(
+    cluster_characteristics,
+    layer,
+    comment_texts,
+    document_map,
+) -> Dict[int, str]:
+    """Build a topic prompt for every (non-noise) cluster in the layer."""
+    prompts: Dict[int, str] = {}
+    for cluster_id in cluster_characteristics.keys():
+        if cluster_id < 0:  # Skip noise points.
+            continue
+        comments = select_representative_comments(
+            cluster_id, layer, comment_texts, document_map
+        )
+        prompts[cluster_id] = build_topic_prompt(comments)
+    return prompts
+
+
+def _label_via_batch(
+    provider,
+    prompts: Dict[int, str],
+    layer_idx: int,
+    max_wait_seconds: float,
+    sleep: Callable[[float], None],
+) -> Dict[int, str]:
+    """
+    Name all clusters in one Anthropic Message Batch. Returns raw (uncleaned)
+    label text keyed by cluster_id; a cluster maps to ``None`` if its request
+    failed (errored/refused/missing) so the caller can substitute a fallback.
+    """
+    custom_id_to_cluster: Dict[str, int] = {}
+    batch_requests = []
+    for cluster_id, prompt in prompts.items():
+        custom_id = f"layer{layer_idx}_cluster{cluster_id}"
+        custom_id_to_cluster[custom_id] = cluster_id
+        batch_requests.append(
+            {
+                "custom_id": custom_id,
+                "params": {
+                    "model": provider.model_name,
+                    "max_tokens": TOPIC_MAX_TOKENS,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+            }
+        )
+
+    created = provider.get_batch_responses(batch_requests)
+    if not isinstance(created, dict) or created.get("error") or not created.get("id"):
+        raise RuntimeError(f"Batch creation failed: {created}")
+
+    batch_id = created["id"]
+    final = provider.poll_batch(
+        batch_id, max_wait_seconds=max_wait_seconds, sleep=sleep
+    )
+    records = provider.get_batch_results(final)
+
+    raw_labels: Dict[int, Optional[str]] = {cid: None for cid in prompts}
+    for record in records:
+        cluster_id = custom_id_to_cluster.get(record.get("custom_id"))
+        if cluster_id is None:
+            continue
+        raw_labels[cluster_id] = provider.extract_text_from_result(record)
+    return raw_labels
+
+
+def _label_one_by_one(provider, prompts: Dict[int, str]) -> Dict[int, Optional[str]]:
+    """Name clusters sequentially (Ollama path)."""
+    raw_labels: Dict[int, Optional[str]] = {}
+    for cluster_id, prompt in prompts.items():
+        try:
+            raw_labels[cluster_id] = provider.get_response("", prompt)
+        except Exception as e:  # noqa: BLE001 - never crash on a single label.
+            logger.error(f"Error naming cluster {cluster_id}: {e}")
+            raw_labels[cluster_id] = None
+    return raw_labels
+
+
+def generate_cluster_topic_labels(
+    cluster_characteristics,
+    comment_texts=None,
+    layer=None,
+    layer_idx=0,
+    conversation_name=None,
+    name_topics=False,
+    document_map=None,
+    provider_type=None,
+    max_wait_seconds: Optional[float] = None,
+    sleep: Callable[[float], None] = None,
+    use_ollama=False,  # Deprecated alias — forces the ollama provider.
+):
+    """
+    Generate topic labels for clusters.
+
+    When ``name_topics`` is truthy and comments/layer are available, labels are
+    produced by an LLM (Anthropic batch by default, or Ollama when
+    ``LLM_PROVIDER=ollama`` / the deprecated ``use_ollama=True``). Otherwise, and
+    on any LLM failure, conventional keyword-based labels are returned.
+
+    Returns a dict mapping cluster_id -> topic label string.
+    """
+    if use_ollama:
+        # Backwards-compatible alias: force the ollama provider for this call.
+        provider_type = "ollama"
+        name_topics = True
+
+    if not (name_topics and comment_texts is not None and layer is not None):
+        return _conventional_labels(cluster_characteristics)
+
+    provider_type = resolve_provider_type(provider_type)
+
+    if max_wait_seconds is None:
+        max_wait_seconds = float(
+            os.environ.get("TOPIC_BATCH_MAX_WAIT_SECONDS", "1800")
+        )
+    if sleep is None:
+        import time as _time
+
+        sleep = _time.sleep
+
+    try:
+        model_name = resolve_model_name(provider_type)
+        provider = get_model_provider(provider_type, model_name)
+        prompts = _cluster_prompts(
+            cluster_characteristics, layer, comment_texts, document_map
+        )
+
+        if not prompts:
+            return _conventional_labels(cluster_characteristics)
+
+        if provider.supports_batching:
+            logger.info(
+                f"Naming {len(prompts)} clusters in layer {layer_idx} via one "
+                f"{provider_type} batch (model={model_name})"
+            )
+            raw_labels = _label_via_batch(
+                provider, prompts, layer_idx, max_wait_seconds, sleep
+            )
+        else:
+            logger.info(
+                f"Naming {len(prompts)} clusters in layer {layer_idx} one-by-one "
+                f"via {provider_type} (model={model_name})"
+            )
+            raw_labels = _label_one_by_one(provider, prompts)
+
+        cluster_labels: Dict[int, str] = {}
+        for cluster_id in prompts:
+            raw = raw_labels.get(cluster_id)
+            fallback = f"Topic {cluster_id}"
+            cleaned = clean_topic_name(raw, fallback) if raw else fallback
+            cluster_labels[cluster_id] = _prefixed(layer_idx, cluster_id, cleaned)
+
+        logger.info(
+            f"Generated {len(cluster_labels)} topic names for layer {layer_idx} "
+            f"using {provider_type}"
+        )
+        return cluster_labels
+
+    except Exception as e:  # noqa: BLE001 - naming must never crash the pipeline.
+        logger.error(
+            f"LLM topic naming failed for layer {layer_idx} ({e}); "
+            "falling back to conventional labels",
+            exc_info=True,
+        )
+        return _conventional_labels(cluster_characteristics)

--- a/example.env
+++ b/example.env
@@ -135,6 +135,9 @@ GOOGLE_APPLICATION_CREDENTIALS=
 # Optional API keys for other services:
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=
+# Delphi topic-cluster naming model (Anthropic Batch API). Resolution order:
+#   ANTHROPIC_TOPIC_MODEL -> ANTHROPIC_MODEL -> claude-haiku-4-5-20251001
+ANTHROPIC_TOPIC_MODEL=claude-haiku-4-5-20251001
 GEMINI_API_KEY=
 OPENAI_API_KEY=
 # A value in miliseconds for caching AI responses for narrativeReport
@@ -154,9 +157,22 @@ SENTENCE_TRANSFORMER_MODEL=all-MiniLM-L6-v2
 DYNAMODB_ENDPOINT=http://host.docker.internal:8000
 
 
+###### LLM PROVIDER (Delphi topic naming) #####
+# anthropic (default, Batch API) or ollama (self-hosted GPU).
+LLM_PROVIDER=anthropic
+
+
 ###### OLLAMA #####
+# Only used when LLM_PROVIDER=ollama. The GPU infra is OFF by default; re-enable
+# it in CDK by deploying with CDK_ENABLE_OLLAMA=true, then set LLM_PROVIDER=ollama.
 OLLAMA_HOST=http://host.docker.internal:11434
 OLLAMA_MODEL=llama3.1:8b
+
+
+###### CDK / INFRA #####
+# Recreate the (temporarily retired) Ollama GPU stack: ASG, GPU launch template,
+# EFS, internal NLB, and the /polis/ollama-service-url secret. Default: off.
+CDK_ENABLE_OLLAMA=false
 
 
 ###### S3 STORAGE ######

--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -108,18 +108,20 @@ elif [ "$SERVICE_FROM_FILE" == "math" ]; then
   sudo /usr/local/bin/docker-compose up -d math --build --force-recreate
 elif [ "$SERVICE_FROM_FILE" == "delphi" ]; then
   echo "Starting docker-compose up for 'delphi' service"
-  echo "Fetching Ollama Service URL for Delphi..."
-  OLLAMA_URL=$(aws secretsmanager get-secret-value --secret-id /polis/ollama-service-url --query SecretString --output text --region us-east-1)
+  # The Ollama GPU stack is optional (topic naming defaults to the Anthropic
+  # Batch API). Only fetch OLLAMA_HOST if the secret exists; never fail the
+  # deploy when it doesn't. Re-enable Ollama with CDK_ENABLE_OLLAMA=true +
+  # LLM_PROVIDER=ollama.
+  echo "Checking for optional Ollama Service URL for Delphi..."
+  OLLAMA_URL=$(aws secretsmanager get-secret-value --secret-id /polis/ollama-service-url --query SecretString --output text --region us-east-1 2>/dev/null || true)
 
-  if [ -z "$OLLAMA_URL" ]; then
-    echo "Error: Could not retrieve Ollama Service URL from Secrets Manager: /polis/ollama-service-url"
-    exit 1
+  if [ -n "$OLLAMA_URL" ]; then
+    echo "Retrieved Ollama Service URL; appending OLLAMA_HOST to .env for Delphi"
+    printf "\nOLLAMA_HOST=%s\n" "$OLLAMA_URL" | sudo tee -a .env > /dev/null
+    echo "OLLAMA_HOST appended."
+  else
+    echo "No Ollama Service URL secret found (/polis/ollama-service-url); skipping OLLAMA_HOST. Delphi will use the Anthropic Batch API for topic naming."
   fi
-  echo "Retrieved Ollama Service URL."
-
-  echo "Appending OLLAMA_HOST to .env for Delphi"
-  printf "\nOLLAMA_HOST=%s\n" "$OLLAMA_URL" | sudo tee -a .env > /dev/null
-  echo "OLLAMA_HOST appended."
 
 
   if [ -f "/etc/app-info/instance_size.txt" ]; then


### PR DESCRIPTION
## Why
The g4dn.xlarge Ollama box (+ EFS + internal NLB ≈ $415/mo) exists to name topic clusters with llama3.1:8b: ~50 short prompts per report, ~8 reports/month. CloudWatch shows **0.0% GPU utilization and zero NLB flows for 14 days.** Self-hosted LLM stays a supported option (Colin's call); the infra is just turned off.

## What
| Area | Change |
|---|---|
| `delphi/umap_narrative/topic_naming.py` (new, torch-free) | Topic naming through the provider factory. Anthropic: **one Message Batch per layer** (create → poll → JSONL results mapped back by `custom_id`), fallback label on any per-item failure, never crashes the pipeline. Ollama: one-by-one as before. `LLM_PROVIDER` default `anthropic`; model `ANTHROPIC_TOPIC_MODEL` → `ANTHROPIC_MODEL` → `claude-haiku-4-5-20251001`. |
| `run_pipeline.py`, `run_delphi.py` | Use the new module; `--use-ollama` kept as a deprecated alias for `LLM_PROVIDER=ollama`; `OLLAMA_MODEL`/`OLLAMA_HOST` required only for the ollama provider. |
| `model_provider.py` | **Bug fix:** `get_batch_responses` posted to `/v1/messages/batch` (404); now `/v1/messages/batches`. Added poll + results helpers. (801/803 use the SDK and are unaffected; `802_process_batch_results.py` has the same singular-endpoint bug — follow-up.) |
| `delphi/scripts/job_poller.py` | The normal worker class now processes **all** job sizes (`should_process_job`); "large" is an opt-in large-only class. Closes the gap where >5,000-comment reports waited forever since the large ASG went to 0 on 2026-07-31. |
| `scripts/after_install.sh` | Ollama secret optional; deploy no longer fails without it. |
| `cdk/` | Everything Ollama (GPU ASG + scaling policy, GPU launch template, EFS + mount targets + SG, NLB + TG + listener, `/polis/ollama-service-url` secret, outputs) gated behind **`CDK_ENABLE_OLLAMA`** (default off) in `bin/cdk.ts`. The shared CloudWatch-agent config asset is intentionally not gated (used by every tier since #2677). |
| docs / example.env | `LLM_PROVIDER`, `ANTHROPIC_TOPIC_MODEL`, how to re-enable Ollama. |

## Verification
- 30 unit tests (HTTP mocked): batch construction, polling to `ended`, result mapping, partial failure, ollama path selectable, routing gate. `cd delphi && PYTHONPATH=. pytest tests/topic_naming/ --noconftest -o addopts=""`.
- `cdk synth`: flag unset → **0 EFS, 0 NLB, 0 g4dn**, 4 ASGs; `CDK_ENABLE_OLLAMA=true` → EFS + 2 mount targets, g4dn ASG, NLB, secret, 5 ASGs. `tsc --noEmit` clean both ways. (Synth run with the Docker-only DB-backup Lambda temporarily stubbed locally; not part of the diff.)
- Not exercised: a live Anthropic batch call (no spend). First real report after deploy is the smoke test; failure mode is a generic label, not a crash.

## Deploy
1. Merge → `cdk deploy` with the flag unset removes the GPU/EFS/NLB (**after #2696 is deployed**, so the Delphi-large guard is in place).
2. Set `LLM_PROVIDER=anthropic` (and optionally `ANTHROPIC_TOPIC_MODEL`) in the `polis-web-app-env-vars` secret; `ANTHROPIC_API_KEY` is already there.
3. Rollback: `CDK_ENABLE_OLLAMA=true` + `LLM_PROVIDER=ollama`, deploy.

Saves ~$415/mo. Part of the cost-reduction effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s