### PR TITLE
fix(poller): consolidate park/rebuild ownership under the worker pool (R03/R04)

### DIFF
--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -277,12 +277,27 @@ class MathPollerService:
         # the coldest (see _remember).
         self._convs: "OrderedDict[int, Conversation]" = OrderedDict()
         self._retry_counts: Dict[int, int] = {}
-        self._parked: set = set()
         self._pool: Optional[ConversationWorkerPool] = None
         self._threads: List[threading.Thread] = []
         self._stop = threading.Event()
         self._vote_wm: Optional[int] = None
         self._mod_wm: Optional[int] = None
+
+    @property
+    def _parked(self) -> set:
+        """Parked-zid truth is owned SOLELY by the worker pool — one
+        lock-protected set (P-022 R04). This is a READ-ONLY view; the service
+        never keeps a second set that could disagree with the pool's. Park and
+        unpark always go through ``pool.park`` / ``pool.unpark`` (each atomic
+        with the pool's queue/active bookkeeping under the same lock), so an
+        interleaving between "mark parked" and "stop the queue" — the old
+        divergence bug — is no longer expressible.
+
+        Returns an empty set before the pool is constructed so early lookups are
+        safe."""
+        if self._pool is None:
+            return set()
+        return self._pool.parked_zids()
 
     # -- lifecycle ---------------------------------------------------------- #
     def _ensure_runtime(self) -> None:
@@ -387,7 +402,7 @@ class MathPollerService:
         re-persists — reprocessing the interval that was skipped when the global
         watermark advanced past the failure."""
         assert self._pool is not None
-        for zid in sorted(self._parked):
+        for zid in sorted(self._pool.parked_zids()):
             logger.info("Reconciler recovering parked zid=%s (M1)", zid)
             self._unpark(zid)  # clears park + invalidates cache
             self._pool.submit(zid, REBUILD, [])
@@ -405,13 +420,11 @@ class MathPollerService:
         batch on the stale cached conv would leave the failed interval missing
         forever. Dropping the cache entry forces `_run_engine` down the
         load-or-init path, which subsumes both the lost and the new votes."""
-        if zid not in self._parked:
+        if self._pool is None or not self._pool.is_parked(zid):
             return
-        self._parked.discard(zid)
         self._retry_counts.pop(zid, None)
         self._convs.pop(zid, None)  # invalidate → next touch rebuilds full history
-        if self._pool is not None:
-            self._pool.unpark(zid)
+        self._pool.unpark(zid)  # pool owns parked truth (P-022 R04)
         logger.info(
             "Un-parked zid=%s: invalidated cache; next batch rebuilds full "
             "history (M1 recovery)", zid,
@@ -455,7 +468,7 @@ class MathPollerService:
 
     # -- per-zid processing (runs on pool threads) -------------------------- #
     def _handle_zid(self, zid: int, coalesced: CoalescedBatch) -> None:
-        if zid in self._parked:
+        if self._pool is not None and self._pool.is_parked(zid):
             return
         try:
             self._run_engine(zid, coalesced)
@@ -639,13 +652,25 @@ class MathPollerService:
                 attempts,
                 error,
             )
-            self._parked.add(zid)
+            # The pool is the SINGLE owner of parked truth (P-022 R04): park
+            # here in one atomic step instead of setting a separate service-side
+            # marker first and then calling pool.park. The old two-step sequence
+            # let a reconciliation land in the gap — clearing the service marker
+            # and queueing a REBUILD that pool.park then dropped — leaving the
+            # service (unparked) and pool (parked) permanently disagreeing.
             if self._pool is not None:
                 self._pool.park(zid)
 
     def _requeue(self, zid: int, coalesced: CoalescedBatch) -> None:
         if self._pool is None:
             return
+        # Preserve ALL coalesced message kinds on retry (P-022 R03). Dropping the
+        # REBUILD flag here was the old bug: a reconciler rebuild that failed once
+        # was never re-submitted, and because the reconciler had already cleared
+        # the parked marker (`_unpark`) the zid ended up neither parked nor queued
+        # — silently lost until an unrelated restart.
+        if coalesced.rebuild:
+            self._pool.submit(zid, REBUILD, [])
         if coalesced.votes:
             self._pool.submit(zid, VOTES, list(coalesced.votes))
         if coalesced.moderation:

--- a/delphi/polismath/poller/worker_pool.py
+++ b/delphi/polismath/poller/worker_pool.py
@@ -111,6 +111,17 @@ class ConversationWorkerPool:
         with self._lock:
             return zid in self._parked
 
