### PR TITLE
test(poller): P-022 part C — recovery matrix R01–R12 on real Postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,62 @@ refresh-prodclone: ## Force prodclone mode, drop prodclone volume, and restart f
 refresh-devdb: ## Force dev DB mode (migrations), drop postgres_data volume, and restart
 	$(MAKE) USE_PRODCLONE=false refresh-db
 
+# ---------------------------------------------------------------------------- #
+# P-022 §C — poller recovery matrix (R01-R12) on a REAL Postgres
+# ---------------------------------------------------------------------------- #
+# Reuses docker-compose.test.yml's postgres service (built from
+# server/Dockerfile-db, which bakes server/postgres/migrations/*.sql into
+# docker-entrypoint-initdb.d) with docker-compose.recovery.yml overriding the
+# host port and making the data directory a tmpfs, so every `up` re-runs initdb
+# with the real migrations and nothing survives teardown.
+#
+# The suite FAILS rather than skips without a Postgres (P-022 §C Acceptance:
+# "Missing Postgres is a failing required job, not pytest skip"), so this is the
+# supported way to run it.
+RECOVERY_PG_PORT ?= 55432
+RECOVERY_COMPOSE = POLIS_RECOVERY_PG_PORT=$(RECOVERY_PG_PORT) docker compose \
+	-f docker-compose.test.yml -f docker-compose.recovery.yml --env-file test.env
+RECOVERY_PG_PASSWORD = $(shell grep -e ^POSTGRES_PASSWORD test.env | cut -d= -f2)
+RECOVERY_PG_URL = postgresql://postgres:$(RECOVERY_PG_PASSWORD)@localhost:$(RECOVERY_PG_PORT)/polis-test
+# Runs in a SUBSHELL so the `cd` cannot leak into the cleanup trap (which must
+# still find this Makefile in the repository root).
+RECOVERY_PYTEST = cd $(CURDIR)/delphi && POLIS_TEST_POSTGRES_URL="$(RECOVERY_PG_URL)" uv run --no-sync pytest
+
+test-recovery-up: ## Start the recovery suite's Postgres (real migrations, ephemeral)
+	$(RECOVERY_COMPOSE) up -d --force-recreate postgres
+	@echo "waiting for postgres to become healthy on port $(RECOVERY_PG_PORT)..."
+	@cid=$$($(RECOVERY_COMPOSE) ps -q postgres); \
+	for i in $$(seq 1 60); do \
+		s=$$(docker inspect -f '{{.State.Health.Status}}' $$cid 2>/dev/null); \
+		if [ "$$s" = "healthy" ]; then echo "postgres healthy"; exit 0; fi; \
+		sleep 1; \
+	done; \
+	echo "postgres did not become healthy"; exit 1
+
+test-recovery-down: ## Stop and remove the recovery suite's Postgres
+	$(RECOVERY_COMPOSE) down -v --remove-orphans
+
+test-recovery: ## Run the P-022 recovery matrix (R01-R12) on a real Postgres
+	@$(MAKE) test-recovery-up
+	@set -e; trap '$(MAKE) test-recovery-down' EXIT; \
+		( $(RECOVERY_PYTEST) tests/poller -q -rxX )
+
+test-recovery-races: ## Re-run the deterministic race schedules 20x (P-022 acceptance)
+	@$(MAKE) test-recovery-up
+	@set -e; trap '$(MAKE) test-recovery-down' EXIT; \
+		for i in $$(seq 1 20); do \
+			echo "=== race iteration $$i/20 ==="; \
+			( $(RECOVERY_PYTEST) \
+				tests/poller/recovery/test_r02_newer_revote_during_retry.py \
+				tests/poller/recovery/test_r04_park_unpark_races.py \
+				tests/poller/recovery/test_r06_lru_in_flight.py \
+				tests/poller/recovery/test_r09_partial_tables_readers.py \
+				tests/poller/recovery/test_r12_publication_cursor.py \
+				tests/poller/test_park_rebuild_recovery.py \
+				-q ) || exit 1; \
+		done; \
+		echo "20/20 race iterations passed"
+
 e2e-install: e2e/node_modules ## Install Cypress E2E testing tools
 	$(E2E_RUN) npm install
 
@@ -208,7 +264,8 @@ rbs: start-rebuild
 	rebuild-delphi rebuild-server rebuild-web 
 	refresh-db refresh-devdb refresh-prodclone regenerate-jwt-keys \
 	rm-ALL rm-containers rm-images rm-volumes \
-	start-FULL-REBUILD start-prodclone start-rebuild start-recreate
+	start-FULL-REBUILD start-prodclone start-rebuild start-recreate \
+	test-recovery test-recovery-up test-recovery-down test-recovery-races
 
 
 help: ## Show this help message

--- a/delphi/pyproject.toml
+++ b/delphi/pyproject.toml
@@ -146,6 +146,7 @@ markers = [
     "local_dataset: mark test as using local (non-committed) datasets from real_data/.local/",
     "clojure_comparison: mark test as comparing with Clojure reference implementation (can be excluded with '-m \"not clojure_comparison\"')",
     "integration: mark test as an opt-in integration test needing a real Postgres (self-skips if docker/port unavailable)",
+    "recovery: P-022 §C poller recovery matrix (R01-R12); REQUIRES a real Postgres via POLIS_TEST_POSTGRES_URL and FAILS (never skips) without one — run via `make test-recovery`",
 ]
 
 [tool.coverage.run]

--- a/delphi/tests/poller/recovery/__init__.py
+++ b/delphi/tests/poller/recovery/__init__.py
@@ -1,0 +1,1 @@
+"""P-022 §C recovery matrix (R01-R12) against a REAL Postgres."""

--- a/delphi/tests/poller/recovery/conftest.py
+++ b/delphi/tests/poller/recovery/conftest.py
@@ -14,6 +14,34 @@ deliberate exception: ``POLIS_RECOVERY_ALLOW_NO_PG=1`` turns the failure into a
 skip, for a developer running an unrelated part of the suite.  CI must not set
 it, and the required job asserts it is unset.
 
+Checkout policy
+---------------
+The migrations (and, for R11, ``docker-compose.yml``) are read from the polis
+checkout, which is located by walking UP from this file until a directory
+containing ``server/postgres/migrations`` is found — never by a hard-coded
+absolute path.  ``POLIS_MIGRATIONS_DIR`` overrides the migrations location.
+
+A real Postgres is a *policy* prerequisite (see above: its absence fails).  The
+checkout is a *packaging* prerequisite: the Delphi Python CI job copies only
+``delphi/tests`` into ``/app/tests`` inside the delphi image
+(.github/workflows/python-ci.yml step 6), so the polis checkout genuinely does
+not exist there.  Its absence is therefore a clean, reasoned
+:func:`pytest.skip` carrying the fixing command — see
+:func:`recovery_migrations_dir` and :func:`require_repo_root`.  An explicitly
+set but wrong ``POLIS_MIGRATIONS_DIR`` still FAILS: that is operator error, not
+an absent prerequisite.
+
+Nothing here hides the matrix from that job by policy — the skip is a statement
+about the image's contents, and it is one step away from being satisfied::
+
+    docker compose ... cp server/postgres/migrations delphi:/app/migrations
+    ... exec -e POLIS_MIGRATIONS_DIR=/app/migrations delphi ...
+
+which makes the whole matrix run there (verified: 122 passed, 1 skipped — R11's
+docker-compose.yml assertion, still outside the image — and 12 xfailed).
+Whether the matrix belongs in that shared job or in its own required job is
+P-022 §C's separate "required recovery job" decision, not this file's.
+
 Schema freshness
 ----------------
 The migrations are applied ONCE per session into a template database; each test
@@ -51,10 +79,53 @@ import sqlalchemy as sa
 # Every module in this package is part of the required recovery job.
 pytestmark = pytest.mark.recovery
 
-_MIGRATIONS_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..",
-                 "server", "postgres", "migrations")
-)
+_MIGRATIONS_SUBPATH = ("server", "postgres", "migrations")
+
+
+def _find_repo_root(start: str) -> Optional[str]:
+    """The polis checkout root at or above ``start``, or None.
+
+    Identified by the thing these tests actually need — a real
+    ``server/postgres/migrations`` directory — rather than by counting ``..``
+    segments, which silently walks off the top of the filesystem when the tests
+    are copied somewhere shallower than the checkout (as the Delphi Python CI
+    job does: ``delphi/tests`` -> ``/app/tests``, four levels up from which is
+    ``/``).
+    """
+    path = os.path.abspath(start)
+    while True:
+        if os.path.isdir(os.path.join(path, *_MIGRATIONS_SUBPATH)):
+            return path
+        parent = os.path.dirname(path)
+        if parent == path:
+            return None
+        path = parent
+
+
+#: The polis checkout root, or None when these tests are running outside one.
+REPO_ROOT = _find_repo_root(os.path.dirname(__file__))
+
+_NO_CHECKOUT_MESSAGE = """
+The P-022 §C recovery matrix reads {needed} from the polis checkout, and no
+checkout was found at or above {here}.
+
+This is NOT the "missing Postgres" case (which fails by policy): the file is a
+packaging prerequisite, so it cannot be supplied by configuration here.  The
+Delphi Python CI job copies only `delphi/tests` into `/app/tests` inside the
+delphi image, so the checkout is genuinely absent there.
+
+Run the suite from a checkout instead:
+
+    make test-recovery                 # from the repository root
+"""
+
+_BAD_MIGRATIONS_OVERRIDE = """
+POLIS_MIGRATIONS_DIR is set to {path!r}, which is not a directory.
+
+An explicit override that does not resolve is operator error, so this FAILS
+rather than skipping.  Unset it to fall back to the checkout's
+server/postgres/migrations.
+"""
 
 _MISSING_PG_MESSAGE = """
 P-022 §C requires a REAL Postgres; POLIS_TEST_POSTGRES_URL is {why}.
@@ -103,6 +174,42 @@ def _quiet_engine_logs():
 # --------------------------------------------------------------------------- #
 # Postgres plumbing
 # --------------------------------------------------------------------------- #
+def require_repo_root(needed: str) -> str:
+    """The checkout root, or a clean skip naming what could not be reached.
+
+    Used by the handful of assertions that read a repository file (R11 reads
+    ``docker-compose.yml``).  The assertion itself is untouched — it either runs
+    against the real file or does not run at all, and says so.
+    """
+    if REPO_ROOT is None:
+        pytest.skip(
+            _NO_CHECKOUT_MESSAGE.format(
+                needed=needed, here=os.path.dirname(os.path.abspath(__file__))
+            )
+        )
+    return REPO_ROOT
+
+
+@pytest.fixture(scope="session")
+def recovery_migrations_dir() -> str:
+    """Directory holding the REAL ``server/postgres/migrations/*.sql``.
+
+    ``POLIS_MIGRATIONS_DIR`` wins when set (and FAILS when it does not resolve);
+    otherwise the checkout found by :func:`_find_repo_root` supplies it, and its
+    absence is a skip.
+    """
+    override = os.environ.get("POLIS_MIGRATIONS_DIR")
+    if override:
+        path = os.path.abspath(override)
+        if not os.path.isdir(path):
+            pytest.fail(
+                _BAD_MIGRATIONS_OVERRIDE.format(path=override), pytrace=False
+            )
+        return path
+    root = require_repo_root(os.path.join(*_MIGRATIONS_SUBPATH))
+    return os.path.join(root, *_MIGRATIONS_SUBPATH)
+
+
 def _fail_or_skip(why: str) -> None:
     message = _MISSING_PG_MESSAGE.format(why=why)
     if os.environ.get("POLIS_RECOVERY_ALLOW_NO_PG") == "1":
@@ -136,13 +243,18 @@ def recovery_postgres_url() -> str:
 
 
 @pytest.fixture(scope="session")
-def migrated_template(recovery_postgres_url: str) -> str:
+def migrated_template(recovery_migrations_dir: str,
+                      recovery_postgres_url: str) -> str:
     """Name of a session-scoped template database carrying the REAL migrations.
 
     Built by applying every ``server/postgres/migrations/*.sql`` in filename
     order, so schema constraints/types under test are the migrated ones (P-022
     §C: "Test schema constraints/types against migrations, not only the
     hand-maintained equivalence schema").
+
+    ``recovery_migrations_dir`` is listed FIRST deliberately: when there is
+    neither a checkout nor a Postgres, the packaging prerequisite is the more
+    actionable diagnosis, so its skip should win over the Postgres failure.
     """
     import psycopg2
 
@@ -150,11 +262,13 @@ def migrated_template(recovery_postgres_url: str) -> str:
     template = f"polis_recovery_tmpl_{os.getpid()}"
 
     files = sorted(
-        f for f in os.listdir(_MIGRATIONS_DIR)
-        if f.endswith(".sql") and os.path.isfile(os.path.join(_MIGRATIONS_DIR, f))
+        f for f in os.listdir(recovery_migrations_dir)
+        if f.endswith(".sql")
+        and os.path.isfile(os.path.join(recovery_migrations_dir, f))
     )
     if not files:  # pragma: no cover - infra guard
-        pytest.fail(f"no migrations found in {_MIGRATIONS_DIR}", pytrace=False)
+        pytest.fail(f"no migrations found in {recovery_migrations_dir}",
+                    pytrace=False)
 
     admin = psycopg2.connect(recovery_postgres_url, connect_timeout=5)
     admin.autocommit = True
@@ -170,7 +284,7 @@ def migrated_template(recovery_postgres_url: str) -> str:
     conn.autocommit = True
     try:
         for name in files:
-            with open(os.path.join(_MIGRATIONS_DIR, name), "r") as fh:
+            with open(os.path.join(recovery_migrations_dir, name), "r") as fh:
                 sql = fh.read()
             with conn.cursor() as cur:
                 cur.execute(sql)

--- a/delphi/tests/poller/recovery/conftest.py
+++ b/delphi/tests/poller/recovery/conftest.py
@@ -432,6 +432,18 @@ def drain(svc, timeout: float = 60.0) -> None:
     )
 
 
+def pool_pending(pool, zid: int) -> bool:
+    """Queued-or-active work for one zid, read under the pool's OWN lock.
+
+    Used to assert that no queued request was dropped and that no handler is
+    still in flight.  Reads the pool's private bookkeeping deliberately: the
+    point IS the pool's internal accounting, and taking ``_lock`` means the
+    snapshot cannot tear against a concurrent submit/park.
+    """
+    with pool._lock:
+        return bool(pool._queues.get(zid)) or zid in pool._active
+
+
 def eventually(
     predicate: Callable[[], bool],
     *,

--- a/delphi/tests/poller/recovery/conftest.py
+++ b/delphi/tests/poller/recovery/conftest.py
@@ -76,6 +76,30 @@ non-required runs only.
 """
 
 
+@pytest.fixture(autouse=True)
+def _quiet_engine_logs():
+    """The engine logs a paragraph per compute at INFO; recovery tests run many
+    computes each.  Nothing here asserts on log output."""
+    import logging
+
+    # conversation.py:91 sets its OWN logger to INFO explicitly, so raising the
+    # parent's level is not enough — every already-created polismath logger has
+    # to be quieted individually.
+    import polismath.conversation.conversation  # noqa: F401  (force creation)
+
+    names = [n for n in logging.root.manager.loggerDict
+             if n == "polismath" or n.startswith(("polismath.", "sqlalchemy"))]
+    loggers = [logging.getLogger("polismath")] + [
+        logging.getLogger(n) for n in names
+    ]
+    previous = [(lg, lg.level) for lg in loggers]
+    for lg in loggers:
+        lg.setLevel(logging.WARNING)
+    yield
+    for lg, level in previous:
+        lg.setLevel(level)
+
+
 # --------------------------------------------------------------------------- #
 # Postgres plumbing
 # --------------------------------------------------------------------------- #

--- a/delphi/tests/poller/recovery/conftest.py
+++ b/delphi/tests/poller/recovery/conftest.py
@@ -1,0 +1,586 @@
+"""Shared fixtures for the P-022 §C recovery matrix (R01-R12).
+
+Postgres policy
+---------------
+Every scenario in which DB behaviour matters runs against a REAL Postgres with
+the REAL ``server/postgres/migrations/*.sql`` applied — never the hand-maintained
+equivalence schema, and never sqlite.  Per P-022 §C "Acceptance":
+
+    Missing Postgres is a failing required job, not pytest skip.
+
+so :func:`recovery_postgres_url` **fails** (loudly, with the command that fixes
+it) when ``POLIS_TEST_POSTGRES_URL`` is unset or unreachable.  There is one
+deliberate exception: ``POLIS_RECOVERY_ALLOW_NO_PG=1`` turns the failure into a
+skip, for a developer running an unrelated part of the suite.  CI must not set
+it, and the required job asserts it is unset.
+
+Schema freshness
+----------------
+The migrations are applied ONCE per session into a template database; each test
+then gets its own database created with ``CREATE DATABASE ... TEMPLATE``.  That
+is a genuinely fresh migrated schema per test (no cross-test residue in
+math_main / math_ticks / votes) at roughly the cost of a file copy.
+
+Fault injection
+---------------
+All hooks live in the tests.  They monkeypatch the WRITER/ENGINE boundary
+(``PostgresClient`` methods, ``MathWriter.write_conv_updates``,
+``MathPollerService._load_or_init``) rather than editing production code, so the
+code under test is byte-for-byte the deployed code.  :class:`FaultInjector`
+provides one-shot and persistent variants and records what it fired.
+
+No fixed sleep is ever used as evidence of an interleaving: ordering comes from
+``threading.Event``/``threading.Barrier`` latches at named boundaries and from
+``ConversationWorkerPool.join`` (which blocks until the pool is idle).
+:func:`eventually` exists only for genuinely asynchronous *progress* assertions,
+and is always bounded.
+"""
+
+import os
+import re
+import subprocess
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import pytest
+import sqlalchemy as sa
+
+# Every module in this package is part of the required recovery job.
+pytestmark = pytest.mark.recovery
+
+_MIGRATIONS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..",
+                 "server", "postgres", "migrations")
+)
+
+_MISSING_PG_MESSAGE = """
+P-022 §C requires a REAL Postgres; POLIS_TEST_POSTGRES_URL is {why}.
+
+This is a REQUIRED job, so it FAILS rather than skipping (P-022 §C Acceptance:
+"Missing Postgres is a failing required job, not pytest skip").
+
+Start the compose test Postgres and run the suite with:
+
+    make test-recovery                 # from the repository root
+
+or, to point at an existing database:
+
+    POLIS_TEST_POSTGRES_URL=postgresql://user:pw@host:port/db \\
+        uv run pytest tests/poller/recovery
+
+Set POLIS_RECOVERY_ALLOW_NO_PG=1 to downgrade this to a skip for local,
+non-required runs only.
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Postgres plumbing
+# --------------------------------------------------------------------------- #
+def _fail_or_skip(why: str) -> None:
+    message = _MISSING_PG_MESSAGE.format(why=why)
+    if os.environ.get("POLIS_RECOVERY_ALLOW_NO_PG") == "1":
+        pytest.skip(message)
+    pytest.fail(message, pytrace=False)
+
+
+def _split_url(url: str):
+    """(server-url-without-database, database-name)."""
+    match = re.match(r"^(?P<head>.*?)/(?P<db>[^/?]+)(?P<tail>\?.*)?$", url)
+    if not match:
+        raise ValueError(f"cannot parse a database name out of {url!r}")
+    return match.group("head"), match.group("db"), match.group("tail") or ""
+
+
+@pytest.fixture(scope="session")
+def recovery_postgres_url() -> str:
+    """The base Postgres server URL, verified reachable.  FAILS if missing."""
+    url = os.environ.get("POLIS_TEST_POSTGRES_URL")
+    if not url:
+        _fail_or_skip("not set")
+    import psycopg2
+
+    try:
+        conn = psycopg2.connect(url, connect_timeout=5)
+    except Exception as exc:  # pragma: no cover - infra guard
+        _fail_or_skip(f"set to {url!r} but unreachable: {exc}")
+    else:
+        conn.close()
+    return url
+
+
+@pytest.fixture(scope="session")
+def migrated_template(recovery_postgres_url: str) -> str:
+    """Name of a session-scoped template database carrying the REAL migrations.
+
+    Built by applying every ``server/postgres/migrations/*.sql`` in filename
+    order, so schema constraints/types under test are the migrated ones (P-022
+    §C: "Test schema constraints/types against migrations, not only the
+    hand-maintained equivalence schema").
+    """
+    import psycopg2
+
+    head, admin_db, tail = _split_url(recovery_postgres_url)
+    template = f"polis_recovery_tmpl_{os.getpid()}"
+
+    files = sorted(
+        f for f in os.listdir(_MIGRATIONS_DIR)
+        if f.endswith(".sql") and os.path.isfile(os.path.join(_MIGRATIONS_DIR, f))
+    )
+    if not files:  # pragma: no cover - infra guard
+        pytest.fail(f"no migrations found in {_MIGRATIONS_DIR}", pytrace=False)
+
+    admin = psycopg2.connect(recovery_postgres_url, connect_timeout=5)
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(f'DROP DATABASE IF EXISTS "{template}"')
+            cur.execute(f'CREATE DATABASE "{template}"')
+    finally:
+        admin.close()
+
+    tmpl_url = f"{head}/{template}{tail}"
+    conn = psycopg2.connect(tmpl_url, connect_timeout=5)
+    conn.autocommit = True
+    try:
+        for name in files:
+            with open(os.path.join(_MIGRATIONS_DIR, name), "r") as fh:
+                sql = fh.read()
+            with conn.cursor() as cur:
+                cur.execute(sql)
+    finally:
+        conn.close()
+
+    yield template
+
+    admin = psycopg2.connect(recovery_postgres_url, connect_timeout=5)
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(f'DROP DATABASE IF EXISTS "{template}" WITH (FORCE)')
+    finally:
+        admin.close()
+
+
+@pytest.fixture
+def pg_url(recovery_postgres_url: str, migrated_template: str) -> str:
+    """A FRESH migrated database for this one test, dropped afterwards."""
+    import psycopg2
+
+    head, _admin_db, tail = _split_url(recovery_postgres_url)
+    name = f"rec_{uuid.uuid4().hex[:12]}"
+
+    admin = psycopg2.connect(recovery_postgres_url, connect_timeout=5)
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(f'CREATE DATABASE "{name}" TEMPLATE "{migrated_template}"')
+    finally:
+        admin.close()
+
+    url = f"{head}/{name}{tail}"
+    try:
+        yield url
+    finally:
+        admin = psycopg2.connect(recovery_postgres_url, connect_timeout=5)
+        admin.autocommit = True
+        try:
+            with admin.cursor() as cur:
+                cur.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        finally:
+            admin.close()
+
+
+@pytest.fixture
+def engine(pg_url: str):
+    eng = sa.create_engine(pg_url, poolclass=sa.pool.NullPool)
+    try:
+        yield eng
+    finally:
+        eng.dispose()
+
+
+# --------------------------------------------------------------------------- #
+# Seeding (plain SQL; no polismath code involved)
+# --------------------------------------------------------------------------- #
+@dataclass
+class SeededConversation:
+    """What a test committed, so the fold can be built from the test's own
+    knowledge of the input rather than from a re-read of the system's output."""
+
+    zid: int
+    vote_events: List[Dict[str, Any]] = field(default_factory=list)
+    comment_rows: List[Dict[str, Any]] = field(default_factory=list)
+    participant_rows: List[Dict[str, Any]] = field(default_factory=list)
+
+
+def seed_conversation(
+    engine,
+    zid: int = 1,
+    n_ptpts: int = 8,
+    n_cmts: int = 5,
+    base_created: Optional[int] = None,
+    vote_pattern: Optional[Callable[[int, int], int]] = None,
+) -> SeededConversation:
+    """Seed one conversation: conversations/participants/comments/votes rows.
+
+    Raw DB vote signs (AGREE=-1, DISAGREE=+1) are written directly, so the
+    poller's ingress conversion is genuinely exercised.  Two opposing camps by
+    participant parity gives a non-degenerate PCA.
+    """
+    now = int(time.time() * 1000)
+    base_created = now - 60_000 if base_created is None else base_created
+    long_ago = now - 2 * 24 * 60 * 60 * 1000
+    if vote_pattern is None:
+        def vote_pattern(pid: int, tid: int) -> int:  # noqa: ARG001
+            return -1 if pid % 2 == 0 else 1
+
+    seeded = SeededConversation(zid=zid)
+    with engine.begin() as conn:
+        conn.execute(sa.text("SET session_replication_role = replica"))
+        conn.execute(sa.text("INSERT INTO conversations (zid) VALUES (:zid) "
+                             "ON CONFLICT DO NOTHING"), {"zid": zid})
+        for pid in range(n_ptpts):
+            conn.execute(
+                sa.text("INSERT INTO participants (pid, uid, zid, created, mod) "
+                        "VALUES (:pid, :uid, :zid, :created, 0)"),
+                {"pid": pid, "uid": 100000 * zid + pid, "zid": zid,
+                 "created": long_ago},
+            )
+            seeded.participant_rows.append({"pid": pid, "mod": 0})
+        for tid in range(n_cmts):
+            conn.execute(
+                sa.text("INSERT INTO comments (tid, zid, pid, uid, txt, mod, "
+                        "is_meta, created, modified) VALUES (:tid, :zid, 0, "
+                        ":uid, :txt, 0, false, :created, :modified)"),
+                {"tid": tid, "zid": zid, "uid": 100000 * zid,
+                 "txt": f"comment {tid}", "created": long_ago,
+                 "modified": long_ago},
+            )
+            seeded.comment_rows.append(
+                {"tid": tid, "mod": 0, "is_meta": False, "modified": long_ago}
+            )
+        created = base_created
+        for pid in range(n_ptpts):
+            for tid in range(n_cmts):
+                created += 1
+                raw = vote_pattern(pid, tid)
+                conn.execute(
+                    sa.text("INSERT INTO votes (zid, pid, tid, vote, created) "
+                            "VALUES (:zid, :pid, :tid, :vote, :created)"),
+                    {"zid": zid, "pid": pid, "tid": tid, "vote": raw,
+                     "created": created},
+                )
+                seeded.vote_events.append(
+                    {"pid": pid, "tid": tid, "vote": raw, "created": created}
+                )
+        conn.execute(sa.text("SET session_replication_role = DEFAULT"))
+    return seeded
+
+
+def commit_vote(engine_or_conn, zid: int, pid: int, tid: int, raw_vote: int,
+                created: int) -> Dict[str, Any]:
+    """Commit ONE vote row (raw storage sign) and return the fold event."""
+    stmt = sa.text("INSERT INTO votes (zid, pid, tid, vote, created) "
+                   "VALUES (:zid, :pid, :tid, :vote, :created)")
+    params = {"zid": zid, "pid": pid, "tid": tid, "vote": raw_vote,
+              "created": created}
+    if isinstance(engine_or_conn, sa.engine.Engine):
+        with engine_or_conn.begin() as conn:
+            conn.execute(sa.text("SET session_replication_role = replica"))
+            conn.execute(stmt, params)
+    else:
+        # An OPEN connection/transaction the caller controls — this is how the
+        # two-real-connections tests keep one commit pending while another lands.
+        engine_or_conn.execute(sa.text("SET session_replication_role = replica"))
+        engine_or_conn.execute(stmt, params)
+    return {"pid": pid, "tid": tid, "vote": raw_vote, "created": created}
+
+
+def read_vote_events(engine, zid: int) -> List[Dict[str, Any]]:
+    """Read back every committed vote EVENT with a plain SELECT, in the poller's
+    own load order.  Used to build the fold from the DB rather than from the
+    test's bookkeeping, so the fold checks what was really committed."""
+    with engine.connect() as conn:
+        rows = conn.execute(
+            sa.text("SELECT pid, tid, vote, created FROM votes WHERE zid = :zid "
+                    "ORDER BY zid, tid, pid, created"),
+            {"zid": zid},
+        ).mappings().all()
+    return [dict(r) for r in rows]
+
+
+def read_math_tables(engine, zid: int, math_env: str) -> Dict[str, Any]:
+    """Read the three published tables + math_ticks for one (zid, math_env)."""
+    out: Dict[str, Any] = {}
+    with engine.connect() as conn:
+        out["main"] = _one(conn,
+            "SELECT zid, math_env, caching_tick, math_tick, last_vote_timestamp, "
+            "data FROM math_main WHERE zid=:z AND math_env=:e", zid, math_env)
+        out["bidtopid"] = _one(conn,
+            "SELECT zid, math_tick, data FROM math_bidtopid "
+            "WHERE zid=:z AND math_env=:e", zid, math_env)
+        out["ptptstats"] = _one(conn,
+            "SELECT zid, math_tick, data FROM math_ptptstats "
+            "WHERE zid=:z AND math_env=:e", zid, math_env)
+        out["ticks"] = _one(conn,
+            "SELECT zid, math_tick, caching_tick FROM math_ticks "
+            "WHERE zid=:z AND math_env=:e", zid, math_env)
+    return out
+
+
+def _one(conn, sql: str, zid: int, math_env: str) -> Optional[Dict[str, Any]]:
+    row = conn.execute(sa.text(sql), {"z": zid, "e": math_env}).mappings().first()
+    return dict(row) if row else None
+
+
+def tables_are_coherent(tables: Dict[str, Any]) -> List[str]:
+    """Return the reasons a published generation is INCOHERENT (empty == fine).
+
+    "Coherent" here is the contract a reader needs: all three data rows exist and
+    carry the SAME math_tick, i.e. one complete generation.
+    """
+    problems = []
+    for name in ("main", "bidtopid", "ptptstats"):
+        if tables.get(name) is None:
+            problems.append(f"{name} row missing")
+    if problems:
+        return problems
+    ticks = {name: tables[name]["math_tick"]
+             for name in ("main", "bidtopid", "ptptstats")}
+    if len(set(ticks.values())) != 1:
+        problems.append(f"mixed generations: math_tick per table = {ticks}")
+    return problems
+
+
+# --------------------------------------------------------------------------- #
+# Service construction
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def make_service(tmp_path):
+    """Build real ``MathPollerService`` instances against the real Postgres
+    client.  Cleans up pools/engines afterwards."""
+    from polismath.database.postgres import PostgresClient, PostgresConfig
+    from polismath.poller.service import MathPollerService, PollerConfig
+
+    built = []
+
+    def _make(url: str, math_env: str = "recovery", **cfg_kwargs):
+        pg = PostgresClient(
+            PostgresConfig(url=url, math_env=math_env, ssl_mode="disable")
+        )
+        pg.initialize()
+        kwargs = dict(
+            database_url=url,
+            math_env=math_env,
+            poll_from_days_ago=1,
+            worker_pool_size=2,
+            dump_dir=str(tmp_path / "errorconv"),
+        )
+        kwargs.update(cfg_kwargs)
+        svc = MathPollerService(pg, PollerConfig(**kwargs))
+        svc._ensure_runtime()
+        built.append((svc, pg))
+        return svc
+
+    yield _make
+
+    for svc, pg in built:
+        try:
+            if svc._pool is not None:
+                svc._pool.shutdown(wait=False)
+        except Exception:  # pragma: no cover - teardown best effort
+            pass
+        try:
+            pg.shutdown()
+        except Exception:  # pragma: no cover - teardown best effort
+            pass
+
+
+def drain(svc, timeout: float = 60.0) -> None:
+    """Block until the pool is idle — a latch on the pool's own condition
+    variable, NOT a sleep."""
+    assert svc._pool is not None
+    assert svc._pool.join(timeout=timeout), (
+        "worker pool did not drain within the bound; work is stuck"
+    )
+
+
+def eventually(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 30.0,
+    interval: float = 0.05,
+    message: str = "bounded eventual-progress assertion failed",
+) -> None:
+    """Bounded eventual-progress assertion.
+
+    Used ONLY where progress is genuinely asynchronous and no latch exists; the
+    passing evidence is the predicate, never elapsed time, and the bound makes a
+    stall a failure rather than a hang.
+    """
+    deadline = time.monotonic() + timeout
+    last = False
+    while time.monotonic() < deadline:
+        last = bool(predicate())
+        if last:
+            return
+        time.sleep(interval)
+    raise AssertionError(f"{message} (bound {timeout}s)")
+
+
+# --------------------------------------------------------------------------- #
+# Fault injection
+# --------------------------------------------------------------------------- #
+class InjectedFault(RuntimeError):
+    """Raised by a :class:`FaultInjector` hook.  A distinct type so a test can
+    assert it saw the injected failure and not an unrelated one."""
+
+
+@dataclass
+class FaultInjector:
+    """One-shot / persistent failure injection at a NAMED boundary.
+
+    ``mode='once'`` fires exactly once (the transient-blip case); ``'always'``
+    fires forever (the persistent-outage case); ``'nth'`` fires on the n-th call.
+    Every call is recorded so a test can assert how many attempts were made
+    (bounded retries, no hot loop).
+    """
+
+    name: str
+    mode: str = "once"
+    nth: int = 1
+    calls: int = 0
+    fired: int = 0
+    exception: Callable[[], BaseException] = lambda: InjectedFault("injected")
+
+    def should_fire(self) -> bool:
+        self.calls += 1
+        if self.mode == "always":
+            hit = True
+        elif self.mode == "once":
+            hit = self.fired == 0
+        elif self.mode == "nth":
+            hit = self.calls == self.nth
+        elif self.mode == "never":
+            hit = False
+        else:  # pragma: no cover - programming error
+            raise ValueError(f"unknown fault mode {self.mode!r}")
+        if hit:
+            self.fired += 1
+        return hit
+
+    def maybe_raise(self) -> None:
+        if self.should_fire():
+            raise self.exception()
+
+
+def fail_stage(target: Any, method: str, injector: FaultInjector,
+               *, after: bool = False) -> Callable[[], None]:
+    """Wrap ``target.method`` so ``injector`` can fail BEFORE (default) or AFTER
+    the real call.  Returns an undo callable.
+
+    ``after=True`` is the committed-write / lost-ack case: the DB work really
+    happened and committed, but the caller sees an exception.
+    """
+    original = getattr(target, method)
+
+    def wrapper(*args, **kwargs):
+        if not after:
+            injector.maybe_raise()
+            return original(*args, **kwargs)
+        result = original(*args, **kwargs)
+        injector.maybe_raise()
+        return result
+
+    setattr(target, method, wrapper)
+    return lambda: setattr(target, method, original)
+
+
+class Latch:
+    """A named boundary latch: the hooked call announces arrival and blocks
+    until released.  Used instead of sleeps to pin an interleaving."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.arrived = threading.Event()
+        self.release = threading.Event()
+        self.arrivals = 0
+
+    def wait_arrival(self, timeout: float = 30.0) -> None:
+        assert self.arrived.wait(timeout), (
+            f"latch {self.name!r} was never reached within {timeout}s"
+        )
+
+    def let_go(self) -> None:
+        self.release.set()
+
+    def block(self, timeout: float = 30.0) -> None:
+        self.arrivals += 1
+        self.arrived.set()
+        assert self.release.wait(timeout), (
+            f"latch {self.name!r} was never released within {timeout}s"
+        )
+
+
+def latch_method(target: Any, method: str, latch: Latch,
+                 predicate: Optional[Callable[..., bool]] = None
+                 ) -> Callable[[], None]:
+    """Block inside ``target.method`` at ``latch`` (optionally only when
+    ``predicate(*args)`` holds).  Returns an undo callable."""
+    original = getattr(target, method)
+
+    def wrapper(*args, **kwargs):
+        if predicate is None or predicate(*args, **kwargs):
+            latch.block()
+        return original(*args, **kwargs)
+
+    setattr(target, method, wrapper)
+    return lambda: setattr(target, method, original)
+
+
+# --------------------------------------------------------------------------- #
+# Misc
+# --------------------------------------------------------------------------- #
+def terminate_backends(admin_url: str, dbname: str) -> int:
+    """Kill every server-side backend on ``dbname`` — a REAL connection loss."""
+    import psycopg2
+
+    conn = psycopg2.connect(admin_url, connect_timeout=5)
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (dbname,),
+            )
+            return len(cur.fetchall())
+    finally:
+        conn.close()
+
+
+def dbname_of(url: str) -> str:
+    return _split_url(url)[1]
+
+
+def run_child(script_args: List[str], env_extra: Dict[str, str],
+              cwd: Optional[str] = None) -> subprocess.Popen:
+    """Start a child Python process (used by R05's real process kills)."""
+    import sys
+
+    env = dict(os.environ)
+    env.update(env_extra)
+    return subprocess.Popen(
+        [sys.executable, *script_args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        env=env,
+        cwd=cwd or os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..")
+        ),
+    )

--- a/delphi/tests/poller/recovery/conftest.py
+++ b/delphi/tests/poller/recovery/conftest.py
@@ -598,6 +598,32 @@ def terminate_backends(admin_url: str, dbname: str) -> int:
         conn.close()
 
 
+def terminate_backend_pid(admin_url: str, backend_pid: int) -> bool:
+    """Terminate ONE specific server-side backend, from a SECOND connection.
+
+    This is the form R01's connection-loss test needs: the caller latches an
+    ACTIVE transaction, learns its ``pg_backend_pid()``, and kills exactly that
+    backend while it is still holding the transaction open — so the next
+    statement or the COMMIT genuinely fails on the tested path.  Killing every
+    idle backend beforehand does not do that: a fresh connection or a pool
+    pre-ping can repair an idle killed connection with no failure ever reaching
+    the code under test.
+
+    Returns Postgres's own answer to ``pg_terminate_backend``.
+    """
+    import psycopg2
+
+    conn = psycopg2.connect(admin_url, connect_timeout=5)
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT pg_terminate_backend(%s)", (backend_pid,))
+            row = cur.fetchone()
+            return bool(row and row[0])
+    finally:
+        conn.close()
+
+
 def dbname_of(url: str) -> str:
     return _split_url(url)[1]
 

--- a/delphi/tests/poller/recovery/fold.py
+++ b/delphi/tests/poller/recovery/fold.py
@@ -1,0 +1,244 @@
+"""An INDEPENDENT reference fold of the raw input stream (P-022 §C).
+
+The recovery matrix requires "a small independent fold of the input votes to
+check final state (not the engine's own methods)".  Everything in this module
+is therefore deliberately dumb, plain-stdlib Python:
+
+* no ``numpy``/``pandas``,
+* **nothing** imported from ``polismath`` — not even the vote-sign converter or
+  the moderation reader, which are themselves under test,
+* no knowledge of ``Conversation`` internals.
+
+It folds the rows a test committed to Postgres (or read back out of it with a
+plain ``SELECT``) into the state the poller must eventually publish, and exposes
+that state in the two shapes ``math_main.data`` actually carries:
+
+``user-vote-counts``
+    per-pid count of cells with a latest vote (``conversation.py``'s
+    ``_compute_user_vote_counts`` = non-missing cells of ``raw_rating_mat``).
+``votes-base``
+    per-tid A/D/S counts, per base-cluster bucket; summing the buckets for one
+    tid gives that comment's agree/disagree/observed totals over the
+    **clustered** participants.  The fold's per-tid totals are over ALL
+    participants, so they are an upper bound that is exact whenever every voter
+    is clustered — which is the case for the small generated fixtures here, and
+    is asserted explicitly rather than assumed.
+
+Vote-sign convention is spelled out locally instead of imported:
+Postgres stores AGREE=-1 / DISAGREE=+1 / PASS=0; the math engine uses
+AGREE=+1 / DISAGREE=-1 / PASS=0.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+# --- raw Postgres storage polarity (P-023 `storage_agree_value`) ------------ #
+RAW_AGREE = -1
+RAW_DISAGREE = 1
+RAW_PASS = 0
+
+# --- engine polarity -------------------------------------------------------- #
+ENGINE_AGREE = 1
+ENGINE_DISAGREE = -1
+ENGINE_PASS = 0
+
+Cell = Tuple[Any, Any]  # (pid, tid)
+
+
+def raw_to_engine(raw_vote: int, storage_agree_value: int = RAW_AGREE) -> int:
+    """Convert a stored vote to the engine convention, given the storage
+    polarity.  ``storage_agree_value`` is the value the DB uses for AGREE
+    (-1 today).  Written out here rather than imported from
+    ``polismath.utils.general`` so the fold cannot inherit a sign bug from the
+    code it is checking."""
+    if raw_vote == RAW_PASS:
+        return ENGINE_PASS
+    return ENGINE_AGREE if raw_vote == storage_agree_value else ENGINE_DISAGREE
+
+
+@dataclass
+class VoteFold:
+    """The authoritative latest-cell state derived from an ordered vote stream."""
+
+    #: (pid, tid) -> engine-convention vote of the winning event
+    cells: Dict[Cell, int] = field(default_factory=dict)
+    #: (pid, tid) -> ``created`` of the winning event
+    cell_created: Dict[Cell, int] = field(default_factory=dict)
+    #: cells whose winner is ambiguous: two or more events tie on max(created)
+    #: with different vote values.  The DB's ``ORDER BY zid, tid, pid, created``
+    #: does not break that tie, so no test may assert a single winner there.
+    ambiguous: Set[Cell] = field(default_factory=set)
+    #: total number of vote EVENTS folded (not cells) — the raw event counter
+    event_count: int = 0
+    #: max(created) over every folded event; 0 for an empty stream (Clojure's
+    #: floor, conversation.clj:161-165)
+    last_vote_timestamp: int = 0
+
+    # -- derived views ------------------------------------------------------ #
+    @property
+    def participants(self) -> Set[Any]:
+        return {pid for pid, _ in self.cells}
+
+    @property
+    def comments(self) -> Set[Any]:
+        return {tid for _, tid in self.cells}
+
+    def user_vote_counts(self) -> Dict[Any, int]:
+        """pid -> number of cells this participant has a latest vote in."""
+        counts: Dict[Any, int] = {}
+        for pid, _tid in self.cells:
+            counts[pid] = counts.get(pid, 0) + 1
+        return counts
+
+    def per_comment_totals(self) -> Dict[Any, Dict[str, int]]:
+        """tid -> {'A': agrees, 'D': disagrees, 'S': observed cells}."""
+        totals: Dict[Any, Dict[str, int]] = {}
+        for (_pid, tid), vote in self.cells.items():
+            entry = totals.setdefault(tid, {"A": 0, "D": 0, "S": 0})
+            entry["S"] += 1
+            if vote == ENGINE_AGREE:
+                entry["A"] += 1
+            elif vote == ENGINE_DISAGREE:
+                entry["D"] += 1
+        return totals
+
+
+def fold_votes(
+    events: List[Dict[str, Any]],
+    storage_agree_value: int = RAW_AGREE,
+) -> VoteFold:
+    """Fold raw vote rows into latest-cell state.
+
+    ``events`` are dicts with ``pid``/``tid``/``vote`` (RAW storage sign) and
+    ``created`` (epoch millis), in the order the DB returns them.  The winner of
+    a cell is the event with the greatest ``created``; a tie on ``created``
+    between DIFFERENT vote values is recorded in :attr:`VoteFold.ambiguous`
+    rather than silently resolved, because the poller's load ordering
+    (``ORDER BY zid, tid, pid, created``) does not define it either.
+    """
+    fold = VoteFold()
+    for ev in events:
+        cell: Cell = (ev["pid"], ev["tid"])
+        created = int(ev["created"])
+        value = raw_to_engine(int(ev["vote"]), storage_agree_value)
+        fold.event_count += 1
+        if created > fold.last_vote_timestamp:
+            fold.last_vote_timestamp = created
+        prior = fold.cell_created.get(cell)
+        if prior is None or created > prior:
+            fold.cells[cell] = value
+            fold.cell_created[cell] = created
+            fold.ambiguous.discard(cell)
+        elif created == prior:
+            if fold.cells[cell] != value:
+                fold.ambiguous.add(cell)
+            # later row of an equal-created pair wins in payload order, which is
+            # what the engine's stable sort + keep='last' does — but the DB row
+            # order between them is arbitrary, hence `ambiguous`.
+            fold.cells[cell] = value
+    return fold
+
+
+@dataclass
+class ModerationFold:
+    mod_out_tids: Set[Any] = field(default_factory=set)
+    mod_in_tids: Set[Any] = field(default_factory=set)
+    meta_tids: Set[Any] = field(default_factory=set)
+    mod_out_ptpts: Set[Any] = field(default_factory=set)
+    last_mod_timestamp: int = 0
+
+
+def fold_moderation(
+    comment_rows: List[Dict[str, Any]],
+    participant_rows: Optional[List[Dict[str, Any]]] = None,
+) -> ModerationFold:
+    """Fold current comment/participant rows into the moderation state.
+
+    A comments snapshot is CURRENT STATE, not a history of moderation actions
+    (P-022 §A) — so this folds the rows as they stand, exactly like a plain
+    ``SELECT``, and never tries to reconstruct a timeline.
+    """
+    fold = ModerationFold()
+    for row in comment_rows:
+        tid = row["tid"]
+        mod = row["mod"]
+        if mod in (1, "1"):
+            fold.mod_in_tids.add(tid)
+        elif mod in (-1, "-1"):
+            fold.mod_out_tids.add(tid)
+        if row.get("is_meta"):
+            fold.meta_tids.add(tid)
+        modified = row.get("modified")
+        if modified is not None and int(modified) > fold.last_mod_timestamp:
+            fold.last_mod_timestamp = int(modified)
+    for row in participant_rows or []:
+        if row.get("mod") in (-1, "-1"):
+            fold.mod_out_ptpts.add(row["pid"])
+    return fold
+
+
+# --------------------------------------------------------------------------- #
+# Comparing the fold against a published math_main blob
+# --------------------------------------------------------------------------- #
+def votes_base_totals(data: Dict[str, Any]) -> Dict[int, Dict[str, int]]:
+    """Sum ``math_main.data['votes-base']``'s per-base-cluster buckets into
+    per-tid A/D/S totals.  ``votes-base`` is ``{tid: {'A': [...], 'D': [...],
+    'S': [...]}}`` — one entry per base cluster, sorted by cluster id."""
+    out: Dict[int, Dict[str, int]] = {}
+    for tid, buckets in (data.get("votes-base") or {}).items():
+        out[int(tid)] = {
+            key: int(sum(buckets.get(key) or []))
+            for key in ("A", "D", "S")
+        }
+    return out
+
+
+def check_published_against_fold(
+    data: Dict[str, Any],
+    fold: VoteFold,
+    *,
+    require_all_clustered: bool = True,
+) -> List[str]:
+    """Return a list of human-readable mismatches between a published
+    ``math_main.data`` blob and the independent fold.  Empty list == agreement.
+
+    Deliberately returns problems instead of asserting, so a caller can use the
+    same routine for a positive assertion and for a negative control.
+    """
+    problems: List[str] = []
+
+    published_ts = data.get("lastVoteTimestamp")
+    if published_ts != fold.last_vote_timestamp:
+        problems.append(
+            f"lastVoteTimestamp: published {published_ts!r} != "
+            f"folded {fold.last_vote_timestamp!r}"
+        )
+
+    expected_counts = {int(k): v for k, v in fold.user_vote_counts().items()}
+    published_counts = {
+        int(k): int(v) for k, v in (data.get("user-vote-counts") or {}).items()
+    }
+    if published_counts != expected_counts:
+        problems.append(
+            f"user-vote-counts: published {published_counts!r} != "
+            f"folded {expected_counts!r}"
+        )
+
+    if data.get("n") != len(fold.participants):
+        problems.append(
+            f"n: published {data.get('n')!r} != folded "
+            f"{len(fold.participants)!r} participants"
+        )
+
+    if require_all_clustered:
+        expected_totals = {
+            int(t): v for t, v in fold.per_comment_totals().items()
+        }
+        published_totals = votes_base_totals(data)
+        if published_totals != expected_totals:
+            problems.append(
+                f"votes-base totals: published {published_totals!r} != "
+                f"folded {expected_totals!r}"
+            )
+
+    return problems

--- a/delphi/tests/poller/recovery/restart_child.py
+++ b/delphi/tests/poller/recovery/restart_child.py
@@ -97,7 +97,11 @@ def _install_after_poll_latch(svc) -> None:
     The latch instead:
 
     1. gates ``_run_engine`` so no compute can start, and records that dispatch
-       really happened (``GATE run_engine``);
+       really happened (``GATE run_engine``).  The marker is WRITTEN AND FLUSHED
+       BEFORE ``dispatched`` is set (astra second-round review): setting the
+       event first lets the polling thread wake and print ``WM_ACK``/``STAGE``
+       between the ``set()`` and the ``write()``, so the stdout ORDER the parent
+       asserts would flake even though the watermark barrier itself is correct;
     2. lets ``_poll_votes_once`` RETURN, then reads the watermark it assigned
        and acknowledges it (``WM_ACK <value>``).  If the watermark did not
        advance, or the pool never picked the work up, the child exits with a
@@ -109,8 +113,13 @@ def _install_after_poll_latch(svc) -> None:
     hold = threading.Event()          # never set: the compute never starts
 
     def gated_run_engine(zid, coalesced):
-        dispatched.set()
+        # ORDER MATTERS: emit + flush the marker BEFORE releasing the polling
+        # thread.  `dispatched` is what unblocks `WM_ACK`/`STAGE after_poll` in
+        # `latched_poll_votes_once`, so setting it first would let those two
+        # lines reach stdout ahead of this one.  The event is now strictly the
+        # LAST thing this gate does before parking.
         _emit_line(f"GATE run_engine zid={zid}")
+        dispatched.set()
         hold.wait()
 
     svc._run_engine = gated_run_engine

--- a/delphi/tests/poller/recovery/restart_child.py
+++ b/delphi/tests/poller/recovery/restart_child.py
@@ -11,7 +11,9 @@ crash simulations do not replace kill/restart tests."
 Stages (the P-022 §C R05 list):
 
 ``after_poll``
-    after the poll cycle advanced the watermark, before any compute
+    after the poll cycle advanced the watermark, before any compute.  This one
+    is LATCHED, not merely hooked (astra review finding 4): see
+    :func:`_install_after_poll_latch`.
 ``during_compute``
     inside ``Conversation.recompute``
 ``after_main_commit``
@@ -31,14 +33,131 @@ import threading
 import time
 
 
+# Exit codes with a specific meaning to the parent tests.  A crash for any
+# OTHER reason exits 1 (or dies by signal) and must never be mistaken for one
+# of these (astra review findings 3 and 4).
+EXIT_OK = 0
+EXIT_OWNERSHIP_REFUSED = 3
+EXIT_OWNERSHIP_LATCH_TIMEOUT = 4
+EXIT_WATERMARK_NOT_ADVANCED = 5
+EXIT_NO_DISPATCH = 6
+
+OWNERSHIP_REFUSAL_MARKER = "OWNERSHIP-REFUSED"
+
+# An ownership refusal is a NAMED, deliberate startup path — not "the process
+# happened to die".  The poller has no such path today (that is R07's defect);
+# these are the shapes a fix would take, and the parent test accepts nothing
+# else as a refusal.
+_OWNERSHIP_ERROR_NAMES = (
+    "OwnershipRefused", "ShardAlreadyOwned", "DuplicateWriterRefused",
+    "FenceRejected", "StaleFenceError",
+)
+_OWNERSHIP_ERROR_PATTERN = (
+    r"already owned|duplicate writer|ownership (lease|refus)|advisory lock "
+    r"(held|not acquired)|fencing token|stale fence"
+)
+
+
 def _emit(stage: str) -> None:
     sys.stdout.write(f"STAGE {stage}\n")
+    sys.stdout.flush()
+
+
+def _emit_line(line: str) -> None:
+    """A non-STAGE acknowledgement line the parent can assert on, in order."""
+    sys.stdout.write(f"{line}\n")
     sys.stdout.flush()
 
 
 def _block_forever() -> None:
     """Park this process so the parent's SIGKILL lands at exactly this point."""
     threading.Event().wait()
+
+
+def _is_ownership_refusal(exc: BaseException) -> bool:
+    import re
+
+    if type(exc).__name__ in _OWNERSHIP_ERROR_NAMES:
+        return True
+    return bool(re.search(_OWNERSHIP_ERROR_PATTERN, str(exc), re.I))
+
+
+def _install_after_poll_latch(svc) -> None:
+    """Make the ``after_poll`` kill point DETERMINISTIC.
+
+    ``MathPollerService._poll_votes_once`` (``polismath/poller/service.py:433``)
+    SUBMITS each zid's batch to the worker pool BEFORE assigning
+    ``self._vote_wm`` (``:447``), and ``_run_engine`` runs on a POOL thread.  So
+    hooking ``_run_engine`` alone — what this child used to do — emits the stage
+    marker from another thread at a moment that may PRECEDE the watermark
+    assignment; the SIGKILL is real but the named ordering "after the poll cycle
+    advanced the watermark, before any compute" is unproven (astra review
+    finding 4).
+
+    The latch instead:
+
+    1. gates ``_run_engine`` so no compute can start, and records that dispatch
+       really happened (``GATE run_engine``);
+    2. lets ``_poll_votes_once`` RETURN, then reads the watermark it assigned
+       and acknowledges it (``WM_ACK <value>``).  If the watermark did not
+       advance, or the pool never picked the work up, the child exits with a
+       distinct code instead of emitting the stage — so a vacuous pass is
+       impossible;
+    3. only then emits ``STAGE after_poll`` and parks for the parent's kill.
+    """
+    dispatched = threading.Event()
+    hold = threading.Event()          # never set: the compute never starts
+
+    def gated_run_engine(zid, coalesced):
+        dispatched.set()
+        _emit_line(f"GATE run_engine zid={zid}")
+        hold.wait()
+
+    svc._run_engine = gated_run_engine
+
+    real_poll = svc._poll_votes_once
+    wm_before = svc._vote_wm
+
+    def latched_poll_votes_once():
+        real_poll()
+        wm_after = svc._vote_wm
+        if wm_after is None or wm_before is None or wm_after <= wm_before:
+            _emit_line(f"WM_NOT_ADVANCED before={wm_before} after={wm_after}")
+            sys.stderr.write(
+                f"after_poll latch: watermark did not advance "
+                f"({wm_before} -> {wm_after}); refusing to claim the stage\n")
+            sys.stderr.flush()
+            os._exit(EXIT_WATERMARK_NOT_ADVANCED)
+        if not dispatched.wait(60):
+            _emit_line("NO_DISPATCH")
+            sys.stderr.write("after_poll latch: the pool never entered "
+                             "_run_engine; nothing was dispatched\n")
+            sys.stderr.flush()
+            os._exit(EXIT_NO_DISPATCH)
+        _emit_line(f"WM_ACK {wm_after}")
+        _emit("after_poll")
+        _block_forever()
+
+    svc._poll_votes_once = latched_poll_votes_once
+
+
+def _hold_ownership(latch_dir: str) -> int:
+    """Announce that this process has taken whatever ownership it takes, then
+    wait for the parent to release.  Lets R07 prove that two duplicate writers
+    were alive AT THE SAME TIME rather than merely one after the other."""
+    os.makedirs(latch_dir, exist_ok=True)
+    with open(os.path.join(latch_dir, f"owned.{os.getpid()}"), "w") as fh:
+        fh.write(str(os.getpid()))
+    _emit("OWNED")
+    release = os.path.join(latch_dir, "release")
+    deadline = time.monotonic() + 120.0
+    while not os.path.exists(release):
+        if time.monotonic() > deadline:
+            sys.stderr.write("ownership latch was never released\n")
+            sys.stderr.flush()
+            return EXIT_OWNERSHIP_LATCH_TIMEOUT
+        time.sleep(0.02)
+    return EXIT_OK
 
 
 def main() -> int:
@@ -48,6 +167,12 @@ def main() -> int:
     parser.add_argument("--kill-stage", default="none")
     parser.add_argument("--poll-from-days-ago", type=float, default=1.0)
     parser.add_argument("--reconcile-interval-ms", type=int, default=60000)
+    parser.add_argument(
+        "--ownership-latch-dir", default=None,
+        help=("Announce ownership into this directory (owned.<pid>) and wait "
+              "for a 'release' file before polling, so the parent can prove "
+              "two duplicate writers were alive CONCURRENTLY."),
+    )
     args = parser.parse_args()
 
     import logging
@@ -58,35 +183,48 @@ def main() -> int:
     from polismath.database.postgres import PostgresClient, PostgresConfig
     from polismath.poller.service import MathPollerService, PollerConfig
 
-    pg = PostgresClient(
-        PostgresConfig(url=args.pg_url, math_env=args.math_env,
-                       ssl_mode="disable")
-    )
-    pg.initialize()
-    svc = MathPollerService(
-        pg,
-        PollerConfig(
-            database_url=args.pg_url,
-            math_env=args.math_env,
-            poll_from_days_ago=args.poll_from_days_ago,
-            worker_pool_size=1,
-            retry_cap=0,
-            reconcile_interval_ms=args.reconcile_interval_ms,
-            dump_dir=os.environ.get("POLIS_RECOVERY_DUMP_DIR", "/tmp/errorconv"),
-        ),
-    )
-    svc._ensure_runtime()
+    # Startup is wrapped so that an OWNERSHIP refusal — a named, deliberate
+    # refusal to run because someone else owns this shard — is reported with
+    # its own exit code and marker, and can never be confused with an import
+    # error, a DB outage or any other crash (astra review finding 3).  The
+    # poller has no such path today; that absence is exactly what R07 asserts.
+    try:
+        pg = PostgresClient(
+            PostgresConfig(url=args.pg_url, math_env=args.math_env,
+                           ssl_mode="disable")
+        )
+        pg.initialize()
+        svc = MathPollerService(
+            pg,
+            PollerConfig(
+                database_url=args.pg_url,
+                math_env=args.math_env,
+                poll_from_days_ago=args.poll_from_days_ago,
+                worker_pool_size=1,
+                retry_cap=0,
+                reconcile_interval_ms=args.reconcile_interval_ms,
+                dump_dir=os.environ.get("POLIS_RECOVERY_DUMP_DIR",
+                                        "/tmp/errorconv"),
+            ),
+        )
+        svc._ensure_runtime()
+    except BaseException as exc:  # noqa: BLE001 - classified and re-raised
+        if _is_ownership_refusal(exc):
+            _emit_line(f"{OWNERSHIP_REFUSAL_MARKER} {type(exc).__name__}: {exc}")
+            sys.stderr.write(f"{OWNERSHIP_REFUSAL_MARKER}: {exc}\n")
+            sys.stderr.flush()
+            return EXIT_OWNERSHIP_REFUSED
+        raise
+
+    if args.ownership_latch_dir:
+        held = _hold_ownership(args.ownership_latch_dir)
+        if held != EXIT_OK:
+            return held
 
     stage = args.kill_stage
 
     if stage == "after_poll":
-        real = svc._run_engine
-
-        def hooked(zid, coalesced):
-            _emit(stage)
-            _block_forever()
-
-        svc._run_engine = hooked
+        _install_after_poll_latch(svc)
 
     elif stage == "during_compute":
         real_recompute = Conversation.recompute

--- a/delphi/tests/poller/recovery/restart_child.py
+++ b/delphi/tests/poller/recovery/restart_child.py
@@ -1,0 +1,139 @@
+"""A REAL poller process, killable at a NAMED stage — the R05 subject.
+
+Run as a subprocess by ``test_r05_mid_batch_restart.py``.  It builds a real
+``PostgresClient`` + ``MathPollerService`` against the test database, installs a
+single hook at the requested stage, and — when that stage is reached — prints
+``STAGE <name>`` on stdout and then blocks forever so the PARENT can deliver the
+kill.  The kill is therefore genuinely external (SIGKILL from the test), which
+is what P-022 §G requires: "A process kill is driven externally.  Stdin-only
+crash simulations do not replace kill/restart tests."
+
+Stages (the P-022 §C R05 list):
+
+``after_poll``
+    after the poll cycle advanced the watermark, before any compute
+``during_compute``
+    inside ``Conversation.recompute``
+``after_main_commit``
+    after ``write_math_main`` committed, before the other two tables
+``before_final_table_commit``
+    after main+bidtopid committed, before ``write_participant_stats``
+``after_all_writes_before_cache``
+    after all three writes committed, before the conversation is cached
+``none``
+    no kill: run one poll cycle and exit 0 (the restart process)
+"""
+
+import argparse
+import os
+import sys
+import threading
+import time
+
+
+def _emit(stage: str) -> None:
+    sys.stdout.write(f"STAGE {stage}\n")
+    sys.stdout.flush()
+
+
+def _block_forever() -> None:
+    """Park this process so the parent's SIGKILL lands at exactly this point."""
+    threading.Event().wait()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pg-url", required=True)
+    parser.add_argument("--math-env", required=True)
+    parser.add_argument("--kill-stage", default="none")
+    parser.add_argument("--poll-from-days-ago", type=float, default=1.0)
+    parser.add_argument("--reconcile-interval-ms", type=int, default=60000)
+    args = parser.parse_args()
+
+    import logging
+
+    logging.disable(logging.CRITICAL)
+
+    from polismath.conversation.conversation import Conversation
+    from polismath.database.postgres import PostgresClient, PostgresConfig
+    from polismath.poller.service import MathPollerService, PollerConfig
+
+    pg = PostgresClient(
+        PostgresConfig(url=args.pg_url, math_env=args.math_env,
+                       ssl_mode="disable")
+    )
+    pg.initialize()
+    svc = MathPollerService(
+        pg,
+        PollerConfig(
+            database_url=args.pg_url,
+            math_env=args.math_env,
+            poll_from_days_ago=args.poll_from_days_ago,
+            worker_pool_size=1,
+            retry_cap=0,
+            reconcile_interval_ms=args.reconcile_interval_ms,
+            dump_dir=os.environ.get("POLIS_RECOVERY_DUMP_DIR", "/tmp/errorconv"),
+        ),
+    )
+    svc._ensure_runtime()
+
+    stage = args.kill_stage
+
+    if stage == "after_poll":
+        real = svc._run_engine
+
+        def hooked(zid, coalesced):
+            _emit(stage)
+            _block_forever()
+
+        svc._run_engine = hooked
+
+    elif stage == "during_compute":
+        real_recompute = Conversation.recompute
+
+        def hooked_recompute(self, *a, **kw):
+            _emit(stage)
+            _block_forever()
+
+        Conversation.recompute = hooked_recompute
+
+    elif stage == "after_main_commit":
+        real_main = pg.write_math_main
+
+        def hooked_main(*a, **kw):
+            result = real_main(*a, **kw)
+            _emit(stage)
+            _block_forever()
+
+        pg.write_math_main = hooked_main
+
+    elif stage == "before_final_table_commit":
+        real_stats = pg.write_participant_stats
+
+        def hooked_stats(*a, **kw):
+            _emit(stage)
+            _block_forever()
+
+        pg.write_participant_stats = hooked_stats
+
+    elif stage == "after_all_writes_before_cache":
+        real_remember = svc._remember
+
+        def hooked_remember(zid, conv):
+            _emit(stage)
+            _block_forever()
+
+        svc._remember = hooked_remember
+
+    elif stage != "none":
+        raise SystemExit(f"unknown --kill-stage {stage!r}")
+
+    _emit("READY")
+    svc.poll_once()
+    _emit("DONE")
+    svc.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/delphi/tests/poller/recovery/test_r01_stage_failures.py
+++ b/delphi/tests/poller/recovery/test_r01_stage_failures.py
@@ -38,6 +38,7 @@ from .conftest import (
     read_vote_events,
     seed_conversation,
     tables_are_coherent,
+    terminate_backend_pid,
     terminate_backends,
 )
 from . import fold as F
@@ -182,25 +183,138 @@ def test_real_db_rollback_leaves_no_partial_main_row(engine, pg_url, make_servic
 
 def test_real_connection_loss_recovers(engine, pg_url, recovery_postgres_url,
                                        make_service):
-    """Terminate the poller's server-side backend mid-cycle (a REAL connection
-    loss), then require bounded eventual recovery with no lost votes."""
+    """Terminate the backend of an ACTIVE write transaction (a REAL connection
+    loss on the tested path), then require bounded eventual recovery with no
+    lost votes.
+
+    The earlier version of this test terminated every backend on the database
+    just BEFORE the next write and asserted only that its hook had run — which
+    proves nothing: a fresh connection, or SQLAlchemy's pre-ping, can repair an
+    idle killed connection without any failure ever reaching the retry path
+    (astra review finding 5).  So instead:
+
+    1. open a real transaction on the POLLER's own engine and latch its
+       ``pg_backend_pid()``;
+    2. run the real ``math_bidtopid`` upsert inside it (uncommitted);
+    3. from a SECOND connection, ``pg_terminate_backend`` exactly that pid, and
+       assert Postgres says it killed it;
+    4. assert the COMMIT fails with a real connection-loss SQLSTATE, and that
+       the failure propagated to the service (which retried the stage);
+    5. then require quiet recovery against the independent fold.
+    """
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
 
-    original = svc._pg.write_math_bidtopid
-    state = {"fired": 0}
+    original = svc._pg._write_returning
+    state = {"bidtopid_calls": 0, "killed_pid": None, "terminated": None,
+             "error": None, "pgcode": None}
 
-    def kill_then_write(zid, data, **kwargs):
-        if state["fired"] == 0:
-            state["fired"] = 1
-            terminate_backends(recovery_postgres_url, dbname_of(pg_url))
-        return original(zid, data, **kwargs)
+    def kill_the_active_backend(sql, params=None):
+        if "math_bidtopid" not in sql:
+            return original(sql, params)
+        state["bidtopid_calls"] += 1
+        if state["bidtopid_calls"] > 1:      # the retry: let it through
+            return original(sql, params)
 
-    svc._pg.write_math_bidtopid = kill_then_write
+        conn = svc._pg.engine.connect()
+        try:
+            trans = conn.begin()
+            state["killed_pid"] = conn.execute(
+                sa.text("select pg_backend_pid()")).scalar()
+            # The REAL upsert, in a REAL open transaction on the poller's own
+            # engine — not a raised stand-in.
+            conn.execute(sa.text(sql), params or {})
+            state["terminated"] = terminate_backend_pid(
+                recovery_postgres_url, state["killed_pid"])
+            try:
+                trans.commit()
+            except sa.exc.DBAPIError as exc:
+                state["error"] = exc
+                state["pgcode"] = getattr(exc.orig, "pgcode", None)
+                raise
+            raise AssertionError(
+                "the terminated backend committed anyway; this test would be "
+                "vacuous"
+            )
+        finally:
+            try:
+                conn.close()
+            except Exception:  # pragma: no cover - the backend is gone
+                pass
+
+    svc._pg._write_returning = kill_the_active_backend
+    try:
+        svc.poll_once()
+    finally:
+        svc._pg._write_returning = original
+
+    assert state["terminated"] is True, (
+        f"pg_terminate_backend({state['killed_pid']}) did not report a kill; "
+        "no connection was actually lost"
+    )
+    assert isinstance(state["error"], sa.exc.DBAPIError), (
+        f"expected a real DBAPI failure from the killed backend, got "
+        f"{state['error']!r}"
+    )
+    text = str(state["error"]).lower()
+    assert state["pgcode"] in ("57P01", "08006", "08003", "08000") or any(
+        marker in text for marker in (
+            "terminating connection", "server closed the connection",
+            "connection already closed", "consuming input failed",
+        )
+    ), (
+        f"the failure must be a connection loss, not something else: pgcode="
+        f"{state['pgcode']!r} error={state['error']!r}"
+    )
+    assert state["bidtopid_calls"] >= 2, (
+        "the connection failure never reached the service's retry path: the "
+        f"bidtopid stage was attempted {state['bidtopid_calls']} time(s)"
+    )
+
+    _publish_and_check(engine, svc, zid=1)
+
+
+def test_terminating_an_idle_backend_is_not_evidence_of_a_failed_write(
+    engine, pg_url, recovery_postgres_url, make_service
+):
+    """The control for the test above (astra review finding 5), asserted rather
+    than assumed: terminating the database's backends between cycles does NOT
+    surface any failure to the poller — the next cycle simply reconnects.
+
+    That is why "a hook ran and then everything recovered" cannot be read as
+    proof that a connection loss was handled."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
     svc.poll_once()
-    svc._pg.write_math_bidtopid = original
-    assert state["fired"] == 1
 
+    seen = {"errors": 0, "attempts": 0}
+    original = svc._pg._write_returning
+
+    def counting(sql, params=None):
+        seen["attempts"] += 1
+        try:
+            return original(sql, params)
+        except Exception:
+            seen["errors"] += 1
+            raise
+
+    svc._pg._write_returning = counting
+    killed = terminate_backends(recovery_postgres_url, dbname_of(pg_url))
+    assert killed >= 1, "the control needs at least one backend to kill"
+
+    from .conftest import commit_vote
+    events = read_vote_events(engine, 1)
+    commit_vote(engine, 1, 0, 0, 1, max(e["created"] for e in events) + 1000)
+    svc._vote_wm = 0
+    svc.poll_once()
+    svc._pg._write_returning = original
+
+    assert seen["attempts"] > 0
+    assert seen["errors"] == 0, (
+        "killing IDLE backends surfaced an error to the writer on this run; if "
+        "that ever becomes reliable, the connection-loss test above can be "
+        "simplified — but it must not be ASSUMED"
+    )
     _publish_and_check(engine, svc, zid=1)
 
 
@@ -270,10 +384,84 @@ def test_real_serialization_failure_recovers(engine, pg_url, make_service):
 # --------------------------------------------------------------------------- #
 # Cache / temporal invariants around a failed write
 # --------------------------------------------------------------------------- #
+# Object identity and `last_updated` are NOT enough: an in-place smoother or
+# PCA mutation would leave both unchanged (astra review finding 6).  These
+# helpers take a DEEP, comparable snapshot of every piece of cached state that
+# can advance with a computation, so "no extra temporal advancement" is checked
+# against the actual numerical state and not only against a timestamp.
+_TEMPORAL_ATTRS = (
+    "last_updated",          # the input watermark
+    "last_mod_timestamp",
+    "tid_arrival_order",     # column lineage
+    "comment_count",
+    "moderation_applied",
+    "mod_in_tids", "mod_out_tids", "meta_tids",
+    "raw_rating_mat", "rating_mat",   # the full vote cells, not aggregates
+    "pca",                   # centre/comps — the geometry a recompute advances
+    "proj",                  # per-participant projected positions
+    "base_clusters", "group_clusters", "in_conv",
+    "repness",
+)
+
+
+def _digest(value):
+    """A stable, ``==``-comparable representation of a conversation attribute.
+
+    NaN (an unvoted cell) is mapped to ``None`` so two identical matrices
+    compare equal; floats are rounded so an exactly-repeated computation is not
+    reported as a change by float noise alone.
+    """
+    import numpy as np
+    import pandas as pd
+
+    if isinstance(value, pd.DataFrame):
+        return ("dataframe",
+                [str(i) for i in value.index],
+                [str(c) for c in value.columns],
+                _digest(value.to_numpy(dtype=float)))
+    if isinstance(value, pd.Series):
+        return ("series", [str(i) for i in value.index],
+                _digest(value.to_numpy()))
+    if isinstance(value, np.ndarray):
+        flat = np.asarray(value, dtype=float).ravel()
+        return ("ndarray", list(value.shape),
+                [None if v != v else round(float(v), 10) for v in flat])
+    if isinstance(value, np.generic):
+        return _digest(value.item())
+    if isinstance(value, dict):
+        return {str(k): _digest(v)
+                for k, v in sorted(value.items(), key=lambda kv: str(kv[0]))}
+    if isinstance(value, (list, tuple)):
+        return [_digest(v) for v in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted(str(v) for v in value)
+    if isinstance(value, float):
+        return None if value != value else round(value, 10)
+    return value
+
+
+def _temporal_snapshot(conv):
+    """Deep snapshot of the cached conversation's temporal + geometric state."""
+    return {name: _digest(getattr(conv, name, None))
+            for name in _TEMPORAL_ATTRS}
+
+
+def _snapshot_diff(before, after):
+    return sorted(k for k in before if before[k] != after.get(k))
+
+
 def test_failed_write_leaves_prior_cached_object_unchanged(engine, pg_url,
                                                            make_service):
     """Write-before-cache (M2): on a failed write the in-memory cache must still
-    hold the LAST PERSISTED conversation object — never an unpersisted one."""
+    hold the LAST PERSISTED conversation object — never an unpersisted one.
+
+    Checked three ways, because the first two are individually weak (astra
+    review finding 6): object identity, ``last_updated``, and a DEEP snapshot
+    of every temporal/geometric attribute (rating matrices cell by cell, PCA
+    centre and components, per-participant projections, base/group clusters,
+    in-conv, repness, moderation lineage).  An in-place smoother or PCA
+    mutation that left the identity and the timestamp untouched would still be
+    caught by the third."""
     from .conftest import commit_vote
 
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
@@ -282,6 +470,7 @@ def test_failed_write_leaves_prior_cached_object_unchanged(engine, pg_url,
     cached_before = svc._convs.get(1)
     assert cached_before is not None
     ts_before = cached_before.last_updated
+    snapshot_before = _temporal_snapshot(cached_before)
 
     events = read_vote_events(engine, 1)
     newer = max(e["created"] for e in events) + 1000
@@ -301,6 +490,12 @@ def test_failed_write_leaves_prior_cached_object_unchanged(engine, pg_url,
     assert cached_after.last_updated == ts_before, (
         "no temporal advancement from a computation that never committed"
     )
+    changed = _snapshot_diff(snapshot_before, _temporal_snapshot(cached_after))
+    assert changed == [], (
+        "a computation that never committed advanced the cached conversation's "
+        f"temporal/geometric state: {changed} differ.  Timestamp equality is "
+        "not enough — this is the in-place-mutation case."
+    )
     # And the persisted row is still the last good one.
     main = read_math_tables(engine, 1, MATH_ENV)["main"]
     assert main["last_vote_timestamp"] == ts_before
@@ -308,6 +503,66 @@ def test_failed_write_leaves_prior_cached_object_unchanged(engine, pg_url,
     # Bounded eventual progress once the stage is healthy again.
     svc._vote_wm = 0
     svc.poll_once()
+    tables, fold = _publish_and_check(engine, svc, zid=1)
+    assert tables["main"]["last_vote_timestamp"] == newer == fold.last_vote_timestamp
+
+
+def test_recovered_state_matches_a_clean_reference_computation(engine, pg_url,
+                                                               make_service):
+    """The successful retry's geometry and lineage must equal what a CLEAN run
+    of the same inputs produces (astra review finding 6).
+
+    The reference is a second service under its own math_env running the SAME
+    checkpoint/restore schedule — one cold cycle over the same rows, then one
+    warm cycle over the same new vote — with no failure anywhere.  The schedule
+    has to match: a cold full rebuild and a warm incremental update produce
+    different (both correct) geometry, because the poller does not persist warm
+    smoother state (see the poller package docstring's "load-or-init finding"),
+    so comparing warm-with-a-failure against cold would say nothing about the
+    failure.
+
+    Comparing the two cached conversations' deep temporal snapshots checks the
+    recovered state cell by cell, rather than only the aggregate vote/count
+    fields the independent fold already covers."""
+    from .conftest import commit_vote
+
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
+    ref = make_service(pg_url, math_env=MATH_ENV + "_reference", retry_cap=0)
+
+    # Checkpoint 1: the cold cycle, identical for both.
+    svc.poll_once()
+    ref.poll_once()
+    assert _snapshot_diff(_temporal_snapshot(ref._convs[1]),
+                          _temporal_snapshot(svc._convs[1])) == [], (
+        "precondition: the same inputs on the same schedule must give the same "
+        "state, or this comparison cannot mean anything"
+    )
+
+    events = read_vote_events(engine, 1)
+    newer = max(e["created"] for e in events) + 1000
+    commit_vote(engine, 1, 0, 0, 1, newer)
+
+    # Checkpoint 2: the warm cycle.  The subject's write fails once and the
+    # service retries it within the cycle; the reference's does not fail.
+    injector = FaultInjector(name="write_math_main", mode="once")
+    undo = fail_stage(svc._pg, "write_math_main", injector)
+    svc._vote_wm = 0
+    svc.poll_once()
+    undo()
+    assert injector.fired == 1, "the fault must actually have fired"
+    ref._vote_wm = 0
+    ref.poll_once()
+
+    recovered, clean = svc._convs.get(1), ref._convs.get(1)
+    assert recovered is not None and clean is not None
+    changed = _snapshot_diff(_temporal_snapshot(clean),
+                             _temporal_snapshot(recovered))
+    assert changed == [], (
+        "the recovered conversation differs from a clean run of the same "
+        f"schedule over the same input in: {changed}"
+    )
+
     tables, fold = _publish_and_check(engine, svc, zid=1)
     assert tables["main"]["last_vote_timestamp"] == newer == fold.last_vote_timestamp
 
@@ -391,6 +646,33 @@ class TestNegativeControl:
         assert F.check_published_against_fold(data, mutilated) != [], (
             "NEGATIVE CONTROL FAILED: the fold check accepted a stream that is "
             "missing a whole participant"
+        )
+
+    def test_the_temporal_snapshot_catches_an_in_place_mutation(
+        self, engine, pg_url, make_service
+    ):
+        """The correction itself, controlled (astra review finding 6): mutate
+        the cached conversation's PCA IN PLACE, leaving object identity and
+        ``last_updated`` untouched.  The identity/timestamp assertions stay
+        green; the deep snapshot must go red."""
+        import numpy as np
+
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0)
+        svc.poll_once()
+        conv = svc._convs.get(1)
+        before = _temporal_snapshot(conv)
+        identity_before, ts_before = conv, conv.last_updated
+
+        centre = np.asarray(conv.pca["center"], dtype=float)
+        conv.pca["center"] = (centre + 0.5).tolist()   # an in-place advance
+
+        assert svc._convs.get(1) is identity_before, "identity is unchanged"
+        assert conv.last_updated == ts_before, "the timestamp is unchanged"
+        changed = _snapshot_diff(before, _temporal_snapshot(conv))
+        assert changed == ["pca"], (
+            "NEGATIVE CONTROL FAILED: an in-place PCA mutation was invisible "
+            f"to the temporal snapshot (diff={changed})"
         )
 
     def test_injector_that_never_fires_is_detected(self, engine, pg_url,

--- a/delphi/tests/poller/recovery/test_r01_stage_failures.py
+++ b/delphi/tests/poller/recovery/test_r01_stage_failures.py
@@ -1,0 +1,408 @@
+"""R01 — stage failures (REAL Postgres, real engine, real writer).
+
+P-022 §C required matrix:
+
+    Fail before/after tick allocation, main write, bidtopid write and ptptstats
+    write; include serialization failure, DB rollback, connection loss and
+    committed-write/lost-ack.  Check final latest vote values, unchanged prior
+    cached object on failed write, no extra temporal advancement from replaying
+    an uncommitted computation, coherent recovered tables.  Tick gaps may occur;
+    gaps are not lost votes.
+
+Every failure is injected at the ``PostgresClient`` boundary that
+``MathWriter.write_conv_updates`` calls (``math_writer.py:238`` — three separate
+calls, each committing on its own ``engine.begin()``), so the code under test is
+the deployed code.  Three of the failures are genuine Postgres failures, not
+Python stand-ins:
+
+* **DB rollback** — a real ``NOT NULL`` violation inside the real upsert.
+* **connection loss** — ``pg_terminate_backend`` on the poller's own backend.
+* **serialization failure** — two real ``SERIALIZABLE`` transactions touching
+  the same math_main row, one of which the server aborts with 40001.
+
+Final state is checked against the INDEPENDENT fold in ``fold.py``.
+"""
+
+import threading
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    FaultInjector,
+    InjectedFault,
+    dbname_of,
+    drain,
+    fail_stage,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+    terminate_backends,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+def _publish_and_check(engine, svc, zid=1):
+    """Poll until quiet, then assert the published generation is coherent and
+    agrees with the independent fold."""
+    svc.poll_once()
+    tables = read_math_tables(engine, zid, MATH_ENV)
+    assert tables_are_coherent(tables) == [], (
+        f"published generation is incoherent: {tables_are_coherent(tables)}"
+    )
+    fold = F.fold_votes(read_vote_events(engine, zid))
+    problems = F.check_published_against_fold(tables["main"]["data"], fold)
+    assert problems == [], problems
+    return tables, fold
+
+
+# --------------------------------------------------------------------------- #
+# Stage-by-stage one-shot failures
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "stage,after",
+    [
+        ("increment_math_tick", False),   # before tick allocation
+        ("increment_math_tick", True),    # after tick allocation
+        ("write_math_main", False),       # before the main write
+        ("write_math_main", True),        # after the main write (lost ack)
+        ("write_math_bidtopid", False),   # before the bidtopid write
+        ("write_math_bidtopid", True),    # after the bidtopid write
+        ("write_participant_stats", False),   # before the ptptstats write
+        ("write_participant_stats", True),    # after all three writes
+    ],
+)
+def test_one_shot_stage_failure_recovers(engine, pg_url, make_service, stage, after):
+    """A transient failure at ANY write stage must recover to a coherent
+    generation whose contents match the independent fold.  Tick GAPS are
+    permitted (a failed cycle may have already minted a tick); lost votes are
+    not."""
+    seeded = seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
+
+    injector = FaultInjector(name=f"{stage}:{'after' if after else 'before'}")
+    undo = fail_stage(svc._pg, stage, injector, after=after)
+    try:
+        svc.poll_once()          # the injected failure fires inside this cycle
+    finally:
+        undo()
+    assert injector.fired == 1, "the fault must actually have fired"
+
+    # Bounded eventual progress: one more quiet cycle with no new votes.
+    tables, fold = _publish_and_check(engine, svc, zid=1)
+
+    # No extra temporal advancement: the published watermark is exactly the
+    # folded max(created) — replaying a computation that never committed must
+    # not push last_vote_timestamp past the real input.
+    assert tables["main"]["last_vote_timestamp"] == fold.last_vote_timestamp
+    assert fold.event_count == len(seeded.vote_events)
+
+
+def test_persistent_stage_failure_parks_then_recovers(engine, pg_url, make_service):
+    """A PERSISTENT main-write failure must park the zid with bounded retries
+    (visible unhealthy state, no hot loop, no phantom publication); once the DB
+    stage is restored the reconciler recovers it with no new votes."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1)
+
+    injector = FaultInjector(name="write_math_main", mode="always")
+    undo = fail_stage(svc._pg, "write_math_main", injector)
+    svc.poll_once()
+    assert 1 in svc._parked, "a persistently failing zid must become visibly parked"
+    assert injector.calls == 2, (
+        f"retries must be bounded to retry_cap+1=2 attempts, saw {injector.calls}"
+    )
+    assert read_math_tables(engine, 1, MATH_ENV)["main"] is None, (
+        "a failing write must never publish"
+    )
+
+    undo()  # DB stage restored; no new votes
+    svc._reconcile_once()
+    drain(svc)
+    tables, fold = _publish_and_check(engine, svc, zid=1)
+    assert 1 not in svc._parked
+
+
+# --------------------------------------------------------------------------- #
+# Real Postgres failures
+# --------------------------------------------------------------------------- #
+def test_real_db_rollback_leaves_no_partial_main_row(engine, pg_url, make_service):
+    """A REAL Postgres error rolls the write back.
+
+    The failure is a genuine ``math_main_zid_fkey`` violation from the real
+    migration (a zid with no ``conversations`` row), raised inside the real
+    upsert on the real ``engine.begin()`` transaction — so the rollback is
+    Postgres's, not a Python stand-in.  Afterwards nothing partial is left and
+    the retry publishes a coherent generation.
+    """
+    GHOST_ZID = 987654321  # deliberately absent from `conversations`
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
+
+    original = svc._pg.write_math_main
+    state = {"fired": 0, "error": None}
+
+    def broken_write(zid, data, **kwargs):
+        if state["fired"] == 0:
+            state["fired"] = 1
+            try:
+                original(GHOST_ZID, data, **kwargs)
+            except Exception as exc:
+                state["error"] = exc
+                raise
+        return original(zid, data, **kwargs)
+
+    svc._pg.write_math_main = broken_write
+    svc.poll_once()
+    svc._pg.write_math_main = original
+
+    assert state["fired"] == 1
+    assert isinstance(state["error"], sa.exc.DBAPIError), (
+        f"expected a real Postgres DBAPI error, got {state['error']!r}"
+    )
+    assert getattr(state["error"].orig, "pgcode", None) == "23503", (
+        "expected a foreign_key_violation (23503) from the real migration's "
+        f"math_main_zid_fkey, saw {state['error']!r}"
+    )
+    # The rolled-back statement left nothing behind.
+    with engine.connect() as conn:
+        ghost = conn.execute(
+            sa.text("SELECT count(*) FROM math_main WHERE zid = :z"),
+            {"z": GHOST_ZID},
+        ).scalar()
+    assert ghost == 0, "a rolled-back write must leave no row"
+
+    _publish_and_check(engine, svc, zid=1)
+
+
+def test_real_connection_loss_recovers(engine, pg_url, recovery_postgres_url,
+                                       make_service):
+    """Terminate the poller's server-side backend mid-cycle (a REAL connection
+    loss), then require bounded eventual recovery with no lost votes."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
+
+    original = svc._pg.write_math_bidtopid
+    state = {"fired": 0}
+
+    def kill_then_write(zid, data, **kwargs):
+        if state["fired"] == 0:
+            state["fired"] = 1
+            terminate_backends(recovery_postgres_url, dbname_of(pg_url))
+        return original(zid, data, **kwargs)
+
+    svc._pg.write_math_bidtopid = kill_then_write
+    svc.poll_once()
+    svc._pg.write_math_bidtopid = original
+    assert state["fired"] == 1
+
+    _publish_and_check(engine, svc, zid=1)
+
+
+def test_real_serialization_failure_recovers(engine, pg_url, make_service):
+    """A REAL 40001 serialization failure (two SERIALIZABLE transactions on the
+    same math_main row) must be a retryable blip, not lost work."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
+
+    # Publish once so a math_main row exists for two transactions to contend on.
+    svc.poll_once()
+    baseline = read_math_tables(engine, 1, MATH_ENV)
+    assert baseline["main"] is not None
+
+    original = svc._pg.write_math_main
+    seen = {"code": None, "fired": 0}
+
+    def contended_write(zid, data, **kwargs):
+        if seen["fired"] == 0:
+            seen["fired"] = 1
+            a = engine.connect().execution_options(isolation_level="SERIALIZABLE")
+            b = engine.connect().execution_options(isolation_level="SERIALIZABLE")
+            try:
+                a.begin()
+                b.begin()
+                # Both read the same row, then both write it: the second commit
+                # must abort with a real serialization failure.
+                a.execute(sa.text("SELECT caching_tick FROM math_main "
+                                  "WHERE zid=:z AND math_env=:e"),
+                          {"z": zid, "e": MATH_ENV}).all()
+                b.execute(sa.text("SELECT caching_tick FROM math_main "
+                                  "WHERE zid=:z AND math_env=:e"),
+                          {"z": zid, "e": MATH_ENV}).all()
+                a.execute(sa.text("UPDATE math_main SET modified = modified + 1 "
+                                  "WHERE zid=:z AND math_env=:e"),
+                          {"z": zid, "e": MATH_ENV})
+                a.commit()
+                try:
+                    b.execute(sa.text("UPDATE math_main SET modified = modified + 2 "
+                                      "WHERE zid=:z AND math_env=:e"),
+                              {"z": zid, "e": MATH_ENV})
+                    b.commit()
+                except sa.exc.DBAPIError as exc:
+                    seen["code"] = getattr(exc.orig, "pgcode", None)
+                    raise
+            finally:
+                a.close()
+                b.close()
+        return original(zid, data, **kwargs)
+
+    svc._pg.write_math_main = contended_write
+    # Force another cycle by committing one more vote.
+    from .conftest import commit_vote
+    events = read_vote_events(engine, 1)
+    commit_vote(engine, 1, 0, 0, 1, max(e["created"] for e in events) + 10)
+    svc._vote_wm = 0
+    svc.poll_once()
+    svc._pg.write_math_main = original
+
+    assert seen["fired"] == 1
+    assert seen["code"] == "40001", (
+        f"expected a REAL serialization failure (40001), saw pgcode {seen['code']!r}"
+    )
+    _publish_and_check(engine, svc, zid=1)
+
+
+# --------------------------------------------------------------------------- #
+# Cache / temporal invariants around a failed write
+# --------------------------------------------------------------------------- #
+def test_failed_write_leaves_prior_cached_object_unchanged(engine, pg_url,
+                                                           make_service):
+    """Write-before-cache (M2): on a failed write the in-memory cache must still
+    hold the LAST PERSISTED conversation object — never an unpersisted one."""
+    from .conftest import commit_vote
+
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0)
+    svc.poll_once()
+    cached_before = svc._convs.get(1)
+    assert cached_before is not None
+    ts_before = cached_before.last_updated
+
+    events = read_vote_events(engine, 1)
+    newer = max(e["created"] for e in events) + 1000
+    commit_vote(engine, 1, 0, 0, 1, newer)
+
+    injector = FaultInjector(name="write_math_main", mode="always")
+    undo = fail_stage(svc._pg, "write_math_main", injector)
+    svc._vote_wm = 0
+    svc.poll_once()
+    undo()
+
+    assert injector.fired >= 1
+    cached_after = svc._convs.get(1)
+    assert cached_after is cached_before, (
+        "a failed write must leave the PREVIOUS cached object in place"
+    )
+    assert cached_after.last_updated == ts_before, (
+        "no temporal advancement from a computation that never committed"
+    )
+    # And the persisted row is still the last good one.
+    main = read_math_tables(engine, 1, MATH_ENV)["main"]
+    assert main["last_vote_timestamp"] == ts_before
+
+    # Bounded eventual progress once the stage is healthy again.
+    svc._vote_wm = 0
+    svc.poll_once()
+    tables, fold = _publish_and_check(engine, svc, zid=1)
+    assert tables["main"]["last_vote_timestamp"] == newer == fold.last_vote_timestamp
+
+
+def test_tick_gap_is_allowed_but_votes_are_not_lost(engine, pg_url, make_service):
+    """A failure AFTER tick allocation burns a math_tick.  P-022: "Tick gaps may
+    occur; gaps are not lost votes." — assert the gap AND the intact input."""
+    from .conftest import commit_vote
+
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0)
+    svc.poll_once()
+    first = read_math_tables(engine, 1, MATH_ENV)["main"]["math_tick"]
+
+    injector = FaultInjector(name="write_math_main", mode="once")
+    undo = fail_stage(svc._pg, "write_math_main", injector)
+    events = read_vote_events(engine, 1)
+    newer = max(e["created"] for e in events) + 1000
+    commit_vote(engine, 1, 1, 1, -1, newer)
+    svc._vote_wm = 0
+    svc.poll_once()          # mints a tick, then fails
+    undo()
+    svc._vote_wm = 0
+    svc.poll_once()          # succeeds
+
+    tables, fold = _publish_and_check(engine, svc, zid=1)
+    assert tables["main"]["math_tick"] > first + 1, (
+        "the failed cycle should have burned a tick (a GAP), which is allowed"
+    )
+    assert tables["main"]["last_vote_timestamp"] == fold.last_vote_timestamp
+    assert fold.cells[(1, 1)] == F.ENGINE_AGREE, (
+        "the vote committed during the failing cycle must survive"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the write-stage failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    """An intentionally broken variant must FAIL, proving the R01 assertions can
+    actually see a stage failure rather than passing vacuously."""
+
+    def test_broken_variant_swallows_the_failure_and_is_caught(
+        self, engine, pg_url, make_service
+    ):
+        """The broken variant is a writer that silently SKIPS the bidtopid and
+        ptptstats writes when the main write fails — i.e. it "recovers" by
+        publishing a partial generation.  The R01 coherence assertion must go
+        red on it."""
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0)
+
+        # Publish a good generation first, then advance only math_main so the
+        # tables disagree — exactly the state a "swallow the error" writer leaves.
+        svc.poll_once()
+        with engine.begin() as conn:
+            conn.execute(
+                sa.text("UPDATE math_main SET math_tick = math_tick + 1 "
+                        "WHERE zid=:z AND math_env=:e"),
+                {"z": 1, "e": MATH_ENV},
+            )
+        problems = tables_are_coherent(read_math_tables(engine, 1, MATH_ENV))
+        assert problems, (
+            "NEGATIVE CONTROL FAILED: a mixed generation was reported coherent"
+        )
+        assert "mixed generations" in problems[0]
+
+    def test_fold_check_detects_a_lost_vote(self, engine, pg_url, make_service):
+        """Drop one vote from the fold's input and the published blob must no
+        longer match — proof the fold comparison is load-bearing."""
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV)
+        svc.poll_once()
+        data = read_math_tables(engine, 1, MATH_ENV)["main"]["data"]
+
+        events = read_vote_events(engine, 1)
+        assert F.check_published_against_fold(
+            data, F.fold_votes(events)
+        ) == []
+        mutilated = F.fold_votes([e for e in events if not (e["pid"] == 0)])
+        assert F.check_published_against_fold(data, mutilated) != [], (
+            "NEGATIVE CONTROL FAILED: the fold check accepted a stream that is "
+            "missing a whole participant"
+        )
+
+    def test_injector_that_never_fires_is_detected(self, engine, pg_url,
+                                                   make_service):
+        """A fault that never fires must not be mistaken for a passed recovery."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV)
+        injector = FaultInjector(name="never", mode="never")
+        undo = fail_stage(svc._pg, "write_math_main", injector)
+        svc.poll_once()
+        undo()
+        assert injector.calls > 0
+        assert injector.fired == 0
+        with pytest.raises(AssertionError):
+            assert injector.fired == 1, "the fault must actually have fired"

--- a/delphi/tests/poller/recovery/test_r02_newer_revote_during_retry.py
+++ b/delphi/tests/poller/recovery/test_r02_newer_revote_during_retry.py
@@ -205,7 +205,7 @@ def test_late_older_batch_does_not_regress_the_watermark(engine, pg_url,
     reason=(
         "DEFECT (latent, retained regression): merging an OLDER batch into "
         "already-newer conversation state overwrites the newer cell. "
-        "polismath/conversation/conversation.py:387 sorts by `created` WITHIN "
+        "polismath/conversation/conversation.py:396 sorts by `created` WITHIN "
         "one payload, but the merge into existing state at "
         "polismath/conversation/conversation.py:470 has NO per-cell timestamp "
         "guard, so a batch whose events are all older than the stored cell "

--- a/delphi/tests/poller/recovery/test_r02_newer_revote_during_retry.py
+++ b/delphi/tests/poller/recovery/test_r02_newer_revote_during_retry.py
@@ -1,0 +1,313 @@
+"""R02 — a newer revote arrives while the older one is being retried.
+
+P-022 §C required matrix:
+
+    Old agree fails; newer disagree is queued while worker is blocked; include
+    pass and equal-time controlled-order variants.  Exercise coalesced and
+    separately scheduled batches with real Conversation.  Final cell is the
+    authoritative winner, timestamp agrees, counters use correct event/cell
+    semantics.
+
+P-019's review flagged that the existing M2 test used a fake conversation which
+"retains per-cell timestamps that the actual merge does not
+(``conversation.py:470``)".  These tests therefore drive the REAL
+``Conversation`` against a REAL Postgres, and cover BOTH shapes:
+
+* **coalesced** — the newer revote lands in the pool queue while the worker is
+  latched inside the failing write, so the retry and the new batch merge into
+  ONE ``CoalescedBatch`` and are resolved by ``update_votes``'s created-sort;
+* **separately scheduled** — the retry batch runs alone to completion and the
+  newer revote arrives in a LATER cycle, so the winner has to survive the
+  cross-batch merge into already-newer state (``conversation.py:470``, the path
+  with no per-cell timestamp guard).
+
+The deterministic interleaving comes from a latch at the ``write_conv_updates``
+boundary, never from a sleep.
+"""
+
+import threading
+
+import pytest
+
+from .conftest import (
+    FaultInjector,
+    InjectedFault,
+    Latch,
+    commit_vote,
+    drain,
+    fail_stage,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+from polismath.poller.worker_pool import VOTES
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+RAW_AGREE = F.RAW_AGREE          # -1 in storage
+RAW_DISAGREE = F.RAW_DISAGREE    # +1 in storage
+RAW_PASS = F.RAW_PASS            # 0
+
+
+def _final_state(engine, zid=1):
+    tables = read_math_tables(engine, zid, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, zid))
+    problems = F.check_published_against_fold(tables["main"]["data"], fold)
+    assert problems == [], problems
+    return tables, fold
+
+
+@pytest.mark.parametrize(
+    "old_raw,new_raw,label",
+    [
+        (RAW_AGREE, RAW_DISAGREE, "agree-then-disagree"),
+        (RAW_DISAGREE, RAW_AGREE, "disagree-then-agree"),
+        (RAW_AGREE, RAW_PASS, "agree-then-pass"),
+        (RAW_PASS, RAW_DISAGREE, "pass-then-disagree"),
+    ],
+)
+def test_coalesced_newer_revote_wins_over_retried_older(
+    engine, pg_url, make_service, old_raw, new_raw, label
+):
+    """The newer revote is queued WHILE the worker is latched inside the failing
+    write of the older one.  Retry + new batch coalesce; the newer value must
+    win, the timestamp must be the newer one, and counters must use cell (not
+    event) semantics."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=2, worker_pool_size=1)
+    svc.poll_once()  # warm the cache with a published, good generation
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    t_old, t_new = base + 1000, base + 2000
+    commit_vote(engine, 1, 0, 0, old_raw, t_old)
+
+    at_write = Latch("write_conv_updates(old)")
+    fault = FaultInjector(name="write(old)", mode="once")
+    real_write = svc._writer.write_conv_updates
+
+    def latched_write(zid, conv):
+        if fault.should_fire():
+            at_write.block()          # hold the worker here, batch in hand
+            raise InjectedFault("old revote write failed")
+        return real_write(zid, conv)
+
+    svc._writer.write_conv_updates = latched_write
+
+    svc._vote_wm = t_old - 1
+    poller = threading.Thread(target=svc._poll_votes_once, daemon=True)
+    poller.start()
+    at_write.wait_arrival()
+
+    # Worker is frozen INSIDE the failing write. Commit + enqueue the newer
+    # revote; the pool queues it behind the in-flight cycle for this zid.
+    commit_vote(engine, 1, 0, 0, new_raw, t_new)
+    svc._pool.submit(1, VOTES, [{"zid": 1, "pid": 0, "tid": 0,
+                                 "vote": F.raw_to_engine(new_raw),
+                                 "created": t_new}])
+    at_write.let_go()
+    poller.join(timeout=30)
+    svc._writer.write_conv_updates = real_write
+    drain(svc)
+
+    # Bounded eventual progress, no new input.
+    svc._vote_wm = 0
+    svc.poll_once()
+
+    tables, fold = _final_state(engine, 1)
+    expected = F.raw_to_engine(new_raw)
+    assert fold.cells[(0, 0)] == expected, "fold disagrees with its own input"
+    assert (0, 0) not in fold.ambiguous
+    assert tables["main"]["last_vote_timestamp"] == t_new == fold.last_vote_timestamp
+
+    # Cell semantics, not event semantics: participant 0 revoted the SAME cell
+    # three times, so their count is unchanged from the seeded 4 cells.
+    counts = {int(k): int(v)
+              for k, v in tables["main"]["data"]["user-vote-counts"].items()}
+    assert counts[0] == 4, f"{label}: revotes must not inflate the cell count"
+    assert fold.event_count == 24 + 2, "both revote EVENTS are in the stream"
+
+
+def test_separately_scheduled_older_retry_then_newer_batch(engine, pg_url,
+                                                           make_service):
+    """The retry of the older vote completes in its OWN batch, and the newer
+    revote arrives in a LATER cycle merged into already-newer state — the
+    cross-batch path (``conversation.py:470``) that has no per-cell timestamp
+    guard."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=2, worker_pool_size=1)
+    svc.poll_once()
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    t_old, t_new = base + 1000, base + 2000
+
+    # Cycle 1: the older agree fails once, then its retry succeeds ALONE.
+    commit_vote(engine, 1, 0, 0, RAW_AGREE, t_old)
+    fault = FaultInjector(name="write(old)", mode="once")
+    undo = fail_stage(svc._writer, "write_conv_updates", fault)
+    svc._vote_wm = t_old - 1
+    svc.poll_once()
+    undo()
+    assert fault.fired == 1
+    assert read_math_tables(engine, 1, MATH_ENV)["main"][
+        "last_vote_timestamp"] == t_old
+
+    # Cycle 2: the newer disagree, as a separate batch.
+    commit_vote(engine, 1, 0, 0, RAW_DISAGREE, t_new)
+    svc._vote_wm = t_new - 1
+    svc.poll_once()
+
+    tables, fold = _final_state(engine, 1)
+    assert fold.cells[(0, 0)] == F.ENGINE_DISAGREE
+    assert tables["main"]["last_vote_timestamp"] == t_new
+
+
+def _apply_new_then_old(engine, svc, t_old, t_new):
+    """Apply the NEWER revote as its own batch, then replay the OLDER one as a
+    separate, later batch."""
+    svc._pool.submit(1, VOTES, [{"zid": 1, "pid": 0, "tid": 0,
+                                 "vote": F.ENGINE_DISAGREE, "created": t_new}])
+    drain(svc)
+    assert read_math_tables(engine, 1, MATH_ENV)["main"][
+        "last_vote_timestamp"] == t_new
+    svc._pool.submit(1, VOTES, [{"zid": 1, "pid": 0, "tid": 0,
+                                 "vote": F.ENGINE_AGREE, "created": t_old}])
+    drain(svc)
+
+
+def test_late_older_batch_does_not_regress_the_watermark(engine, pg_url,
+                                                         make_service):
+    """The watermark half of the new-then-old ordering: ``advance_watermark``'s
+    monotonic max means a late OLDER batch can never pull
+    ``last_vote_timestamp`` backwards.  This part holds today."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=1)
+    svc.poll_once()
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    t_old, t_new = base + 1000, base + 2000
+    commit_vote(engine, 1, 0, 0, RAW_AGREE, t_old)
+    commit_vote(engine, 1, 0, 0, RAW_DISAGREE, t_new)
+    _apply_new_then_old(engine, svc, t_old, t_new)
+
+    main = read_math_tables(engine, 1, MATH_ENV)["main"]
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert main["last_vote_timestamp"] == t_new == fold.last_vote_timestamp, (
+        "a late older batch must never regress the watermark"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (latent, retained regression): merging an OLDER batch into "
+        "already-newer conversation state overwrites the newer cell. "
+        "polismath/conversation/conversation.py:387 sorts by `created` WITHIN "
+        "one payload, but the merge into existing state at "
+        "polismath/conversation/conversation.py:470 has NO per-cell timestamp "
+        "guard, so a batch whose events are all older than the stored cell "
+        "still wins. Observed here: with the newer DISAGREE published first, a "
+        "later OLDER-AGREE batch flips tid 0 back to A=3/D=3 where the "
+        "independent fold says A=2/D=4. The published watermark is unaffected "
+        "(advance_watermark is a monotonic max), so nothing else signals the "
+        "regression. REACHABILITY: the current pool cannot produce this "
+        "ordering on its own — _requeue runs on the worker thread before it "
+        "re-checks the queue (poller/service.py:664), so a retry always "
+        "coalesces with any newer batch instead of following it. This is "
+        "therefore a hardening gap and a retained regression test, not a "
+        "presently-triggerable production bug; any future change that lets a "
+        "stale batch be scheduled separately (a second writer, a queue "
+        "reorder, a cross-process replay) turns it into one."
+    ),
+)
+def test_late_older_batch_must_not_overwrite_the_newer_cell(engine, pg_url,
+                                                            make_service):
+    """The cell-value half of the new-then-old ordering — the authoritative
+    winner must still be the newer value."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=1)
+    svc.poll_once()
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    t_old, t_new = base + 1000, base + 2000
+    commit_vote(engine, 1, 0, 0, RAW_AGREE, t_old)
+    commit_vote(engine, 1, 0, 0, RAW_DISAGREE, t_new)
+    _apply_new_then_old(engine, svc, t_old, t_new)
+
+    tables, fold = _final_state(engine, 1)
+    assert fold.cells[(0, 0)] == F.ENGINE_DISAGREE
+
+
+def test_equal_time_controlled_order_is_flagged_ambiguous(engine, pg_url,
+                                                          make_service):
+    """Equal-``created`` opposite votes on one cell: the DB's
+    ``ORDER BY zid, tid, pid, created`` does not break the tie, so no single
+    winner may be asserted.  The published value must be ONE of the two, the
+    watermark must be the shared timestamp, and the cell count must still be 1.
+
+    P-022 §A: "Ambiguous equal-time opposite votes need a separately specified
+    contract/test; do not invent historical order."
+    """
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    tie = base + 1000
+    commit_vote(engine, 1, 0, 0, RAW_AGREE, tie)
+    commit_vote(engine, 1, 0, 0, RAW_DISAGREE, tie)
+
+    svc._vote_wm = tie - 1
+    svc.poll_once()
+
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert (0, 0) in fold.ambiguous, (
+        "the fold must REFUSE to pick a winner for an equal-time opposite pair"
+    )
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    data = tables["main"]["data"]
+    assert data["lastVoteTimestamp"] == tie == fold.last_vote_timestamp
+    counts = {int(k): int(v) for k, v in data["user-vote-counts"].items()}
+    assert counts[0] == 4, "an ambiguous tie is still ONE cell"
+    totals = F.votes_base_totals(data)
+    assert totals[0]["S"] == 6, "six participants have an observed cell on tid 0"
+    assert totals[0]["A"] + totals[0]["D"] == 6
+    # Exactly one of the two possible resolutions, and nothing else.
+    assert (totals[0]["A"], totals[0]["D"]) in {(3, 3), (4, 2), (2, 4)}
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the retry-ordering failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_stale_older_value_would_be_caught(self, engine, pg_url,
+                                               make_service):
+        """Intentionally broken variant: publish the state produced by applying
+        ONLY the older vote, and check that the R02 assertions go red.  This
+        proves the suite would notice a retry that overwrote a newer revote."""
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        svc.poll_once()
+
+        base = max(e["created"] for e in read_vote_events(engine, 1))
+        t_old, t_new = base + 1000, base + 2000
+        commit_vote(engine, 1, 0, 0, RAW_AGREE, t_old)
+        commit_vote(engine, 1, 0, 0, RAW_DISAGREE, t_new)
+
+        # The BROKEN behaviour: only the older batch is ever applied.
+        svc._pool.submit(1, VOTES, [{"zid": 1, "pid": 0, "tid": 0,
+                                     "vote": F.ENGINE_AGREE, "created": t_old}])
+        drain(svc)
+
+        tables = read_math_tables(engine, 1, MATH_ENV)
+        fold = F.fold_votes(read_vote_events(engine, 1))
+        problems = F.check_published_against_fold(tables["main"]["data"], fold)
+        assert problems, (
+            "NEGATIVE CONTROL FAILED: publishing only the OLDER revote was "
+            "accepted as matching the input fold"
+        )
+        assert tables["main"]["last_vote_timestamp"] != fold.last_vote_timestamp

--- a/delphi/tests/poller/recovery/test_r03_park_then_silence.py
+++ b/delphi/tests/poller/recovery/test_r03_park_then_silence.py
@@ -1,0 +1,205 @@
+"""R03 — park, then silence (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Exhaust retries, no new traffic, reconcile, and fail the first rebuild once.
+    Require eventual successful publication and all park/retry markers cleared.
+    Repeat with persistent failure: visible unhealthy/parked state and bounded
+    retries, not silent loss or a hot loop.
+
+``tests/poller/test_park_rebuild_recovery.py`` already covers this control flow
+with an in-process pool and a fake loader (the R03/R04 fix's regression suite).
+This module re-runs the same scenarios end-to-end against a real migrated
+Postgres with the real ``Conversation``, real ``MathWriter`` and real rows, so
+the recovery is proved to actually re-derive and re-publish authoritative state
+rather than merely to call the right methods.
+"""
+
+import pytest
+
+from .conftest import (
+    FaultInjector,
+    commit_vote,
+    drain,
+    fail_stage,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+def test_transient_rebuild_failure_eventually_publishes(engine, pg_url,
+                                                        make_service):
+    """Retries exhausted -> parked; NO new traffic; the reconciler's first
+    rebuild fails once and its retry succeeds.  Require eventual publication
+    matching the fold and all park/retry markers cleared."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1, worker_pool_size=1)
+
+    # 2 failures park the zid (attempt + 1 retry); the 3rd is the reconciler's
+    # first rebuild, which also fails; the 4th (its retry) wins.
+    injector = FaultInjector(name="write_conv_updates", mode="nth", nth=1)
+    injector.mode = "always"
+
+    undo = fail_stage(svc._writer, "write_conv_updates", injector)
+    svc.poll_once()
+    assert 1 in svc._parked, "exhausting retries must park the zid"
+    assert injector.calls == 2, f"bounded retries, saw {injector.calls} attempts"
+    assert read_math_tables(engine, 1, MATH_ENV)["main"] is None
+
+    # One more transient failure on the reconciler's rebuild, then health.
+    undo()
+    once = FaultInjector(name="write_conv_updates", mode="once")
+    undo2 = fail_stage(svc._writer, "write_conv_updates", once)
+    svc._reconcile_once()
+    drain(svc)
+    undo2()
+    assert once.fired == 1, "the reconciler's first rebuild must have failed once"
+
+    # The retry of a REBUILD must preserve the rebuild kind (service.py:672),
+    # so this already published without any further reconcile pass.
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    assert 1 not in svc._parked
+    assert svc._retry_counts.get(1) is None, "retry markers must be cleared"
+
+
+def test_parked_zid_recovers_the_interval_the_watermark_skipped(engine, pg_url,
+                                                                make_service):
+    """The point of the reconciler: the global watermark advanced PAST the votes
+    that failed, so only a full-history rebuild can recover them.  Assert the
+    published state contains the skipped interval, with no new votes at all."""
+    seeded = seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=1)
+
+    injector = FaultInjector(name="write_conv_updates", mode="always")
+    undo = fail_stage(svc._writer, "write_conv_updates", injector)
+    svc.poll_once()
+    undo()
+    assert 1 in svc._parked
+    # The watermark has moved past every seeded vote even though none published.
+    assert svc._vote_wm >= max(e["created"] for e in seeded.vote_events)
+
+    svc._reconcile_once()
+    drain(svc)
+
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == [], (
+        "the reconciler must recover the interval the watermark skipped"
+    )
+    assert fold.event_count == len(seeded.vote_events)
+
+
+def test_persistent_failure_stays_parked_with_bounded_retries(engine, pg_url,
+                                                              make_service):
+    """A persistent failure must leave a VISIBLE parked state, retry a bounded
+    number of times per cycle (no hot loop), and never publish."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1, worker_pool_size=1)
+
+    injector = FaultInjector(name="write_conv_updates", mode="always")
+    undo = fail_stage(svc._writer, "write_conv_updates", injector)
+    svc.poll_once()
+    assert 1 in svc._parked
+    assert injector.calls == 2
+
+    for cycle in range(3):
+        svc._reconcile_once()
+        drain(svc)
+        assert 1 in svc._parked, f"still visibly parked after cycle {cycle}"
+    assert injector.calls == 2 + 3 * 2, (
+        f"each reconcile must retry a BOUNDED 2 times, saw {injector.calls} total"
+    )
+    assert read_math_tables(engine, 1, MATH_ENV)["main"] is None, (
+        "a persistently failing rebuild must never publish"
+    )
+
+    # And once the fault clears, the very next reconcile recovers it.
+    undo()
+    svc._reconcile_once()
+    drain(svc)
+    assert 1 not in svc._parked
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+
+
+def test_a_healthy_conversation_is_never_parked_by_a_neighbours_failure(
+    engine, pg_url, make_service
+):
+    """Parking is per-zid: a persistently failing zid must not park a healthy
+    one that shares the pool."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    seed_conversation(engine, zid=2, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=2)
+
+    real_write = svc._writer.write_conv_updates
+
+    def poison_zid_1(zid, conv):
+        if zid == 1:
+            raise RuntimeError("poison zid")
+        return real_write(zid, conv)
+
+    svc._writer.write_conv_updates = poison_zid_1
+    svc.poll_once()
+    svc._writer.write_conv_updates = real_write
+
+    assert svc._parked == {1}
+    healthy = read_math_tables(engine, 2, MATH_ENV)
+    assert tables_are_coherent(healthy) == []
+    fold2 = F.fold_votes(read_vote_events(engine, 2))
+    assert F.check_published_against_fold(healthy["main"]["data"], fold2) == []
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the park/rebuild failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_dropping_the_rebuild_on_retry_loses_the_zid(self, engine, pg_url,
+                                                         make_service):
+        """Intentionally broken variant: restore the pre-fix ``_requeue`` that
+        drops the REBUILD kind.  The reconciler has ALREADY cleared the parked
+        marker, so a single transient rebuild failure leaves the zid neither
+        parked nor queued — silently lost.  This is the R03 defect, and it must
+        reproduce on the broken variant."""
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1,
+                           worker_pool_size=1)
+
+        always = FaultInjector(name="write_conv_updates", mode="always")
+        undo = fail_stage(svc._writer, "write_conv_updates", always)
+        svc.poll_once()
+        undo()
+        assert 1 in svc._parked
+
+        # The PRE-FIX _requeue: votes/moderation only, rebuild dropped.
+        from polismath.poller.worker_pool import VOTES, MODERATION
+
+        def broken_requeue(zid, coalesced):
+            if coalesced.votes:
+                svc._pool.submit(zid, VOTES, list(coalesced.votes))
+            if coalesced.moderation:
+                svc._pool.submit(zid, MODERATION, list(coalesced.moderation))
+
+        svc._requeue = broken_requeue
+        once = FaultInjector(name="write_conv_updates", mode="once")
+        undo2 = fail_stage(svc._writer, "write_conv_updates", once)
+        svc._reconcile_once()
+        drain(svc)
+        undo2()
+
+        assert once.fired == 1
+        assert 1 not in svc._parked, "the reconciler already cleared the marker"
+        assert read_math_tables(engine, 1, MATH_ENV)["main"] is None, (
+            "NEGATIVE CONTROL FAILED: the broken _requeue still published, so "
+            "the R03 test would pass even with the defect present"
+        )

--- a/delphi/tests/poller/recovery/test_r04_park_unpark_races.py
+++ b/delphi/tests/poller/recovery/test_r04_park_unpark_races.py
@@ -28,6 +28,7 @@ from .conftest import (
     commit_vote,
     drain,
     fail_stage,
+    pool_pending as _pool_pending,
     read_math_tables,
     read_vote_events,
     seed_conversation,
@@ -136,22 +137,52 @@ def test_overlapping_reconciliation_triggers_run_one_handler_per_zid(
                 conc["cur"] -= 1
 
     svc._load_or_init = latched_load
+    writes = []
+    real_write = svc._writer.write_conv_updates
+
+    def counting_write(zid, conv):
+        writes.append(zid)
+        return real_write(zid, conv)
+
+    svc._writer.write_conv_updates = counting_write
 
     svc._pool.park(1)
     svc._reconcile_once()                    # trigger 1: unpark + REBUILD
-    assert entered.wait(timeout=30)
-    svc._pool.park(1)                        # re-park under the in-flight handler
-    svc._reconcile_once()                    # trigger 2, overlapping
-    svc._reconcile_once()                    # trigger 3, overlapping
+    assert entered.wait(timeout=30), "the first rebuild never started"
+
+    # Two more triggers arrive while the first handler is PROVABLY in flight.
+    # Neither may run now (per-zid serialization) and neither may be dropped:
+    # the pool must coalesce them into exactly one further cycle.
+    svc._pool.submit(1, REBUILD, [])
+    svc._pool.submit(1, REBUILD, [])
     proceed.set()
     drain(svc)
     svc._load_or_init = real_load
+    svc._writer.write_conv_updates = real_write
 
+    # --- handler accounting (exact, not ">= 1") ---------------------------- #
     assert conc["max"] == 1, (
         f"at most one active handler per zid, saw {conc['max']} concurrent"
     )
-    assert conc["n"] >= 1, "the rebuild ran; nothing silently dropped"
-    assert 1 not in svc._parked
+    assert conc["n"] == 2, (
+        "expected EXACTLY two rebuild executions — the in-flight one plus one "
+        f"coalesced cycle for the two overlapping triggers — but saw {conc['n']}. "
+        "A count of 1 means the queued rebuilds were DROPPED; more than 2 means "
+        "per-zid serialization or coalescing broke."
+    )
+    assert conc["cur"] == 0, "no handler left in flight"
+
+    # --- final state ------------------------------------------------------- #
+    assert writes == [1, 1], (
+        f"each executed rebuild must publish exactly once, saw {writes!r}"
+    )
+    assert not _pool_pending(svc._pool, 1), (
+        "the pool must have no queued or active work left for the zid"
+    )
+    assert 1 not in svc._parked and not svc._pool.is_parked(1), (
+        "a successful rebuild must leave the zid quiet and unparked"
+    )
+    assert svc._retry_counts.get(1) is None, "retry markers must be cleared"
     _assert_published(engine, 1)
 
 

--- a/delphi/tests/poller/recovery/test_r04_park_unpark_races.py
+++ b/delphi/tests/poller/recovery/test_r04_park_unpark_races.py
@@ -1,0 +1,256 @@
+"""R04 — park/unpark races (REAL Postgres, real pool threads).
+
+P-022 §C required matrix:
+
+    Barrier between service marker and pool park; trigger both reconciler and
+    new-vote unpark while worker is in flight.  Also overlap two reconciliation
+    triggers.  Require one active handler per zid, no dropped rebuild, and
+    eventual quiet recovery.
+
+The park/rebuild-ownership fix made the worker pool the SINGLE owner of parked
+truth (``worker_pool.py:114`` ``parked_zids()``; ``service.py`` ``_parked`` is a
+read-only property over it), so the "service marker then pool park" gap the
+P-022 probe exploited is no longer expressible.  These tests pin the
+interleaving with latches at the ``pool.park`` and ``_load_or_init`` boundaries
+and assert the invariant directly — the two views must agree at EVERY observed
+instant — then require a real published generation at the end.
+
+Deterministic schedules; run repeatedly (>=20x) by
+``make test-recovery-races``.
+"""
+
+import threading
+
+import pytest
+
+from .conftest import (
+    FaultInjector,
+    commit_vote,
+    drain,
+    fail_stage,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+from polismath.poller.worker_pool import REBUILD, VOTES
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+def _assert_published(engine, zid=1):
+    tables = read_math_tables(engine, zid, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, zid))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    return tables
+
+
+def test_reconcile_and_new_vote_while_worker_parks_never_diverges(
+    engine, pg_url, make_service
+):
+    """Freeze the worker exactly AT the ``pool.park`` boundary, then fire BOTH a
+    reconciliation and a new-vote unpark.  Service and pool views must agree at
+    every instant, no rebuild may be dropped, and recovery must complete."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=2)
+
+    fail_once = FaultInjector(name="write_conv_updates", mode="once")
+    undo = fail_stage(svc._writer, "write_conv_updates", fail_once)
+
+    at_park = threading.Event()
+    release = threading.Event()
+    real_park = svc._pool.park
+
+    def hooked_park(zid):
+        at_park.set()
+        assert release.wait(timeout=30)
+        real_park(zid)
+
+    svc._pool.park = hooked_park
+
+    svc._pool.submit(1, VOTES, [])   # empty batch: has_work() is False
+    svc._pool.submit(1, REBUILD, [])
+    assert at_park.wait(timeout=30), "the worker never reached the park boundary"
+
+    # Worker frozen mid-park. Fire a reconcile AND a new-vote poll.
+    observations = []
+    svc._reconcile_once()
+    observations.append((set(svc._parked), svc._pool.parked_zids()))
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
+    svc._vote_wm = base
+    svc._poll_votes_once()
+    observations.append((set(svc._parked), svc._pool.parked_zids()))
+
+    release.set()
+    drain(svc)
+    svc._pool.park = real_park
+    undo()
+    observations.append((set(svc._parked), svc._pool.parked_zids()))
+
+    for i, (service_view, pool_view) in enumerate(observations):
+        assert service_view == pool_view, (
+            f"observation {i}: service view {service_view} != pool view "
+            f"{pool_view} — parked truth has diverged"
+        )
+
+    # Bounded eventual quiet recovery: reconcile until it publishes.
+    for _ in range(3):
+        svc._reconcile_once()
+        drain(svc)
+        if read_math_tables(engine, 1, MATH_ENV)["main"] is not None:
+            break
+    assert 1 not in svc._parked
+    _assert_published(engine, 1)
+
+
+def test_overlapping_reconciliation_triggers_run_one_handler_per_zid(
+    engine, pg_url, make_service
+):
+    """Two reconciliation triggers overlap while a rebuild is in flight.  At
+    most ONE handler may be active for the zid, and no rebuild may be lost."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1, worker_pool_size=4)
+
+    entered = threading.Event()
+    proceed = threading.Event()
+    lock = threading.Lock()
+    conc = {"cur": 0, "max": 0, "n": 0}
+    real_load = svc._load_or_init
+
+    def latched_load(zid):
+        with lock:
+            conc["n"] += 1
+            conc["cur"] += 1
+            conc["max"] = max(conc["max"], conc["cur"])
+        entered.set()
+        assert proceed.wait(timeout=30)
+        try:
+            return real_load(zid)
+        finally:
+            with lock:
+                conc["cur"] -= 1
+
+    svc._load_or_init = latched_load
+
+    svc._pool.park(1)
+    svc._reconcile_once()                    # trigger 1: unpark + REBUILD
+    assert entered.wait(timeout=30)
+    svc._pool.park(1)                        # re-park under the in-flight handler
+    svc._reconcile_once()                    # trigger 2, overlapping
+    svc._reconcile_once()                    # trigger 3, overlapping
+    proceed.set()
+    drain(svc)
+    svc._load_or_init = real_load
+
+    assert conc["max"] == 1, (
+        f"at most one active handler per zid, saw {conc['max']} concurrent"
+    )
+    assert conc["n"] >= 1, "the rebuild ran; nothing silently dropped"
+    assert 1 not in svc._parked
+    _assert_published(engine, 1)
+
+
+def test_reconcile_racing_a_new_vote_converges_once(engine, pg_url,
+                                                    make_service):
+    """The reconciler and a new-vote unpark fire simultaneously on a parked zid
+    (a two-thread barrier).  Both funnel through the pool-owned parked state, so
+    the outcome is a single quiet recovery with the views in agreement."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=2)
+
+    svc._pool.park(1)
+    assert 1 in svc._parked
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
+    svc._vote_wm = base
+
+    barrier = threading.Barrier(2)
+    errors = []
+
+    def reconcile():
+        try:
+            barrier.wait(timeout=30)
+            svc._reconcile_once()
+        except Exception as exc:  # pragma: no cover - surfaced by the assert
+            errors.append(exc)
+
+    def poll():
+        try:
+            barrier.wait(timeout=30)
+            svc._poll_votes_once()
+        except Exception as exc:  # pragma: no cover
+            errors.append(exc)
+
+    threads = [threading.Thread(target=reconcile), threading.Thread(target=poll)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    drain(svc)
+
+    assert errors == []
+    assert 1 not in svc._parked
+    assert set(svc._parked) == svc._pool.parked_zids()
+    _assert_published(engine, 1)
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the park/unpark race failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_second_parked_set_diverges_from_the_pool(self, engine, pg_url,
+                                                        make_service):
+        """Intentionally broken variant: reinstate the pre-fix two-step park
+        (service-side marker first, ``pool.park`` second) and let a
+        reconciliation land in the gap.  The two views MUST diverge — proof the
+        divergence assertion above is load-bearing rather than trivially true.
+        """
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0,
+                           worker_pool_size=2)
+
+        # The pre-fix design: a SECOND parked set the service keeps itself.
+        service_parked = set()
+        at_gap = threading.Event()
+        release = threading.Event()
+        real_park = svc._pool.park
+
+        def two_step_park(zid):
+            service_parked.add(zid)      # step 1: the service's own marker
+            at_gap.set()
+            assert release.wait(timeout=30)
+            real_park(zid)               # step 2: the pool, much later
+
+        def broken_on_error(zid, coalesced, error):
+            two_step_park(zid)
+
+        svc._on_engine_error = broken_on_error
+
+        fail_once = FaultInjector(name="write_conv_updates", mode="once")
+        undo = fail_stage(svc._writer, "write_conv_updates", fail_once)
+        svc._pool.submit(1, REBUILD, [])
+        assert at_gap.wait(timeout=30)
+
+        # A reconciliation lands in the gap: it clears the SERVICE marker (the
+        # pre-fix _unpark) while the pool has not parked yet.
+        service_parked.discard(1)
+        divergent = (set(service_parked), svc._pool.parked_zids())
+        release.set()
+        drain(svc)
+        undo()
+        after = (set(service_parked), svc._pool.parked_zids())
+
+        assert divergent[0] != divergent[1] or after[0] != after[1], (
+            "NEGATIVE CONTROL FAILED: the two-set design did not diverge, so "
+            "the R04 agreement assertion proves nothing"
+        )
+        assert after == (set(), {1}), (
+            f"expected the classic divergence (service unparked, pool parked), "
+            f"saw {after}"
+        )

--- a/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
+++ b/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
@@ -60,27 +60,40 @@ STAGES = [
 
 
 class Child:
-    """A real poller subprocess whose stdout stage markers the test can await."""
+    """A real poller subprocess whose stdout markers the test can await.
 
-    def __init__(self, pg_url, stage, days=1.0, tmp_path=None):
+    ``stages`` holds the ``STAGE <name>`` markers; ``lines`` holds EVERY stdout
+    line in order, so a test can assert the ORDER of the child's own
+    acknowledgements (``GATE run_engine`` before ``WM_ACK``, and so on).
+    """
+
+    def __init__(self, pg_url, stage, days=1.0, tmp_path=None,
+                 ownership_latch_dir=None, math_env=MATH_ENV):
         env = dict(os.environ)
         env["PYTHONPATH"] = _DELPHI_ROOT + os.pathsep + env.get("PYTHONPATH", "")
         if tmp_path is not None:
             env["POLIS_RECOVERY_DUMP_DIR"] = str(tmp_path / "errorconv")
+        argv = [sys.executable, _CHILD, "--pg-url", pg_url,
+                "--math-env", math_env, "--kill-stage", stage,
+                "--poll-from-days-ago", str(days)]
+        if ownership_latch_dir is not None:
+            argv += ["--ownership-latch-dir", str(ownership_latch_dir)]
         self.proc = subprocess.Popen(
-            [sys.executable, _CHILD, "--pg-url", pg_url,
-             "--math-env", MATH_ENV, "--kill-stage", stage,
-             "--poll-from-days-ago", str(days)],
+            argv,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
             bufsize=1, env=env, cwd=_DELPHI_ROOT,
         )
         self.stages = []
+        self.lines = []
         self._reader = threading.Thread(target=self._read, daemon=True)
         self._reader.start()
 
     def _read(self):
         for line in self.proc.stdout:
             line = line.strip()
+            if not line:
+                continue
+            self.lines.append(line)
             if line.startswith("STAGE "):
                 self.stages.append(line.split(" ", 1)[1])
 
@@ -91,6 +104,22 @@ class Child:
             message=(f"child never reported stage {stage!r} "
                      f"(saw {self.stages}); stderr:\n{self._peek_stderr()}"),
         )
+
+    def await_line(self, prefix, timeout=90.0):
+        """Wait for a non-STAGE acknowledgement line and return it."""
+        eventually(
+            lambda: any(l.startswith(prefix) for l in self.lines),
+            timeout=timeout,
+            message=(f"child never printed a line starting {prefix!r} "
+                     f"(saw {self.lines})"),
+        )
+        return next(l for l in self.lines if l.startswith(prefix))
+
+    def line_index(self, prefix):
+        for i, line in enumerate(self.lines):
+            if line.startswith(prefix):
+                return i
+        raise AssertionError(f"no line starting {prefix!r} in {self.lines}")
 
     def _peek_stderr(self):
         try:
@@ -128,8 +157,8 @@ def children():
         c.cleanup()
 
 
-def _spawn(children, pg_url, stage, days=1.0, tmp_path=None):
-    c = Child(pg_url, stage, days=days, tmp_path=tmp_path)
+def _spawn(children, pg_url, stage, days=1.0, tmp_path=None, **kwargs):
+    c = Child(pg_url, stage, days=days, tmp_path=tmp_path, **kwargs)
     children.append(c)
     return c
 
@@ -147,6 +176,14 @@ def test_kill_at_stage_then_restart_recovers(engine, pg_url, children,
 
     victim = _spawn(children, pg_url, stage, tmp_path=tmp_path)
     victim.await_stage(stage)
+    if stage == "after_poll":
+        # The stage name claims the watermark ALREADY advanced.  The child
+        # proves it (restart_child._install_after_poll_latch) and this is the
+        # control that fails loudly if that acknowledgement was skipped.
+        assert any(l.startswith("WM_ACK ") for l in victim.lines), (
+            "after_poll must not be claimed without the watermark "
+            f"acknowledgement: {victim.lines}"
+        )
     victim.kill()
 
     # Restart. No new votes are committed between the kill and the restart.
@@ -162,6 +199,57 @@ def test_kill_at_stage_then_restart_recovers(engine, pg_url, children,
     fold = F.fold_votes(read_vote_events(engine, 1))
     assert F.check_published_against_fold(tables["main"]["data"], fold) == []
     assert fold.event_count == len(seeded.vote_events)
+
+
+def test_after_poll_kill_point_is_latched_after_the_watermark_advance(
+    engine, pg_url, children, tmp_path
+):
+    """The R05 "after poll/watermark advance, before any compute" kill point is
+    ORDERED, not hoped for (astra review finding 4).
+
+    ``_poll_votes_once`` submits to the pool BEFORE assigning ``_vote_wm``
+    (``polismath/poller/service.py:437-448``) and ``_run_engine`` runs on a pool
+    thread, so a hook on ``_run_engine`` alone can fire before the assignment.
+    The child now gates ``_run_engine``, lets ``_poll_votes_once`` return,
+    acknowledges the watermark it actually assigned, and only then names the
+    stage.  Assert that whole sequence, including the exact watermark value."""
+    seeded = seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    expected_wm = max(e["created"] for e in seeded.vote_events)
+
+    victim = _spawn(children, pg_url, "after_poll", tmp_path=tmp_path)
+    victim.await_stage("after_poll")
+
+    # 1. work was really dispatched (so "before any compute" is not vacuous),
+    # 2. the watermark was assigned and acknowledged AFTER that,
+    # 3. only then was the stage named.
+    gate = victim.line_index("GATE run_engine")
+    ack = victim.line_index("WM_ACK ")
+    marker = victim.line_index("STAGE after_poll")
+    assert gate < ack < marker, (
+        f"expected dispatch -> watermark ack -> stage marker, saw "
+        f"{victim.lines}"
+    )
+    acked = int(victim.await_line("WM_ACK ").split(" ", 1)[1])
+    assert acked == expected_wm, (
+        f"the child acknowledged watermark {acked}, but the newest seeded vote "
+        f"is {expected_wm}: the poll cycle did not advance the watermark over "
+        "the whole batch before the kill point"
+    )
+
+    victim.kill()
+
+    # "before any compute": nothing was published at all.
+    assert read_math_tables(engine, 1, MATH_ENV)["main"] is None, (
+        "the kill point is before compute, so no generation may exist"
+    )
+    assert "DONE" not in victim.stages
+
+    survivor = _spawn(children, pg_url, "none", tmp_path=tmp_path)
+    survivor.wait_done()
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
 
 
 def test_kill_after_main_commit_leaves_a_mixed_generation_before_restart(
@@ -290,6 +378,30 @@ class TestNegativeControl:
         child = _spawn(children, pg_url, "none", tmp_path=tmp_path)
         with pytest.raises(AssertionError):
             child.await_stage("after_main_commit", timeout=5.0)
+
+    def test_the_after_poll_latch_refuses_to_claim_an_unadvanced_watermark(
+        self, engine, pg_url, children, tmp_path
+    ):
+        """The after_poll latch's own control: point it at a database whose
+        only conversation is OUTSIDE the lookback, so the poll returns no rows
+        and the watermark cannot advance.  The child must exit with the
+        watermark code and must NOT name the stage — otherwise the stage name
+        would mean nothing."""
+        _seed_dormant(engine, zid=2)
+        child = _spawn(children, pg_url, "after_poll", days=1.0,
+                       tmp_path=tmp_path)
+        rc = child.proc.wait(timeout=90)
+        assert rc == 5, (
+            f"expected EXIT_WATERMARK_NOT_ADVANCED (5), got {rc}; "
+            f"stdout: {child.lines}"
+        )
+        assert "after_poll" not in child.stages, (
+            "NEGATIVE CONTROL FAILED: the child named the after_poll stage "
+            "even though the watermark never advanced"
+        )
+        assert any(l.startswith("WM_NOT_ADVANCED") for l in child.lines), (
+            child.lines
+        )
 
     def test_the_kill_is_real(self, engine, pg_url, children, tmp_path):
         """The victim must die by signal, not exit cleanly — otherwise the

--- a/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
+++ b/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
@@ -1,0 +1,305 @@
+"""R05 — mid-batch restart of the ACTUAL Python process (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Kill the actual Python process after poll/watermark advance, during compute,
+    after main commit, before final table commit and after all writes before
+    cache publication.  Restart with no new vote; recover from DB, complete the
+    missing work and serve coherent state.  Include a dormant zid older than
+    lookback.
+
+The subject is ``restart_child.py``: a real ``MathPollerService`` in a real
+subprocess, which announces the named stage on stdout and then blocks so the
+TEST delivers ``SIGKILL``.  Nothing is simulated in-process.
+
+Two of these scenarios expose the seam P-022 predicted
+(``math_writer.py:238`` issues three separate calls, each committing on its own
+``engine.begin()`` — ``database/postgres.py:413``, ``:432``): a process killed
+between them leaves math_main published at a generation the other two tables
+never reach, and there is no parked marker to reconcile because the marker only
+ever lived in the dead process's memory.  With a recent conversation the next
+poll happens to repair it; with a DORMANT one (older than the boot lookback) it
+never does.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    dbname_of,
+    eventually,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+_CHILD = os.path.join(os.path.dirname(__file__), "restart_child.py")
+_DELPHI_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                            "..", "..", ".."))
+_MS_PER_DAY = 24 * 60 * 60 * 1000
+
+STAGES = [
+    "after_poll",
+    "during_compute",
+    "after_main_commit",
+    "before_final_table_commit",
+    "after_all_writes_before_cache",
+]
+
+
+class Child:
+    """A real poller subprocess whose stdout stage markers the test can await."""
+
+    def __init__(self, pg_url, stage, days=1.0, tmp_path=None):
+        env = dict(os.environ)
+        env["PYTHONPATH"] = _DELPHI_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+        if tmp_path is not None:
+            env["POLIS_RECOVERY_DUMP_DIR"] = str(tmp_path / "errorconv")
+        self.proc = subprocess.Popen(
+            [sys.executable, _CHILD, "--pg-url", pg_url,
+             "--math-env", MATH_ENV, "--kill-stage", stage,
+             "--poll-from-days-ago", str(days)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            bufsize=1, env=env, cwd=_DELPHI_ROOT,
+        )
+        self.stages = []
+        self._reader = threading.Thread(target=self._read, daemon=True)
+        self._reader.start()
+
+    def _read(self):
+        for line in self.proc.stdout:
+            line = line.strip()
+            if line.startswith("STAGE "):
+                self.stages.append(line.split(" ", 1)[1])
+
+    def await_stage(self, stage, timeout=90.0):
+        eventually(
+            lambda: stage in self.stages,
+            timeout=timeout,
+            message=(f"child never reported stage {stage!r} "
+                     f"(saw {self.stages}); stderr:\n{self._peek_stderr()}"),
+        )
+
+    def _peek_stderr(self):
+        try:
+            self.proc.stderr.flush()
+        except Exception:  # pragma: no cover
+            pass
+        return "(see child stderr on failure)"
+
+    def kill(self):
+        """A genuinely EXTERNAL, uncatchable kill."""
+        self.proc.send_signal(signal.SIGKILL)
+        self.proc.wait(timeout=30)
+        assert self.proc.returncode in (-signal.SIGKILL, 137), (
+            f"child exited {self.proc.returncode}, expected a SIGKILL"
+        )
+
+    def wait_done(self, timeout=180.0):
+        rc = self.proc.wait(timeout=timeout)
+        assert rc == 0, (
+            f"restart child exited {rc}; stderr:\n{self.proc.stderr.read()}"
+        )
+        assert "DONE" in self.stages
+
+    def cleanup(self):
+        if self.proc.poll() is None:  # pragma: no cover - safety net
+            self.proc.kill()
+            self.proc.wait(timeout=10)
+
+
+@pytest.fixture
+def children():
+    made = []
+    yield made
+    for c in made:
+        c.cleanup()
+
+
+def _spawn(children, pg_url, stage, days=1.0, tmp_path=None):
+    c = Child(pg_url, stage, days=days, tmp_path=tmp_path)
+    children.append(c)
+    return c
+
+
+# --------------------------------------------------------------------------- #
+# Recent conversation: a restart within the lookback recovers
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("stage", STAGES)
+def test_kill_at_stage_then_restart_recovers(engine, pg_url, children,
+                                             tmp_path, stage):
+    """Kill the real process at each named stage, then restart it with NO new
+    vote.  The restarted process must recover from the DB and serve a coherent
+    generation that matches the independent fold."""
+    seeded = seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+
+    victim = _spawn(children, pg_url, stage, tmp_path=tmp_path)
+    victim.await_stage(stage)
+    victim.kill()
+
+    # Restart. No new votes are committed between the kill and the restart.
+    survivor = _spawn(children, pg_url, "none", tmp_path=tmp_path)
+    survivor.wait_done()
+
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    problems = tables_are_coherent(tables)
+    assert problems == [], (
+        f"after a kill at {stage!r} and a restart, the published generation is "
+        f"still incoherent: {problems}"
+    )
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    assert fold.event_count == len(seeded.vote_events)
+
+
+def test_kill_after_main_commit_leaves_a_mixed_generation_before_restart(
+    engine, pg_url, children, tmp_path
+):
+    """The seam itself, asserted directly: a kill between the three writes DOES
+    leave math_main ahead of the other two tables.  (Recovery is the test
+    above; this one pins the intermediate state so the defect is documented
+    rather than inferred.)"""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+
+    victim = _spawn(children, pg_url, "after_main_commit", tmp_path=tmp_path)
+    victim.await_stage("after_main_commit")
+    victim.kill()
+
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables["main"] is not None, "math_main committed on its own"
+    assert tables["bidtopid"] is None and tables["ptptstats"] is None, (
+        "the other two tables must not exist yet — that is the non-atomic "
+        "three-table write (math_writer.py:238)"
+    )
+    assert tables_are_coherent(tables) != []
+
+
+# --------------------------------------------------------------------------- #
+# Dormant zid older than the lookback — the predicted defect
+# --------------------------------------------------------------------------- #
+def _seed_dormant(engine, zid=2):
+    """A conversation whose newest vote is 10 days old: outside a 1-day boot
+    lookback, so a restarted poller never polls it."""
+    now = int(time.time() * 1000)
+    return seed_conversation(
+        engine, zid=zid, n_ptpts=6, n_cmts=4,
+        base_created=now - 10 * _MS_PER_DAY,
+    )
+
+
+def test_dormant_zid_is_outside_the_lookback(engine, pg_url, children,
+                                             tmp_path):
+    """Control: with a 1-day lookback a dormant conversation is genuinely never
+    polled, so the xfail below is about repair and not about a mis-seeded
+    fixture."""
+    _seed_dormant(engine, zid=2)
+    child = _spawn(children, pg_url, "none", days=1.0, tmp_path=tmp_path)
+    child.wait_done()
+    assert read_math_tables(engine, 2, MATH_ENV)["main"] is None, (
+        "a dormant zid must not be polled with a 1-day lookback"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (predicted by P-022 §C): a process killed between the three "
+        "non-atomic table writes leaves a permanently mixed generation for a "
+        "DORMANT conversation. polismath/poller/math_writer.py:238 issues "
+        "write_math_main / write_math_bidtopid / write_participant_stats as "
+        "three separate calls, each committing on its own engine.begin() "
+        "(polismath/database/postgres.py:413, :432), so a main-row watermark "
+        "is not proof of all-table completion. The only repair path is the "
+        "parked-zid reconciler (polismath/poller/service.py:393), which "
+        "iterates the pool's in-memory parked set — that set died with the "
+        "process, and the conversation's newest vote is older than the boot "
+        "lookback (service.py:55 initial_watermark), so nothing ever revisits "
+        "it. math_main stays published at math_tick N while math_bidtopid and "
+        "math_ptptstats are absent, indefinitely. Fixing this needs either a "
+        "transaction spanning all three writes or a durable "
+        "table-generation-completeness scan; both are a separate decision."
+    ),
+)
+def test_dormant_zid_partial_write_is_repaired_after_restart(
+    engine, pg_url, children, tmp_path
+):
+    """Kill the process after the main commit for a DORMANT conversation, then
+    restart with the production-like lookback and no new votes.  A correct
+    system repairs the mixed generation; this one cannot."""
+    _seed_dormant(engine, zid=2)
+
+    # The conversation was active when the poller last ran (wide lookback).
+    victim = _spawn(children, pg_url, "after_main_commit", days=30.0,
+                    tmp_path=tmp_path)
+    victim.await_stage("after_main_commit")
+    victim.kill()
+    assert read_math_tables(engine, 2, MATH_ENV)["main"] is not None
+
+    # It has since gone quiet for longer than the boot lookback.
+    survivor = _spawn(children, pg_url, "none", days=1.0, tmp_path=tmp_path)
+    survivor.wait_done()
+
+    tables = read_math_tables(engine, 2, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+
+
+def test_dormant_zid_partial_write_is_repaired_with_a_wide_lookback(
+    engine, pg_url, children, tmp_path
+):
+    """The same partial write DOES repair when the restarted process's lookback
+    still covers the conversation — isolating the defect above to the missing
+    durable repair path rather than to the write seam alone."""
+    _seed_dormant(engine, zid=2)
+
+    victim = _spawn(children, pg_url, "after_main_commit", days=30.0,
+                    tmp_path=tmp_path)
+    victim.await_stage("after_main_commit")
+    victim.kill()
+
+    survivor = _spawn(children, pg_url, "none", days=30.0, tmp_path=tmp_path)
+    survivor.wait_done()
+
+    tables = read_math_tables(engine, 2, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, 2))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the restart failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_child_that_never_reaches_the_stage_is_detected(self, engine,
+                                                              pg_url, children,
+                                                              tmp_path):
+        """If the stage hook silently failed to fire, the R05 tests must not
+        pass vacuously: awaiting a stage that cannot happen has to time out."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        child = _spawn(children, pg_url, "none", tmp_path=tmp_path)
+        with pytest.raises(AssertionError):
+            child.await_stage("after_main_commit", timeout=5.0)
+
+    def test_the_kill_is_real(self, engine, pg_url, children, tmp_path):
+        """The victim must die by signal, not exit cleanly — otherwise the
+        'restart' would just be a graceful shutdown."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        victim = _spawn(children, pg_url, "during_compute", tmp_path=tmp_path)
+        victim.await_stage("during_compute")
+        victim.kill()
+        assert victim.proc.returncode in (-signal.SIGKILL, 137)
+        assert "DONE" not in victim.stages, (
+            "NEGATIVE CONTROL FAILED: the victim completed its poll cycle, so "
+            "the kill did not interrupt anything"
+        )

--- a/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
+++ b/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
@@ -212,7 +212,15 @@ def test_after_poll_kill_point_is_latched_after_the_watermark_advance(
     thread, so a hook on ``_run_engine`` alone can fire before the assignment.
     The child now gates ``_run_engine``, lets ``_poll_votes_once`` return,
     acknowledges the watermark it actually assigned, and only then names the
-    stage.  Assert that whole sequence, including the exact watermark value."""
+    stage.  Assert that whole sequence, including the exact watermark value.
+
+    The ordering is DETERMINISTIC, not merely likely: the gate writes and
+    flushes ``GATE run_engine`` before setting the event that unblocks
+    ``WM_ACK``/``STAGE`` (``restart_child._install_after_poll_latch``).  Setting
+    the event first — which it used to do — allowed the polling thread to
+    interleave its two lines between the ``set()`` and the ``write()``, making
+    this assertion flake on a harness detail rather than on the barrier it is
+    testing (astra second-round review)."""
     seeded = seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     expected_wm = max(e["created"] for e in seeded.vote_events)
 
@@ -222,6 +230,13 @@ def test_after_poll_kill_point_is_latched_after_the_watermark_advance(
     # 1. work was really dispatched (so "before any compute" is not vacuous),
     # 2. the watermark was assigned and acknowledged AFTER that,
     # 3. only then was the stage named.
+    ordered = [l for l in victim.lines
+               if l.startswith(("GATE run_engine", "WM_ACK ",
+                                "STAGE after_poll"))]
+    assert [l.split(" ", 1)[0] for l in ordered] == ["GATE", "WM_ACK", "STAGE"], (
+        f"expected dispatch -> watermark ack -> stage marker exactly once each, "
+        f"saw {victim.lines}"
+    )
     gate = victim.line_index("GATE run_engine")
     ack = victim.line_index("WM_ACK ")
     marker = victim.line_index("STAGE after_poll")
@@ -229,6 +244,9 @@ def test_after_poll_kill_point_is_latched_after_the_watermark_advance(
         f"expected dispatch -> watermark ack -> stage marker, saw "
         f"{victim.lines}"
     )
+    # ...and neither bail-out path fired, so the acknowledgement is real.
+    assert not any(l.startswith(("WM_NOT_ADVANCED", "NO_DISPATCH"))
+                   for l in victim.lines), victim.lines
     acked = int(victim.await_line("WM_ACK ").split(" ", 1)[1])
     assert acked == expected_wm, (
         f"the child acknowledged watermark {acked}, but the newest seeded vote "

--- a/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
+++ b/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
@@ -165,7 +165,7 @@ def test_cache_stays_bounded_under_pool_concurrency(engine, pg_url,
         "DEFECT (P-019 should-fix #5, unaddressed): the conversation cache is "
         "an unsynchronized OrderedDict. polismath/poller/service.py:497 reads "
         "`conv = self._convs.get(zid)` and then, as a separate step, calls "
-        "`self._convs.move_to_end(zid)`; polismath/poller/service.py:488 "
+        "`self._convs.move_to_end(zid)`; polismath/poller/service.py:489 "
         "concurrently evicts with `self._convs.popitem(last=False)` from "
         "another pool thread. With the key evicted in that window, move_to_end "
         "raises KeyError, which escapes _run_engine into _handle_zid's blanket "

--- a/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
+++ b/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
@@ -1,0 +1,271 @@
+"""R06 — LRU eviction while work is in flight (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Cap=1/2, >=4 worker threads, barriers between cache get/touch/store while
+    other zids evict.  Repeat touches/restarts, inspect final outputs and peak
+    memory.  No KeyError, dropped handler or lost input; cache bookkeeping
+    synchronized.  Compare restart geometry against a reference using the same
+    restore seam, not an uninterrupted smoother trajectory.
+
+The conversation cache is a bare ``OrderedDict`` mutated from pool threads with
+no lock (``poller/service.py:278``; ``_remember`` at ``:479``, the LRU touch at
+``:497``).  The barrier here sits at the named "cache get" boundary and holds
+one worker between its ``self._convs.get(zid)`` and its
+``self._convs.move_to_end(zid)`` while another worker's ``_remember`` evicts
+that very key — P-019's unaddressed should-fix #5.
+"""
+
+import threading
+from collections import OrderedDict
+
+import pytest
+
+from .conftest import (
+    drain,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+from polismath.poller.worker_pool import VOTES
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+class LatchedCache(OrderedDict):
+    """An ``OrderedDict`` that can block INSIDE ``get`` for one named zid.
+
+    This is the "barrier between cache get / touch / store" the matrix asks
+    for: it freezes a worker at the exact instant between
+    ``self._convs.get(zid)`` returning a conversation and the following
+    ``self._convs.move_to_end(zid)`` LRU touch.
+    """
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.latch_zid = None
+        self.arrived = threading.Event()
+        self.release = threading.Event()
+
+    def get(self, key, default=None):
+        value = super().get(key, default)
+        if key == self.latch_zid and value is not None:
+            self.arrived.set()
+            self.release.wait(timeout=30)
+        return value
+
+
+def _assert_all_published(engine, zids):
+    for zid in zids:
+        tables = read_math_tables(engine, zid, MATH_ENV)
+        problems = tables_are_coherent(tables)
+        assert problems == [], f"zid {zid}: {problems}"
+        fold = F.fold_votes(read_vote_events(engine, zid))
+        assert F.check_published_against_fold(
+            tables["main"]["data"], fold
+        ) == [], f"zid {zid} disagrees with the fold"
+
+
+# --------------------------------------------------------------------------- #
+# Churn: a tiny cap with many zids must not lose anything
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("cap", [1, 2])
+def test_cap_smaller_than_the_working_set_loses_nothing(engine, pg_url,
+                                                        make_service, cap):
+    """cap-1/cap-2 with 4 workers and 5 conversations, repeatedly touched: every
+    zid must end with a coherent generation matching its own fold.  Eviction is
+    a memory/latency trade, never a correctness one."""
+    zids = [1, 2, 3, 4, 5]
+    for zid in zids:
+        seed_conversation(engine, zid=zid, n_ptpts=6, n_cmts=4)
+
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=4,
+                       conv_cache_cap=cap)
+    for _ in range(3):          # repeat touches: every zid cycles through the LRU
+        svc._vote_wm = 0
+        svc.poll_once()
+
+    assert len(svc._convs) <= cap, (
+        f"cache grew past its cap: {len(svc._convs)} > {cap}"
+    )
+    _assert_all_published(engine, zids)
+
+
+def test_evicted_conversation_reloads_identically_via_the_same_restore_seam(
+    engine, pg_url, make_service
+):
+    """"Compare restart geometry against a reference using the SAME restore
+    seam": a zid evicted and reloaded must publish the same blob as a cold
+    service that loaded it through ``_load_or_init`` — not the same blob as an
+    uninterrupted warm trajectory."""
+    zids = [1, 2, 3]
+    for zid in zids:
+        seed_conversation(engine, zid=zid, n_ptpts=6, n_cmts=4)
+
+    # Reference: a cold service, restoring zid 1 through _load_or_init.
+    reference_svc = make_service(pg_url, math_env=MATH_ENV + "_ref",
+                                 worker_pool_size=1, conv_cache_cap=0)
+    reference_svc.poll_once()
+    reference = read_math_tables(engine, 1, MATH_ENV + "_ref")["main"]["data"]
+
+    # Subject: cap=1, so zid 1 is evicted by 2 and 3, then reloaded.
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       conv_cache_cap=1)
+    svc.poll_once()
+    assert list(svc._convs) == [3], "zid 1 must have been evicted"
+    svc._vote_wm = 0
+    svc.poll_once()             # zid 1 reloads through the same restore seam
+    subject = read_math_tables(engine, 1, MATH_ENV)["main"]["data"]
+
+    for key in ("user-vote-counts", "votes-base", "lastVoteTimestamp", "n",
+                "n-cmts", "base-clusters", "group-clusters"):
+        assert subject[key] == reference[key], (
+            f"reloaded zid 1 differs from the cold reference at {key!r}"
+        )
+
+
+def test_cache_stays_bounded_under_pool_concurrency(engine, pg_url,
+                                                    make_service):
+    """Peak cache occupancy — the memory proxy this suite can actually measure —
+    must respect the cap even while four workers store concurrently."""
+    zids = list(range(1, 9))
+    for zid in zids:
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=4,
+                       conv_cache_cap=2)
+    peak = {"n": 0}
+    real_remember = svc._remember
+
+    def watched_remember(zid, conv):
+        real_remember(zid, conv)
+        peak["n"] = max(peak["n"], len(svc._convs))
+
+    svc._remember = watched_remember
+    svc.poll_once()
+    drain(svc)
+
+    assert peak["n"] <= 2 + 1, (
+        f"cache peaked at {peak['n']} entries with cap=2; the eviction loop is "
+        "not keeping up with concurrent stores"
+    )
+    _assert_all_published(engine, zids)
+
+
+# --------------------------------------------------------------------------- #
+# The in-flight race itself
+# --------------------------------------------------------------------------- #
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (P-019 should-fix #5, unaddressed): the conversation cache is "
+        "an unsynchronized OrderedDict. polismath/poller/service.py:497 reads "
+        "`conv = self._convs.get(zid)` and then, as a separate step, calls "
+        "`self._convs.move_to_end(zid)`; polismath/poller/service.py:488 "
+        "concurrently evicts with `self._convs.popitem(last=False)` from "
+        "another pool thread. With the key evicted in that window, move_to_end "
+        "raises KeyError, which escapes _run_engine into _handle_zid's blanket "
+        "except (:476) and is treated as an ENGINE error: the batch is retried "
+        "or the healthy zid is PARKED, and an errorconv dump is written — a "
+        "spurious failure caused purely by cache bookkeeping. P-022 §C R06 "
+        "requires 'No KeyError, dropped handler or lost input; cache "
+        "bookkeeping synchronized.' The fix is a lock (or a thread-safe cache) "
+        "around get/touch/store/evict; that is a separate decision."
+    ),
+)
+def test_lru_touch_racing_an_eviction_does_not_park_a_healthy_zid(
+    engine, pg_url, make_service
+):
+    """Barrier at the cache-get boundary: hold worker A between its cache read
+    and its LRU touch while another worker's ``_remember`` evicts that key.
+
+    Worker A is doing perfectly healthy work on real, valid input; only the
+    cache bookkeeping is racing.  It must not fail, and it must not park.
+    """
+    from polismath.poller.worker_pool import CoalescedBatch
+
+    seeded = seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=4,
+                       conv_cache_cap=1, retry_cap=0)
+    svc.poll_once()
+    assert 1 in svc._convs, "zid 1 must be warm before the race can be staged"
+
+    cache = LatchedCache(svc._convs)
+    svc._convs = cache
+    cache.latch_zid = 1
+
+    errors = []
+    newer = max(e["created"] for e in seeded.vote_events) + 1000
+    batch = CoalescedBatch(votes=[{"zid": 1, "pid": 0, "tid": 0,
+                                   "vote": F.ENGINE_DISAGREE,
+                                   "created": newer}])
+
+    def worker_a():
+        try:
+            svc._handle_zid(1, batch)
+        except BaseException as exc:  # pragma: no cover - _handle_zid catches
+            errors.append(exc)
+
+    real_error_handler = svc._on_engine_error
+
+    def recording_error(zid, coalesced, error):
+        errors.append(error)
+        return real_error_handler(zid, coalesced, error)
+
+    svc._on_engine_error = recording_error
+
+    thread = threading.Thread(target=worker_a, daemon=True)
+    thread.start()
+    assert cache.arrived.wait(timeout=30), "worker A never reached cache-get"
+
+    # Worker A is frozen between get() and move_to_end(). Evict zid 1 from
+    # another thread, exactly as a concurrent _remember for zid 2 would.
+    svc._remember(2, object())
+    assert 1 not in cache, "the eviction must have removed zid 1"
+    cache.release.set()
+    thread.join(timeout=30)
+    assert not thread.is_alive()
+
+    assert errors == [] and 1 not in svc._parked, (
+        f"a healthy zid failed purely because of cache bookkeeping: "
+        f"errors={errors!r} parked={set(svc._parked)!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the cache/LRU failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_cache_that_never_evicts_is_detected(self, engine, pg_url,
+                                                   make_service):
+        """Intentionally broken variant: disable eviction and check that the
+        bound assertion goes red — proving it is not vacuous."""
+        for zid in (1, 2, 3):
+            seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                           conv_cache_cap=1)
+
+        def never_evicts(zid, conv):
+            svc._convs[zid] = conv
+
+        svc._remember = never_evicts
+        svc.poll_once()
+        with pytest.raises(AssertionError):
+            assert len(svc._convs) <= 1, "cache grew past its cap"
+
+    def test_eviction_is_lossless_control(self, engine, pg_url, make_service):
+        """Positive counterpart: with eviction ENABLED the same workload still
+        publishes every zid correctly, so the bound above is not being met by
+        dropping work."""
+        zids = (1, 2, 3)
+        for zid in zids:
+            seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                           conv_cache_cap=1)
+        svc.poll_once()
+        assert len(svc._convs) <= 1
+        _assert_all_published(engine, zids)

--- a/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
+++ b/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
@@ -37,12 +37,18 @@ MATH_ENV = "recovery"
 
 
 class LatchedCache(OrderedDict):
-    """An ``OrderedDict`` that can block INSIDE ``get`` for one named zid.
+    """An ``OrderedDict`` that can block INSIDE ``get`` for one named zid, and
+    that announces every eviction it performs.
 
     This is the "barrier between cache get / touch / store" the matrix asks
     for: it freezes a worker at the exact instant between
     ``self._convs.get(zid)`` returning a conversation and the following
-    ``self._convs.move_to_end(zid)`` LRU touch.
+    ``self._convs.move_to_end(zid)`` LRU touch.  The latch fires ONCE, so the
+    error path's own ``_convs.get`` cannot re-enter it.
+
+    ``evicted`` records which zids ``popitem`` actually removed, and
+    ``eviction_reached`` fires when a *concurrent* thread got as far as
+    mutating the cache — see :class:`ObservedLock` for the other half.
     """
 
     def __init__(self, *a, **kw):
@@ -50,13 +56,63 @@ class LatchedCache(OrderedDict):
         self.latch_zid = None
         self.arrived = threading.Event()
         self.release = threading.Event()
+        self.eviction_reached = threading.Event()
+        self.evicted = []
+        self._latched = False
 
     def get(self, key, default=None):
         value = super().get(key, default)
-        if key == self.latch_zid and value is not None:
+        if key == self.latch_zid and value is not None and not self._latched:
+            self._latched = True
             self.arrived.set()
             self.release.wait(timeout=30)
         return value
+
+    def popitem(self, last=True):
+        item = super().popitem(last=last)
+        self.evicted.append(item[0])
+        # Unblock the driver on UNLOCKED code: the evictor got all the way in.
+        self.eviction_reached.set()
+        return item
+
+
+class ObservedLock:
+    """A pass-through wrapper for the service's cache lock that reports real
+    CONTENTION.
+
+    The R06 race is staged from the LOCK BOUNDARY, not from inside ``get``
+    (R06-cache-lock-report should-fix): once ``_run_engine``'s lookup and LRU
+    touch run under ``_convs_lock``, a driver that calls ``svc._remember`` while
+    worker A is latched inside ``get`` blocks on that very lock, so the schedule
+    only unwinds when the latch's own 30 s timeout expires — after which the
+    touch happens *before* the eviction and the documented interleaving is never
+    staged at all.
+
+    So the driver waits for ``eviction_reached`` instead, which fires from
+    OUTSIDE the locked region in whichever way is possible:
+
+    * unlocked code — the evictor reaches ``LatchedCache.popitem`` and really
+      does remove the key in the window, exposing the ``KeyError``;
+    * locked code — the evictor is refused the lock and blocks here, proving it
+      arrived at the cache while worker A held the critical section.
+
+    Either way the driver releases in milliseconds and the outcome is decided by
+    the production code, not by a timeout.
+    """
+
+    def __init__(self, lock, reached: threading.Event):
+        self._lock = lock
+        self._reached = reached
+
+    def __enter__(self):
+        if not self._lock.acquire(blocking=False):
+            self._reached.set()
+            assert self._lock.acquire(timeout=30), "cache lock never released"
+        return self
+
+    def __exit__(self, *exc):
+        self._lock.release()
+        return False
 
 
 def _assert_all_published(engine, zids):
@@ -185,6 +241,16 @@ def test_lru_touch_racing_an_eviction_does_not_park_a_healthy_zid(
 
     Worker A is doing perfectly healthy work on real, valid input; only the
     cache bookkeeping is racing.  It must not fail, and it must not park.
+
+    The eviction runs on its OWN thread and the driver releases worker A as
+    soon as that thread has reached the cache — either by evicting (unlocked
+    code, which then loses the key under worker A and raises ``KeyError``) or by
+    blocking on the cache lock (locked code, where the compound get/touch is
+    atomic and nothing is lost).  Latching *inside* ``get`` and evicting from
+    the driver, as this test used to do, deadlocks against a locked cache until
+    the 30 s latch timeout expires and then stages the wrong order entirely
+    (R06-cache-lock-report should-fix).  This version decides in milliseconds
+    and is decided by the production code either way.
     """
     from polismath.poller.worker_pool import CoalescedBatch
 
@@ -197,6 +263,11 @@ def test_lru_touch_racing_an_eviction_does_not_park_a_healthy_zid(
     cache = LatchedCache(svc._convs)
     svc._convs = cache
     cache.latch_zid = 1
+    # Present on the fixed service, absent on today's; either way the evictor's
+    # arrival at the cache becomes observable from outside the critical section.
+    svc._convs_lock = ObservedLock(
+        getattr(svc, "_convs_lock", threading.Lock()), cache.eviction_reached
+    )
 
     errors = []
     newer = max(e["created"] for e in seeded.vote_events) + 1000
@@ -204,11 +275,13 @@ def test_lru_touch_racing_an_eviction_does_not_park_a_healthy_zid(
                                    "vote": F.ENGINE_DISAGREE,
                                    "created": newer}])
 
-    def worker_a():
-        try:
-            svc._handle_zid(1, batch)
-        except BaseException as exc:  # pragma: no cover - _handle_zid catches
-            errors.append(exc)
+    def collecting(fn):
+        def run():
+            try:
+                fn()
+            except BaseException as exc:  # pragma: no cover - handler catches
+                errors.append(exc)
+        return run
 
     real_error_handler = svc._on_engine_error
 
@@ -218,18 +291,28 @@ def test_lru_touch_racing_an_eviction_does_not_park_a_healthy_zid(
 
     svc._on_engine_error = recording_error
 
-    thread = threading.Thread(target=worker_a, daemon=True)
-    thread.start()
+    worker = threading.Thread(
+        target=collecting(lambda: svc._handle_zid(1, batch)), daemon=True)
+    evictor = threading.Thread(
+        target=collecting(lambda: svc._remember(2, object())), daemon=True)
+
+    worker.start()
     assert cache.arrived.wait(timeout=30), "worker A never reached cache-get"
-
-    # Worker A is frozen between get() and move_to_end(). Evict zid 1 from
-    # another thread, exactly as a concurrent _remember for zid 2 would.
-    svc._remember(2, object())
-    assert 1 not in cache, "the eviction must have removed zid 1"
+    # Worker A is frozen between get() and move_to_end(). A concurrent
+    # _remember for zid 2 now evicts that very key.
+    evictor.start()
+    assert cache.eviction_reached.wait(timeout=30), (
+        "the evicting thread never reached the cache at all"
+    )
     cache.release.set()
-    thread.join(timeout=30)
-    assert not thread.is_alive()
+    worker.join(timeout=60)
+    evictor.join(timeout=60)
+    assert not worker.is_alive() and not evictor.is_alive()
 
+    assert 1 in cache.evicted, (
+        "the in-flight zid was never actually evicted, so no race was staged: "
+        f"evicted={cache.evicted}"
+    )
     assert errors == [] and 1 not in svc._parked, (
         f"a healthy zid failed purely because of cache bookkeeping: "
         f"errors={errors!r} parked={set(svc._parked)!r}"

--- a/delphi/tests/poller/recovery/test_r07_overlapping_shards.py
+++ b/delphi/tests/poller/recovery/test_r07_overlapping_shards.py
@@ -19,6 +19,8 @@ is what the duplicate-writer tests below establish, on real processes against
 real rows.
 """
 
+import time
+
 import pytest
 import sqlalchemy as sa
 
@@ -49,6 +51,39 @@ MATH_ENV = "recovery"
 # Nothing else is accepted, and any other nonzero exit is a HARD failure.
 OWNERSHIP_REFUSAL_EXIT = 3
 OWNERSHIP_REFUSAL_MARKER = "OWNERSHIP-REFUSED"
+
+# The FENCE contract, likewise defined by name (astra second-round review).
+#
+# "Any advisory lock, or any table whose name contains owner/lease/fence/shard"
+# is NOT a fence: creating an unrelated `lease_notes` table, or holding an
+# advisory lock for something else entirely, would flip the acceptance green
+# with the same two unfenced publishers and the same output.  Only these two
+# shapes count, and each is tied to THIS zid:
+#
+# ``lease row``
+#     a row in a lease/owner/fence table that names this zid AND carries both
+#     an owner column and a version/epoch/fence-token column, so a stale writer
+#     is distinguishable from the live one;
+# ``advisory lock keyed by this zid``
+#     a GRANTED advisory lock whose key encodes the zid — the two-int form
+#     ``(namespace, zid)`` or the bigint form ``namespace << 32 | zid`` — held
+#     by a backend other than this test's own.
+#
+# Even then, a lock alone is not stale-writer fencing: the fence must have had
+# an OBSERVABLE effect, so `test_duplicate_shard_start_is_refused_or_fenced`
+# additionally requires exactly one healthy publisher.  Two processes that both
+# completed a full write cycle were not exclusively owned, whatever the catalog
+# says.  Catalog-wide `_advisory_locks` / `_ownership_table_names` remain in the
+# evidence dict as DIAGNOSTICS for the failure message only.
+OWNERSHIP_LEASE_OWNER_COLUMNS = (
+    "owner", "owner_id", "owner_pid", "owner_name", "holder", "locked_by",
+    "lease_owner",
+)
+OWNERSHIP_LEASE_VERSION_COLUMNS = (
+    "version", "epoch", "fence", "fence_token", "token", "generation",
+    "lease_version",
+)
+OWNERSHIP_LEASE_ZID_COLUMNS = ("zid", "conversation_id", "conv_id")
 
 
 class OwnershipNotFenced(AssertionError):
@@ -145,13 +180,18 @@ def _advisory_locks(engine) -> list:
     with engine.connect() as conn:
         rows = conn.execute(sa.text(
             "select locktype, classid, objid, objsubid, granted, pid "
-            "from pg_locks where locktype = 'advisory'"
+            "from pg_locks where locktype = 'advisory' "
+            "  and database = "
+            "      (select oid from pg_database where datname = current_database())"
         )).mappings().all()
     return [dict(r) for r in rows]
 
 
 def _ownership_table_names(engine) -> list:
-    """Tables that would carry a durable lease / fencing token, if any existed."""
+    """Tables that would carry a durable lease / fencing token, if any existed.
+
+    DIAGNOSTIC ONLY.  A name match is not a fence — see
+    :func:`_zid_ownership_leases` for the check the acceptance actually uses."""
     with engine.connect() as conn:
         rows = conn.execute(sa.text(
             "select table_name from information_schema.tables "
@@ -162,31 +202,173 @@ def _ownership_table_names(engine) -> list:
     return list(rows)
 
 
-def _run_two_latched_children(engine, pg_url, tmp_path, children, days=1.0):
-    """Two identical poller processes held CONCURRENTLY at their ownership
-    point, so "both ran" cannot be two one-shot processes running one after the
-    other (astra review finding 3).
+def _zid_ownership_leases(engine, zid: int) -> list:
+    """LEASE ROWS for ``zid``: the first of the two fence shapes.
+
+    A candidate table qualifies only if its COLUMNS make it a lease — a zid
+    column, an owner column and a version/epoch/fence-token column — and only
+    if it actually holds a row for this zid with a non-null owner.  A table that
+    merely has "lease" in its name contributes nothing (astra second-round
+    review: ``unrelated_lease_notes`` used to flip this green)."""
+    found = []
+    with engine.connect() as conn:
+        candidates = conn.execute(sa.text(
+            "select table_name from information_schema.tables "
+            "where table_schema = 'public' and ("
+            "  table_name ilike '%owner%' or table_name ilike '%lease%' "
+            "  or table_name ilike '%fence%' or table_name ilike '%shard%')"
+        )).scalars().all()
+        for table in candidates:
+            cols = set(conn.execute(sa.text(
+                "select column_name from information_schema.columns "
+                "where table_schema = 'public' and table_name = :t"
+            ), {"t": table}).scalars().all())
+            zid_col = next((c for c in OWNERSHIP_LEASE_ZID_COLUMNS
+                            if c in cols), None)
+            owner_col = next((c for c in OWNERSHIP_LEASE_OWNER_COLUMNS
+                              if c in cols), None)
+            version_col = next((c for c in OWNERSHIP_LEASE_VERSION_COLUMNS
+                                if c in cols), None)
+            if not (zid_col and owner_col and version_col):
+                continue
+            rows = conn.execute(sa.text(
+                f'select "{owner_col}" as owner, "{version_col}" as version '
+                f'from "{table}" where "{zid_col}" = :z '
+                f'and "{owner_col}" is not null'
+            ), {"z": zid}).mappings().all()
+            for row in rows:
+                found.append({"table": table, "zid": zid,
+                              "owner": row["owner"], "version": row["version"]})
+    return found
+
+
+def _zid_keyed_advisory_locks(engine, zid: int) -> list:
+    """ADVISORY LOCKS KEYED BY ``zid``: the second fence shape.
+
+    Postgres reports ``pg_advisory_lock(k1 int, k2 int)`` as
+    ``(classid, objid, objsubid) = (k1, k2, 2)`` and
+    ``pg_advisory_lock(k bigint)`` as ``(k >> 32, k & 0xffffffff, 1)``.  Either
+    encoding of this zid counts; an advisory lock on any other key does not.
+    The holder must also be some OTHER backend, so the test's own session can
+    never satisfy its own fence check.
+
+    Read WHILE the duplicate writers hold their ownership latch, so an empty
+    result is real evidence rather than a timing artefact."""
+    with engine.connect() as conn:
+        rows = conn.execute(sa.text(
+            "select locktype, classid, objid, objsubid, granted, pid "
+            "from pg_locks "
+            "where locktype = 'advisory' and granted "
+            "  and database = "
+            "      (select oid from pg_database where datname = current_database()) "
+            "  and pid <> pg_backend_pid() "
+            "  and ((objsubid = 2 and objid = :z) "
+            "    or (objsubid = 1 and (classid::bigint << 32 | objid::bigint) "
+            "        = :z) "
+            "    or (objsubid = 1 and objid = :z))"
+        ), {"z": zid}).mappings().all()
+    return [dict(r) for r in rows]
+
+
+def _collect_evidence(engine, zid: int, owners: int, refusals: int) -> dict:
+    return {
+        # The fence contract, per zid.  These two decide the acceptance.
+        "zid_leases": _zid_ownership_leases(engine, zid),
+        "zid_advisory_locks": _zid_keyed_advisory_locks(engine, zid),
+        # Diagnostics for the failure message; NOT acceptance criteria.
+        "advisory_locks": _advisory_locks(engine),
+        "ownership_tables": _ownership_table_names(engine),
+        "owners": owners,
+        "refusals": refusals,
+        "held_concurrently": owners >= 2,
+    }
+
+
+def _await_ownership_outcome(kid, timeout=120.0):
+    """Wait for a child to declare EITHER outcome the contract allows.
+
+    ``'owned'``
+        it announced ``STAGE OWNED`` and is holding the ownership latch;
+    ``'refused'``
+        it printed the named ownership refusal (and will exit
+        ``OWNERSHIP_REFUSAL_EXIT``);
+    ``'dead'``
+        it exited without saying either — never a fence, always a real failure.
+
+    Waiting for OWNED from BOTH children, which this helper used to do, makes
+    the PASSING shape unreachable (astra second-round review): a correctly
+    refused startup exits before ``_hold_ownership`` and can never emit OWNED,
+    so the helper timed out before the classifier ever saw the valid refusal."""
+    deadline = time.monotonic() + timeout
+
+    def _settled():
+        if any(l.startswith(OWNERSHIP_REFUSAL_MARKER) for l in kid.lines):
+            return "refused"
+        if "OWNED" in kid.stages:
+            return "owned"
+        return None
+
+    while True:
+        settled = _settled()
+        if settled:
+            return settled
+        if kid.proc.poll() is not None:
+            # Exited without either announcement: give the stdout reader a beat
+            # to drain the pipe, then call it what it is.
+            time.sleep(0.2)
+            return _settled() or "dead"
+        if time.monotonic() > deadline:
+            raise AssertionError(
+                f"child neither took ownership nor refused within {timeout}s "
+                f"(stages={kid.stages}, lines={kid.lines})"
+            )
+        time.sleep(0.02)
+
+
+def _run_two_latched_children(engine, pg_url, tmp_path, children, days=1.0,
+                              zid=1):
+    """Two identical poller processes driven to their ownership decision, held
+    CONCURRENTLY if they both take ownership — so "both ran" cannot be two
+    one-shot processes running one after the other (astra review finding 3).
+
+    BOTH contract shapes are reachable from here:
+
+    * two owners  — today's unfenced reality; the caller's classifier decides;
+    * one owner + one named refusal — the PASSING shape, which this helper no
+      longer deadlocks on.
+
+    Anything else (a child that died for an unrelated reason, or no owner at
+    all) is a hard failure, never evidence of a fence.
 
     Returns ``(kids, evidence)`` where ``evidence`` is what the database showed
-    while both were alive and holding.
+    while the owner(s) were alive and holding.
     """
     latch_dir = tmp_path / "ownership"
     kids = [
         _spawn_latched(children, pg_url, tmp_path, latch_dir, days)
         for _ in range(2)
     ]
-    for kid in kids:
-        kid.await_stage("OWNED", timeout=120)
-    assert all(kid.proc.poll() is None for kid in kids), (
-        "both duplicate processes must still be ALIVE while holding ownership"
+    outcomes = [_await_ownership_outcome(kid) for kid in kids]
+
+    dead = [(kid.proc.returncode, kid.stages, kid.lines)
+            for kid, out in zip(kids, outcomes) if out == "dead"]
+    assert not dead, (
+        "a duplicate-writer process exited without taking ownership and "
+        f"without the named refusal; that is a crash, not a fence: {dead}"
+    )
+    owners = [kid for kid, out in zip(kids, outcomes) if out == "owned"]
+    refusals = [kid for kid, out in zip(kids, outcomes) if out == "refused"]
+    assert owners, (
+        "neither process took ownership; a shard with no owner is not fencing, "
+        f"it is an outage: {[(k.stages, k.lines) for k in kids]}"
+    )
+    assert all(kid.proc.poll() is None for kid in owners), (
+        "an owning process died while it was supposed to be holding ownership"
     )
 
-    evidence = {
-        "advisory_locks": _advisory_locks(engine),
-        "ownership_tables": _ownership_table_names(engine),
-        "held_concurrently": True,
-    }
+    evidence = _collect_evidence(engine, zid, len(owners), len(refusals))
 
+    latch_dir.mkdir(parents=True, exist_ok=True)
     (latch_dir / "release").write_text("go")
     for kid in kids:
         kid.proc.wait(timeout=180)
@@ -230,7 +412,11 @@ def _classify(kid):
         "one replica, which is not observable from the database. A fix (a "
         "pg_advisory_lock lease per (math_env, shard) held for the process "
         "lifetime, or a fencing token checked in the writes) is a separate "
-        "decision. NOTE the xfail names OwnershipNotFenced explicitly: an "
+        "decision. The acceptance recognises ONLY a lease row or advisory lock "
+        "keyed by this zid, AND observably exclusive publication; a "
+        "lease-NAMED table or an unrelated advisory lock is diagnostics, not a "
+        "fence (see TestNegativeControl). NOTE the xfail names "
+        "OwnershipNotFenced explicitly: an "
         "unrelated crash, a missing healthy publisher or an incoherent final "
         "generation is a REAL failure here, never a green xfail."
     ),
@@ -243,14 +429,25 @@ def test_duplicate_shard_start_is_refused_or_fenced(engine, pg_url, tmp_path,
 
     Every precondition is a plain assertion, so it fails for real:
 
-    * both processes were alive concurrently while holding ownership (two
-      one-shot children running sequentially would prove nothing);
+    * whichever children took ownership were alive concurrently while holding
+      it (two one-shot children running sequentially would prove nothing);
     * exactly one proven-healthy publisher exists (exit 0 with a completed
       cycle);
     * no process crashed for an unrelated reason — a nonzero exit only counts
       as a refusal when it is ``OWNERSHIP_REFUSAL_EXIT`` with the marker;
     * no losing process is left running;
     * the final generation is coherent and matches the independent fold.
+
+    The PASSING shape is exactly one of:
+
+    * **refusal** — exactly one owner and exactly one named refusal, leaving
+      exactly one publisher; or
+    * **fence** — exactly one publisher, plus a lease row or advisory lock
+      keyed by THIS zid (:func:`_zid_ownership_leases` /
+      :func:`_zid_keyed_advisory_locks`).  A zid-keyed lock is necessary but
+      not sufficient: two processes that both completed a full write cycle were
+      not exclusively owned no matter what the catalog holds, so the publisher
+      count is required as well (astra second-round review).
 
     Only the ownership question itself raises :class:`OwnershipNotFenced`.
     """
@@ -260,7 +457,6 @@ def test_duplicate_shard_start_is_refused_or_fenced(engine, pg_url, tmp_path,
     outcomes = [_classify(kid) for kid in kids]
     kinds = [kind for kind, _err in outcomes]
 
-    assert evidence["held_concurrently"]
     crashes = [(kid.proc.returncode, kid.lines, err)
                for kid, (kind, err) in zip(kids, outcomes) if kind == "crash"]
     assert not crashes, (
@@ -281,17 +477,40 @@ def test_duplicate_shard_start_is_refused_or_fenced(engine, pg_url, tmp_path,
 
     refused = [kid for kid, (kind, _e) in zip(kids, outcomes)
                if kind == "refusal"]
-    fenced = bool(evidence["advisory_locks"]) or bool(
-        evidence["ownership_tables"])
-    if not refused and not fenced:
-        raise OwnershipNotFenced(
-            "both duplicate processes started and completed a full write "
-            f"cycle (outcomes {kinds}); none refused with exit "
-            f"{OWNERSHIP_REFUSAL_EXIT}/{OWNERSHIP_REFUSAL_MARKER}, no advisory "
-            "lock was held while both were alive "
-            f"({evidence['advisory_locks']}) and no lease/fence table exists "
-            f"({evidence['ownership_tables']})"
+    exclusive = kinds.count("publisher") == 1
+    fence_for_zid = (evidence.get("zid_leases") or
+                     evidence.get("zid_advisory_locks"))
+
+    if refused:
+        # Shape 1: a named startup refusal. Reachable now that the helper waits
+        # for either outcome rather than OWNED from both.
+        assert len(refused) == 1 and evidence["owners"] == 1, (
+            "a refusal must leave exactly one owner, not "
+            f"{evidence['owners']} owners and {len(refused)} refusals"
         )
+        assert exclusive, (
+            f"one process refused, yet {kinds.count('publisher')} processes "
+            f"published: {kinds}"
+        )
+        return
+
+    if fence_for_zid and exclusive:
+        # Shape 2: a real per-zid lease/lock AND observably exclusive
+        # publication.
+        return
+
+    raise OwnershipNotFenced(
+        "both duplicate processes started and completed a full write cycle "
+        f"(outcomes {kinds}, owners={evidence.get('owners')}, "
+        f"refusals={evidence.get('refusals')}); none refused with exit "
+        f"{OWNERSHIP_REFUSAL_EXIT}/{OWNERSHIP_REFUSAL_MARKER}, no advisory "
+        "lock keyed by zid 1 was held while both were alive "
+        f"({evidence.get('zid_advisory_locks')}) and no lease row names it "
+        f"with an owner and a version ({evidence.get('zid_leases')}). "
+        "Diagnostics only, NOT accepted as fencing: advisory locks "
+        f"{evidence['advisory_locks']}, lease/owner/fence/shard-named tables "
+        f"{evidence['ownership_tables']}"
+    )
 
 
 def test_duplicate_writers_both_write_the_same_rows(engine, pg_url, tmp_path,
@@ -305,7 +524,10 @@ def test_duplicate_writers_both_write_the_same_rows(engine, pg_url, tmp_path,
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     kids, evidence = _run_two_latched_children(engine, pg_url, tmp_path,
                                                children)
-    assert evidence["held_concurrently"]
+    assert evidence["held_concurrently"] and evidence["owners"] == 2, (
+        "both duplicates were expected to take ownership concurrently: "
+        f"owners={evidence['owners']} refusals={evidence['refusals']}"
+    )
     assert [kid.proc.returncode for kid in kids] == [0, 0], (
         "both duplicates were expected to run to completion: "
         f"{[(k.proc.returncode, k.lines) for k in kids]}"
@@ -314,6 +536,10 @@ def test_duplicate_writers_both_write_the_same_rows(engine, pg_url, tmp_path,
     assert evidence["advisory_locks"] == [], (
         "no advisory lock was taken while two duplicate writers were both "
         f"alive: {evidence['advisory_locks']}"
+    )
+    assert evidence["zid_advisory_locks"] == [] and evidence["zid_leases"] == [], (
+        "no fence keyed by this zid existed either: "
+        f"{evidence['zid_advisory_locks']} / {evidence['zid_leases']}"
     )
     with engine.connect() as conn:
         tick = conn.execute(
@@ -439,6 +665,144 @@ class TestNegativeControl:
         assert not _is_ownership_refusal(ImportError("no module named x"))
         assert not _is_ownership_refusal(
             RuntimeError("could not connect to server"))
+
+    # -- the fence detector itself (astra second-round review) -------------- #
+    def test_an_unrelated_lease_named_table_is_not_a_fence(self, engine):
+        """The correction, controlled: a table whose NAME merely matches
+        lease/owner/fence/shard used to flip the acceptance green with the same
+        two unfenced publishers.  It must now count as diagnostics only."""
+        with engine.begin() as conn:
+            conn.execute(sa.text(
+                "create table unrelated_lease_notes "
+                "(id int primary key, note text)"))
+            conn.execute(sa.text(
+                "insert into unrelated_lease_notes values (1, 'not a lease')"))
+        try:
+            assert "unrelated_lease_notes" in _ownership_table_names(engine), (
+                "the diagnostic name scan should still see it"
+            )
+            assert _zid_ownership_leases(engine, 1) == [], (
+                "NEGATIVE CONTROL FAILED: a lease-NAMED table with no zid, "
+                "owner or version column was accepted as a fence"
+            )
+        finally:
+            with engine.begin() as conn:
+                conn.execute(sa.text("drop table unrelated_lease_notes"))
+
+    def test_a_lease_table_without_a_version_is_not_a_fence(self, engine):
+        """Owner without a version/fence token cannot distinguish a live owner
+        from a stale one, so it is not a fence either."""
+        with engine.begin() as conn:
+            conn.execute(sa.text(
+                "create table shard_owner_hint (zid int, owner text)"))
+            conn.execute(sa.text(
+                "insert into shard_owner_hint values (:z, 'pid-42')"),
+                {"z": 1})
+        try:
+            assert _zid_ownership_leases(engine, 1) == [], (
+                "NEGATIVE CONTROL FAILED: an owner column with no version / "
+                "fence token was accepted as a fence"
+            )
+        finally:
+            with engine.begin() as conn:
+                conn.execute(sa.text("drop table shard_owner_hint"))
+
+    def test_an_advisory_lock_on_an_unrelated_key_is_not_a_fence(self, engine):
+        """An advisory lock for something else entirely must not read as
+        ownership of THIS zid."""
+        holder = engine.connect()
+        try:
+            holder.execute(sa.text("select pg_advisory_lock(4242, 987654)"))
+            holder.commit()
+            assert _advisory_locks(engine), (
+                "the diagnostic scan should see the unrelated lock"
+            )
+            assert _zid_keyed_advisory_locks(engine, 1) == [], (
+                "NEGATIVE CONTROL FAILED: an advisory lock keyed (4242, 987654) "
+                "was accepted as ownership of zid 1"
+            )
+        finally:
+            holder.execute(sa.text("select pg_advisory_unlock_all()"))
+            holder.commit()
+            holder.close()
+
+    def test_a_real_per_zid_lease_row_is_recognised(self, engine):
+        """...and the detector is not merely always-false: a lease row that
+        names this zid with an owner AND a version IS a fence, so the xfail
+        above is waiting on production rather than on an unreachable check."""
+        with engine.begin() as conn:
+            conn.execute(sa.text(
+                "create table poller_shard_lease "
+                "(zid int primary key, owner text, version bigint)"))
+            conn.execute(sa.text(
+                "insert into poller_shard_lease values (:z, 'poller-a', 7)"),
+                {"z": 1})
+        try:
+            leases = _zid_ownership_leases(engine, 1)
+            assert [(l["table"], l["owner"], l["version"]) for l in leases] == [
+                ("poller_shard_lease", "poller-a", 7)
+            ], leases
+            assert _zid_ownership_leases(engine, 2) == [], (
+                "a lease for one zid must not fence a different zid"
+            )
+        finally:
+            with engine.begin() as conn:
+                conn.execute(sa.text("drop table poller_shard_lease"))
+
+    def test_a_real_per_zid_advisory_lock_is_recognised(self, engine):
+        """Positive counterpart for the lock shape: a lock keyed by the zid, in
+        either of Postgres' two encodings, IS recognised — and only for its own
+        zid."""
+        holder = engine.connect()
+        try:
+            holder.execute(sa.text("select pg_advisory_lock(1234, :z)"),
+                           {"z": 1})
+            holder.commit()
+            locks = _zid_keyed_advisory_locks(engine, 1)
+            assert locks, "a (namespace, zid) advisory lock was not recognised"
+            assert all(l["objid"] == 1 and l["granted"] for l in locks), locks
+            assert _zid_keyed_advisory_locks(engine, 2) == [], (
+                "a lock keyed by one zid must not fence a different zid"
+            )
+        finally:
+            holder.execute(sa.text("select pg_advisory_unlock_all()"))
+            holder.commit()
+            holder.close()
+
+    # -- the ownership helper's accepted shapes ----------------------------- #
+    def test_a_named_refusal_reaches_the_classifier(self):
+        """The second correction, controlled: a child that legitimately REFUSED
+        never emits OWNED, so waiting for OWNED from both children made the
+        passing shape unreachable.  ``_await_ownership_outcome`` must settle it
+        as a refusal without waiting for a stage that will never come."""
+        class FakeProc:
+            def __init__(self, returncode):
+                self.returncode = returncode
+
+            def poll(self):
+                return self.returncode
+
+        class FakeKid:
+            def __init__(self, stages, lines, returncode):
+                self.stages, self.lines = stages, lines
+                self.proc = FakeProc(returncode)
+
+        owner = FakeKid(["OWNED"], ["STAGE OWNED"], None)
+        refuser = FakeKid(
+            [], [f"{OWNERSHIP_REFUSAL_MARKER} ShardAlreadyOwned: pid 42"],
+            OWNERSHIP_REFUSAL_EXIT)
+        crashed = FakeKid([], ["boom"], 1)
+
+        assert _await_ownership_outcome(owner, timeout=1) == "owned"
+        assert _await_ownership_outcome(refuser, timeout=1) == "refused"
+        assert _await_ownership_outcome(crashed, timeout=1) == "dead"
+
+        # ...and the classifier then reads that refusal as a refusal, not a
+        # crash, so the exactly-one-owner-plus-a-named-refusal shape passes.
+        refuser.proc.stderr = None
+        assert _classify(refuser)[0] == "refusal"
+        crashed.proc.stderr = None
+        assert _classify(crashed)[0] == "crash"
 
     def test_a_shard_that_owns_nothing_would_be_caught(self):
         """A shard index outside its count owns no zid at all — the failure

--- a/delphi/tests/poller/recovery/test_r07_overlapping_shards.py
+++ b/delphi/tests/poller/recovery/test_r07_overlapping_shards.py
@@ -1,0 +1,273 @@
+"""R07 — overlapping shards / duplicate writers (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Two processes, same shard index and math env; then partially overlapping
+    allowlists and a rolling shard-count change.  Require startup refusal or
+    demonstrable exclusive/fenced ownership.  For this cutover, deployment
+    enforces one replica; duplicate-start must be prevented/observable.  Do not
+    claim modulus filtering alone prevents duplicate writers.  Disjoint valid
+    shards must cover every selected zid exactly once.
+
+The partitioning arithmetic (``should_process_zid``,
+``polismath/poller/service.py:62``) is correct and is asserted here as a pure
+property.  Ownership is a different question: nothing in the poller takes a
+lease, advisory lock or fence before writing, and ``ConversationWorkerPool``
+serialises per zid only WITHIN a process (``worker_pool.py:5``).  Two processes
+that both accept a zid therefore both write it, with no mutual exclusion — which
+is what the duplicate-writer tests below establish, on real processes against
+real rows.
+"""
+
+import os
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+from polismath.poller.service import PollerConfig, should_process_zid
+from .test_r05_mid_batch_restart import Child, _DELPHI_ROOT
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+# --------------------------------------------------------------------------- #
+# Partition arithmetic — a pure property, no DB needed
+# --------------------------------------------------------------------------- #
+def test_disjoint_shards_cover_every_zid_exactly_once():
+    """For every shard count, the shards partition the zid space: each zid is
+    accepted by exactly one shard index."""
+    zids = list(range(0, 500))
+    for count in (1, 2, 3, 4, 7, 8, 16):
+        owners = {}
+        for zid in zids:
+            accepting = [
+                idx for idx in range(count)
+                if should_process_zid(zid, [], [], idx, count)
+            ]
+            assert len(accepting) == 1, (
+                f"zid {zid} accepted by {accepting} of {count} shards"
+            )
+            owners[zid] = accepting[0]
+        assert set(owners.values()) <= set(range(count))
+
+
+def test_shard_test_precedes_the_allowlist():
+    """A shard must never process a zid outside its slice, even one an
+    allowlist names — the allowlist cannot widen ownership."""
+    assert not should_process_zid(3, [3], [], shard_index=0, shard_count=2)
+    assert should_process_zid(3, [3], [], shard_index=1, shard_count=2)
+
+
+def test_out_of_range_shard_is_a_startup_refusal():
+    """An unusable shard slice must crash at construction, not start healthy and
+    silently process nothing."""
+    with pytest.raises(ValueError, match="shard_index must be in"):
+        PollerConfig(shard_index=2, shard_count=2)
+    with pytest.raises(ValueError, match="shard_index must be in"):
+        PollerConfig(shard_index=-1, shard_count=2)
+    with pytest.raises(ValueError, match="shard_count must be >= 1"):
+        PollerConfig(shard_count=0)
+
+
+def test_rolling_shard_count_change_leaves_no_zid_unowned(engine, pg_url,
+                                                          make_service):
+    """A rolling shard-count change (2 -> 3) may DOUBLE-cover a zid mid-roll,
+    but it must never leave one unowned.  Assert both halves explicitly."""
+    zids = list(range(1, 61))
+    old, new = 2, 3
+    unowned, double = [], []
+    for zid in zids:
+        owners = [("old", i) for i in range(old)
+                  if should_process_zid(zid, [], [], i, old)]
+        owners += [("new", i) for i in range(new)
+                   if should_process_zid(zid, [], [], i, new)]
+        if not owners:
+            unowned.append(zid)
+        if len(owners) > 1:
+            double.append(zid)
+    assert unowned == [], f"zids with no owner during a rolling change: {unowned}"
+    assert double, (
+        "a rolling shard-count change necessarily double-covers some zids; "
+        "that is exactly why ownership needs a fence, not just a modulus"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Duplicate writers — the ownership question
+# --------------------------------------------------------------------------- #
+def _run_two_children(pg_url, tmp_path, days=1.0):
+    """Start two identical poller processes at once (same shard, same math_env)
+    and wait for both to finish one cycle."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _DELPHI_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+    env["POLIS_RECOVERY_DUMP_DIR"] = str(tmp_path / "errorconv")
+    child = os.path.join(os.path.dirname(__file__), "restart_child.py")
+    procs = [
+        subprocess.Popen(
+            [sys.executable, child, "--pg-url", pg_url, "--math-env", MATH_ENV,
+             "--kill-stage", "none", "--poll-from-days-ago", str(days)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            env=env, cwd=_DELPHI_ROOT,
+        )
+        for _ in range(2)
+    ]
+    outs = []
+    for p in procs:
+        out, err = p.communicate(timeout=180)
+        outs.append((p.returncode, out, err))
+    return outs
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (P-022 §C R07): nothing prevents or fences a duplicate writer. "
+        "Two poller processes with the SAME POLL_SHARD_INDEX/POLL_SHARD_COUNT "
+        "and the same MATH_ENV both start cleanly and both write the same "
+        "zid's math_main / math_bidtopid / math_ptptstats rows. There is no "
+        "startup refusal, no advisory lock, no lease and no fencing token "
+        "anywhere in polismath/poller/service.py or "
+        "polismath/database/postgres.py; ConversationWorkerPool serialises per "
+        "zid only WITHIN one process (polismath/poller/worker_pool.py:5). "
+        "P-022 §C requires 'startup refusal or demonstrable exclusive/fenced "
+        "ownership' and warns not to claim modulus filtering alone prevents "
+        "duplicate writers. Today the only control is the deployment promising "
+        "one replica, which is not observable from the database. A fix (a "
+        "pg_advisory_lock lease per (math_env, shard) held for the process "
+        "lifetime, or a fencing token checked in the writes) is a separate "
+        "decision."
+    ),
+)
+def test_duplicate_shard_start_is_refused_or_fenced(engine, pg_url, tmp_path):
+    """Two identical processes, same shard index and math env: one must refuse
+    to start, or ownership must be demonstrably exclusive."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    results = _run_two_children(pg_url, tmp_path)
+    exit_codes = [rc for rc, _out, _err in results]
+    refusals = [rc for rc in exit_codes if rc != 0]
+    assert refusals, (
+        "both duplicate processes started and completed a full write cycle "
+        f"(exit codes {exit_codes}); neither refused, and nothing fenced them"
+    )
+
+
+def test_duplicate_writers_both_write_the_same_rows(engine, pg_url, tmp_path):
+    """The observable consequence, asserted directly so the defect above is
+    documented rather than inferred: two duplicate processes both advance the
+    same zid's math_tick.  (Both write authoritative full-history state, so the
+    CONTENT stays correct here — the hazard is unfenced concurrent ownership,
+    not a demonstrated corruption on this fixture.)"""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    results = _run_two_children(pg_url, tmp_path)
+    assert [rc for rc, _o, _e in results] == [0, 0], (
+        f"both duplicates were expected to run to completion: {results}"
+    )
+    with engine.connect() as conn:
+        tick = conn.execute(
+            sa.text("SELECT math_tick FROM math_ticks WHERE zid=:z AND "
+                    "math_env=:e"), {"z": 1, "e": MATH_ENV},
+        ).scalar()
+    assert tick is not None and tick >= 1, (
+        f"two writers must have advanced the shared math_tick at least twice "
+        f"(saw math_tick={tick})"
+    )
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+
+
+def test_partially_overlapping_allowlists_both_accept_the_shared_zid(engine,
+                                                                     pg_url,
+                                                                     make_service):
+    """Two configurations whose allowlists overlap on zid 2: both accept it.
+    Allowlists are a selection mechanism, not an ownership mechanism."""
+    for zid in (1, 2, 3):
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+
+    a = make_service(pg_url, math_env=MATH_ENV, allowlist=[1, 2],
+                     worker_pool_size=1)
+    b = make_service(pg_url, math_env=MATH_ENV, allowlist=[2, 3],
+                     worker_pool_size=1)
+    for zid in (1, 2, 3):
+        accepted_by = [
+            name for name, svc in (("a", a), ("b", b))
+            if should_process_zid(zid, svc.config.allowlist, svc.config.blocklist,
+                                  svc.config.shard_index, svc.config.shard_count)
+        ]
+        expected = {1: ["a"], 2: ["a", "b"], 3: ["b"]}[zid]
+        assert accepted_by == expected
+
+    a.poll_once()
+    b.poll_once()
+    for zid in (1, 2, 3):
+        tables = read_math_tables(engine, zid, MATH_ENV)
+        assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+        fold = F.fold_votes(read_vote_events(engine, zid))
+        assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+
+
+def test_disjoint_shards_cover_every_seeded_zid_exactly_once_on_real_pg(
+    engine, pg_url, make_service
+):
+    """End-to-end partitioning: shard 0/2 and shard 1/2 together publish every
+    seeded conversation, and neither touches the other's zids."""
+    zids = [1, 2, 3, 4, 5, 6]
+    for zid in zids:
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+
+    shard0 = make_service(pg_url, math_env=MATH_ENV + "_s0", shard_index=0,
+                          shard_count=2, worker_pool_size=1)
+    shard1 = make_service(pg_url, math_env=MATH_ENV + "_s1", shard_index=1,
+                          shard_count=2, worker_pool_size=1)
+    shard0.poll_once()
+    shard1.poll_once()
+
+    for zid in zids:
+        owner = MATH_ENV + ("_s0" if zid % 2 == 0 else "_s1")
+        other = MATH_ENV + ("_s1" if zid % 2 == 0 else "_s0")
+        assert read_math_tables(engine, zid, owner)["main"] is not None, (
+            f"zid {zid} was not published by its owning shard"
+        )
+        assert read_math_tables(engine, zid, other)["main"] is None, (
+            f"zid {zid} was published by the NON-owning shard"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the shard-ownership failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_broken_partition_is_detected(self):
+        """Intentionally broken variant: a filter that ignores the shard index.
+        The exactly-once partition assertion must go red on it."""
+        def broken(zid, allowlist, blocklist, shard_index, shard_count):
+            return True  # every shard accepts every zid
+
+        accepting = [idx for idx in range(4) if broken(7, [], [], idx, 4)]
+        assert len(accepting) != 1, (
+            "NEGATIVE CONTROL FAILED: a shard filter that accepts everything "
+            "still looked like an exactly-once partition"
+        )
+
+    def test_a_shard_that_owns_nothing_would_be_caught(self):
+        """A shard index outside its count owns no zid at all — the failure
+        mode ``_validate_shard`` exists to prevent.  Assert the arithmetic
+        really would go silent, so the startup refusal is load-bearing."""
+        owned = [z for z in range(200)
+                 if should_process_zid(z, [], [], shard_index=5, shard_count=2)]
+        assert owned == [], (
+            "an out-of-range shard owns nothing; without the constructor's "
+            "ValueError such a process would start and look healthy"
+        )

--- a/delphi/tests/poller/recovery/test_r07_overlapping_shards.py
+++ b/delphi/tests/poller/recovery/test_r07_overlapping_shards.py
@@ -19,12 +19,6 @@ is what the duplicate-writer tests below establish, on real processes against
 real rows.
 """
 
-import os
-import subprocess
-import sys
-import threading
-import time
-
 import pytest
 import sqlalchemy as sa
 
@@ -36,11 +30,34 @@ from .conftest import (
 )
 from . import fold as F
 from polismath.poller.service import PollerConfig, should_process_zid
-from .test_r05_mid_batch_restart import Child, _DELPHI_ROOT
+from .test_r05_mid_batch_restart import (  # noqa: F401  (children is a fixture)
+    _spawn,
+    children,
+)
 
 pytestmark = pytest.mark.recovery
 
 MATH_ENV = "recovery"
+
+# The refusal contract, defined by the harness and asserted by name.
+#
+# "Nonzero exit" is NOT a refusal: an import error, a DB outage or two crashed
+# workers would all satisfy it (astra review finding 3).  A refusal is a
+# process that declined to run BECAUSE someone else owns this shard, and it
+# announces itself with this exit code and this marker
+# (``restart_child._is_ownership_refusal`` / ``OWNERSHIP_REFUSAL_MARKER``).
+# Nothing else is accepted, and any other nonzero exit is a HARD failure.
+OWNERSHIP_REFUSAL_EXIT = 3
+OWNERSHIP_REFUSAL_MARKER = "OWNERSHIP-REFUSED"
+
+
+class OwnershipNotFenced(AssertionError):
+    """Raised when duplicate writers were neither refused nor fenced.
+
+    A distinct type so the ``xfail`` below can name it with ``raises=``: any
+    OTHER failure — an unrelated crash, no healthy publisher, an incoherent
+    final generation — is then a real FAILURE and not a green xfail.
+    """
 
 
 # --------------------------------------------------------------------------- #
@@ -82,10 +99,19 @@ def test_out_of_range_shard_is_a_startup_refusal():
         PollerConfig(shard_count=0)
 
 
-def test_rolling_shard_count_change_leaves_no_zid_unowned(engine, pg_url,
-                                                          make_service):
+def test_rolling_shard_count_change_arithmetic_leaves_no_zid_unowned(
+    engine, pg_url, make_service
+):
     """A rolling shard-count change (2 -> 3) may DOUBLE-cover a zid mid-roll,
-    but it must never leave one unowned.  Assert both halves explicitly."""
+    but it must never leave one unowned.  Assert both halves explicitly.
+
+    LIMITATION, kept explicit (astra review finding 3): this evaluates two
+    complete arithmetic partitions side by side.  It is NOT a rolling ownership
+    handoff — no process starts, stops, or hands anything over, and nothing
+    here shows what the two generations of processes do to the same rows while
+    both are live.  A real handoff test needs process-level fencing and
+    reconfiguration to exist first; until then the duplicate-writer tests below
+    are the only process-level ownership evidence in this module."""
     zids = list(range(1, 61))
     old, new = 2, 3
     unowned, double = [], []
@@ -108,31 +134,87 @@ def test_rolling_shard_count_change_leaves_no_zid_unowned(engine, pg_url,
 # --------------------------------------------------------------------------- #
 # Duplicate writers — the ownership question
 # --------------------------------------------------------------------------- #
-def _run_two_children(pg_url, tmp_path, days=1.0):
-    """Start two identical poller processes at once (same shard, same math_env)
-    and wait for both to finish one cycle."""
-    env = dict(os.environ)
-    env["PYTHONPATH"] = _DELPHI_ROOT + os.pathsep + env.get("PYTHONPATH", "")
-    env["POLIS_RECOVERY_DUMP_DIR"] = str(tmp_path / "errorconv")
-    child = os.path.join(os.path.dirname(__file__), "restart_child.py")
-    procs = [
-        subprocess.Popen(
-            [sys.executable, child, "--pg-url", pg_url, "--math-env", MATH_ENV,
-             "--kill-stage", "none", "--poll-from-days-ago", str(days)],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
-            env=env, cwd=_DELPHI_ROOT,
-        )
+def _advisory_locks(engine) -> list:
+    """Every advisory lock held on this database right now.
+
+    An "exclusive/fenced ownership" implementation would show up here (a
+    ``pg_advisory_lock`` lease per ``(math_env, shard)`` is the obvious form).
+    Read WHILE both duplicate writers hold their ownership latch, so an empty
+    result is real evidence that nothing was fenced rather than a timing
+    artefact."""
+    with engine.connect() as conn:
+        rows = conn.execute(sa.text(
+            "select locktype, classid, objid, objsubid, granted, pid "
+            "from pg_locks where locktype = 'advisory'"
+        )).mappings().all()
+    return [dict(r) for r in rows]
+
+
+def _ownership_table_names(engine) -> list:
+    """Tables that would carry a durable lease / fencing token, if any existed."""
+    with engine.connect() as conn:
+        rows = conn.execute(sa.text(
+            "select table_name from information_schema.tables "
+            "where table_schema = 'public' and ("
+            "  table_name ilike '%owner%' or table_name ilike '%lease%' "
+            "  or table_name ilike '%fence%' or table_name ilike '%shard%')"
+        )).scalars().all()
+    return list(rows)
+
+
+def _run_two_latched_children(engine, pg_url, tmp_path, children, days=1.0):
+    """Two identical poller processes held CONCURRENTLY at their ownership
+    point, so "both ran" cannot be two one-shot processes running one after the
+    other (astra review finding 3).
+
+    Returns ``(kids, evidence)`` where ``evidence`` is what the database showed
+    while both were alive and holding.
+    """
+    latch_dir = tmp_path / "ownership"
+    kids = [
+        _spawn_latched(children, pg_url, tmp_path, latch_dir, days)
         for _ in range(2)
     ]
-    outs = []
-    for p in procs:
-        out, err = p.communicate(timeout=180)
-        outs.append((p.returncode, out, err))
-    return outs
+    for kid in kids:
+        kid.await_stage("OWNED", timeout=120)
+    assert all(kid.proc.poll() is None for kid in kids), (
+        "both duplicate processes must still be ALIVE while holding ownership"
+    )
+
+    evidence = {
+        "advisory_locks": _advisory_locks(engine),
+        "ownership_tables": _ownership_table_names(engine),
+        "held_concurrently": True,
+    }
+
+    (latch_dir / "release").write_text("go")
+    for kid in kids:
+        kid.proc.wait(timeout=180)
+    return kids, evidence
+
+
+def _spawn_latched(kids, pg_url, tmp_path, latch_dir, days):
+    return _spawn(kids, pg_url, "none", days=days, tmp_path=tmp_path,
+                  ownership_latch_dir=latch_dir)
+
+
+def _classify(kid):
+    """``'publisher'`` (exit 0, completed a cycle), ``'refusal'`` (the named
+    ownership refusal) or ``'crash'`` (anything else)."""
+    rc = kid.proc.returncode
+    stderr = kid.proc.stderr.read() if kid.proc.stderr else ""
+    if rc == 0 and "DONE" in kid.stages:
+        return "publisher", stderr
+    if rc == OWNERSHIP_REFUSAL_EXIT and any(
+        l.startswith(OWNERSHIP_REFUSAL_MARKER) for l in kid.lines
+    ):
+        return "refusal", stderr
+    return "crash", stderr
 
 
 @pytest.mark.xfail(
     strict=True,
+    raises=OwnershipNotFenced,
     reason=(
         "DEFECT (P-022 §C R07): nothing prevents or fences a duplicate writer. "
         "Two poller processes with the SAME POLL_SHARD_INDEX/POLL_SHARD_COUNT "
@@ -148,32 +230,90 @@ def _run_two_children(pg_url, tmp_path, days=1.0):
         "one replica, which is not observable from the database. A fix (a "
         "pg_advisory_lock lease per (math_env, shard) held for the process "
         "lifetime, or a fencing token checked in the writes) is a separate "
-        "decision."
+        "decision. NOTE the xfail names OwnershipNotFenced explicitly: an "
+        "unrelated crash, a missing healthy publisher or an incoherent final "
+        "generation is a REAL failure here, never a green xfail."
     ),
 )
-def test_duplicate_shard_start_is_refused_or_fenced(engine, pg_url, tmp_path):
-    """Two identical processes, same shard index and math env: one must refuse
-    to start, or ownership must be demonstrably exclusive."""
+def test_duplicate_shard_start_is_refused_or_fenced(engine, pg_url, tmp_path,
+                                                    children):
+    """Two identical processes, same shard index and math env, held ALIVE at
+    the same time: one must refuse to start for a named ownership reason, or
+    ownership must be demonstrably exclusive/fenced.
+
+    Every precondition is a plain assertion, so it fails for real:
+
+    * both processes were alive concurrently while holding ownership (two
+      one-shot children running sequentially would prove nothing);
+    * exactly one proven-healthy publisher exists (exit 0 with a completed
+      cycle);
+    * no process crashed for an unrelated reason — a nonzero exit only counts
+      as a refusal when it is ``OWNERSHIP_REFUSAL_EXIT`` with the marker;
+    * no losing process is left running;
+    * the final generation is coherent and matches the independent fold.
+
+    Only the ownership question itself raises :class:`OwnershipNotFenced`.
+    """
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
-    results = _run_two_children(pg_url, tmp_path)
-    exit_codes = [rc for rc, _out, _err in results]
-    refusals = [rc for rc in exit_codes if rc != 0]
-    assert refusals, (
-        "both duplicate processes started and completed a full write cycle "
-        f"(exit codes {exit_codes}); neither refused, and nothing fenced them"
+    kids, evidence = _run_two_latched_children(engine, pg_url, tmp_path,
+                                               children)
+    outcomes = [_classify(kid) for kid in kids]
+    kinds = [kind for kind, _err in outcomes]
+
+    assert evidence["held_concurrently"]
+    crashes = [(kid.proc.returncode, kid.lines, err)
+               for kid, (kind, err) in zip(kids, outcomes) if kind == "crash"]
+    assert not crashes, (
+        "a duplicate-writer process died for a reason that is NOT the named "
+        f"ownership refusal, which must never be read as fencing: {crashes}"
+    )
+    assert kinds.count("publisher") >= 1, (
+        f"no healthy publisher survived the duplicate start: {kinds}"
+    )
+    assert all(kid.proc.poll() is not None for kid in kids), (
+        "a losing process is still running"
     )
 
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
 
-def test_duplicate_writers_both_write_the_same_rows(engine, pg_url, tmp_path):
+    refused = [kid for kid, (kind, _e) in zip(kids, outcomes)
+               if kind == "refusal"]
+    fenced = bool(evidence["advisory_locks"]) or bool(
+        evidence["ownership_tables"])
+    if not refused and not fenced:
+        raise OwnershipNotFenced(
+            "both duplicate processes started and completed a full write "
+            f"cycle (outcomes {kinds}); none refused with exit "
+            f"{OWNERSHIP_REFUSAL_EXIT}/{OWNERSHIP_REFUSAL_MARKER}, no advisory "
+            "lock was held while both were alive "
+            f"({evidence['advisory_locks']}) and no lease/fence table exists "
+            f"({evidence['ownership_tables']})"
+        )
+
+
+def test_duplicate_writers_both_write_the_same_rows(engine, pg_url, tmp_path,
+                                                    children):
     """The observable consequence, asserted directly so the defect above is
-    documented rather than inferred: two duplicate processes both advance the
-    same zid's math_tick.  (Both write authoritative full-history state, so the
-    CONTENT stays correct here — the hazard is unfenced concurrent ownership,
-    not a demonstrated corruption on this fixture.)"""
+    documented rather than inferred: two duplicate processes, proven ALIVE AT
+    THE SAME TIME by the ownership latch, both advance the same zid's
+    math_tick.  (Both write authoritative full-history state, so the CONTENT
+    stays correct here — the hazard is unfenced concurrent ownership, not a
+    demonstrated corruption on this fixture.)"""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
-    results = _run_two_children(pg_url, tmp_path)
-    assert [rc for rc, _o, _e in results] == [0, 0], (
-        f"both duplicates were expected to run to completion: {results}"
+    kids, evidence = _run_two_latched_children(engine, pg_url, tmp_path,
+                                               children)
+    assert evidence["held_concurrently"]
+    assert [kid.proc.returncode for kid in kids] == [0, 0], (
+        "both duplicates were expected to run to completion: "
+        f"{[(k.proc.returncode, k.lines) for k in kids]}"
+    )
+    assert all("DONE" in kid.stages for kid in kids)
+    assert evidence["advisory_locks"] == [], (
+        "no advisory lock was taken while two duplicate writers were both "
+        f"alive: {evidence['advisory_locks']}"
     )
     with engine.connect() as conn:
         tick = conn.execute(
@@ -260,6 +400,45 @@ class TestNegativeControl:
             "NEGATIVE CONTROL FAILED: a shard filter that accepts everything "
             "still looked like an exactly-once partition"
         )
+
+    def test_an_unrelated_crash_is_not_classified_as_a_refusal(self, pg_url,
+                                                               tmp_path,
+                                                               children):
+        """The correction itself, controlled (astra review finding 3): a child
+        that dies of a DB outage — the very thing "any nonzero exit" used to
+        accept — must classify as a CRASH, never as an ownership refusal."""
+        kid = _spawn(children, pg_url.replace("/rec_", "/nope_does_not_exist_"),
+                     "none", tmp_path=tmp_path)
+        rc = kid.proc.wait(timeout=120)
+        assert rc != 0, "the unreachable-database child must fail"
+        assert rc != OWNERSHIP_REFUSAL_EXIT
+        kind, _err = _classify(kid)
+        assert kind == "crash", (
+            "NEGATIVE CONTROL FAILED: an unrelated process failure was "
+            f"classified as {kind!r}"
+        )
+        assert not any(l.startswith(OWNERSHIP_REFUSAL_MARKER)
+                       for l in kid.lines)
+
+    def test_the_refusal_classifier_recognises_a_real_refusal(self):
+        """...and the classifier is not merely always-false: the shapes an
+        ownership refusal would take ARE recognised, so the xfail above is
+        waiting on production, not on an unreachable assertion."""
+        from .restart_child import _is_ownership_refusal
+
+        class OwnershipRefused(RuntimeError):
+            pass
+
+        assert _is_ownership_refusal(OwnershipRefused("shard 0/2"))
+        assert _is_ownership_refusal(
+            RuntimeError("shard (recovery, 0/2) is already owned by pid 42"))
+        assert _is_ownership_refusal(
+            RuntimeError("ownership lease advisory lock not acquired"))
+        assert _is_ownership_refusal(RuntimeError("stale fence rejected"))
+        # ...and not by accident:
+        assert not _is_ownership_refusal(ImportError("no module named x"))
+        assert not _is_ownership_refusal(
+            RuntimeError("could not connect to server"))
 
     def test_a_shard_that_owns_nothing_would_be_caught(self):
         """A shard index outside its count owns no zid at all — the failure

--- a/delphi/tests/poller/recovery/test_r08_timestamp_boundary.py
+++ b/delphi/tests/poller/recovery/test_r08_timestamp_boundary.py
@@ -1,0 +1,309 @@
+"""R08 — strict ``>`` watermark boundary (REAL Postgres, two real connections).
+
+P-022 §C required matrix:
+
+    Commit vote A at t; poll/advance; commit B with created=t and then one with
+    created<t on another connection.  Repeat for moderation, timestamp ties and
+    clock skew.  Without a later vote, all committed input must eventually be
+    represented.  Strict ``>`` plus max timestamp is insufficient.  Test
+    overlap/dedup or durable scan/reconciliation repair; a lookback needs a
+    proven bound or a repair path for older commits.
+
+The poll queries are ``WHERE created > :since`` / ``WHERE modified > :since``
+(``polismath/database/postgres.py:572``, ``:606``) and the watermark advances to
+``max(created)`` (``polismath/poller/service.py:40``).  Two real connections are
+used so the "committed later, timestamped earlier" case is a genuine commit-order
+event and not a Python-side reordering: ``votes.created`` defaults to
+``now_as_millis()`` but is explicitly supplied here, which is exactly what a
+client-supplied or clock-skewed timestamp looks like.
+"""
+
+import time
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    commit_vote,
+    drain,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+def _published_fold_problems(engine, zid=1):
+    tables = read_math_tables(engine, zid, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, zid))
+    return F.check_published_against_fold(tables["main"]["data"], fold), tables, fold
+
+
+# --------------------------------------------------------------------------- #
+# The boundary itself
+# --------------------------------------------------------------------------- #
+def test_watermark_advances_to_exactly_the_max_created(engine, pg_url,
+                                                       make_service):
+    """Control: after a poll, the vote watermark is exactly ``max(created)``, so
+    the next poll's ``created > watermark`` excludes that row."""
+    seeded = seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    assert svc._vote_wm == max(e["created"] for e in seeded.vote_events)
+
+    with engine.connect() as conn:
+        rows = conn.execute(
+            sa.text("SELECT count(*) FROM votes WHERE created > :w"),
+            {"w": svc._vote_wm},
+        ).scalar()
+    assert rows == 0, "the strict > boundary excludes the row it advanced onto"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (predicted by P-022 §C): a vote committed with created EXACTLY "
+        "equal to the current watermark is never delivered. "
+        "polismath/database/postgres.py:572 polls `WHERE created > :since` and "
+        "polismath/poller/service.py:40 advances the watermark to max(created) "
+        "of the rows it just saw, so the boundary row is skipped by the very "
+        "poll that moved onto it. Nothing repairs it: the parked-zid "
+        "reconciler (polismath/poller/service.py:393) only visits zids that "
+        "FAILED, and a never-polled late commit creates no parked marker. "
+        "Without a later vote on the same conversation the input is silently "
+        "absent from math_main indefinitely. P-022 §C: 'Without a later vote, "
+        "all committed input must eventually be represented. Strict > plus max "
+        "timestamp is insufficient.' The fix is an overlap/dedup window or a "
+        "durable scan; that is a separate decision."
+    ),
+)
+def test_equal_timestamp_commit_is_eventually_represented(engine, pg_url,
+                                                          make_service):
+    """Commit A at t, poll (watermark -> t), then commit B with created == t on
+    ANOTHER connection.  With no later vote, B must still be represented."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    t = svc._vote_wm
+
+    # Second, independent connection — a genuinely separate committer.
+    with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as conn:
+        with conn.begin():
+            commit_vote(conn, 1, 0, 0, F.RAW_DISAGREE, t)
+
+    for _ in range(3):          # bounded eventual progress: repeated cycles
+        svc.poll_once()
+
+    problems, _tables, _fold = _published_fold_problems(engine, 1)
+    assert problems == [], problems
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (same root cause, clock-skew / late-commit variant): a vote "
+        "COMMITTED after the poll but TIMESTAMPED before the watermark is never "
+        "delivered either. votes.created is a client/server-supplied bigint "
+        "(server/postgres/migrations/000000_initial.sql: `created bigint "
+        "default now_as_millis()`), so commit order and timestamp order are "
+        "independent; polismath/database/postgres.py:572's `created > :since` "
+        "keys on the timestamp alone. There is no repair path for a "
+        "never-polled commit — see the equal-timestamp case above."
+    ),
+)
+def test_late_commit_with_earlier_timestamp_is_eventually_represented(
+    engine, pg_url, make_service
+):
+    """Commit-order vs timestamp-order: B commits AFTER the poll but carries
+    ``created < watermark``.
+
+    B targets cell (0, 0), whose seeded event is the OLDEST in the stream, and
+    carries a timestamp strictly between that event and the watermark — so B is
+    unambiguously the cell's new winner and its absence is observable.
+    """
+    seeded = seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    t = svc._vote_wm
+    oldest = min(e["created"] for e in seeded.vote_events)
+    late = (oldest + t) // 2
+    assert oldest < late < t
+
+    with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as conn:
+        with conn.begin():
+            commit_vote(conn, 1, 0, 0, F.RAW_DISAGREE, late)
+
+    for _ in range(3):
+        svc.poll_once()
+
+    problems, _tables, _fold = _published_fold_problems(engine, 1)
+    assert problems == [], problems
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (moderation variant of the same boundary): "
+        "polismath/database/postgres.py:606 polls comments with `WHERE "
+        "modified > :since` and polismath/poller/service.py:465 advances the "
+        "moderation watermark to max(modified), so a moderation change whose "
+        "`modified` equals the watermark is never delivered. The per-zid worker "
+        "re-derives FULL moderation state once it is woken "
+        "(polismath/poller/service.py:533), so the damage is bounded to 'the "
+        "conversation is never woken' — but with no later vote or later "
+        "moderation change, nothing wakes it."
+    ),
+)
+def test_equal_timestamp_moderation_change_is_eventually_represented(
+    engine, pg_url, make_service
+):
+    """The moderation loop has the same strict boundary."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    # Move the moderation watermark onto a real modified value.
+    now = int(time.time() * 1000)
+    with engine.begin() as conn:
+        conn.execute(sa.text("SET session_replication_role = replica"))
+        conn.execute(
+            sa.text("UPDATE comments SET modified = :m WHERE zid=1 AND tid=0"),
+            {"m": now},
+        )
+    svc.poll_once()
+    assert svc._mod_wm == now
+
+    # A second moderation action lands with modified EXACTLY on the watermark.
+    with engine.begin() as conn:
+        conn.execute(sa.text("SET session_replication_role = replica"))
+        conn.execute(
+            sa.text("UPDATE comments SET mod = -1, modified = :m "
+                    "WHERE zid=1 AND tid=1"),
+            {"m": now},
+        )
+    for _ in range(3):
+        svc.poll_once()
+
+    data = read_math_tables(engine, 1, MATH_ENV)["main"]["data"]
+    with engine.connect() as conn:
+        comment_rows = [dict(r) for r in conn.execute(
+            sa.text("SELECT tid, mod, is_meta, modified FROM comments "
+                    "WHERE zid = 1")).mappings()]
+    expected = F.fold_moderation(comment_rows)
+    assert set(data["moderation"]["mod_out_tids"]) == expected.mod_out_tids, (
+        "the moderated-out comment must eventually be represented"
+    )
+
+
+def test_a_later_vote_repairs_the_skipped_boundary_row(engine, pg_url,
+                                                       make_service):
+    """The bound on the damage: ANY later vote on the same conversation wakes
+    it, and the per-zid worker's full-history rebuild subsumes the skipped row.
+    So the defect is 'no repair without further traffic', not 'lost forever
+    under traffic' — asserted so the xfails above are correctly scoped."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       conv_cache_cap=0)
+    svc.poll_once()
+    t = svc._vote_wm
+
+    with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as conn:
+        with conn.begin():
+            commit_vote(conn, 1, 0, 0, F.RAW_DISAGREE, t)      # skipped
+    svc.poll_once()
+    assert _published_fold_problems(engine, 1)[0] != [], (
+        "precondition: the boundary row must indeed be missing at this point"
+    )
+
+    # Any later vote wakes the conversation. The cached conv is warm, so the
+    # skipped row is only recovered via a full rebuild — force the rebuild path
+    # the reconciler would use.
+    commit_vote(engine, 1, 2, 2, F.RAW_AGREE, t + 1000)
+    svc._convs.pop(1, None)
+    svc.poll_once()
+
+    problems, tables, fold = _published_fold_problems(engine, 1)
+    assert problems == [], problems
+    assert tables["main"]["last_vote_timestamp"] == fold.last_vote_timestamp
+
+
+def test_a_warm_cached_conversation_does_not_recover_the_skipped_row(
+    engine, pg_url, make_service
+):
+    """Scope the repair claim honestly: with a WARM cache the later vote is
+    applied incrementally, so the skipped boundary row stays missing even under
+    traffic.  Only a full-history rebuild (eviction, restart, reconcile)
+    recovers it."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       conv_cache_cap=0)
+    svc.poll_once()
+    t = svc._vote_wm
+
+    with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as conn:
+        with conn.begin():
+            commit_vote(conn, 1, 0, 0, F.RAW_DISAGREE, t)
+    commit_vote(engine, 1, 2, 2, F.RAW_AGREE, t + 1000)
+    svc.poll_once()             # warm cache: incremental update only
+
+    problems, _tables, _fold = _published_fold_problems(engine, 1)
+    assert problems != [], (
+        "a warm incremental update cannot recover a row the poll never "
+        "delivered; if this passes, the scoping of the R08 xfails is wrong"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the timestamp-boundary failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_an_inclusive_boundary_would_deliver_the_row(self, engine, pg_url,
+                                                         make_service):
+        """Intentionally 'fixed' variant: poll with an OVERLAP window
+        (``created > watermark - overlap``).  The same scenario then passes,
+        proving the xfails above are caused by the strict boundary and not by
+        the fixture."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                           conv_cache_cap=0)
+        svc.poll_once()
+        t = svc._vote_wm
+
+        with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as c:
+            with c.begin():
+                commit_vote(c, 1, 0, 0, F.RAW_DISAGREE, t)
+
+        real_poll = svc._pg.poll_votes_since
+        svc._pg.poll_votes_since = lambda since: real_poll(since - 1)
+        svc._convs.pop(1, None)
+        svc.poll_once()
+        svc._pg.poll_votes_since = real_poll
+
+        problems, _tables, _fold = _published_fold_problems(engine, 1)
+        assert problems == [], (
+            "NEGATIVE CONTROL FAILED: even an overlapping poll window did not "
+            f"deliver the boundary row ({problems})"
+        )
+
+    def test_the_row_really_is_committed(self, engine, pg_url, make_service):
+        """Guard against a vacuous xfail: the boundary row must actually be in
+        the votes table."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        svc.poll_once()
+        t = svc._vote_wm
+        with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as c:
+            with c.begin():
+                commit_vote(c, 1, 0, 0, F.RAW_DISAGREE, t)
+        events = read_vote_events(engine, 1)
+        assert any(e["created"] == t and e["pid"] == 0 and e["tid"] == 0
+                   and e["vote"] == F.RAW_DISAGREE for e in events), (
+            "the boundary vote was never committed; the R08 xfails would be "
+            "vacuous"
+        )

--- a/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
+++ b/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
@@ -1,0 +1,369 @@
+"""R09 — partial tables and concurrent readers (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Pause after main but before bidtopid/ptptstats; continuously query through
+    Node.  No response may combine incompatible generations.  Prefer a
+    transaction spanning all three writes or a reader-visible completed
+    generation.  Eventual repair alone does not make a mixed mapping safe.  Seed
+    preexisting partial rows, restart and repair; fail on absent/mismatched
+    required rows.
+
+The reader here is a Python transcription of the TWO server queries that
+together produce a participant mapping —
+``server/src/utils/pca.ts:360`` (``select * from math_main where zid = $1 and
+math_env = $2``) and ``server/src/utils/participants.ts:10``
+(``select * from math_bidtopid where zid = $1 and math_env = $2``) — plus
+``getPidsForGid``'s positional join of ``base-clusters.id`` ->
+``bidToPid[index]`` (``participants.ts:25-60``).  Running the real Node server
+is D's job (see the notes file); what R09 needs is the exact query pair and the
+exact join, which is what is reproduced.
+"""
+
+import json
+import threading
+import time
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    Latch,
+    eventually,
+    latch_method,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+# --------------------------------------------------------------------------- #
+# The server's reader, transcribed
+# --------------------------------------------------------------------------- #
+def read_generation(engine, zid: int, math_env: str):
+    """One SNAPSHOT of the reader's two queries, taken inside a single
+    REPEATABLE READ transaction so any incoherence is the writer's, not a
+    torn read of the test's own making."""
+    conn = engine.connect().execution_options(isolation_level="REPEATABLE READ")
+    try:
+        with conn.begin():
+            main = conn.execute(
+                sa.text("select * from math_main where zid = :z and "
+                        "math_env = :e"), {"z": zid, "e": math_env},
+            ).mappings().first()
+            bid = conn.execute(
+                sa.text("select * from math_bidtopid where zid = :z and "
+                        "math_env = :e"), {"z": zid, "e": math_env},
+            ).mappings().first()
+            pts = conn.execute(
+                sa.text("select * from math_ptptstats where zid = :z and "
+                        "math_env = :e"), {"z": zid, "e": math_env},
+            ).mappings().first()
+    finally:
+        conn.close()
+    return (dict(main) if main else None,
+            dict(bid) if bid else None,
+            dict(pts) if pts else None)
+
+
+def response_problems(main, bid, pts):
+    """Everything wrong with the response a reader would build from this
+    snapshot.  Empty list == a usable, single-generation response."""
+    problems = []
+    if main is None:
+        return ["no math_main row: nothing to serve"]
+    if bid is None:
+        problems.append("math_bidtopid row absent while math_main is published")
+    if pts is None:
+        problems.append("math_ptptstats row absent while math_main is published")
+    if bid is not None and bid["math_tick"] != main["math_tick"]:
+        problems.append(
+            f"MIXED GENERATIONS: math_main math_tick={main['math_tick']} vs "
+            f"math_bidtopid math_tick={bid['math_tick']}"
+        )
+    if pts is not None and pts["math_tick"] != main["math_tick"]:
+        problems.append(
+            f"MIXED GENERATIONS: math_main math_tick={main['math_tick']} vs "
+            f"math_ptptstats math_tick={pts['math_tick']}"
+        )
+    if bid is not None:
+        problems.extend(_mapping_problems(main["data"], bid["data"]))
+    return problems
+
+
+def _mapping_problems(main_data, bid_data):
+    """``getPidsForGid``'s positional join (participants.ts:25-60): index a
+    group's base-cluster ids through ``base-clusters.id`` into ``bidToPid``."""
+    problems = []
+    ids = (main_data.get("base-clusters") or {}).get("id") or []
+    bid_to_pid = bid_data.get("bidToPid") or []
+    if len(ids) != len(bid_to_pid):
+        problems.append(
+            f"positional contract broken: base-clusters.id has {len(ids)} "
+            f"entries, bidToPid has {len(bid_to_pid)}"
+        )
+        return problems
+    bid_to_index = {b: i for i, b in enumerate(ids)}
+    known_pids = set()
+    for members in bid_to_pid:
+        known_pids.update(members)
+    for group in main_data.get("group-clusters") or []:
+        for member in group.get("members", []):
+            # group-clusters members are already unfolded to pids by the writer;
+            # the base-cluster ids are the ones that must resolve.
+            if member not in known_pids:
+                problems.append(
+                    f"group {group.get('id')} references pid {member!r} that "
+                    "no base cluster in this bidToPid contains"
+                )
+    for bid_id in ids:
+        if bid_id not in bid_to_index:
+            problems.append(f"base cluster {bid_id} has no bidToPid index")
+    return problems
+
+
+# --------------------------------------------------------------------------- #
+# Continuous reader while a write is paused mid-way
+# --------------------------------------------------------------------------- #
+class ContinuousReader(threading.Thread):
+    """Polls the reader's query pair until stopped, recording every snapshot."""
+
+    def __init__(self, engine, zid, math_env):
+        super().__init__(daemon=True)
+        self.engine = engine
+        self.zid = zid
+        self.math_env = math_env
+        self.snapshots = []
+        self._halt = threading.Event()
+
+    def run(self):
+        while not self._halt.is_set():
+            self.snapshots.append(read_generation(self.engine, self.zid,
+                                                  self.math_env))
+            self._halt.wait(0.01)
+
+    def stop(self):
+        self._halt.set()
+        self.join(timeout=30)
+
+    def incoherent(self):
+        return [response_problems(*s) for s in self.snapshots
+                if s[0] is not None and response_problems(*s)]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (predicted by P-022 §C): the three tables are published "
+        "NON-ATOMICALLY, so a reader can observe math_main at generation N "
+        "together with math_bidtopid/math_ptptstats at N-1 or absent. "
+        "polismath/poller/math_writer.py:238 makes three separate client "
+        "calls and each commits on its own engine.begin() "
+        "(polismath/database/postgres.py:413, :432). The consumer joins the "
+        "two blobs POSITIONALLY — server/src/utils/participants.ts:33-51 maps "
+        "base-clusters.id -> index -> bidToPid[index] — so a mixed pair is a "
+        "wrong participant mapping, not merely a stale one. P-022 §C: 'No "
+        "response may combine incompatible generations... Eventual repair "
+        "alone does not make a mixed mapping safe.' The fix is a transaction "
+        "spanning all three writes, or a reader-visible completed-generation "
+        "marker; that is a separate decision."
+    ),
+)
+def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service):
+    """Pause the writer after the main commit and before the bidtopid commit,
+    while a reader polls continuously."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()          # generation 1: complete
+
+    reader = ContinuousReader(engine, 1, MATH_ENV)
+    reader.start()
+
+    latch = Latch("write_math_bidtopid")
+    undo = latch_method(svc._pg, "write_math_bidtopid", latch)
+    from .conftest import commit_vote
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
+    svc._vote_wm = base
+
+    worker = threading.Thread(target=svc.poll_once, daemon=True)
+    worker.start()
+    latch.wait_arrival()
+    # The reader is running while math_main is committed and bidtopid is not.
+    eventually(lambda: len(reader.snapshots) > 3, timeout=10,
+               message="the reader took no snapshots during the pause")
+    latch.let_go()
+    worker.join(timeout=60)
+    undo()
+    reader.stop()
+
+    bad = reader.incoherent()
+    assert bad == [], (
+        f"{len(bad)} of {len(reader.snapshots)} reader snapshots combined "
+        f"incompatible generations, e.g. {bad[0]}"
+    )
+
+
+def test_the_mixed_window_is_real_and_observable(engine, pg_url, make_service):
+    """Companion to the xfail: assert the incoherent window EXISTS, so the
+    defect is documented directly rather than only as a failing expectation."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    first_tick = read_math_tables(engine, 1, MATH_ENV)["main"]["math_tick"]
+
+    latch = Latch("write_math_bidtopid")
+    undo = latch_method(svc._pg, "write_math_bidtopid", latch)
+    from .conftest import commit_vote
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
+    svc._vote_wm = base
+    worker = threading.Thread(target=svc.poll_once, daemon=True)
+    worker.start()
+    latch.wait_arrival()
+
+    main, bid, pts = read_generation(engine, 1, MATH_ENV)
+    assert main["math_tick"] > first_tick, "math_main advanced on its own"
+    assert bid["math_tick"] == first_tick, "math_bidtopid is a generation behind"
+    assert pts["math_tick"] == first_tick
+    problems = response_problems(main, bid, pts)
+    assert any("MIXED GENERATIONS" in p for p in problems), problems
+
+    latch.let_go()
+    worker.join(timeout=60)
+    undo()
+    assert tables_are_coherent(read_math_tables(engine, 1, MATH_ENV)) == []
+
+
+# --------------------------------------------------------------------------- #
+# Preexisting partial rows: repair on restart
+# --------------------------------------------------------------------------- #
+def test_preexisting_partial_rows_are_repaired(engine, pg_url, make_service):
+    """Seed a math_main row with NO bidtopid/ptptstats (the state a crash
+    between writes leaves) and require a subsequent cycle to repair it into a
+    single coherent generation matching the fold."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text("insert into math_main (zid, math_env, data, "
+                    "last_vote_timestamp, caching_tick, math_tick) values "
+                    "(:z, :e, cast(:d as jsonb), 0, 1, 7)"),
+            {"z": 1, "e": MATH_ENV, "d": json.dumps({"zid": 1})},
+        )
+    main, bid, pts = read_generation(engine, 1, MATH_ENV)
+    assert response_problems(main, bid, pts), "precondition: partial rows"
+
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    main, bid, pts = read_generation(engine, 1, MATH_ENV)
+    assert response_problems(main, bid, pts) == [], (
+        response_problems(main, bid, pts)
+    )
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(main["data"], fold) == []
+
+
+def test_absent_required_rows_fail_the_reader_check(engine, pg_url,
+                                                    make_service):
+    """"fail on absent/mismatched required rows": deleting either companion row
+    must make the reader check go red."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    assert response_problems(*read_generation(engine, 1, MATH_ENV)) == []
+
+    for table in ("math_bidtopid", "math_ptptstats"):
+        with engine.begin() as conn:
+            conn.execute(
+                sa.text(f"delete from {table} where zid=:z and math_env=:e"),
+                {"z": 1, "e": MATH_ENV},
+            )
+        problems = response_problems(*read_generation(engine, 1, MATH_ENV))
+        assert any(table in p for p in problems), (
+            f"deleting {table} was not detected: {problems}"
+        )
+
+
+def test_positional_bidtopid_contract_holds_for_a_complete_generation(
+    engine, pg_url, make_service
+):
+    """The contract the server relies on (``math_writer.py:42``): every base
+    cluster id has a positionally aligned bidToPid entry, and every group
+    member resolves."""
+    seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    main, bid, _pts = read_generation(engine, 1, MATH_ENV)
+    assert _mapping_problems(main["data"], bid["data"]) == []
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the partial-table / reader failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_an_atomic_three_table_write_is_never_observed_mixed(self, engine,
+                                                                 pg_url,
+                                                                 make_service):
+        """Intentionally 'fixed' variant: write all three rows inside ONE
+        transaction and show the continuous reader never observes a split.
+        This proves the observer above can distinguish atomic from non-atomic
+        publication — the xfail is about the writer, not about the check."""
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        svc.poll_once()
+        tables = read_math_tables(engine, 1, MATH_ENV)
+        blob = tables["main"]["data"]
+        bid_blob = tables["bidtopid"]["data"]
+        pts_blob = tables["ptptstats"]["data"]
+
+        reader = ContinuousReader(engine, 1, MATH_ENV)
+        reader.start()
+        for tick in range(50, 55):
+            with engine.begin() as conn:      # ONE transaction for all three
+                conn.execute(
+                    sa.text("update math_main set math_tick=:t, data=cast(:d as "
+                            "jsonb) where zid=:z and math_env=:e"),
+                    {"t": tick, "d": json.dumps(blob), "z": 1, "e": MATH_ENV})
+                conn.execute(
+                    sa.text("update math_bidtopid set math_tick=:t, "
+                            "data=cast(:d as jsonb) where zid=:z and "
+                            "math_env=:e"),
+                    {"t": tick, "d": json.dumps(bid_blob), "z": 1,
+                     "e": MATH_ENV})
+                conn.execute(
+                    sa.text("update math_ptptstats set math_tick=:t, "
+                            "data=cast(:d as jsonb) where zid=:z and "
+                            "math_env=:e"),
+                    {"t": tick, "d": json.dumps(pts_blob), "z": 1,
+                     "e": MATH_ENV})
+        reader.stop()
+
+        assert len(reader.snapshots) > 1
+        assert reader.incoherent() == [], (
+            "NEGATIVE CONTROL FAILED: an ATOMIC three-table write was still "
+            "observed as a mixed generation, so the reader check has a false "
+            f"positive: {reader.incoherent()[:1]}"
+        )
+
+    def test_a_deliberately_misaligned_mapping_is_caught(self, engine, pg_url,
+                                                         make_service):
+        """Break the positional contract on purpose; the mapping check must
+        detect it."""
+        seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        svc.poll_once()
+        main, bid, _pts = read_generation(engine, 1, MATH_ENV)
+        broken = dict(bid["data"])
+        broken["bidToPid"] = broken["bidToPid"][:-1]      # drop one bucket
+        problems = _mapping_problems(main["data"], broken)
+        assert problems, (
+            "NEGATIVE CONTROL FAILED: a truncated bidToPid was accepted as "
+            "positionally aligned"
+        )

--- a/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
+++ b/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
@@ -18,6 +18,46 @@ math_env = $2``) and ``server/src/utils/participants.ts:10``
 ``bidToPid[index]`` (``participants.ts:25-60``).  Running the real Node server
 is D's job (see the notes file); what R09 needs is the exact query pair and the
 exact join, which is what is reproduced.
+
+What this module does and does NOT prove (astra review finding 2)
+-----------------------------------------------------------------
+:func:`read_generation` takes an observation in one of two modes:
+
+``repeatable_read``
+    both SELECTs inside ONE ``REPEATABLE READ`` transaction.  Any incoherence
+    it reports is therefore the WRITER's, never a torn read of the test's own
+    making.  This is the mode the writer-atomicity evidence uses, and it is
+    STRICTLY STRONGER than what the server does.
+``separate_statements``
+    each SELECT on its OWN connection in its own autocommit statement — which
+    is what Node actually does: ``getPidsForGid`` (``participants.ts:24-30``)
+    is a ``Promise.all`` of ``getPca`` and ``getBidIndexToPidMapping``, and
+    ``pg.queryP_readOnly`` takes a separate pooled connection per query with no
+    enclosing transaction.  A writer commit can land BETWEEN the two.
+
+So:
+
+* **Proved here.** The three tables are published NON-ATOMICALLY, and a reader
+  can observe math_main at generation N with the other two at N-1 or absent —
+  in both observer modes, because the window is the writer's.  A writer that
+  commits all three in ONE transaction closes that window *for the snapshot
+  observer* (``TestNegativeControl``), so the observer can tell atomic from
+  non-atomic publication.  That is WRITER-ISOLATION evidence and nothing more.
+* **NOT proved here.** That an atomic writer makes the *Node* reader safe.  Two
+  tests demonstrate the opposite, deterministically and without any race:
+
+  - ``test_an_atomic_write_is_still_observed_mixed_by_a_node_shaped_reader`` —
+    an atomic commit landing BETWEEN the reader's two independent autocommit
+    statements still yields a mixed response.
+  - ``test_a_cached_main_blob_can_pair_with_a_newer_mapping_even_when_the_writer_is_atomic``
+    — ``getPca`` serves ``math_main`` out of an in-process LRU
+    (``server/src/utils/pca.ts:330-347``) while ``getBidIndexToPidMapping``
+    always re-queries the DB, so a CACHED older main blob can pair with a newer
+    mapping no matter how the writer commits.
+
+  Closing that needs generation-matching retry or versioned snapshot reads IN
+  THE SERVER, and a real Node test (P-022 §D).  #2704 cannot make the R09 row
+  green on its own, and no test in this module should be read as saying it can.
 """
 
 import json
@@ -46,30 +86,59 @@ MATH_ENV = "recovery"
 # --------------------------------------------------------------------------- #
 # The server's reader, transcribed
 # --------------------------------------------------------------------------- #
-def read_generation(engine, zid: int, math_env: str):
-    """One SNAPSHOT of the reader's two queries, taken inside a single
-    REPEATABLE READ transaction so any incoherence is the writer's, not a
-    torn read of the test's own making."""
-    conn = engine.connect().execution_options(isolation_level="REPEATABLE READ")
-    try:
-        with conn.begin():
-            main = conn.execute(
-                sa.text("select * from math_main where zid = :z and "
-                        "math_env = :e"), {"z": zid, "e": math_env},
-            ).mappings().first()
-            bid = conn.execute(
-                sa.text("select * from math_bidtopid where zid = :z and "
-                        "math_env = :e"), {"z": zid, "e": math_env},
-            ).mappings().first()
-            pts = conn.execute(
-                sa.text("select * from math_ptptstats where zid = :z and "
-                        "math_env = :e"), {"z": zid, "e": math_env},
-            ).mappings().first()
-    finally:
-        conn.close()
-    return (dict(main) if main else None,
-            dict(bid) if bid else None,
-            dict(pts) if pts else None)
+_TABLE_SQL = {
+    "main": "select * from math_main where zid = :z and math_env = :e",
+    "bidtopid": "select * from math_bidtopid where zid = :z and math_env = :e",
+    "ptptstats": "select * from math_ptptstats where zid = :z and math_env = :e",
+}
+
+READER_MODES = ("repeatable_read", "separate_statements")
+
+
+def _one_row(conn, table: str, zid: int, math_env: str):
+    row = conn.execute(sa.text(_TABLE_SQL[table]),
+                       {"z": zid, "e": math_env}).mappings().first()
+    return dict(row) if row else None
+
+
+def read_generation(engine, zid: int, math_env: str,
+                    mode: str = "repeatable_read"):
+    """One OBSERVATION of the reader's query pair (plus ptptstats).
+
+    ``mode="repeatable_read"`` (default) takes all three SELECTs inside a
+    single REPEATABLE READ transaction, so any incoherence it reports is the
+    WRITER's and never a torn read of the test's own making.  That is stronger
+    than the server: see the module docstring.
+
+    ``mode="separate_statements"`` takes each SELECT on its OWN connection in
+    its own autocommit statement, which is what Node does — ``getPidsForGid``
+    is a ``Promise.all`` of two independent ``pg.queryP_readOnly`` calls
+    (``server/src/utils/participants.ts:24-30``), each on its own pooled
+    connection with no enclosing transaction, so a writer commit can land
+    between them.
+    """
+    if mode == "repeatable_read":
+        conn = engine.connect().execution_options(
+            isolation_level="REPEATABLE READ")
+        try:
+            with conn.begin():
+                rows = [_one_row(conn, t, zid, math_env)
+                        for t in ("main", "bidtopid", "ptptstats")]
+        finally:
+            conn.close()
+        return tuple(rows)
+
+    if mode == "separate_statements":
+        rows = []
+        for table in ("main", "bidtopid", "ptptstats"):
+            with engine.connect() as conn:
+                # AUTOCOMMIT: no enclosing transaction, no shared snapshot —
+                # one statement, one connection, exactly like node-postgres.
+                conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+                rows.append(_one_row(conn, table, zid, math_env))
+        return tuple(rows)
+
+    raise ValueError(f"unknown reader mode {mode!r}; expected {READER_MODES}")
 
 
 def response_problems(main, bid, pts):
@@ -93,38 +162,237 @@ def response_problems(main, bid, pts):
             f"math_ptptstats math_tick={pts['math_tick']}"
         )
     if bid is not None:
-        problems.extend(_mapping_problems(main["data"], bid["data"]))
+        problems.extend(_mapping_problems(
+            main["data"], bid["data"],
+            pts["data"] if pts is not None else None,
+        ))
     return problems
 
 
-def _mapping_problems(main_data, bid_data):
-    """``getPidsForGid``'s positional join (participants.ts:25-60): index a
-    group's base-cluster ids through ``base-clusters.id`` into ``bidToPid``."""
+def _as_int(value):
+    """``participants.ts:52-55`` runs every resolved pid through ``parseInt``;
+    normalise the same way so a string pid and an int pid compare equal."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def resolve_pids_for_gid(main_data, bid_data, gid):
+    """``getPidsForGid``'s join, transcribed literally
+    (``server/src/utils/participants.ts:24-60``)::
+
+        indexToBid = o[0]["base-clusters"].id
+        bidToIndex[indexToBid[i]] = i                  # :33-36
+        cluster    = o[0]["group-clusters"][gid]       # :44  POSITIONAL
+        members    = cluster.members                   # :48  these are BIDS
+        pids      += indexToPids[bidToIndex[bid]]      # :49-51
+
+    Returns ``(pids, problems)``.  ``pids`` is what the server would answer.
+    """
     problems = []
-    ids = (main_data.get("base-clusters") or {}).get("id") or []
+    base = main_data.get("base-clusters") or {}
+    ids = base.get("id") or []
     bid_to_pid = bid_data.get("bidToPid") or []
+    bid_to_index = {}
+    for i, b in enumerate(ids):
+        bid_to_index.setdefault(b, i)
+
+    groups = main_data.get("group-clusters") or []
+    if gid < 0 or gid >= len(groups):
+        return [], [f"no group-clusters[{gid}]: getPidsForGid would answer []"]
+    cluster = groups[gid]
+
+    pids = []
+    for bid in cluster.get("members", []):
+        if bid not in bid_to_index:
+            problems.append(
+                f"group-clusters[{gid}] member bid {bid!r} does not appear in "
+                "base-clusters.id, so bidToIndex[bid] is undefined and "
+                "getPidsForGid DROPS it silently (participants.ts:49-51)"
+            )
+            continue
+        index = bid_to_index[bid]
+        if index >= len(bid_to_pid):
+            problems.append(
+                f"group-clusters[{gid}] member bid {bid!r} resolves to index "
+                f"{index}, past the end of bidToPid ({len(bid_to_pid)})"
+            )
+            continue
+        pids.extend(_as_int(p) for p in bid_to_pid[index] or [])
+    return sorted(pids), problems
+
+
+def _mapping_problems(main_data, bid_data, pts_data=None):
+    """Everything wrong with the (pid -> bid -> gid) mapping these two blobs
+    describe, walked through the join the SERVER actually performs.
+
+    ``group-clusters[*].members`` are **base-cluster ids (bids)**, not pids.
+    ``server/src/utils/participants.ts:44-51`` resolves each member through
+    ``base-clusters.id`` to a POSITION and reads ``bidToPid[position]``.
+    Python emits exactly that shape: ``_apply_legacy_blob_shape``
+    (``polismath/conversation/conversation.py:1783-1790``) overwrites the
+    kebab-case ``group-clusters`` members with the FOLDED base-cluster ids —
+    the unfolded pid view survives only under the snake-case ``group_clusters``
+    alias — and ``derive_bidtopid`` (``polismath/poller/math_writer.py:74-78``)
+    builds ``bidToPid`` as ``[c["members"] for c in sorted(base_clusters, key
+    id)]``, positionally aligned with both ``base-clusters.id`` and
+    ``base-clusters.members``.
+
+    The pre-review version of this helper read those members as PIDS and only
+    asked whether each appeared somewhere in the union of all ``bidToPid``
+    buckets.  That is wrong in both directions and the astra review (finding 1)
+    reproduced both: with distinct bid/pid ranges it REJECTED a valid mapping,
+    and it ACCEPTED a swap of two same-length buckets even though the swap
+    routes every group to the wrong participants.  The checks below therefore
+
+    * compare each bucket against math_main's own ``base-clusters.members`` for
+      the same position — the equality that a same-length swap breaks;
+    * resolve every group through the real bid -> index -> pid join;
+    * validate the group ids/indices the positional ``clusters[gid]`` lookup
+      depends on; and
+    * (when ``pts_data`` is given) check math_ptptstats' published ``(pid, gid)``
+      links against the pids that join actually yields.
+
+    Deliberately SELF-CONTAINED (its helpers are nested, not module-level): the
+    review's harness ``cost-reduction/scripts/p022-review-2702-checks.py``
+    lifts this one function out of the module with ``ast`` and ``exec``s it in
+    an empty namespace, and that reproduction must keep working.
+    """
+    def as_int(value):
+        """``participants.ts:52-55`` runs every resolved pid through
+        ``parseInt``; normalise the same way."""
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return value
+
+    problems = []
+    base = main_data.get("base-clusters") or {}
+    ids = base.get("id") or []
+    published_members = base.get("members")
+    bid_to_pid = bid_data.get("bidToPid") or []
+
     if len(ids) != len(bid_to_pid):
         problems.append(
             f"positional contract broken: base-clusters.id has {len(ids)} "
             f"entries, bidToPid has {len(bid_to_pid)}"
         )
         return problems
-    bid_to_index = {b: i for i, b in enumerate(ids)}
-    known_pids = set()
-    for members in bid_to_pid:
-        known_pids.update(members)
-    for group in main_data.get("group-clusters") or []:
-        for member in group.get("members", []):
-            # group-clusters members are already unfolded to pids by the writer;
-            # the base-cluster ids are the ones that must resolve.
-            if member not in known_pids:
-                problems.append(
-                    f"group {group.get('id')} references pid {member!r} that "
-                    "no base cluster in this bidToPid contains"
+
+    bid_to_index = {}
+    for i, b in enumerate(ids):
+        if b in bid_to_index:
+            problems.append(
+                f"duplicate base-cluster id {b!r} at positions "
+                f"{bid_to_index[b]} and {i}: bidToIndex "
+                "(participants.ts:33-36) keeps only the last one, so one "
+                "bucket becomes unreachable"
+            )
+        bid_to_index[b] = i
+
+    def resolve(gid):
+        """``getPidsForGid``'s join for one gid — ``(pids, problems)``."""
+        local = []
+        groups_ = main_data.get("group-clusters") or []
+        if gid is None or not isinstance(gid, int) or not 0 <= gid < len(groups_):
+            return [], [f"no group-clusters[{gid!r}]: getPidsForGid answers []"]
+        out = []
+        for bid in groups_[gid].get("members", []):
+            if bid not in bid_to_index:
+                local.append(
+                    f"group-clusters[{gid}] member bid {bid!r} does not appear "
+                    "in base-clusters.id, so bidToIndex[bid] is undefined and "
+                    "getPidsForGid DROPS it silently (participants.ts:49-51)"
                 )
-    for bid_id in ids:
-        if bid_id not in bid_to_index:
-            problems.append(f"base cluster {bid_id} has no bidToPid index")
+                continue
+            index = bid_to_index[bid]
+            if index >= len(bid_to_pid):
+                local.append(
+                    f"group-clusters[{gid}] member bid {bid!r} resolves to "
+                    f"index {index}, past the end of bidToPid "
+                    f"({len(bid_to_pid)})"
+                )
+                continue
+            out.extend(as_int(p) for p in (bid_to_pid[index] or []))
+        return sorted(out), local
+
+    # The join's payload: each bucket must be the membership math_main itself
+    # published for the base cluster at that position.  A same-length SWAP of
+    # two buckets keeps every length and every id resolvable and is caught
+    # here, and only here.
+    if published_members is None:
+        problems.append(
+            "math_main has base-clusters.id but no base-clusters.members: the "
+            "bidToPid buckets cannot be corroborated"
+        )
+    elif len(published_members) != len(ids):
+        problems.append(
+            f"math_main is self-inconsistent: base-clusters.id has {len(ids)} "
+            f"entries, base-clusters.members has {len(published_members)}"
+        )
+    else:
+        for i, bid_id in enumerate(ids):
+            mapped = [as_int(p) for p in (bid_to_pid[i] or [])]
+            published = [as_int(p) for p in (published_members[i] or [])]
+            if mapped != published:
+                problems.append(
+                    f"bidToPid[{i}] (base cluster {bid_id!r}) routes to pids "
+                    f"{mapped} but math_main's base-clusters.members[{i}] is "
+                    f"{published}: the two blobs name DIFFERENT participants "
+                    "for the same base cluster"
+                )
+
+    # Group membership, through the real join.
+    groups = main_data.get("group-clusters") or []
+    pid_owner = {}
+    for gid, group in enumerate(groups):
+        # participants.ts:44 indexes the ARRAY by gid, so position and id must
+        # agree or every caller gets another group's participants.
+        if group.get("id") != gid:
+            problems.append(
+                f"group-clusters[{gid}].id is {group.get('id')!r}: "
+                "getPidsForGid does clusters[gid] (participants.ts:44), so the "
+                "array position and the group id must be the same value"
+            )
+        members = group.get("members", [])
+        pids, join_problems = resolve(gid)
+        problems.extend(join_problems)
+        if members and not pids and not join_problems:
+            problems.append(
+                f"group {group.get('id')!r} has members {members} but resolves "
+                "to NO pids through bidToPid"
+            )
+        for pid in pids:
+            if pid in pid_owner and pid_owner[pid] != gid:
+                problems.append(
+                    f"pid {pid!r} is routed to BOTH group {pid_owner[pid]} and "
+                    f"group {gid}: the group partition is not disjoint"
+                )
+            pid_owner.setdefault(pid, gid)
+
+    # math_ptptstats publishes (pid, gid) for the same generation; every pair
+    # must agree with the join above (ptptstats drops participants with no PCA
+    # projection — math_writer.py:193 — so it is a SUBSET, not an equality).
+    if pts_data is not None:
+        stats = (pts_data or {}).get("ptptstats") or {}
+        stat_pids = stats.get("pid") or []
+        stat_gids = stats.get("gid") or []
+        if len(stat_pids) != len(stat_gids):
+            problems.append(
+                f"math_ptptstats columns are ragged: pid has {len(stat_pids)} "
+                f"entries, gid has {len(stat_gids)}"
+            )
+        else:
+            for pid, gid in zip(stat_pids, stat_gids):
+                pids, _ = resolve(gid)
+                if as_int(pid) not in pids:
+                    problems.append(
+                        f"math_ptptstats says pid {pid!r} is in group {gid!r}, "
+                        "but getPidsForGid for that group answers "
+                        f"{pids} — the three tables describe different "
+                        "participant mappings"
+                    )
     return problems
 
 
@@ -134,18 +402,20 @@ def _mapping_problems(main_data, bid_data):
 class ContinuousReader(threading.Thread):
     """Polls the reader's query pair until stopped, recording every snapshot."""
 
-    def __init__(self, engine, zid, math_env):
+    def __init__(self, engine, zid, math_env, mode="repeatable_read"):
         super().__init__(daemon=True)
         self.engine = engine
         self.zid = zid
         self.math_env = math_env
+        self.mode = mode
         self.snapshots = []
         self._halt = threading.Event()
 
     def run(self):
         while not self._halt.is_set():
             self.snapshots.append(read_generation(self.engine, self.zid,
-                                                  self.math_env))
+                                                  self.math_env,
+                                                  mode=self.mode))
             self._halt.wait(0.01)
 
     def stop(self):
@@ -175,14 +445,21 @@ class ContinuousReader(threading.Thread):
         "marker; that is a separate decision."
     ),
 )
-def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service):
+@pytest.mark.parametrize("mode", READER_MODES)
+def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service,
+                                              mode):
     """Pause the writer after the main commit and before the bidtopid commit,
-    while a reader polls continuously."""
+    while a reader polls continuously.
+
+    Run in BOTH observer modes: the REPEATABLE READ observer (writer-isolation
+    evidence, stronger than the server) and the separate-autocommit-statement
+    observer (what Node's two independent ``queryP_readOnly`` calls actually
+    do).  Both see the window, because the window is the writer's."""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
     svc.poll_once()          # generation 1: complete
 
-    reader = ContinuousReader(engine, 1, MATH_ENV)
+    reader = ContinuousReader(engine, 1, MATH_ENV, mode=mode)
     reader.start()
 
     latch = Latch("write_math_bidtopid")
@@ -300,8 +577,213 @@ def test_positional_bidtopid_contract_holds_for_a_complete_generation(
     seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5)
     svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
     svc.poll_once()
+    main, bid, pts = read_generation(engine, 1, MATH_ENV)
+    assert _mapping_problems(main["data"], bid["data"], pts["data"]) == []
+
+
+def test_group_cluster_members_are_base_cluster_ids_not_pids(engine, pg_url,
+                                                             make_service):
+    """The namespace the checker depends on, asserted against a REAL published
+    blob (astra review finding 1): every ``group-clusters[*].members`` entry is
+    a ``base-clusters.id``, and the group's participants come out of the join,
+    not out of the members list."""
+    seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
     main, bid, _pts = read_generation(engine, 1, MATH_ENV)
-    assert _mapping_problems(main["data"], bid["data"]) == []
+    ids = set(main["data"]["base-clusters"]["id"])
+    groups = main["data"]["group-clusters"]
+    assert groups, "fixture must produce at least one group"
+    for gid, group in enumerate(groups):
+        members = group["members"]
+        assert members, f"group {gid} has no members"
+        assert set(members) <= ids, (
+            f"group-clusters[{gid}].members {members} are not all "
+            f"base-cluster ids {sorted(ids)}; the writer's namespace changed "
+            "(conversation.py:1783 emits the FOLDED, bid-valued form)"
+        )
+        pids, problems = resolve_pids_for_gid(main["data"], bid["data"], gid)
+        assert problems == [], problems
+        assert pids, f"group {gid} resolved to no pids through bidToPid"
+
+    # The snake-case alias keeps the UNFOLDED pid view; it is a different
+    # namespace and is NOT what participants.ts reads.
+    unfolded = main["data"].get("group_clusters")
+    if unfolded:
+        all_pids = set()
+        for members in bid["data"]["bidToPid"]:
+            all_pids.update(members)
+        for group in unfolded:
+            assert set(group["members"]) <= all_pids
+
+
+# --------------------------------------------------------------------------- #
+# The Node reader's OTHER hazard: a cached main blob (astra review finding 2)
+# --------------------------------------------------------------------------- #
+def _rebalance_one_participant(main_blob, bid_blob, pts_blob):
+    """Move one pid from base cluster 0 to base cluster 1 in ALL THREE blobs —
+    a real, coherent NEXT generation with a genuinely different participant
+    mapping (participants do change base cluster between cycles).
+
+    Returns ``(new_main, new_bid, new_pts, moved_pid)``."""
+    import copy
+
+    new_main = copy.deepcopy(main_blob)
+    new_bid = copy.deepcopy(bid_blob)
+    new_pts = copy.deepcopy(pts_blob)
+
+    ids = new_main["base-clusters"]["id"]
+    members = new_main["base-clusters"]["members"]
+    assert len(ids) >= 2 and len(members[0]) >= 2, (
+        "fixture must have two base clusters and a movable participant"
+    )
+    moved = members[0].pop()
+    members[1].append(moved)
+    new_bid["bidToPid"] = [list(m) for m in members]
+
+    # Keep math_ptptstats' (pid, gid) links consistent with the new mapping, so
+    # generation N+1 is coherent on its own and the ONLY incoherence in this
+    # test comes from pairing it with a CACHED generation-N main blob.
+    gid_of_bid = {}
+    for gid, group in enumerate(new_main.get("group-clusters") or []):
+        for bid in group.get("members", []):
+            gid_of_bid[bid] = gid
+    gid_of_pid = {}
+    for i, bid in enumerate(ids):
+        for pid in members[i]:
+            gid_of_pid[pid] = gid_of_bid.get(bid)
+    stats = new_pts.get("ptptstats") or {}
+    if stats.get("pid") and stats.get("gid"):
+        stats["gid"] = [gid_of_pid.get(pid, g)
+                        for pid, g in zip(stats["pid"], stats["gid"])]
+    return new_main, new_bid, new_pts, moved
+
+
+def test_a_cached_main_blob_can_pair_with_a_newer_mapping_even_when_the_writer_is_atomic(
+    engine, pg_url, make_service
+):
+    """ATOMIC publication does not make the SERVER's reader safe.
+
+    ``getPidsForGid`` (``server/src/utils/participants.ts:24-30``) is a
+    ``Promise.all`` of ``getPca`` and ``getBidIndexToPidMapping``.  ``getPca``
+    can answer out of the in-process LRU populated by the math poll
+    (``server/src/utils/pca.ts:330-347``) while ``getBidIndexToPidMapping``
+    ALWAYS re-queries ``math_bidtopid``.  So even with all three tables written
+    in one transaction, a response can combine a cached main blob at generation
+    N with the mapping at N+1.
+
+    This test holds the generation-N main blob (standing in for the cache
+    entry), commits generation N+1 for all three tables in ONE transaction, and
+    then evaluates the response the server would build.  It must be reported as
+    incoherent — which is the point: the atomic-writer negative control above
+    does not close this hole, #2704 cannot close it, and only a
+    generation-matching retry / versioned snapshot read in the SERVER can."""
+    seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    cached_main, _bid_n, _pts_n = read_generation(engine, 1, MATH_ENV)
+    assert response_problems(cached_main, _bid_n, _pts_n) == [], (
+        "precondition: generation N is coherent"
+    )
+
+    next_main_blob, next_bid_blob, next_pts_blob, moved = (
+        _rebalance_one_participant(cached_main["data"], _bid_n["data"],
+                                   _pts_n["data"]))
+    next_tick = cached_main["math_tick"] + 1
+    with engine.begin() as conn:      # ONE transaction: an ATOMIC writer
+        conn.execute(
+            sa.text("update math_main set math_tick=:t, data=cast(:d as jsonb) "
+                    "where zid=:z and math_env=:e"),
+            {"t": next_tick, "d": json.dumps(next_main_blob), "z": 1,
+             "e": MATH_ENV})
+        conn.execute(
+            sa.text("update math_bidtopid set math_tick=:t, "
+                    "data=cast(:d as jsonb) where zid=:z and math_env=:e"),
+            {"t": next_tick, "d": json.dumps(next_bid_blob), "z": 1,
+             "e": MATH_ENV})
+        conn.execute(
+            sa.text("update math_ptptstats set math_tick=:t, "
+                    "data=cast(:d as jsonb) where zid=:z and math_env=:e"),
+            {"t": next_tick, "d": json.dumps(next_pts_blob), "z": 1,
+             "e": MATH_ENV})
+
+    # Fresh DB read of the mapping, as getBidIndexToPidMapping always does.
+    _main_now, fresh_bid, fresh_pts = read_generation(
+        engine, 1, MATH_ENV, mode="separate_statements")
+    assert fresh_bid["math_tick"] == next_tick
+
+    # The response the server would build: CACHED main + FRESH mapping.
+    problems = response_problems(cached_main, fresh_bid, fresh_pts)
+    assert any("MIXED GENERATIONS" in p for p in problems), problems
+    assert any("DIFFERENT participants" in p for p in problems), (
+        f"the cached blob and the fresh mapping disagree about pid {moved}, "
+        f"which the mapping check must report: {problems}"
+    )
+
+    # ...and the whole DB is atomic and coherent at the same instant, so a
+    # DB-snapshot-only observer would have declared this safe.
+    assert response_problems(*read_generation(engine, 1, MATH_ENV)) == [], (
+        "the database itself is coherent; the incoherence is in the RESPONSE"
+    )
+
+
+def test_an_atomic_write_is_still_observed_mixed_by_a_node_shaped_reader(
+    engine, pg_url, make_service
+):
+    """The same conclusion without any cache: a reader that issues each query
+    as its OWN autocommit statement — which is what node-postgres does for
+    ``getPidsForGid``'s two ``queryP_readOnly`` calls — observes a mixed
+    generation even when the writer commits all three tables atomically,
+    because a commit can land BETWEEN the two statements.
+
+    The interleaving is pinned, not raced: statement 1 runs, the atomic commit
+    lands, statement 2 runs.  Asserted directly (rather than as an xfail) so
+    that the R09 row cannot be read as "atomic publication closes this".  It
+    does not: the remaining hole is reader-side and belongs to the server
+    (generation-matching retry or a versioned snapshot read) plus a real Node
+    test in P-022 §D."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    gen_n = read_math_tables(engine, 1, MATH_ENV)
+    # STATEMENT 1 — getPca's query, its own autocommit statement.
+    with engine.connect() as conn:
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+        main_before = _one_row(conn, "main", 1, MATH_ENV)
+
+    # ...an ATOMIC writer commits generation N+1 in ONE transaction, between
+    # the reader's two statements (Promise.all gives no ordering guarantee and
+    # no shared snapshot).
+    next_main, next_bid, next_pts, moved = _rebalance_one_participant(
+        gen_n["main"]["data"], gen_n["bidtopid"]["data"],
+        gen_n["ptptstats"]["data"])
+    next_tick = gen_n["main"]["math_tick"] + 1
+    with engine.begin() as conn:
+        for table, payload in (("math_main", next_main),
+                               ("math_bidtopid", next_bid),
+                               ("math_ptptstats", next_pts)):
+            conn.execute(
+                sa.text(f"update {table} set math_tick=:t, "
+                        "data=cast(:d as jsonb) where zid=:z and math_env=:e"),
+                {"t": next_tick, "d": json.dumps(payload), "z": 1,
+                 "e": MATH_ENV})
+
+    # STATEMENT 2 — getBidIndexToPidMapping's query, its own autocommit
+    # statement, on its own pooled connection.
+    with engine.connect() as conn:
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+        bid_after = _one_row(conn, "bidtopid", 1, MATH_ENV)
+        pts_after = _one_row(conn, "ptptstats", 1, MATH_ENV)
+
+    problems = response_problems(main_before, bid_after, pts_after)
+    assert any("MIXED GENERATIONS" in p for p in problems), problems
+    assert any("DIFFERENT participants" in p for p in problems), (
+        f"the two statements disagree about pid {moved}: {problems}"
+    )
+    # The database was atomic throughout: a snapshot observer sees nothing.
+    assert response_problems(*read_generation(engine, 1, MATH_ENV)) == []
 
 
 # --------------------------------------------------------------------------- #
@@ -312,9 +794,19 @@ class TestNegativeControl:
                                                                  pg_url,
                                                                  make_service):
         """Intentionally 'fixed' variant: write all three rows inside ONE
-        transaction and show the continuous reader never observes a split.
-        This proves the observer above can distinguish atomic from non-atomic
-        publication — the xfail is about the writer, not about the check."""
+        transaction and show the SNAPSHOT reader never observes a split.  This
+        proves the ``repeatable_read`` observer can distinguish atomic from
+        non-atomic publication — the xfail is about the WRITER, not about the
+        check.
+
+        Scope, stated exactly (astra review finding 2): this is
+        writer-isolation evidence only.  It does NOT show that an atomic writer
+        would make the SERVER's reader safe — see
+        ``test_an_atomic_write_is_still_observed_mixed_by_a_node_shaped_reader``
+        and
+        ``test_a_cached_main_blob_can_pair_with_a_newer_mapping_even_when_the_writer_is_atomic``
+        below, and the module docstring."""
+        mode = "repeatable_read"
         seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
         svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
         svc.poll_once()
@@ -323,7 +815,7 @@ class TestNegativeControl:
         bid_blob = tables["bidtopid"]["data"]
         pts_blob = tables["ptptstats"]["data"]
 
-        reader = ContinuousReader(engine, 1, MATH_ENV)
+        reader = ContinuousReader(engine, 1, MATH_ENV, mode=mode)
         reader.start()
         for tick in range(50, 55):
             with engine.begin() as conn:      # ONE transaction for all three
@@ -367,3 +859,107 @@ class TestNegativeControl:
             "NEGATIVE CONTROL FAILED: a truncated bidToPid was accepted as "
             "positionally aligned"
         )
+
+    def test_a_swapped_pair_of_buckets_is_caught_on_a_real_generation(
+        self, engine, pg_url, make_service
+    ):
+        """Swap two ``bidToPid`` buckets of a REAL published generation.  Every
+        length and every id still resolves, so only the bid -> index -> pid
+        join can see it — the exact corruption the pre-review checker accepted
+        (astra review finding 1)."""
+        seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        svc.poll_once()
+        main, bid, pts = read_generation(engine, 1, MATH_ENV)
+        buckets = [list(b) for b in bid["data"]["bidToPid"]]
+        assert len(buckets) >= 2, "fixture must produce >= 2 base clusters"
+        assert buckets[0] != buckets[1], (
+            "the two buckets must differ for a swap to be a real corruption"
+        )
+        swapped = dict(bid["data"])
+        swapped["bidToPid"] = [buckets[1], buckets[0]] + buckets[2:]
+        assert len(swapped["bidToPid"]) == len(buckets), "same length"
+
+        problems = _mapping_problems(main["data"], swapped, pts["data"])
+        assert problems, (
+            "NEGATIVE CONTROL FAILED: a same-length bucket SWAP was accepted "
+            "as a valid participant mapping"
+        )
+        assert any("DIFFERENT participants" in p for p in problems), problems
+
+
+# --------------------------------------------------------------------------- #
+# The astra review's synthetic mutation cases, as first-class controls.
+#
+# These need no database: they are the exact observations
+# `cost-reduction/scripts/p022-review-2702-checks.py` makes, pinned so the
+# helper can never regress to the pid-namespace reading again.  Bid ids and pid
+# ids are deliberately drawn from DISJOINT ranges (bids 10/20/30, pids 0..5) so
+# that reading one namespace as the other cannot accidentally look correct.
+# --------------------------------------------------------------------------- #
+_MAIN = {
+    "base-clusters": {"id": [10, 20, 30],
+                      "members": [[0, 1], [2, 3], [4, 5]]},
+    "group-clusters": [{"id": 0, "members": [10, 20]},
+                       {"id": 1, "members": [30]}],
+}
+_BID = {"bidToPid": [[0, 1], [2, 3], [4, 5]]}
+_PTS = {"ptptstats": {"pid": [0, 1, 2, 3, 4, 5],
+                      "gid": [0, 0, 0, 0, 1, 1]}}
+
+
+class TestMappingCheckerMutations:
+    """Each mutation must be REJECTED; the unmutated fixture must be ACCEPTED."""
+
+    def test_a_valid_distinct_bid_pid_mapping_is_accepted(self):
+        assert _mapping_problems(_MAIN, _BID, _PTS) == []
+        assert resolve_pids_for_gid(_MAIN, _BID, 0) == ([0, 1, 2, 3], [])
+        assert resolve_pids_for_gid(_MAIN, _BID, 1) == ([4, 5], [])
+
+    def test_a_same_length_bucket_swap_is_rejected(self):
+        swapped = {"bidToPid": [[2, 3], [0, 1], [4, 5]]}
+        problems = _mapping_problems(_MAIN, swapped, _PTS)
+        assert problems, "a same-length bucket swap must not be accepted"
+        assert any("DIFFERENT participants" in p for p in problems), problems
+
+    def test_a_truncated_bidtopid_is_rejected(self):
+        assert _mapping_problems(_MAIN, {"bidToPid": [[0, 1], [2, 3]]})
+
+    def test_group_members_read_as_pids_are_rejected(self):
+        """The pre-review bug, inverted: a blob whose group members are PIDS
+        rather than BIDS is a broken blob and must be reported."""
+        pid_valued = dict(_MAIN)
+        pid_valued["group-clusters"] = [{"id": 0, "members": [0, 1, 2, 3]},
+                                        {"id": 1, "members": [4, 5]}]
+        problems = _mapping_problems(pid_valued, _BID)
+        assert problems
+        assert any("does not appear in base-clusters.id" in p
+                   for p in problems), problems
+
+    def test_a_group_id_that_disagrees_with_its_position_is_rejected(self):
+        misnumbered = dict(_MAIN)
+        misnumbered["group-clusters"] = [{"id": 1, "members": [10, 20]},
+                                         {"id": 0, "members": [30]}]
+        problems = _mapping_problems(misnumbered, _BID)
+        assert any("clusters[gid]" in p for p in problems), problems
+
+    def test_a_duplicate_base_cluster_id_is_rejected(self):
+        dup = {"base-clusters": {"id": [10, 10, 30],
+                                 "members": [[0, 1], [2, 3], [4, 5]]},
+               "group-clusters": [{"id": 0, "members": [10]},
+                                  {"id": 1, "members": [30]}]}
+        problems = _mapping_problems(dup, _BID)
+        assert any("duplicate base-cluster id" in p for p in problems), problems
+
+    def test_a_contradicting_ptptstats_link_is_rejected(self):
+        wrong = {"ptptstats": {"pid": [0, 1, 2, 3, 4, 5],
+                               "gid": [1, 1, 0, 0, 0, 0]}}
+        problems = _mapping_problems(_MAIN, _BID, wrong)
+        assert any("math_ptptstats says pid" in p for p in problems), problems
+
+    def test_a_bucket_that_contradicts_main_is_rejected(self):
+        """math_main and math_bidtopid naming different pids for the same base
+        cluster — the mixed-generation symptom, seen through the mapping."""
+        drifted = {"bidToPid": [[0, 1], [2, 9], [4, 5]]}
+        problems = _mapping_problems(_MAIN, drifted)
+        assert any("DIFFERENT participants" in p for p in problems), problems

--- a/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
+++ b/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
@@ -26,10 +26,22 @@ from .conftest import (
     tables_are_coherent,
 )
 from . import fold as F
+from polismath.poller import service as _service
 
 pytestmark = pytest.mark.recovery
 
 MATH_ENV = "recovery"
+
+# The join-timeout contract, named rather than inferred (astra review of #2708).
+#
+# #2708 introduces ``PoolDrainTimeout(TimeoutError)`` in
+# ``polismath/poller/service.py`` precisely so an exhausted POOL DRAIN is
+# distinguishable from a socket/DB ``TimeoutError`` (the builtin is an
+# ``OSError``, so a bare ``except TimeoutError`` would swallow both).  It does
+# not exist on this base, so the assertion resolves the class BY NAME and falls
+# back to the builtin: the test states the same contract before and after #2708
+# and needs no edit on rebase.
+POOL_DRAIN_TIMEOUT = getattr(_service, "PoolDrainTimeout", TimeoutError)
 
 
 def _assert_published(engine, zid):
@@ -239,7 +251,11 @@ def test_one_poison_zid_does_not_starve_healthy_zids(engine, pg_url,
         "conversation as a successful cycle. P-022 §C: 'Exhaust a join timeout: "
         "poll_once must surface failure, not successful completion.' The fix is "
         "to raise (or return a status) when join() is False; that is a separate "
-        "decision."
+        "decision (#2708 raises PoolDrainTimeout). The oracle requires the poll "
+        "thread to have COMPLETED and the failure to be that named class "
+        "(resolved by name, falling back to the builtin TimeoutError on this "
+        "base): a permanently hung observer used to satisfy the old "
+        "`raised is not None or not returned` form."
     ),
 )
 def test_poll_once_surfaces_a_join_timeout(engine, pg_url, make_service):
@@ -279,10 +295,24 @@ def test_poll_once_surfaces_a_join_timeout(engine, pg_url, make_service):
     thread.join(timeout=30)
 
     try:
-        assert result["raised"] is not None or not result["returned"], (
+        # "or not returned" alone was satisfied by an observer that simply
+        # HUNG — the very failure mode this row is about (astra review of
+        # #2708).  Require both halves of the contract instead.
+        assert not thread.is_alive(), (
+            "poll_once never came back at all: a permanently blocked cycle is "
+            "not a surfaced failure, and must not satisfy this assertion"
+        )
+        raised = result["raised"]
+        assert raised is not None and not result["returned"], (
             "poll_once returned normally after its pool join timed out with "
             "work still in flight — a stuck cycle is indistinguishable from a "
             "successful one"
+        )
+        assert isinstance(raised, POOL_DRAIN_TIMEOUT), (
+            f"the exhausted pool drain surfaced as "
+            f"{type(raised).__name__}: {raised!r}; it must be "
+            f"{POOL_DRAIN_TIMEOUT.__name__}, so a drain failure is separately "
+            "catchable from a socket/DB timeout"
         )
     finally:
         release.set()
@@ -295,6 +325,33 @@ def test_poll_once_surfaces_a_join_timeout(engine, pg_url, make_service):
 # Negative control for the poll/load failure class
 # --------------------------------------------------------------------------- #
 class TestNegativeControl:
+    def test_a_hung_observer_is_not_a_surfaced_failure(self):
+        """The join-timeout correction, controlled (astra review of #2708): a
+        poll thread that simply never comes back satisfied the old
+        ``raised is not None or not returned`` form.  The tightened oracle must
+        go red on it, and its class check must be real."""
+        hung = threading.Event()
+        thread = threading.Thread(target=lambda: hung.wait(30), daemon=True)
+        thread.start()
+        try:
+            result = {"returned": False, "raised": None}
+            # The old form: green on an observer that never returned at all.
+            assert result["raised"] is not None or not result["returned"]
+            # The tightened form: red, as it must be.
+            with pytest.raises(AssertionError):
+                assert not thread.is_alive(), "poll_once never came back"
+        finally:
+            hung.set()
+            thread.join(timeout=10)
+        assert not thread.is_alive()
+
+        # ...and the named class is not merely "any exception".
+        assert not isinstance(RuntimeError("boom"), POOL_DRAIN_TIMEOUT)
+        assert issubclass(POOL_DRAIN_TIMEOUT, TimeoutError), (
+            "PoolDrainTimeout must stay a TimeoutError subclass so existing "
+            "handlers keep matching"
+        )
+
     def test_a_watermark_that_advances_on_failure_is_caught(self, engine,
                                                             pg_url,
                                                             make_service):

--- a/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
+++ b/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
@@ -106,7 +106,7 @@ def test_failing_math_main_load_cold_starts_without_a_false_empty(engine,
                                                                   pg_url,
                                                                   make_service):
     """``_load_or_init`` swallows a ``load_math_main`` failure and cold-starts
-    (``service.py:568``).  That is safe ONLY because the rebuild then reads the
+    (``service.py:570``).  That is safe ONLY because the rebuild then reads the
     full authoritative vote history — assert the published result is the full
     fold, not an empty conversation."""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)

--- a/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
+++ b/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
@@ -1,0 +1,336 @@
+"""R10 — poll/load failure and fairness (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Fail vote/mod SELECT, math_main load and full-history load; verify no false
+    empty publication or inappropriate watermark advancement, and subsequent
+    quiet recovery.  One poison zid must not starve healthy zids.  Exhaust a
+    join timeout: ``poll_once`` must surface failure, not successful completion
+    (``service.py:350``).
+"""
+
+import threading
+import time
+
+import pytest
+
+from .conftest import (
+    FaultInjector,
+    InjectedFault,
+    commit_vote,
+    drain,
+    fail_stage,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+def _assert_published(engine, zid):
+    tables = read_math_tables(engine, zid, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, zid))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    return tables
+
+
+# --------------------------------------------------------------------------- #
+# Poll SELECT failures
+# --------------------------------------------------------------------------- #
+def test_failing_vote_select_does_not_advance_the_watermark(engine, pg_url,
+                                                            make_service):
+    """A failed vote poll must leave the watermark untouched (so nothing is
+    skipped) and must recover on the next cycle."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    before = svc._vote_wm
+
+    injector = FaultInjector(name="poll_votes_since", mode="always")
+    undo = fail_stage(svc._pg, "poll_votes_since", injector)
+    with pytest.raises(InjectedFault):
+        svc._poll_votes_once()
+    undo()
+
+    assert svc._vote_wm == before, "a failed poll must not advance the watermark"
+    assert read_math_tables(engine, 1, MATH_ENV)["main"] is None
+
+    svc.poll_once()
+    _assert_published(engine, 1)
+
+
+def test_failing_moderation_select_does_not_advance_the_watermark(engine,
+                                                                  pg_url,
+                                                                  make_service):
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    before = svc._mod_wm
+
+    injector = FaultInjector(name="poll_moderation_since", mode="always")
+    undo = fail_stage(svc._pg, "poll_moderation_since", injector)
+    with pytest.raises(InjectedFault):
+        svc._poll_moderation_once()
+    undo()
+
+    assert svc._mod_wm == before
+    svc.poll_once()
+    _assert_published(engine, 1)
+
+
+def test_vote_loop_survives_a_failing_poll_and_recovers(engine, pg_url,
+                                                        make_service):
+    """The running loop swallows and logs the poll failure (``_vote_loop``,
+    ``service.py:367``) and the very next cycle publishes correctly."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    injector = FaultInjector(name="poll_votes_since", mode="once")
+    undo = fail_stage(svc._pg, "poll_votes_since", injector)
+    try:
+        svc._poll_votes_once()
+    except InjectedFault:
+        pass
+    undo()
+    svc.poll_once()
+    _assert_published(engine, 1)
+
+
+# --------------------------------------------------------------------------- #
+# Load failures
+# --------------------------------------------------------------------------- #
+def test_failing_math_main_load_cold_starts_without_a_false_empty(engine,
+                                                                  pg_url,
+                                                                  make_service):
+    """``_load_or_init`` swallows a ``load_math_main`` failure and cold-starts
+    (``service.py:568``).  That is safe ONLY because the rebuild then reads the
+    full authoritative vote history — assert the published result is the full
+    fold, not an empty conversation."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    _assert_published(engine, 1)
+
+    injector = FaultInjector(name="load_math_main", mode="always")
+    undo = fail_stage(svc._pg, "load_math_main", injector)
+    svc._convs.pop(1, None)
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
+    svc._vote_wm = base
+    svc.poll_once()
+    undo()
+
+    assert injector.fired >= 1, "the load failure must have fired"
+    tables = _assert_published(engine, 1)
+    assert tables["main"]["data"]["n"] == 6, (
+        "a swallowed load failure must not publish an EMPTY conversation"
+    )
+
+
+def test_failing_full_history_load_never_publishes(engine, pg_url,
+                                                   make_service):
+    """A failing full-history ``poll_votes`` is NOT swallowed: it must abort the
+    cycle (retry/park) rather than publish an empty or partial conversation."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       retry_cap=0)
+
+    injector = FaultInjector(name="poll_votes", mode="always")
+    undo = fail_stage(svc._pg, "poll_votes", injector)
+    svc.poll_once()
+    undo()
+
+    assert injector.fired >= 1
+    assert 1 in svc._parked, "the zid must park rather than publish"
+    assert read_math_tables(engine, 1, MATH_ENV)["main"] is None, (
+        "a failed full-history load must never publish a false empty result"
+    )
+
+    svc._reconcile_once()
+    drain(svc)
+    _assert_published(engine, 1)
+
+
+def test_an_existing_row_is_never_replaced_by_an_empty_one(engine, pg_url,
+                                                           make_service):
+    """The worst false-empty shape: a good math_main row must never be
+    overwritten by an empty conversation because a load failed."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       retry_cap=0)
+    svc.poll_once()
+    good = read_math_tables(engine, 1, MATH_ENV)["main"]
+
+    load_fault = FaultInjector(name="load_math_main", mode="always")
+    hist_fault = FaultInjector(name="poll_votes", mode="always")
+    undo1 = fail_stage(svc._pg, "load_math_main", load_fault)
+    undo2 = fail_stage(svc._pg, "poll_votes", hist_fault)
+    svc._convs.pop(1, None)
+    svc._pool.submit(1, "rebuild", [])
+    drain(svc)
+    undo1()
+    undo2()
+
+    after = read_math_tables(engine, 1, MATH_ENV)["main"]
+    assert after["data"] == good["data"], (
+        "the previously published row was replaced while both loads were "
+        "failing"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Fairness
+# --------------------------------------------------------------------------- #
+def test_one_poison_zid_does_not_starve_healthy_zids(engine, pg_url,
+                                                     make_service):
+    """A permanently failing zid must not stop healthy conversations from
+    making progress, across repeated cycles."""
+    zids = [1, 2, 3, 4]
+    for zid in zids:
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=2,
+                       retry_cap=1)
+
+    real_write = svc._writer.write_conv_updates
+    attempts = {"poison": 0}
+
+    def poison(zid, conv):
+        if zid == 1:
+            attempts["poison"] += 1
+            raise InjectedFault("poison zid")
+        return real_write(zid, conv)
+
+    svc._writer.write_conv_updates = poison
+
+    for cycle in range(3):
+        svc._vote_wm = 0
+        svc.poll_once()
+        for zid in zids[1:]:
+            assert read_math_tables(engine, zid, MATH_ENV)["main"] is not None, (
+                f"healthy zid {zid} starved on cycle {cycle}"
+            )
+    svc._writer.write_conv_updates = real_write
+
+    assert 1 in svc._parked, "the poison zid must be visibly parked"
+    for zid in zids[1:]:
+        _assert_published(engine, zid)
+    # Bounded, not a hot loop: 2 attempts to park + 2 per later reconcile pass.
+    assert attempts["poison"] <= 2 + 2 * 3, (
+        f"the poison zid consumed {attempts['poison']} attempts — unbounded "
+        "retrying starves the pool"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The join timeout
+# --------------------------------------------------------------------------- #
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (P-022 §C R10): poll_once IGNORES the pool join result. "
+        "polismath/poller/service.py:365 calls `self._pool.join(timeout=120.0)` "
+        "and discards its boolean; ConversationWorkerPool.join returns False on "
+        "timeout (polismath/poller/worker_pool.py:156). So a cycle whose work "
+        "never drained returns NORMALLY and looks like a completed poll — the "
+        "`--once` CLI exits 0, and the integration harness treats a stuck "
+        "conversation as a successful cycle. P-022 §C: 'Exhaust a join timeout: "
+        "poll_once must surface failure, not successful completion.' The fix is "
+        "to raise (or return a status) when join() is False; that is a separate "
+        "decision."
+    ),
+)
+def test_poll_once_surfaces_a_join_timeout(engine, pg_url, make_service):
+    """Stall a worker past the join bound and require ``poll_once`` to surface
+    the failure instead of returning as if the cycle completed."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+
+    stalled = threading.Event()
+    release = threading.Event()
+    real_load = svc._load_or_init
+
+    def stalling_load(zid):
+        stalled.set()
+        release.wait(timeout=60)
+        return real_load(zid)
+
+    svc._load_or_init = stalling_load
+
+    # Shrink the join bound so the timeout is reached deterministically, and
+    # observe what poll_once does with it.
+    real_join = svc._pool.join
+    svc._pool.join = lambda timeout=120.0: real_join(timeout=0.5)
+
+    result = {"returned": False, "raised": None}
+
+    def run():
+        try:
+            svc.poll_once()
+            result["returned"] = True
+        except BaseException as exc:
+            result["raised"] = exc
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    assert stalled.wait(timeout=30), "the worker never stalled"
+    thread.join(timeout=30)
+
+    try:
+        assert result["raised"] is not None or not result["returned"], (
+            "poll_once returned normally after its pool join timed out with "
+            "work still in flight — a stuck cycle is indistinguishable from a "
+            "successful one"
+        )
+    finally:
+        release.set()
+        svc._pool.join = real_join
+        svc._load_or_init = real_load
+        drain(svc)
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the poll/load failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_watermark_that_advances_on_failure_is_caught(self, engine,
+                                                            pg_url,
+                                                            make_service):
+        """Intentionally broken variant: advance the watermark BEFORE the
+        (failing) poll.  The R10 assertion must go red, proving it can see an
+        inappropriate advancement."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        before = svc._vote_wm
+
+        def broken_poll(since):
+            svc._vote_wm = since + 1_000_000   # advance first, then fail
+            raise InjectedFault("poll failed after advancing")
+
+        svc._pg.poll_votes_since = broken_poll
+        with pytest.raises(InjectedFault):
+            svc._poll_votes_once()
+
+        with pytest.raises(AssertionError):
+            assert svc._vote_wm == before, "a failed poll must not advance"
+
+    def test_a_false_empty_publication_is_caught(self, engine, pg_url,
+                                                 make_service):
+        """Publish an EMPTY conversation on purpose; the fold check must reject
+        it."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        real_history = svc._pg.poll_votes
+        svc._pg.poll_votes = lambda zid, since=None: []
+        svc.poll_once()
+        svc._pg.poll_votes = real_history
+
+        tables = read_math_tables(engine, 1, MATH_ENV)
+        fold = F.fold_votes(read_vote_events(engine, 1))
+        problems = F.check_published_against_fold(tables["main"]["data"], fold)
+        assert problems, (
+            "NEGATIVE CONTROL FAILED: an EMPTY publication was accepted as "
+            "matching a conversation with 12 votes"
+        )

--- a/delphi/tests/poller/recovery/test_r11_namespace_config.py
+++ b/delphi/tests/poller/recovery/test_r11_namespace_config.py
@@ -23,6 +23,7 @@ import sqlalchemy as sa
 from .conftest import (
     read_math_tables,
     read_vote_events,
+    require_repo_root,
     seed_conversation,
     tables_are_coherent,
 )
@@ -33,9 +34,6 @@ pytestmark = pytest.mark.recovery
 
 PROD_ENV = "prod"
 SHADOW_ENV = "python"
-_REPO_ROOT = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
-)
 
 
 def _seed_prod_rows(engine, zid: int):
@@ -266,7 +264,8 @@ def test_effective_container_settings_reach_the_config(monkeypatch):
 def test_compose_math_python_service_passes_the_required_settings():
     """The container definition must actually forward the settings above, or
     the validated defaults never reach the deployed process."""
-    with open(os.path.join(_REPO_ROOT, "docker-compose.yml")) as fh:
+    repo_root = require_repo_root("docker-compose.yml")
+    with open(os.path.join(repo_root, "docker-compose.yml")) as fh:
         compose = fh.read()
     service = compose.split("  math-python:", 1)[1].split("\n  postgres:", 1)[0]
     for var in ("MATH_ENV", "MATH_CONV_CACHE_CAP",

--- a/delphi/tests/poller/recovery/test_r11_namespace_config.py
+++ b/delphi/tests/poller/recovery/test_r11_namespace_config.py
@@ -1,0 +1,321 @@
+"""R11 — math_env namespace isolation and effective configuration (REAL PG).
+
+P-022 §C required matrix:
+
+    Assert all reads, writes and restore operations stay in the selected math
+    env; validate negative/zero cap policy, shard bounds and effective container
+    settings.  A shadow job cannot mutate prod math rows.
+
+The write side holds: every writer and ``load_math_main`` is scoped by
+``math_env`` and ``UNIQUE(zid, math_env)`` keeps the namespaces apart.  The
+READER side does not: the server's prefetch query is not math_env-scoped, so a
+shadow row still reaches the server's in-process PCA cache.  That is asserted
+below against the server's own SQL.
+"""
+
+import json
+import os
+import re
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+from polismath.poller.service import PollerConfig
+
+pytestmark = pytest.mark.recovery
+
+PROD_ENV = "prod"
+SHADOW_ENV = "python"
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
+
+
+def _seed_prod_rows(engine, zid: int):
+    """A pre-existing, complete prod generation the shadow job must not touch."""
+    blob = {"zid": zid, "sentinel": "PROD-ROW-DO-NOT-TOUCH", "n": 999}
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text("insert into math_main (zid, math_env, data, "
+                    "last_vote_timestamp, caching_tick, math_tick) values "
+                    "(:z, :e, cast(:d as jsonb), 42, 5, 5)"),
+            {"z": zid, "e": PROD_ENV, "d": json.dumps(blob)},
+        )
+        conn.execute(
+            sa.text("insert into math_bidtopid (zid, math_env, math_tick, data) "
+                    "values (:z, :e, 5, cast(:d as jsonb))"),
+            {"z": zid, "e": PROD_ENV, "d": json.dumps({"bidToPid": [[0]]})},
+        )
+        conn.execute(
+            sa.text("insert into math_ptptstats (zid, math_env, math_tick, data) "
+                    "values (:z, :e, 5, cast(:d as jsonb))"),
+            {"z": zid, "e": PROD_ENV, "d": json.dumps({"ptptstats": {}})},
+        )
+        conn.execute(
+            sa.text("insert into math_ticks (zid, math_env, math_tick, "
+                    "caching_tick) values (:z, :e, 5, 5)"),
+            {"z": zid, "e": PROD_ENV},
+        )
+    return blob
+
+
+def _prod_snapshot(engine, zid: int):
+    with engine.connect() as conn:
+        return {
+            name: [dict(r) for r in conn.execute(
+                sa.text(f"select * from {name} where zid=:z and math_env=:e "
+                        "order by zid"), {"z": zid, "e": PROD_ENV}).mappings()]
+            for name in ("math_main", "math_bidtopid", "math_ptptstats",
+                         "math_ticks")
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Write / restore isolation
+# --------------------------------------------------------------------------- #
+def test_shadow_job_never_mutates_prod_math_rows(engine, pg_url, make_service):
+    """A full shadow cycle must leave every prod row byte-identical."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    _seed_prod_rows(engine, 1)
+    before = _prod_snapshot(engine, 1)
+
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    assert _prod_snapshot(engine, 1) == before, (
+        "the shadow job mutated prod math rows"
+    )
+    shadow = read_math_tables(engine, 1, SHADOW_ENV)
+    assert tables_are_coherent(shadow) == [], tables_are_coherent(shadow)
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(shadow["main"]["data"], fold) == []
+
+
+def test_restore_never_reads_another_math_env(engine, pg_url, make_service):
+    """``load_math_main`` (``database/postgres.py:763``) filters by math_env, so
+    a cold shadow start must NOT restore the prod blob."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    sentinel = _seed_prod_rows(engine, 1)["sentinel"]
+
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    assert svc._pg.load_math_main(1) is None, (
+        "a shadow client must not see the prod row"
+    )
+    svc.poll_once()
+    published = json.dumps(read_math_tables(engine, 1, SHADOW_ENV)["main"]["data"])
+    assert sentinel not in published, (
+        "prod state leaked into the shadow namespace's published blob"
+    )
+
+
+def test_math_tick_counters_are_per_math_env(engine, pg_url, make_service):
+    """``increment_math_tick`` upserts on (zid, math_env), so the two namespaces
+    keep independent counters."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    _seed_prod_rows(engine, 1)
+
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    for _ in range(3):
+        svc._vote_wm = 0
+        svc.poll_once()
+
+    with engine.connect() as conn:
+        rows = {r["math_env"]: r["math_tick"] for r in conn.execute(
+            sa.text("select math_env, math_tick from math_ticks where zid=1")
+        ).mappings()}
+    assert rows[PROD_ENV] == 5, "the prod counter must not move"
+    assert rows[SHADOW_ENV] >= 2, f"the shadow counter must advance: {rows}"
+
+
+def test_caching_tick_is_scoped_to_its_math_env(engine, pg_url, make_service):
+    """``write_math_main``'s caching_tick subquery is
+    ``max(caching_tick)+1 WHERE math_env = ?`` (``database/postgres.py:838``),
+    so each namespace has its OWN cursor sequence — which is why the two
+    sequences overlap numerically (see R12)."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    _seed_prod_rows(engine, 1)          # prod caching_tick = 5
+
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    svc.poll_once()
+    shadow_tick = read_math_tables(engine, 1, SHADOW_ENV)["main"]["caching_tick"]
+    assert shadow_tick == 1, (
+        f"the shadow namespace must start its own cursor at 1, saw {shadow_tick}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The reader side of namespace isolation
+# --------------------------------------------------------------------------- #
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (R11 reader side): the server's PCA PREFETCH is not scoped to "
+        "math_env. server/src/utils/pca.ts:98 runs `select * from math_main "
+        "where caching_tick > ($1) order by caching_tick limit 10` with NO "
+        "math_env predicate, then calls processMathObject/updatePcaCache on "
+        "every row (pca.ts:117-137). Point reads ARE scoped "
+        "(server/src/utils/pca.ts:360, participants.ts:10), so the hazard is "
+        "specific to the prefetch cache: while a shadow poller writes under "
+        "MATH_ENV=python (docker-compose.yml:169) with the server on prod, the "
+        "shadow's rows enter the prod server's in-process PCA cache keyed by "
+        "zid alone. P-022 §C R11: 'Assert all reads, writes and restore "
+        "operations stay in the selected math env.' The writes and restores "
+        "do; this read does not. Fix: add `and math_env = ($2)` to the "
+        "prefetch, which is a server change and a separate decision."
+    ),
+)
+def test_the_server_prefetch_query_is_math_env_scoped(engine, pg_url,
+                                                      make_service):
+    """Run the server's OWN prefetch SQL and require it to return only rows of
+    the server's configured math_env."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    _seed_prod_rows(engine, 1)
+
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    # Verbatim from server/src/utils/pca.ts:98 (the deployed prefetch).
+    with engine.connect() as conn:
+        rows = [dict(r) for r in conn.execute(
+            sa.text("select * from math_main where caching_tick > :last "
+                    "order by caching_tick limit 10"), {"last": -1},
+        ).mappings()]
+    envs = sorted({r["math_env"] for r in rows})
+    assert envs == [PROD_ENV], (
+        f"the prefetch returned rows from {envs}; a server on {PROD_ENV!r} "
+        "would cache the shadow namespace's PCA blob"
+    )
+
+
+def test_the_server_point_reads_are_math_env_scoped(engine, pg_url,
+                                                    make_service):
+    """The scoping that DOES hold, asserted so the xfail above is narrow: the
+    per-zid reads used by getPca and getBidIndexToPidMapping filter on
+    math_env."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    sentinel = _seed_prod_rows(engine, 1)["sentinel"]
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    with engine.connect() as conn:
+        main = conn.execute(
+            sa.text("select * from math_main where zid = :z and math_env = :e"),
+            {"z": 1, "e": PROD_ENV},
+        ).mappings().first()
+        bid = conn.execute(
+            sa.text("select * from math_bidtopid where zid = :z and "
+                    "math_env = :e"), {"z": 1, "e": PROD_ENV},
+        ).mappings().first()
+    assert main["data"]["sentinel"] == sentinel
+    assert bid["data"] == {"bidToPid": [[0]]}
+
+
+# --------------------------------------------------------------------------- #
+# Configuration policy
+# --------------------------------------------------------------------------- #
+def test_cache_cap_policy(monkeypatch):
+    """0 = unlimited (explicit and documented), positive = a real LRU bound,
+    negative rejected at construction."""
+    assert PollerConfig().conv_cache_cap == 200, "the default must be FINITE"
+    assert PollerConfig(conv_cache_cap=0).conv_cache_cap == 0
+    with pytest.raises(ValueError, match="conv_cache_cap must be >= 0"):
+        PollerConfig(conv_cache_cap=-1)
+
+    monkeypatch.setenv("MATH_CONV_CACHE_CAP", "-5")
+    with pytest.raises(ValueError, match="conv_cache_cap must be >= 0"):
+        PollerConfig.from_env()
+
+
+def test_shard_bounds_policy():
+    with pytest.raises(ValueError):
+        PollerConfig(shard_index=3, shard_count=3)
+    with pytest.raises(ValueError):
+        PollerConfig(shard_count=0)
+    assert PollerConfig(shard_index=2, shard_count=3).shard_index == 2
+
+
+def test_effective_container_settings_reach_the_config(monkeypatch):
+    """"validate ... effective container settings": every env var the compose
+    math-python service sets must actually be consumed by ``from_env``."""
+    monkeypatch.setenv("MATH_ENV", "python")
+    monkeypatch.setenv("MATH_CONV_CACHE_CAP", "37")
+    monkeypatch.setenv("MATH_POLLER_RECONCILE_INTERVAL_MS", "1234")
+    monkeypatch.setenv("POLL_SHARD_INDEX", "1")
+    monkeypatch.setenv("POLL_SHARD_COUNT", "4")
+    monkeypatch.setenv("MATH_WORKER_POOL_SIZE", "3")
+    monkeypatch.setenv("MATH_POLLER_RETRY_CAP", "2")
+    monkeypatch.setenv("POLL_FROM_DAYS_AGO", "7")
+
+    cfg = PollerConfig.from_env()
+    assert cfg.math_env == "python"
+    assert cfg.conv_cache_cap == 37
+    assert cfg.reconcile_interval_ms == 1234
+    assert (cfg.shard_index, cfg.shard_count) == (1, 4)
+    assert cfg.worker_pool_size == 3
+    assert cfg.retry_cap == 2
+    assert cfg.poll_from_days_ago == 7
+
+
+def test_compose_math_python_service_passes_the_required_settings():
+    """The container definition must actually forward the settings above, or
+    the validated defaults never reach the deployed process."""
+    with open(os.path.join(_REPO_ROOT, "docker-compose.yml")) as fh:
+        compose = fh.read()
+    service = compose.split("  math-python:", 1)[1].split("\n  postgres:", 1)[0]
+    for var in ("MATH_ENV", "MATH_CONV_CACHE_CAP",
+                "MATH_POLLER_RECONCILE_INTERVAL_MS", "POLL_SHARD_INDEX",
+                "POLL_SHARD_COUNT", "MATH_WORKER_POOL_SIZE",
+                "MATH_POLLER_RETRY_CAP", "POLL_FROM_DAYS_AGO"):
+        assert re.search(rf"^\s*-\s*{var}=", service, re.M), (
+            f"docker-compose.yml's math-python service does not pass {var}"
+        )
+    assert "MATH_ENV=${MATH_PYTHON_ENV:-python}" in service, (
+        "the shadow service must default to a DISTINCT math_env"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the namespace failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_an_unscoped_writer_is_caught(self, engine, pg_url, make_service):
+        """Intentionally broken variant: a writer that ignores math_env and
+        overwrites the prod row.  The isolation assertion must go red."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        _seed_prod_rows(engine, 1)
+        before = _prod_snapshot(engine, 1)
+
+        with engine.begin() as conn:      # the broken write
+            conn.execute(
+                sa.text("update math_main set data = cast(:d as jsonb) "
+                        "where zid = :z"),
+                {"d": json.dumps({"zid": 1, "sentinel": "SHADOW"}), "z": 1},
+            )
+        assert _prod_snapshot(engine, 1) != before, (
+            "NEGATIVE CONTROL FAILED: an unscoped write to math_main did not "
+            "change the prod snapshot, so the isolation assertion is vacuous"
+        )
+
+    def test_the_prefetch_control_would_pass_when_scoped(self, engine, pg_url,
+                                                         make_service):
+        """The 'fixed' prefetch (with a math_env predicate) returns only prod
+        rows — proving the xfail above is about the missing predicate."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        _seed_prod_rows(engine, 1)
+        svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+        svc.poll_once()
+
+        with engine.connect() as conn:
+            rows = [dict(r) for r in conn.execute(
+                sa.text("select * from math_main where caching_tick > :last "
+                        "and math_env = :e order by caching_tick limit 10"),
+                {"last": -1, "e": PROD_ENV},
+            ).mappings()]
+        assert sorted({r["math_env"] for r in rows}) == [PROD_ENV]

--- a/delphi/tests/poller/recovery/test_r12_publication_cursor.py
+++ b/delphi/tests/poller/recovery/test_r12_publication_cursor.py
@@ -1,0 +1,364 @@
+"""R12 — the concurrent publication cursor (REAL Postgres, two real connections).
+
+P-022 §C required matrix:
+
+    Two different zids publish concurrently; hold one transaction while the
+    other commits and the Node prefetcher advances.  Require both conversations
+    to become visible without a later update.  Exercise equal caching ticks and
+    out-of-order commits; do not assume ``MAX(caching_tick)+1`` is a safe global
+    change cursor.
+
+Two halves, both real:
+
+* the WRITER's cursor allocation — ``polismath/database/postgres.py:838``'s
+  ``COALESCE((select max(caching_tick) + 1 from math_main where math_env = ?), 1)``,
+  evaluated inside each write's own transaction;
+* the READER's cursor consumption — ``server/src/utils/pca.ts:98``'s
+  ``select * from math_main where caching_tick > ($1) order by caching_tick
+  limit 10``, with ``lastPrefetchedMathTick`` advanced to the largest
+  ``caching_tick`` seen (``pca.ts:130-132``).
+
+The writer SQL is reproduced verbatim in :func:`allocate_and_write` so a
+transaction can be HELD open across the allocation; a companion test proves the
+production client produces the same allocation, so the transcription is not
+drifting from the code under test.
+"""
+
+import json
+import threading
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+# Verbatim from polismath/database/postgres.py:834-847 (write_math_main).
+_WRITE_MAIN_SQL = sa.text("""
+    insert into math_main
+        (zid, math_env, last_vote_timestamp, math_tick, data, caching_tick)
+    values
+        (:zid, :math_env, :last_vote_timestamp, :math_tick,
+         cast(:data as jsonb),
+         COALESCE((select max(caching_tick) + 1 from math_main
+                   where math_env = :math_env), 1))
+    on conflict (zid, math_env)
+    do update set modified = now_as_millis(),
+                  data = excluded.data,
+                  last_vote_timestamp = excluded.last_vote_timestamp,
+                  math_tick = excluded.math_tick,
+                  caching_tick = excluded.caching_tick
+    returning caching_tick;
+""")
+
+
+def allocate_and_write(conn, zid: int, math_env: str = MATH_ENV) -> int:
+    """Run the production upsert on an OPEN transaction and return the
+    caching_tick it allocated (without committing)."""
+    return conn.execute(_WRITE_MAIN_SQL, {
+        "zid": zid, "math_env": math_env, "last_vote_timestamp": 0,
+        "math_tick": 1, "data": json.dumps({"zid": zid}),
+    }).scalar()
+
+
+class Prefetcher:
+    """The server's prefetch cursor (``pca.ts:98``, ``:130-132``)."""
+
+    def __init__(self, engine):
+        self.engine = engine
+        self.last = -1
+        self.seen = []
+
+    def poll(self):
+        with self.engine.connect() as conn:
+            rows = [dict(r) for r in conn.execute(
+                sa.text("select * from math_main where caching_tick > :last "
+                        "order by caching_tick limit 10"),
+                {"last": self.last},
+            ).mappings()]
+        for row in rows:
+            self.seen.append(row["zid"])
+            if row["caching_tick"] > self.last:
+                self.last = row["caching_tick"]
+        return rows
+
+
+# --------------------------------------------------------------------------- #
+# The transcription matches the production client
+# --------------------------------------------------------------------------- #
+def test_transcribed_sql_allocates_the_same_cursor_as_the_client(engine, pg_url,
+                                                                 make_service):
+    """Guard against the reproduction drifting from ``write_math_main``."""
+    for zid in (1, 2, 3):
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       allowlist=[1, 2])
+    svc.poll_once()
+    ticks = {zid: read_math_tables(engine, zid, MATH_ENV)["main"]["caching_tick"]
+             for zid in (1, 2)}
+    assert sorted(ticks.values()) == [1, 2], (
+        f"the production client allocates a strictly increasing cursor: {ticks}"
+    )
+
+    with engine.connect() as conn:
+        with conn.begin():
+            allocated = allocate_and_write(conn, 3)
+    assert allocated == max(ticks.values()) + 1, (
+        "the transcribed SQL must allocate exactly what the client would"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The concurrent cursor
+# --------------------------------------------------------------------------- #
+def test_two_concurrent_publications_allocate_the_SAME_cursor(engine, pg_url):
+    """The root observation: with A's transaction still open, B's
+    ``max(caching_tick)+1`` cannot see A's row, so both allocate the same
+    value."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    seed_conversation(engine, zid=2, n_ptpts=4, n_cmts=3)
+
+    conn_a = engine.connect()
+    conn_b = engine.connect()
+    try:
+        tx_a = conn_a.begin()
+        tick_a = allocate_and_write(conn_a, 1)      # NOT committed
+        tx_b = conn_b.begin()
+        tick_b = allocate_and_write(conn_b, 2)
+        tx_b.commit()
+        tx_a.commit()
+    finally:
+        conn_a.close()
+        conn_b.close()
+
+    assert tick_a == tick_b == 1, (
+        f"two concurrent publications allocated {tick_a} and {tick_b}; "
+        "MAX+1 is not a globally unique change cursor"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (predicted by P-022 §C): MAX(caching_tick)+1 is not a safe "
+        "global change cursor. polismath/database/postgres.py:838 allocates "
+        "`COALESCE((select max(caching_tick)+1 from math_main where math_env = "
+        "?), 1)` INSIDE each write's own transaction, so two conversations "
+        "publishing concurrently allocate the SAME value; the consumer "
+        "(server/src/utils/pca.ts:98, :130-132) polls `caching_tick > "
+        "lastPrefetchedMathTick` and advances the cursor to the largest value "
+        "it saw. If the reader advances past a value between the two commits, "
+        "the later-committing row is NEVER prefetched: its conversation stays "
+        "invisible to the server's PCA cache until some unrelated later update "
+        "allocates a higher tick. P-022 §C: 'Require both conversations to "
+        "become visible without a later update... an earlier allocated value "
+        "can commit after a reader has advanced past it.' A replacement "
+        "sequence alone does not fix this — it also needs a commit-order or "
+        "reader-recovery argument. Separate decision."
+    ),
+)
+def test_both_zids_become_visible_to_the_prefetcher(engine, pg_url):
+    """Hold A's transaction, let B commit, let the prefetcher advance, THEN
+    commit A.  Both conversations must still become visible with no later
+    update."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    seed_conversation(engine, zid=2, n_ptpts=4, n_cmts=3)
+    prefetcher = Prefetcher(engine)
+
+    conn_a = engine.connect()
+    conn_b = engine.connect()
+    try:
+        tx_a = conn_a.begin()
+        allocate_and_write(conn_a, 1)          # allocated, uncommitted
+        tx_b = conn_b.begin()
+        allocate_and_write(conn_b, 2)
+        tx_b.commit()                          # zid 2 lands first
+        prefetcher.poll()                      # the reader advances past it
+        tx_a.commit()                          # zid 1 lands, out of order
+    finally:
+        conn_a.close()
+        conn_b.close()
+
+    for _ in range(5):                         # bounded eventual visibility
+        prefetcher.poll()
+
+    assert set(prefetcher.seen) == {1, 2}, (
+        f"the prefetcher only ever saw {sorted(set(prefetcher.seen))}; "
+        f"cursor is at {prefetcher.last}"
+    )
+
+
+def test_the_invisible_row_is_present_and_correct_in_the_table(engine, pg_url):
+    """Scope the defect: the row IS committed and correct — the loss is purely
+    in the change cursor, so a point read still serves it while the prefetch
+    cache never learns about it."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    seed_conversation(engine, zid=2, n_ptpts=4, n_cmts=3)
+    prefetcher = Prefetcher(engine)
+
+    conn_a = engine.connect()
+    conn_b = engine.connect()
+    try:
+        tx_a = conn_a.begin()
+        allocate_and_write(conn_a, 1)
+        tx_b = conn_b.begin()
+        allocate_and_write(conn_b, 2)
+        tx_b.commit()
+        prefetcher.poll()
+        tx_a.commit()
+    finally:
+        conn_a.close()
+        conn_b.close()
+
+    assert set(prefetcher.seen) == {2}, "precondition: zid 1 was skipped"
+    with engine.connect() as conn:
+        row = conn.execute(
+            sa.text("select zid, caching_tick from math_main where zid = 1 and "
+                    "math_env = :e"), {"e": MATH_ENV},
+        ).mappings().first()
+    assert row is not None and row["caching_tick"] == prefetcher.last, (
+        "the skipped row is committed with a caching_tick the cursor has "
+        f"already passed: {dict(row) if row else None}, cursor={prefetcher.last}"
+    )
+
+
+def test_a_later_update_makes_the_skipped_row_visible_again(engine, pg_url,
+                                                            make_service):
+    """The bound on the damage: any LATER publication for that zid allocates a
+    higher tick and the prefetcher picks it up.  So the defect is 'invisible
+    until further traffic', which is exactly what P-022 forbids for a quiet
+    conversation."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    seed_conversation(engine, zid=2, n_ptpts=4, n_cmts=3)
+    prefetcher = Prefetcher(engine)
+
+    conn_a = engine.connect()
+    conn_b = engine.connect()
+    try:
+        tx_a = conn_a.begin()
+        allocate_and_write(conn_a, 1)
+        tx_b = conn_b.begin()
+        allocate_and_write(conn_b, 2)
+        tx_b.commit()
+        prefetcher.poll()
+        tx_a.commit()
+    finally:
+        conn_a.close()
+        conn_b.close()
+    assert set(prefetcher.seen) == {2}
+
+    with engine.connect() as conn:              # a later publication for zid 1
+        with conn.begin():
+            allocate_and_write(conn, 1)
+    prefetcher.poll()
+    assert set(prefetcher.seen) == {1, 2}
+
+
+def test_out_of_order_commits_of_equal_ticks_across_many_zids(engine, pg_url):
+    """Three concurrent publications allocating equal ticks, committed in
+    reverse order: count how many the strict cursor can ever deliver."""
+    for zid in (1, 2, 3):
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+    prefetcher = Prefetcher(engine)
+
+    conns = [engine.connect() for _ in range(3)]
+    txs = []
+    try:
+        for conn, zid in zip(conns, (1, 2, 3)):
+            txs.append(conn.begin())
+            allocate_and_write(conn, zid)
+        for tx in reversed(txs):                # commit in reverse order
+            tx.commit()
+            prefetcher.poll()
+    finally:
+        for conn in conns:
+            conn.close()
+
+    with engine.connect() as conn:
+        ticks = {r["zid"]: r["caching_tick"] for r in conn.execute(
+            sa.text("select zid, caching_tick from math_main where math_env=:e"),
+            {"e": MATH_ENV}).mappings()}
+    assert len(set(ticks.values())) == 1, (
+        f"all three publications allocated the same cursor value: {ticks}"
+    )
+    assert set(prefetcher.seen) == {3}, (
+        "only the FIRST committer of an equal-tick group is ever prefetched; "
+        f"saw {sorted(set(prefetcher.seen))}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the publication-cursor failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_sequence_allocated_cursor_is_unique(self, engine, pg_url):
+        """Intentionally 'fixed' variant: allocate from a real Postgres
+        SEQUENCE instead of MAX+1.  Concurrent transactions then get DISTINCT
+        values, proving the collision above is caused by the MAX+1 allocation.
+
+        (It does NOT make the scenario safe: the out-of-order-commit half of
+        the defect survives, which is why P-022 says a replacement sequence
+        alone still needs a commit-order/reader-recovery argument — asserted
+        below.)"""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        seed_conversation(engine, zid=2, n_ptpts=4, n_cmts=3)
+        with engine.begin() as conn:
+            conn.execute(sa.text("create sequence caching_tick_seq"))
+
+        sql = sa.text(
+            "insert into math_main (zid, math_env, last_vote_timestamp, "
+            "math_tick, data, caching_tick) values (:zid, :e, 0, 1, "
+            "cast(:d as jsonb), nextval('caching_tick_seq')) returning "
+            "caching_tick"
+        )
+        prefetcher = Prefetcher(engine)
+        conn_a, conn_b = engine.connect(), engine.connect()
+        try:
+            tx_a = conn_a.begin()
+            tick_a = conn_a.execute(
+                sql, {"zid": 1, "e": MATH_ENV, "d": json.dumps({})}).scalar()
+            tx_b = conn_b.begin()
+            tick_b = conn_b.execute(
+                sql, {"zid": 2, "e": MATH_ENV, "d": json.dumps({})}).scalar()
+            tx_b.commit()
+            prefetcher.poll()
+            tx_a.commit()
+        finally:
+            conn_a.close()
+            conn_b.close()
+
+        assert tick_a != tick_b, (
+            "NEGATIVE CONTROL FAILED: even a sequence produced colliding "
+            "cursor values, so the MAX+1 finding would be misattributed"
+        )
+        for _ in range(3):
+            prefetcher.poll()
+        assert set(prefetcher.seen) == {2}, (
+            "a sequence alone does NOT fix visibility: zid 1's smaller value "
+            "committed after the reader advanced past it, so it is still "
+            f"never delivered (saw {sorted(set(prefetcher.seen))})"
+        )
+
+    def test_the_prefetcher_model_can_see_a_normal_publication(self, engine,
+                                                               pg_url,
+                                                               make_service):
+        """Guard against a vacuous xfail: in the ordinary (serial) case the
+        prefetcher model does deliver every zid."""
+        for zid in (1, 2, 3):
+            seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        svc.poll_once()
+        prefetcher = Prefetcher(engine)
+        for _ in range(3):
+            prefetcher.poll()
+        assert set(prefetcher.seen) == {1, 2, 3}

--- a/delphi/tests/poller/test_integration_postgres.py
+++ b/delphi/tests/poller/test_integration_postgres.py
@@ -45,6 +45,18 @@ def _seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5):
     old_modified = now - 2 * 24 * 60 * 60 * 1000  # 2 days ago
     with engine.begin() as conn:
         conn.execute(sa.text("SET session_replication_role = replica"))
+        # Make the seed RE-RUNNABLE. When POLIS_TEST_POSTGRES_URL points at a
+        # long-lived service database (the compose `postgres` service, and now
+        # `make test-recovery`), rows from a previous run survive: the INSERT
+        # below hit conversations_zid_key, and the caching_tick == 1 assertion
+        # below additionally requires this math_env to have no prior math_main
+        # row. Clear this zid's own rows first rather than depending on a
+        # freshly-initialised database.
+        for table in ("votes", "votes_latest_unique", "comments",
+                      "participants", "math_main", "math_bidtopid",
+                      "math_ptptstats", "math_ticks", "conversations"):
+            conn.execute(sa.text(f"DELETE FROM {table} WHERE zid = :zid"),
+                         {"zid": zid})
         conn.execute(sa.text("INSERT INTO conversations (zid) VALUES (:zid)"),
                      {"zid": zid})
         for p in range(n_ptpts):

--- a/delphi/tests/poller/test_park_rebuild_recovery.py
+++ b/delphi/tests/poller/test_park_rebuild_recovery.py
@@ -93,6 +93,18 @@ def _drain(svc, timeout=5.0):
     assert svc._pool.join(timeout=timeout), "worker pool did not drain in time"
 
 
+def _pool_pending(pool, zid):
+    """Queued-or-active work for one zid, read under the pool's OWN lock.
+
+    Used to assert that no queued request was dropped and that no handler is
+    still in flight.  Reads the pool's private bookkeeping deliberately: the
+    point is to check the pool's internal accounting, and taking ``_lock``
+    means the snapshot cannot tear against a concurrent submit/park.
+    """
+    with pool._lock:
+        return bool(pool._queues.get(zid)) or zid in pool._active
+
+
 # --------------------------------------------------------------------------- #
 # Retry-preserves-rebuild unit test (the R03 root-cause fix)
 # --------------------------------------------------------------------------- #
@@ -267,13 +279,38 @@ class TestR04ParkUnparkRaces:
 
         svc._pool.submit(1, REBUILD, [])  # worker A enters loader and freezes
         assert entered.wait(timeout=5)
-        svc._pool.submit(1, REBUILD, [])  # overlapping trigger: must NOT run now
+        # Two overlapping triggers arrive while worker A is provably in flight.
+        # Neither may run NOW (per-zid serialization) and neither may be
+        # DROPPED: the pool must coalesce them into exactly one further cycle
+        # once worker A finishes.
+        svc._pool.submit(1, REBUILD, [])
+        svc._pool.submit(1, REBUILD, [])
         proceed.set()
         _drain(svc)
 
+        # --- handler accounting (exact, not ">= 1") ------------------------ #
         assert conc["max"] == 1, "at most one active handler per zid"
-        assert conc["n"] >= 1, "the rebuild ran; nothing silently dropped"
-        assert svc._writer.writes and svc._writer.writes[0] == 1
+        assert conc["n"] == 2, (
+            "expected EXACTLY two rebuild executions — the in-flight one plus "
+            "one coalesced cycle for the two overlapping triggers — but saw "
+            f"{conc['n']}. A count of 1 means the queued rebuilds were "
+            "DROPPED; more than 2 means per-zid serialization or coalescing "
+            "broke."
+        )
+        assert conc["cur"] == 0, "no handler left in flight"
+
+        # --- final state --------------------------------------------------- #
+        assert svc._writer.writes == [1, 1], (
+            f"each executed rebuild must publish exactly once, saw "
+            f"{svc._writer.writes!r}"
+        )
+        assert not _pool_pending(svc._pool, 1), (
+            "the pool must have no queued or active work left for the zid"
+        )
+        assert 1 not in svc._parked and not svc._pool.is_parked(1), (
+            "a successful rebuild must leave the zid unparked"
+        )
+        assert svc._retry_counts.get(1) is None, "retry markers must be cleared"
 
     def test_reconcile_and_new_vote_unpark_converge(self, make_svc):
         """Trigger the reconciler and a new-vote unpark concurrently on a parked

--- a/docker-compose.recovery.yml
+++ b/docker-compose.recovery.yml
@@ -1,0 +1,20 @@
+# Compose override for the P-022 §C poller recovery suite.
+#
+# Used with docker-compose.test.yml, e.g.
+#   docker compose -f docker-compose.test.yml -f docker-compose.recovery.yml \
+#     --env-file test.env up -d postgres
+#
+# Two deliberate differences from the plain test stack:
+#   * the host port is NOT 5432 — a developer's live local Postgres usually owns
+#     that port, and the recovery suite creates/drops databases, so it must never
+#     be able to reach a real one by accident. Override with
+#     POLIS_RECOVERY_PG_PORT.
+#   * the data directory is tmpfs: every `up` starts from a clean initdb, which
+#     re-runs server/postgres/migrations/*.sql (the REAL migrations baked into
+#     server/Dockerfile-db), and nothing survives teardown.
+services:
+  postgres:
+    ports: !override
+      - "${POLIS_RECOVERY_PG_PORT:-55432}:5432"
+    tmpfs:
+      - /var/lib/postgresql/data


### PR DESCRIPTION
## What
The failure-injection suite for the Python math poller: the class of bug the Clojure↔Python parity battery cannot see. Twelve scenarios (`delphi/tests/poller/recovery/`), each on a fresh migrated database, with an independent fold of the input votes checking final state, barriers instead of sleeps, a negative control per failure class, and missing Postgres as a **failure**, not a skip.

| ID | Scenario | Backend |
|---|---|---|
| R01 | write-stage failures (before/after tick, each table, serialization, rollback, lost ack) | real PG |
| R02 | newer revote queued during a retry, real `Conversation` | real PG |
| R03 | park → silence → reconciler, transient and persistent failure | real PG |
| R04 | park/unpark races, overlapping reconciles (exact accounting, per review of #2700) | real PG |
| R05 | real process SIGKILL mid-batch at five points, restart with no new vote | real PG + subprocess |
| R06 | LRU eviction while work is in flight | real PG |
| R07 | overlapping shards, duplicate writers | subprocess + in-process |
| R08 | strict `>` timestamp boundary, ties, clock skew | real PG, 2 connections |
| R09 | partial three-table writes vs. readers | real PG |
| R10 | poll/load failures, poison zid fairness, join timeout | real PG |
| R11 | math_env namespace isolation, cap/shard config | in-process |
| R12 | concurrent publication cursor (`MAX+1`), 3 connections | real PG |

**No production code changed.** Hooks monkeypatch the writer/engine boundary or replicate server SQL verbatim, with a guard test that the R12 transcription matches the real client.

## Results
- Recovery package: **97 passed, 11 xfailed (strict), 0 failed.** Whole `tests/poller` via `make test-recovery`: 209 passed, 1 pre-existing skip, 11 xfailed.
- `make test-recovery-races`: 20/20 clean loops. R05 real-SIGKILL restarts: 20/20.

## Defects pinned as `xfail(strict=True)` — each is a real gap, kept failing on purpose
Predicted by the program design: non-atomic three-table write leaves a dormant zid with a permanently mixed generation (R05) and mixed generations for readers (R09); strict-`>` watermark loses same-timestamp / earlier-committed votes, three variants (R08); `MAX(caching_tick)+1` publication cursor is not a safe global change cursor (R12).

Found beyond the design: no duplicate-writer fencing (R07); `poll_once` swallows the pool join timeout (R10); unsynchronized conv cache can park a healthy zid (R06); **the server's PCA prefetch is not `math_env`-scoped, so shadow-run rows would poison the prod cache (R11)** — this one changes the shadow-run plan; no per-cell timestamp guard on a cross-batch merge (R02, latent, documented as unreachable through today's queue).

Fixing these is separate work, one PR per seam. Notes with file:line for every defect are in the program notes.

Also: `docker-compose.recovery.yml` (Postgres-only stack for these tests), `make test-recovery` / `test-recovery-races` targets, and `uv.lock` (shared with #2701; whichever merges second rebases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s