### PR TITLE
fix(server): scope math_main/math_bidtopid reads and caches by math_env (R11)

### DIFF
--- a/server/__tests__/integration/math-env-isolation.test.ts
+++ b/server/__tests__/integration/math-env-isolation.test.ts
@@ -1,0 +1,196 @@
+import Config from "../../src/config";
+import pg from "../../src/db/pg-query";
+import { getPca, prefetchLatestPcaData } from "../../src/utils/pca";
+import {
+  getBidIndexToPidMapping,
+  getPidsForGid,
+} from "../../src/utils/participants";
+import { pool, closePool } from "../setup/db-test-helpers";
+
+// Real migrated Postgres, both engines publishing for the SAME conversation.
+// The Clojure service in the test stack uses dev, leaving these fixtures alone.
+describe("math_env namespace isolation", () => {
+  const originalEnv = Config.mathEnv;
+  let zid: number;
+  let tickBase = 0;
+  let reads: jest.SpyInstance;
+
+  async function seed(env: string, tick: number, pid: number) {
+    const data = {
+      sentinel: env,
+      math_tick: tick,
+      "group-clusters": [{ id: 0, members: [0], center: [0, 0] }],
+      "base-clusters": {
+        id: [0],
+        x: [0],
+        y: [0],
+        count: [1],
+        members: [[pid]],
+      },
+    };
+    await pool.query(
+      `insert into math_main (zid, math_env, data, last_vote_timestamp, math_tick, caching_tick)
+       values ($1, $2, $3, 0, $4, $4)`,
+      [zid, env, data, tick]
+    );
+    await pool.query(
+      "insert into math_bidtopid (zid, math_env, data, math_tick) values ($1, $2, $3, $4)",
+      [zid, env, { math_tick: tick, bidToPid: [[pid]] }, tick]
+    );
+    await pool.query(
+      "insert into math_ptptstats (zid, math_env, data, math_tick) values ($1, $2, $3, $4)",
+      [zid, env, { sentinel: env }, tick]
+    );
+  }
+
+  async function setTick(env: string, tick: number) {
+    await pool.query(
+      "update math_main set math_tick = $1, caching_tick = $1 where zid = $2 and math_env = $3",
+      [tick, zid, env]
+    );
+  }
+
+  beforeEach(async () => {
+    tickBase += 10000;
+    const result = await pool.query(
+      "insert into conversations default values returning zid"
+    );
+    zid = result.rows[0].zid;
+    await seed("prod", tickBase + 10, 11);
+    await seed("python", tickBase + 1000, 22);
+    reads = jest.spyOn(pg, "queryP_readOnly"); // Calls through to real Postgres.
+  });
+
+  afterEach(async () => {
+    reads?.mockRestore();
+    Config.mathEnv = originalEnv;
+    for (const table of [
+      "math_main",
+      "math_bidtopid",
+      "math_ptptstats",
+      "conversations",
+    ]) {
+      await pool.query(`delete from ${table} where zid = $1`, [zid]);
+    }
+  });
+  afterAll(closePool);
+
+  test.each(["prod", "python"])(
+    "%s point reads, participant joins, and cached latest/tick reads",
+    async (env) => {
+      Config.mathEnv = env;
+      const tick = tickBase + (env === "prod" ? 10 : 1000);
+      const pid = env === "prod" ? 11 : 22;
+      // A point read must not pick the other engine's newer row.
+      expect(await getPca(zid, tick)).toBeUndefined();
+      const result = await getPca(zid, -1);
+      expect(result?.asPOJO.sentinel).toBe(env);
+      expect(result?.asPOJO.math_tick).toBe(tick);
+      reads.mockClear();
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe(env);
+      expect((await getPca(zid, tick - 1))?.asPOJO.sentinel).toBe(env);
+      expect(await getPca(zid, tick)).toBeUndefined();
+      expect(reads).not.toHaveBeenCalled();
+      expect((await getBidIndexToPidMapping(zid, -1)).bidToPid).toEqual([
+        [pid],
+      ]);
+      expect(await getBidIndexToPidMapping(zid, tick)).toEqual(
+        new Error("polis_err_get_pca_results_not_new")
+      );
+      expect(await getPidsForGid(zid, 0, -1)).toEqual([pid]);
+      Config.mathEnv = env === "prod" ? "python" : "prod";
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe(Config.mathEnv);
+      expect(await getPidsForGid(zid, 0, -1)).toEqual([
+        env === "prod" ? 22 : 11,
+      ]);
+      Config.mathEnv = env;
+      expect((await getPca(zid, -1))?.asPOJO.sentinel).toBe(env);
+    }
+  );
+
+  test("empty fallback cache stays in its namespace", async () => {
+    await pool.query(
+      "delete from math_main where zid = $1 and math_env = 'prod'",
+      [zid]
+    );
+    Config.mathEnv = "prod";
+    expect((await getPca(zid))?.asPOJO.math_tick).toBe(0);
+    Config.mathEnv = "python";
+    expect((await getPca(zid))?.asPOJO.sentinel).toBe("python");
+    Config.mathEnv = "prod";
+    expect((await getPca(zid))?.asPOJO.math_tick).toBe(0);
+  });
+
+  test.each(["prod", "python"])(
+    "%s prefetch cursor and cache stay scoped across batches and env switches",
+    async (env) => {
+      const otherEnv = env === "prod" ? "python" : "prod";
+      const currentTick = tickBase + 10;
+      const foreignTick = tickBase + 1000;
+      await setTick(env, currentTick);
+      await setTick(otherEnv, foreignTick);
+      Config.mathEnv = env;
+      await prefetchLatestPcaData();
+      reads.mockClear();
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe(env);
+      expect(reads).not.toHaveBeenCalled(); // Really served the prefetched cache.
+      await setTick(env, currentTick + 1);
+      await prefetchLatestPcaData();
+      expect(reads.mock.calls[0][1]).toEqual([currentTick, env]);
+      expect((await getPca(zid))?.asPOJO.math_tick).toBe(currentTick + 1);
+      Config.mathEnv = otherEnv;
+      await prefetchLatestPcaData();
+      reads.mockClear();
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe(otherEnv);
+      expect(reads).not.toHaveBeenCalled();
+      await prefetchLatestPcaData();
+      expect(reads.mock.calls[0][1]).toEqual([foreignTick, otherEnv]);
+      Config.mathEnv = env;
+      reads.mockClear();
+      await prefetchLatestPcaData();
+      expect(reads.mock.calls[0][1]).toEqual([currentTick + 1, env]);
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe(env);
+    }
+  );
+
+  test.each(["point", "prefetch"])(
+    "%s results keep their original env when config changes in flight",
+    async (path) => {
+      const query = pg.queryP_readOnly.bind(pg);
+      let release!: () => void;
+      let arrived!: () => void;
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const queried = new Promise<void>((resolve) => {
+        arrived = resolve;
+      });
+      reads.mockImplementationOnce(
+        async (...args: Parameters<typeof pg.queryP_readOnly>) => {
+          const rows = await query(...args); // Real DB result, held before delivery.
+          arrived();
+          await held;
+          return rows;
+        }
+      );
+      Config.mathEnv = "prod";
+      const pending = path === "point" ? getPca(zid) : prefetchLatestPcaData();
+      try {
+        await queried;
+        Config.mathEnv = "python";
+      } finally {
+        release();
+      }
+      await pending;
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe("python");
+      Config.mathEnv = "prod";
+      reads.mockClear();
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe("prod");
+      expect(reads).not.toHaveBeenCalled();
+      if (path === "prefetch") {
+        await prefetchLatestPcaData();
+        expect(reads.mock.calls[0][1]).toEqual([tickBase + 10, "prod"]);
+      }
+    }
+  );
+});

