### PR TITLE
cdk: fix docker-compose download for ARM instances (math worker boot failure)

### DIFF
--- a/cdk/launchTemplates.ts
+++ b/cdk/launchTemplates.ts
@@ -52,7 +52,9 @@ export default (
       'sudo systemctl start docker',
       'sudo systemctl enable docker',
       'sudo usermod -a -G docker ec2-user',
-      'sudo curl -L https://github.com/docker/compose/releases/download/v2.40.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose',
+      // $(uname -m) → x86_64 on the web/delphi tiers, aarch64 on the Graviton math worker. A hardcoded
+      // x86_64 binary aborts the boot script on ARM (Exec format error) and the CodeDeploy agent never installs.
+      'sudo curl -L https://github.com/docker/compose/releases/download/v2.40.0/docker-compose-linux-$(uname -m) -o /usr/local/bin/docker-compose',
       'sudo chmod +x /usr/local/bin/docker-compose',
       'docker-compose --version',
       'sudo yum install -y jq',


### PR DESCRIPTION
## What
`cdk/launchTemplates.ts`: the boot script downloads `docker-compose-linux-x86_64` (hardcoded since the v2.40.0 pin). On the Graviton math worker that binary fails with `Exec format error`, the user-data script aborts under `set -e`, and the CodeDeploy agent, which CDK appends after it, never installs. Result: a fresh math instance comes up with no app and CodeDeploy waits forever.

Fix: `docker-compose-linux-$(uname -m)` (x86_64 on web/delphi, aarch64 on math).

## Context
Latent since January's deploy; surfaced on 2026-09-08 during the first math-ASG instance refresh after #2696 (r8g.4xlarge → r8g.2xlarge). Already deployed to the live stack from this commit to restore the math worker; this PR makes `edge` match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s