+    def parked_zids(self) -> Set[int]:
+        """Snapshot of currently-parked zids under the pool lock.
+
+        The pool is the SINGLE owner of parked-zid truth (P-022 R04): the
+        service reads its parked set through this method rather than keeping a
+        second set that must agree by convention. Returning a fresh copy under
+        the lock guarantees the snapshot cannot tear against a concurrent
+        park()/unpark()/submit()."""
+        with self._lock:
+            return set(self._parked)
+
     def submit(self, zid: int, message_type: str, batch: List[Any]) -> None:
         """Queue a batch for a zid; ensure exactly one worker drains it."""
         with self._lock:

--- a/delphi/tests/poller/test_error_path.py
+++ b/delphi/tests/poller/test_error_path.py
@@ -12,11 +12,44 @@ from polismath.poller.worker_pool import CoalescedBatch
 from unittest.mock import MagicMock
 
 
+class FakePool:
+    """A synchronous stand-in for ConversationWorkerPool that OWNS parked truth
+    the same way the real pool does (P-022 R04), so ``service._parked`` — now a
+    read-through view of the pool — reflects reality. It records submit/park/
+    unpark calls for assertions without spawning worker threads (these tests
+    drive ``_handle_zid`` / ``_poll_votes_once`` directly)."""
+
+    def __init__(self):
+        self._parked = set()
+        self.submitted = []
+        self.park_calls = []
+        self.unpark_calls = []
+
+    def submit(self, zid, message_type, batch):
+        if zid in self._parked:
+            return
+        self.submitted.append((zid, message_type, batch))
+
+    def park(self, zid):
+        self.park_calls.append(zid)
+        self._parked.add(zid)
+
+    def unpark(self, zid):
+        self.unpark_calls.append(zid)
+        self._parked.discard(zid)
+
+    def is_parked(self, zid):
+        return zid in self._parked
+
+    def parked_zids(self):
+        return set(self._parked)
+
+
 def _service(tmp_path, retry_cap=1):
     pg = MagicMock()
     cfg = PollerConfig(dump_dir=str(tmp_path), retry_cap=retry_cap)
     svc = MathPollerService(pg, cfg)
-    svc._pool = MagicMock()  # capture requeue / park without real threads
+    svc._pool = FakePool()  # capture requeue / park without real threads
     return svc
 
 
@@ -43,9 +76,9 @@ class TestErrorPath:
         assert "kaboom" in payload["error"]
         assert payload["batch"]["votes"] == [{"pid": "1", "tid": "1", "vote": 1}]
         # retry: batch requeued, zid NOT parked yet
-        svc._pool.submit.assert_called()
+        assert svc._pool.submitted, "the batch must be requeued on the first failure"
         assert 5 not in svc._parked
-        svc._pool.park.assert_not_called()
+        assert svc._pool.park_calls == []
 
     def test_second_failure_parks_zid(self, tmp_path, monkeypatch):
         svc = _service(tmp_path)
@@ -59,7 +92,7 @@ class TestErrorPath:
         svc._handle_zid(5, batch)  # attempt 2 -> park (exceeds retry_cap=1)
 
         assert 5 in svc._parked
-        svc._pool.park.assert_called_once_with(5)
+        assert svc._pool.park_calls == [5]
         assert len(_dumps(tmp_path, 5)) == 2  # dumped on each failure
 
     def test_parked_zid_is_skipped(self, tmp_path, monkeypatch):
@@ -112,8 +145,8 @@ class TestErrorPath:
 
         assert 5 not in svc._parked
         assert svc._retry_counts.get(5) is None
-        svc._pool.unpark.assert_called_once_with(5)
-        svc._pool.submit.assert_called_with(5, "votes", [{"zid": 5, "created": 100}])
+        assert svc._pool.unpark_calls == [5]
+        assert svc._pool.submitted[-1] == (5, "votes", [{"zid": 5, "created": 100}])
 
 
 def test_pool_unpark_reenables_dispatch():