--- a/server/src/routes/math.ts
+++ b/server/src/routes/math.ts
@@ -26,8 +26,8 @@ function handle_GET_math_pca(
 
 // Cache the knowledge of whether there are any pca results for a given zid.
 // Needed to determine whether to return a 404 or a 304.
-// zid -> boolean
-const pcaResultsExistForZid: Record<number, boolean> = {};
+// [math_env, zid] -> boolean
+const pcaResultsExistForZid: Record<string, boolean> = {};
 
 function handle_GET_math_pca2(
   req: {
@@ -54,6 +54,7 @@ function handle_GET_math_pca2(
   }
 ) {
   const zid = req.p.zid;
+  const cacheKey = JSON.stringify([Config.mathEnv, zid]);
   let math_tick = req.p.math_tick;
   const keys = req.p.keys;
 
@@ -84,7 +85,7 @@ function handle_GET_math_pca2(
   }
 
   function finishWith304or404() {
-    if (pcaResultsExistForZid[zid]) {
+    if (pcaResultsExistForZid[cacheKey]) {
       res.status(304).end();
     } else {
       // Technically, this should probably be a 404, but
@@ -122,12 +123,12 @@ function handle_GET_math_pca2(
         res.send(data.asBufferOfGzippedJson);
       } else {
         // check whether we should return a 304 or a 404
-        if (pcaResultsExistForZid[zid] === undefined) {
+        if (pcaResultsExistForZid[cacheKey] === undefined) {
           // This server doesn't know yet if there are any PCA results in the DB
           // So try querying from -1
           return getPca(zid, -1).then(function (data: any) {
             const exists = !!data;
-            pcaResultsExistForZid[zid] = exists;
+            pcaResultsExistForZid[cacheKey] = exists;
             finishWith304or404();
           });
         } else {

--- a/server/src/utils/pca.ts
+++ b/server/src/utils/pca.ts
@@ -73,77 +73,76 @@ export type PcaCacheItem = {
 };
 
 const pcaCacheSize = Config.cacheMathResults ? 300 : 1;
-const pcaCache = new LruCache<number, PcaCacheItem>({
+const pcaCache = new LruCache<string, PcaCacheItem>({
   max: pcaCacheSize,
 });
 
-// this scheme might not last forever. For now, there are only a couple of MB worth of conversation pca data.
-let lastPrefetchedMathTick = -1;
+// Each namespace has an independent publication cursor and cache entries.
+const lastPrefetchedMathTicks = new Map<string, number>();
+
+function pcaCacheKey(mathEnv: string, zid: number): string {
+  return JSON.stringify([mathEnv, zid]);
+}
+
+// One batch, shared by the background loop and integration tests. Capture the
+// namespace before any async work so a config change cannot relabel its results.
+export async function prefetchLatestPcaData(): Promise<void> {
+  const mathEnv = Config.mathEnv;
+  let lastPrefetchedMathTick = lastPrefetchedMathTicks.get(mathEnv) ?? -1;
+  const rows = await pg.queryP_readOnly<
+    Array<{ data: any; math_tick: any; caching_tick: any; zid: number }>
+  >(
+    "select * from math_main where caching_tick > ($1) and math_env = ($2) order by caching_tick limit 10;",
+    [lastPrefetchedMathTick, mathEnv]
+  );
+
+  await Promise.all(
+    (
+      rows as Array<{
+        data: any;
+        math_tick: any;
+        caching_tick: any;
+        zid: number;
+      }>
+    ).map((row) => {
+      const item = row.data;
+      if (row.math_tick) {
+        item.math_tick = Number(row.math_tick);
+      }
+      if (row.caching_tick) {
+        item.caching_tick = Number(row.caching_tick);
+      }
+      logger.info("mathpoll updating", {
+        caching_tick: item.caching_tick,
+        zid: row.zid,
+      });
+      lastPrefetchedMathTick = Math.max(
+        lastPrefetchedMathTick,
+        Number(row.caching_tick)
+      );
+      processMathObject(item);
+      return updatePcaCache(mathEnv, row.zid, item);
+    })
+  );
+  lastPrefetchedMathTicks.set(
+    mathEnv,
+    Math.max(lastPrefetchedMathTicks.get(mathEnv) ?? -1, lastPrefetchedMathTick)
+  );
+}
 
 // Background polling function to proactively cache PCA data
 export function fetchAndCacheLatestPcaData() {
-  let lastPrefetchPollStartTime = Date.now();
-
-  function waitTime() {
-    const timePassed = Date.now() - lastPrefetchPollStartTime;
-    return Math.max(0, 2500 - timePassed);
-  }
-
-  function pollForLatestPcaData() {
-    lastPrefetchPollStartTime = Date.now();
-
-    pg.queryP_readOnly<
-      Array<{ data: any; math_tick: any; caching_tick: any; zid: number }>
-    >(
-      "select * from math_main where caching_tick > ($1) order by caching_tick limit 10;",
-      [lastPrefetchedMathTick]
-    )
-      .then((rows) => {
-        const rowsArray = rows as Array<{
-          data: any;
-          math_tick: any;
-          caching_tick: any;
-          zid: number;
-        }>;
-
-        if (!rowsArray || !rowsArray.length) {
-          // call again
-          setTimeout(pollForLatestPcaData, waitTime());
-          return;
-        }
-
-        const results = rowsArray.map((row) => {
-          const item = row.data;
-
-          if (row.math_tick) {
-            item.math_tick = Number(row.math_tick);
-          }
-          if (row.caching_tick) {
-            item.caching_tick = Number(row.caching_tick);
-          }
-
-          logger.info("mathpoll updating", {
-            caching_tick: item.caching_tick,
-            zid: row.zid,
-          });
-
-          if (item.caching_tick > lastPrefetchedMathTick) {
-            lastPrefetchedMathTick = item.caching_tick;
-          }
-
-          processMathObject(item);
-
-          return updatePcaCache(row.zid, item);
-        });
-
-        Promise.all(results).then(() => {
-          setTimeout(pollForLatestPcaData, waitTime());
-        });
-      })
-      .catch((err) => {
-        logger.error("mathpoll error", err);
-        setTimeout(pollForLatestPcaData, waitTime());
-      });
+  async function pollForLatestPcaData() {
+    const pollStart = Date.now();
+    try {
+      await prefetchLatestPcaData();
+    } catch (err) {
+      logger.error("mathpoll error", err);
+    }
+    setTimeout(
+      pollForLatestPcaData,
+      Math.max(0, 2500 - (Date.now() - pollStart))
+    );
   }
 
   // Start the polling process
@@ -321,7 +320,8 @@ export function getPca(
   zid?: number,
   math_tick?: number
 ): Promise<PcaCacheItem | undefined> {
-  let cached = pcaCache.get(zid);
+  const mathEnv = Config.mathEnv;
+  let cached = pcaCache.get(pcaCacheKey(mathEnv, zid));
   if (cached && cached.expiration < Date.now()) {
     cached = undefined;
   }
@@ -358,7 +358,7 @@ export function getPca(
   return pg
     .queryP_readOnly<Array<{ data: any; math_tick: any }>>(
       "select * from math_main where zid = ($1) and math_env = ($2);",
-      [zid, Config.mathEnv]
+      [zid, mathEnv]
     )
     .then((rows) => {
       const queryEnd = Date.now();
@@ -374,7 +374,7 @@ export function getPca(
           {
             zid,
             math_tick,
-            math_env: Config.mathEnv,
+            math_env: mathEnv,
           }
         );
 
@@ -387,7 +387,7 @@ export function getPca(
           );
           return ensureCompletePcaStructure(zid).then((completeData) => {
             const dataWithZid = { ...completeData, zid: zid };
-            return updatePcaCache(zid, dataWithZid);
+            return updatePcaCache(mathEnv, zid, dataWithZid);
           });
         }
 
@@ -416,12 +416,13 @@ export function getPca(
       // Ensure all required fields exist by merging with empty structure if needed
       return ensureCompletePcaStructure(zid, item).then((completeData) => {
         const dataWithZid = { ...completeData, zid: zid };
-        return updatePcaCache(zid, dataWithZid);
+        return updatePcaCache(mathEnv, zid, dataWithZid);
       });
     });
 }
 
 function updatePcaCache(
+  mathEnv: string,
   zid: number,
   item: { zid: number }
 ): Promise<PcaCacheItem> {
@@ -448,7 +449,7 @@ function updatePcaCache(
           repness: (item as any).repness || {},
         } as unknown as PcaCacheItem;
         // save in LRU cache, but don't update the lastPrefetchedMathTick
-        pcaCache.set(zid, o);
+        pcaCache.set(pcaCacheKey(mathEnv, zid), o);
         resolve(o);
       }
     );


### PR DESCRIPTION
## Why
The server's PCA prefetch and its in-process caches were keyed by zid alone and never filtered by `math_env`, unchanged since 2017. That is harmless while exactly one engine writes math rows. A shadow run of the Python engine alongside Clojure would be the first time in nine years that assumption breaks, and the live site would read and cache the other engine's rows. Recovery scenario R11 in the Clojure-deprecation test program.

## What
- `server/src/utils/pca.ts`: prefetch (`caching_tick > $1`) and latest-tick queries bind `math_env = $2` from `Config.mathEnv` as a parameter; `pcaCache` and `pcaResultsExistForZid` keyed by `[math_env, zid]`; env captured before any async work.
- `server/src/routes/math.ts`: same scoping.
- `server/__tests__/integration/math-env-isolation.test.ts`: seeds `prod` and `python` rows for one zid with different `caching_tick`s; asserts every read path and the cursor see only the configured env. Mutation-checked by the reviewer: unscoped SQL fails 3/7, env-blind cache key fails 7/7.

Single-engine behavior unchanged (old vs new SQL compared on a real DB). No new per-request queries; `/api/v3/math/pca2` responses unchanged. Reader coverage: the only other readers (`pca.ts` point read, `participants.ts` bidtopid) were already scoped.

## Verification
Worker: jest 43 suites / 302 passed / 1 skipped. Independent reviewer re-ran: identical; `tsc --noEmit`, prettier, eslint clean.

## Follow-up (separate, after #2702 merges)
The recovery suite's R11 test is `xfail(strict=True)` on the unscoped SQL and will XPASS once this lands; its transcription (and R12's) must be updated in the same change as its xfail removal. Held out of this PR to avoid colliding with #2702.

Implemented by a headless Codex worker under Claude's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s