--- a/delphi/tests/poller/test_park_rebuild_recovery.py
+++ b/delphi/tests/poller/test_park_rebuild_recovery.py
@@ -1,0 +1,316 @@
+"""P-022 §C R03/R04: park/rebuild recovery under fault and race.
+
+These drive the REAL ``MathPollerService`` and REAL ``ConversationWorkerPool``
+(threads, coalescing, retry, park) and exercise the two control-flow defects the
+P-022 recovery probes reproduced against the integration branch:
+
+* R03 (park then silence) — a reconciler REBUILD that fails transiently must be
+  retried WITH the rebuild flag preserved and eventually publish; a persistent
+  failure must leave a visible parked state with BOUNDED retries (no hot loop,
+  no silent loss).  Exercises the ``_requeue`` rebuild-preservation fix.
+
+* R04 (park/unpark races) — the pool is the SINGLE owner of parked truth, so a
+  reconciliation interleaved with parking can never leave service and pool
+  disagreeing, and overlapping rebuild triggers still run at most one handler
+  per zid with no dropped rebuild.
+
+Determinism comes from ``threading.Event`` latches at named boundaries (the
+``_load_or_init`` entry and the ``pool.park`` boundary) and from ``pool.join``
+(which blocks until the pool is idle) — never from ``sleep`` timing.
+"""
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from polismath.poller.service import MathPollerService, PollerConfig
+from polismath.poller.worker_pool import CoalescedBatch, REBUILD, VOTES, MODERATION
+
+
+class RecordingWriter:
+    """Records the zids whose updates were published (a successful rebuild)."""
+
+    def __init__(self, pg=None):
+        self.writes = []
+
+    def write_conv_updates(self, zid, conv):
+        self.writes.append(zid)
+
+
+class RecordingPool:
+    """A non-threaded pool that records submit/park/unpark and owns parked truth
+    the same way the real pool does — for the ``_requeue`` unit test."""
+
+    def __init__(self):
+        self._parked = set()
+        self.submitted = []
+
+    def submit(self, zid, message_type, batch):
+        if zid in self._parked:
+            return
+        self.submitted.append((zid, message_type, batch))
+
+    def park(self, zid):
+        self._parked.add(zid)
+
+    def unpark(self, zid):
+        self._parked.discard(zid)
+
+    def is_parked(self, zid):
+        return zid in self._parked
+
+    def parked_zids(self):
+        return set(self._parked)
+
+
+@pytest.fixture
+def make_svc():
+    """Build MathPollerServices with a REAL worker pool + recording writer.
+
+    ``_load_or_init`` is monkeypatched per test to control the rebuild outcome,
+    so the rebuild path (reconciler REBUILD -> _run_engine conv=None ->
+    _load_or_init -> write -> remember) is exercised end-to-end without a real
+    Conversation/Postgres."""
+    created = []
+
+    def _make(retry_cap=1, pool_size=1):
+        svc = MathPollerService(
+            MagicMock(),
+            PollerConfig(worker_pool_size=pool_size, retry_cap=retry_cap),
+        )
+        svc._writer = RecordingWriter()
+        svc._ensure_runtime()
+        created.append(svc)
+        return svc
+
+    yield _make
+    for s in created:
+        s._pool.shutdown()
+
+
+def _drain(svc, timeout=5.0):
+    assert svc._pool.join(timeout=timeout), "worker pool did not drain in time"
+
+
+# --------------------------------------------------------------------------- #
+# Retry-preserves-rebuild unit test (the R03 root-cause fix)
+# --------------------------------------------------------------------------- #
+class TestRequeuePreservesRebuild:
+    def test_requeue_preserves_rebuild_and_all_kinds(self):
+        svc = MathPollerService(MagicMock(), PollerConfig(retry_cap=1))
+        svc._pool = RecordingPool()
+        batch = CoalescedBatch(
+            votes=[{"pid": 1}], moderation=[{"tid": 2}], rebuild=True
+        )
+        svc._requeue(7, batch)
+        kinds = [mt for _, mt, _ in svc._pool.submitted]
+        assert REBUILD in kinds, "a retry MUST preserve the rebuild flag (R03)"
+        assert VOTES in kinds and MODERATION in kinds
+
+    def test_requeue_rebuild_only_still_resubmits_rebuild(self):
+        svc = MathPollerService(MagicMock(), PollerConfig(retry_cap=1))
+        svc._pool = RecordingPool()
+        svc._requeue(7, CoalescedBatch(rebuild=True))
+        assert svc._pool.submitted == [(7, REBUILD, [])], (
+            "a rebuild-only batch (the reconciler case) must be re-submitted, "
+            "not dropped"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# R03 — park then silence
+# --------------------------------------------------------------------------- #
+class TestR03ParkThenSilence:
+    def test_transient_rebuild_failure_eventually_publishes(self, make_svc):
+        """Exhaust retries -> parked; no new traffic; reconciler runs and the
+        first rebuild fails once, then succeeds. Require eventual publication and
+        ALL park/retry markers cleared."""
+        svc = make_svc(retry_cap=1)
+        calls = {"n": 0}
+
+        def loader(zid):
+            calls["n"] += 1
+            if calls["n"] <= 3:  # 2 to park, then 1 transient reconcile failure
+                raise RuntimeError("transient rebuild failure")
+            return object()
+
+        svc._load_or_init = loader
+
+        # Exhaust retries -> park (attempt 1 fails -> requeue REBUILD -> attempt 2
+        # fails -> park). This ALREADY depends on the rebuild-preservation fix:
+        # without it the requeue drops the rebuild and the zid never parks.
+        svc._pool.submit(1, REBUILD, [])
+        _drain(svc)
+        assert 1 in svc._parked, "the zid must be parked after exhausting retries"
+        assert svc._writer.writes == []
+
+        # Silence. The reconciler recovers: unpark + REBUILD; fail once, then win.
+        svc._reconcile_once()
+        _drain(svc)
+
+        assert svc._writer.writes == [1], "the rebuild must eventually publish"
+        assert 1 not in svc._parked and not svc._pool.is_parked(1)
+        assert svc._retry_counts.get(1) is None, "retry markers must be cleared"
+
+    def test_persistent_failure_stays_parked_with_bounded_retries(self, make_svc):
+        """Persistent failure -> visible parked/unhealthy state, BOUNDED retries
+        each cycle (no hot loop), and no silent loss (no phantom publication)."""
+        svc = make_svc(retry_cap=1)
+        calls = {"n": 0}
+
+        def loader(zid):
+            calls["n"] += 1
+            raise RuntimeError("persistent failure")
+
+        svc._load_or_init = loader
+
+        svc._pool.submit(1, REBUILD, [])
+        _drain(svc)
+        assert 1 in svc._parked
+        # retry_cap + 1 attempts before parking: strictly bounded, not a hot loop.
+        assert calls["n"] == 2
+
+        # Repeated reconcile cycles keep the zid visibly parked with the SAME
+        # bounded number of attempts each cycle — never a runaway loop, never
+        # silently dropped.
+        for cycle in range(3):
+            svc._reconcile_once()
+            _drain(svc)
+            assert 1 in svc._parked, f"still parked after reconcile cycle {cycle}"
+
+        assert svc._writer.writes == [], "a failing rebuild must never publish"
+        assert calls["n"] == 2 + 3 * 2, "each reconcile retries a bounded 2 times"
+
+
+# --------------------------------------------------------------------------- #
+# R04 — park/unpark races
+# --------------------------------------------------------------------------- #
+class TestR04ParkUnparkRaces:
+    def test_reconcile_while_worker_parks_never_diverges(self, make_svc):
+        """Barrier at the pool.park boundary: freeze the worker mid-park and fire
+        the reconciler (and a new-vote unpark). Because the pool is the sole owner
+        of parked truth, the reconciler cannot observe a half-parked zid, so
+        service and pool never disagree and no rebuild is dropped. Recovery then
+        completes quietly."""
+        svc = make_svc(retry_cap=0, pool_size=2)
+        calls = {"n": 0}
+
+        def loader(zid):
+            calls["n"] += 1
+            if calls["n"] == 1:  # only the first (parking) rebuild fails
+                raise RuntimeError("force park on active worker")
+            return object()
+
+        svc._load_or_init = loader
+
+        at_park = threading.Event()
+        release = threading.Event()
+        real_park = svc._pool.park
+
+        def hooked_park(zid):
+            at_park.set()
+            assert release.wait(timeout=5)
+            real_park(zid)
+
+        svc._pool.park = hooked_park
+
+        # Kick off the failing rebuild; the worker heads into park and freezes.
+        svc._pool.submit(1, REBUILD, [])
+        assert at_park.wait(timeout=5)
+
+        # Worker frozen AT the park boundary. Fire a reconcile + a new-vote poll.
+        # The pool is not yet parked, so both are safely no-ops here — and,
+        # crucially, service and pool agree at every instant.
+        svc._reconcile_once()
+        svc._pg.poll_votes_since.return_value = [
+            {"zid": 1, "pid": 9, "tid": 9, "vote": 1, "created": 100}
+        ]
+        svc._vote_wm = 0
+        svc._poll_votes_once()
+        assert svc._parked == svc._pool.parked_zids(), "views must never diverge"
+
+        # Let the worker finish parking.
+        release.set()
+        _drain(svc)
+        assert svc._pool.is_parked(1) and 1 in svc._parked, "consistent: both parked"
+
+        # A later reconcile recovers cleanly (loader now succeeds).
+        svc._pool.park = real_park  # remove the freeze hook
+        svc._reconcile_once()
+        _drain(svc)
+        assert not svc._pool.is_parked(1) and 1 not in svc._parked
+        assert svc._writer.writes == [1], "the rebuild is recovered, not dropped"
+
+    def test_overlapping_rebuilds_run_one_handler_per_zid(self, make_svc):
+        """Overlap two rebuild triggers for one zid while a handler is in flight
+        (multi-worker pool). Require at most ONE active handler per zid and no
+        dropped rebuild."""
+        svc = make_svc(retry_cap=1, pool_size=4)
+        entered = threading.Event()
+        proceed = threading.Event()
+        lock = threading.Lock()
+        conc = {"cur": 0, "max": 0, "n": 0}
+
+        def loader(zid):
+            with lock:
+                conc["n"] += 1
+                conc["cur"] += 1
+                conc["max"] = max(conc["max"], conc["cur"])
+            entered.set()
+            assert proceed.wait(timeout=5)
+            with lock:
+                conc["cur"] -= 1
+            return object()
+
+        svc._load_or_init = loader
+
+        svc._pool.submit(1, REBUILD, [])  # worker A enters loader and freezes
+        assert entered.wait(timeout=5)
+        svc._pool.submit(1, REBUILD, [])  # overlapping trigger: must NOT run now
+        proceed.set()
+        _drain(svc)
+
+        assert conc["max"] == 1, "at most one active handler per zid"
+        assert conc["n"] >= 1, "the rebuild ran; nothing silently dropped"
+        assert svc._writer.writes and svc._writer.writes[0] == 1
+
+    def test_reconcile_and_new_vote_unpark_converge(self, make_svc):
+        """Trigger the reconciler and a new-vote unpark concurrently on a parked
+        zid. Both funnel through the pool-owned parked state, so the outcome is a
+        single quiet recovery with service and pool in agreement."""
+        svc = make_svc(retry_cap=0, pool_size=2)
+        svc._load_or_init = lambda zid: object()  # rebuild always succeeds now
+
+        # Park zid 1 directly (pool is the owner of parked truth).
+        svc._pool.park(1)
+        assert 1 in svc._parked
+
+        svc._pg.poll_votes_since.return_value = [
+            {"zid": 1, "pid": 1, "tid": 1, "vote": 1, "created": 100}
+        ]
+        svc._vote_wm = 0
+
+        barrier = threading.Barrier(2)
+
+        def reconcile():
+            barrier.wait(timeout=5)
+            svc._reconcile_once()
+
+        def poll():
+            barrier.wait(timeout=5)
+            svc._poll_votes_once()
+
+        t1 = threading.Thread(target=reconcile)
+        t2 = threading.Thread(target=poll)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+        _drain(svc)
+
+        assert not svc._pool.is_parked(1) and 1 not in svc._parked
+        assert svc._parked == svc._pool.parked_zids()
+        assert svc._writer.writes and svc._writer.writes[-1] == 1, (
+            "the zid recovers exactly once, from authoritative history"
+        )


### PR DESCRIPTION
## What
Two control-flow defects in the parked-zid recovery path added by #2697's M1 fix, found by independent review probes and reproduced deterministically:

1. **A failed reconciler rebuild disappeared.** `_reconcile_once` cleared the parked marker and submitted a `REBUILD`; on a transient failure `_requeue` resubmitted only votes/moderation, dropping the rebuild. The zid was then neither parked nor queued, so it stayed stale while quiet.
2. **Park/unpark could disagree permanently.** `_on_engine_error` set a service-side parked marker before `pool.park`; a reconciliation between those steps cleared the marker and queued a rebuild, then the worker parked the pool and dropped it. Service and pool parked-sets diverged.

## Fix
- The **worker pool is the single owner of parked truth**: the service's `_parked` set is gone; `service._parked` is a read-only view of `pool.parked_zids()`. Parking is one atomic `pool.park(zid)`.
- `_requeue` preserves **all** message kinds, including `rebuild`.

## Tests
- `tests/poller/test_park_rebuild_recovery.py` (7 tests): R03 transient + persistent failure, R04 reconcile-during-park, overlapping rebuilds, reconcile + new-vote race, `_requeue` unit test. Barriers/latches at the named boundaries, no sleeps.
- `uv run pytest tests/poller -q` → 112 passed, 1 skipped (needs Postgres). Race classes looped 20/20.
- The review's offline probes report both defects **not reproduced** on this branch and still reproduced on `edge` (`db98945af`).

Out of scope, tracked in the integration-test program (P-022 §C): the rest of the R01–R12 matrix on real Postgres, the three-table non-atomic write seam, cache-access synchronization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s