### PR TITLE
fix(poller): publish math_tick + all three math tables in one transaction (R05/R09)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,62 @@ refresh-prodclone: ## Force prodclone mode, drop prodclone volume, and restart f
 refresh-devdb: ## Force dev DB mode (migrations), drop postgres_data volume, and restart
 	$(MAKE) USE_PRODCLONE=false refresh-db
 
+# ---------------------------------------------------------------------------- #
+# P-022 §C — poller recovery matrix (R01-R12) on a REAL Postgres
+# ---------------------------------------------------------------------------- #
+# Reuses docker-compose.test.yml's postgres service (built from
+# server/Dockerfile-db, which bakes server/postgres/migrations/*.sql into
+# docker-entrypoint-initdb.d) with docker-compose.recovery.yml overriding the
+# host port and making the data directory a tmpfs, so every `up` re-runs initdb
+# with the real migrations and nothing survives teardown.
+#
+# The suite FAILS rather than skips without a Postgres (P-022 §C Acceptance:
+# "Missing Postgres is a failing required job, not pytest skip"), so this is the
+# supported way to run it.
+RECOVERY_PG_PORT ?= 55432
+RECOVERY_COMPOSE = POLIS_RECOVERY_PG_PORT=$(RECOVERY_PG_PORT) docker compose \
+	-f docker-compose.test.yml -f docker-compose.recovery.yml --env-file test.env
+RECOVERY_PG_PASSWORD = $(shell grep -e ^POSTGRES_PASSWORD test.env | cut -d= -f2)
+RECOVERY_PG_URL = postgresql://postgres:$(RECOVERY_PG_PASSWORD)@localhost:$(RECOVERY_PG_PORT)/polis-test
+# Runs in a SUBSHELL so the `cd` cannot leak into the cleanup trap (which must
+# still find this Makefile in the repository root).
+RECOVERY_PYTEST = cd $(CURDIR)/delphi && POLIS_TEST_POSTGRES_URL="$(RECOVERY_PG_URL)" uv run --no-sync pytest
+
+test-recovery-up: ## Start the recovery suite's Postgres (real migrations, ephemeral)
+	$(RECOVERY_COMPOSE) up -d --force-recreate postgres
+	@echo "waiting for postgres to become healthy on port $(RECOVERY_PG_PORT)..."
+	@cid=$$($(RECOVERY_COMPOSE) ps -q postgres); \
+	for i in $$(seq 1 60); do \
+		s=$$(docker inspect -f '{{.State.Health.Status}}' $$cid 2>/dev/null); \
+		if [ "$$s" = "healthy" ]; then echo "postgres healthy"; exit 0; fi; \
+		sleep 1; \
+	done; \
+	echo "postgres did not become healthy"; exit 1
+
+test-recovery-down: ## Stop and remove the recovery suite's Postgres
+	$(RECOVERY_COMPOSE) down -v --remove-orphans
+
+test-recovery: ## Run the P-022 recovery matrix (R01-R12) on a real Postgres
+	@$(MAKE) test-recovery-up
+	@set -e; trap '$(MAKE) test-recovery-down' EXIT; \
+		( $(RECOVERY_PYTEST) tests/poller -q -rxX )
+
+test-recovery-races: ## Re-run the deterministic race schedules 20x (P-022 acceptance)
+	@$(MAKE) test-recovery-up
+	@set -e; trap '$(MAKE) test-recovery-down' EXIT; \
+		for i in $$(seq 1 20); do \
+			echo "=== race iteration $$i/20 ==="; \
+			( $(RECOVERY_PYTEST) \
+				tests/poller/recovery/test_r02_newer_revote_during_retry.py \
+				tests/poller/recovery/test_r04_park_unpark_races.py \
+				tests/poller/recovery/test_r06_lru_in_flight.py \
+				tests/poller/recovery/test_r09_partial_tables_readers.py \
+				tests/poller/recovery/test_r12_publication_cursor.py \
+				tests/poller/test_park_rebuild_recovery.py \
+				-q ) || exit 1; \
+		done; \
+		echo "20/20 race iterations passed"
+
 e2e-install: e2e/node_modules ## Install Cypress E2E testing tools
 	$(E2E_RUN) npm install
 
@@ -208,7 +264,8 @@ rbs: start-rebuild
 	rebuild-delphi rebuild-server rebuild-web 
 	refresh-db refresh-devdb refresh-prodclone regenerate-jwt-keys \
 	rm-ALL rm-containers rm-images rm-volumes \
-	start-FULL-REBUILD start-prodclone start-rebuild start-recreate
+	start-FULL-REBUILD start-prodclone start-rebuild start-recreate \
+	test-recovery test-recovery-up test-recovery-down test-recovery-races
 
 
 help: ## Show this help message

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ test-recovery-races: ## Re-run the deterministic race schedules 20x (P-022 accep
 				tests/poller/recovery/test_r04_park_unpark_races.py \
 				tests/poller/recovery/test_r06_lru_in_flight.py \
 				tests/poller/recovery/test_r09_partial_tables_readers.py \
+				tests/poller/recovery/test_atomic_publish.py::test_blocked_zid_does_not_block_other_zid_transactions \
 				tests/poller/recovery/test_r12_publication_cursor.py \
 				tests/poller/test_park_rebuild_recovery.py \
 				-q ) || exit 1; \

--- a/delphi/Makefile
+++ b/delphi/Makefile
@@ -5,6 +5,10 @@ help: ## Show this help message
 	@echo "Available commands:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: test-recovery test-recovery-races
+test-recovery test-recovery-races: ## Run the root recovery target with isolated Postgres
+	$(MAKE) -C .. $@
+
 install: ## Install production dependencies
 	pip install -e .
 

--- a/delphi/polismath/database/postgres.py
+++ b/delphi/polismath/database/postgres.py
@@ -31,6 +31,21 @@ from polismath.utils.serialization import convert_numpy_types
 logger = logging.getLogger(__name__)
 
 
+def encode_math_blob(data: Any) -> str:
+    """Encode a math blob for a ``jsonb`` parameter, or pass one through.
+
+    The poller pre-encodes all three blobs BEFORE opening the publication
+    transaction (``math_writer.write_conv_updates``) so that ``json.dumps`` of a
+    large ``math_main`` blob does not run while the ``(zid, math_env)`` row
+    locks are held — it lengthens both the lock hold and the
+    caching_tick allocate -> commit window (R12). Every other caller still
+    hands these writers a dict.
+    """
+    if isinstance(data, str):
+        return data
+    return json.dumps(data, default=convert_numpy_types)
+
+
 # Base class for SQLAlchemy models
 class Base(DeclarativeBase):
     """Base class for all SQLAlchemy models."""
@@ -875,7 +890,7 @@ class PostgresClient:
                 "math_env": self.config.math_env,
                 "last_vote_timestamp": last_vote_timestamp,
                 "math_tick": math_tick if math_tick is not None else -1,
-                "data": json.dumps(data, default=convert_numpy_types),
+                "data": encode_math_blob(data),
             },
             connection=connection,
         )
@@ -908,7 +923,7 @@ class PostgresClient:
                 "zid": zid,
                 "math_env": self.config.math_env,
                 "math_tick": math_tick if math_tick is not None else -1,
-                "data": json.dumps(data, default=convert_numpy_types),
+                "data": encode_math_blob(data),
             },
             connection=connection,
         )
@@ -941,7 +956,7 @@ class PostgresClient:
                 "zid": zid,
                 "math_env": self.config.math_env,
                 "math_tick": math_tick if math_tick is not None else -1,
-                "data": json.dumps(data, default=convert_numpy_types),
+                "data": encode_math_blob(data),
             },
             connection=connection,
         )

--- a/delphi/polismath/database/postgres.py
+++ b/delphi/polismath/database/postgres.py
@@ -414,26 +414,34 @@ class PostgresClient:
             result = conn.execute(text(sql), params or {})
             return result.rowcount
 
-    def _write_returning(
-        self, sql: str, params: Optional[Dict[str, Any]] = None
-    ) -> List[Dict[str, Any]]:
-        """Execute a writing statement inside a COMMITTED transaction and return
-        any RETURNING rows.
+    @contextmanager
+    def transaction(self):
+        """One commit/rollback boundary; the connection belongs to the caller.
 
-        ``query()`` uses ``engine.connect()`` (SQLAlchemy 2.0 "commit as you go"),
-        which rolls back on close — fine for SELECTs but it silently discards
-        INSERT/UPDATEs.  The upsert writers (math_main / math_ticks / math_bidtopid
-        / math_ptptstats) MUST persist, so they route through here:
-        ``engine.begin()`` commits on successful exit.
+        Never store it on this shared client: different zid workers must use
+        independent connections and transactions.
         """
         if not self._initialized:
             self.initialize()
-
         with self.engine.begin() as conn:
-            result = conn.execute(text(sql), params or {})
-            if result.returns_rows:
-                return [dict(row) for row in result.mappings().all()]
-            return []
+            yield conn
+
+    def _write_returning(
+        self, sql: str, params: Optional[Dict[str, Any]] = None,
+        *, connection: Optional[sa.Connection] = None,
+    ) -> List[Dict[str, Any]]:
+        """Write within the supplied transaction, or commit a standalone call.
+
+        Only the owner of ``connection`` commits or rolls back. This lets the
+        poller publish a complete snapshot while retaining per-table callers.
+        """
+        if connection is None:
+            with self.transaction() as conn:
+                return self._write_returning(sql, params, connection=conn)
+        result = connection.execute(text(sql), params or {})
+        if result.returns_rows:
+            return [dict(row) for row in result.mappings().all()]
+        return []
 
     def get_zinvite_from_zid(self, zid: int) -> Optional[str]:
         """
@@ -761,36 +769,51 @@ class PostgresClient:
         }
 
     def load_math_main(self, zid: int) -> Optional[Dict[str, Any]]:
+        """Load main plus generation completeness in ONE statement snapshot.
+
+        Separate SELECTs at READ COMMITTED could straddle a successful publish
+        and falsely diagnose a mixed generation. Missing companions and NULL
+        ticks are incomplete, even if both companions are missing/NULL alike.
         """
-        Load math results for a conversation.
+        rows = self.query(
+            """
+            SELECT m.*, COALESCE(
+                m.math_tick = b.math_tick AND m.math_tick = p.math_tick,
+                false) AS snapshot_complete
+            FROM math_main m
+            LEFT JOIN math_bidtopid b USING (zid, math_env)
+            LEFT JOIN math_ptptstats p USING (zid, math_env)
+            WHERE m.zid = :zid AND m.math_env = :math_env
+            """,
+            {"zid": zid, "math_env": self.config.math_env},
+        )
+        return rows[0] if rows else None
 
-        Args:
-            zid: Conversation ID
+    def find_incomplete_math_snapshots(self) -> List[int]:
+        """Find legacy partial publications, including dormant/orphan rows.
 
-        Returns:
-            Math data, or None if not found
+        Run once at startup, independent of vote/moderation lookback. FULL
+        JOINs include companion-only remnants; namespace predicates are applied
+        before joining so another engine's rows cannot complete this snapshot.
         """
-        with self.session() as session:
-            # Query for math main data
-            math_main = (
-                session.query(MathMain)
-                .filter_by(zid=zid, math_env=self.config.math_env)
-                .first()
-            )
-
-            if not math_main:
-                return None
-
-            # Return data with all fields
-            return {
-                "zid": math_main.zid,
-                "math_env": math_main.math_env,
-                "data": math_main.data,
-                "last_vote_timestamp": math_main.last_vote_timestamp,
-                "caching_tick": math_main.caching_tick,
-                "math_tick": math_main.math_tick,
-                "modified": math_main.modified,
-            }
+        rows = self.query(
+            """
+            SELECT zid FROM
+                (SELECT zid, math_tick AS main_tick FROM math_main
+                 WHERE math_env = :math_env) m
+            FULL JOIN
+                (SELECT zid, math_tick AS bid_tick FROM math_bidtopid
+                 WHERE math_env = :math_env) b USING (zid)
+            FULL JOIN
+                (SELECT zid, math_tick AS stats_tick FROM math_ptptstats
+                 WHERE math_env = :math_env) p USING (zid)
+            WHERE main_tick IS NULL OR bid_tick IS NULL OR stats_tick IS NULL
+               OR main_tick <> bid_tick OR main_tick <> stats_tick
+            ORDER BY zid
+            """,
+            {"math_env": self.config.math_env},
+        )
+        return [row["zid"] for row in rows]
 
     def write_math_main(
         self,
@@ -799,6 +822,7 @@ class PostgresClient:
         last_vote_timestamp: Optional[int] = None,
         caching_tick: Optional[int] = None,
         math_tick: Optional[int] = None,
+        *, connection: Optional[sa.Connection] = None,
     ) -> None:
         """
         Write math results for a conversation (Clojure upload-math-main parity).
@@ -810,9 +834,10 @@ class PostgresClient:
                 (SELECT max(caching_tick) + 1 FROM math_main WHERE math_env = ?),
                 1)
 
-        so the TS server's prefetch (pca.ts:84-151 polls caching_tick > last) sees
-        a strictly increasing, per-math_env cursor.  The `caching_tick` parameter
-        is accepted for signature compatibility but ignored.
+        Allocation happens inside the publication transaction. MAX+1 still
+        races across different zids (R12); it is not a commit-order guarantee.
+        The `caching_tick` parameter is accepted for signature compatibility
+        but ignored.
 
         Args:
             zid: Conversation ID
@@ -852,10 +877,12 @@ class PostgresClient:
                 "math_tick": math_tick if math_tick is not None else -1,
                 "data": json.dumps(data, default=convert_numpy_types),
             },
+            connection=connection,
         )
 
     def write_math_bidtopid(
-        self, zid: int, data: Dict[str, Any], math_tick: Optional[int] = None
+        self, zid: int, data: Dict[str, Any], math_tick: Optional[int] = None,
+        *, connection: Optional[sa.Connection] = None,
     ) -> None:
         """
         Write the bid -> participant-id mapping (Clojure upload-math-bidtopid,
@@ -883,10 +910,12 @@ class PostgresClient:
                 "math_tick": math_tick if math_tick is not None else -1,
                 "data": json.dumps(data, default=convert_numpy_types),
             },
+            connection=connection,
         )
 
     def write_participant_stats(
-        self, zid: int, data: Dict[str, Any], math_tick: Optional[int] = None
+        self, zid: int, data: Dict[str, Any], math_tick: Optional[int] = None,
+        *, connection: Optional[sa.Connection] = None,
     ) -> None:
         """
         Write participant statistics (Clojure upload-math-ptptstats parity,
@@ -914,6 +943,7 @@ class PostgresClient:
                 "math_tick": math_tick if math_tick is not None else -1,
                 "data": json.dumps(data, default=convert_numpy_types),
             },
+            connection=connection,
         )
 
     def write_correlation_matrix(self, rid: int, data: Dict[str, Any]) -> None:
@@ -945,7 +975,9 @@ class PostgresClient:
                 )
                 session.add(corr_matrix)
 
-    def increment_math_tick(self, zid: int) -> int:
+    def increment_math_tick(
+        self, zid: int, *, connection: Optional[sa.Connection] = None,
+    ) -> int:
         """
         Atomically increment the math tick counter for a conversation.
 
@@ -973,6 +1005,7 @@ class PostgresClient:
             returning math_tick;
             """,
             {"zid": zid, "math_env": self.config.math_env},
+            connection=connection,
         )
         return rows[0]["math_tick"]
 

--- a/delphi/polismath/poller/math_writer.py
+++ b/delphi/polismath/poller/math_writer.py
@@ -11,7 +11,8 @@ write-conv-updates! (conv_man.clj:158-169):
 
 The Clojure-exact SQL (caching_tick = MAX+1 subquery, atomic tick upsert) lives
 in polismath.database.postgres.PostgresClient; this module orchestrates the
-per-cycle write and derives the bidToPid blob.
+per-cycle write and derives the bidToPid blob. Python publishes the tick and
+all three tables in ONE transaction so readers never see a partial commit.
 """
 
 import json
@@ -224,36 +225,32 @@ class MathWriter:
         self._pg = pg_client
 
     def write_conv_updates(self, zid: int, conv: Any) -> int:
-        """Mint one math_tick and write all three data tables with it.
+        """Atomically mint one math_tick and publish all three data tables.
 
         Returns the math_tick used (handy for logging / tests).
         """
-        math_tick = self._pg.increment_math_tick(zid)
-
         data = conv.to_dict()
         last_vote_timestamp = data.get("lastVoteTimestamp")
         if last_vote_timestamp is None:
             last_vote_timestamp = getattr(conv, "last_updated", None)
 
-        # 1. math_main — client-facing PCA/cluster/repness blob (fidelity-critical)
-        self._pg.write_math_main(
-            zid,
-            data,
-            last_vote_timestamp=last_vote_timestamp,
-            math_tick=math_tick,
-        )
-        # 2. math_bidtopid — server bid->pid mapping (fidelity-critical)
-        self._pg.write_math_bidtopid(
-            zid, data=derive_bidtopid(conv, zid), math_tick=math_tick
-        )
-        # 3. math_ptptstats — participant stats (clj-shaped, 2026-07-24 fix).
-        # Reuses data["user-vote-counts"] (already computed above for
-        # math_main) rather than recomputing it a second time.
-        self._pg.write_participant_stats(
-            zid,
-            data=derive_ptptstats(conv, zid, data.get("user-vote-counts", {})),
-            math_tick=math_tick,
-        )
+        # Derive blobs before opening the transaction/holding any row locks.
+        bidtopid = derive_bidtopid(conv, zid)
+        ptptstats = derive_ptptstats(conv, zid, data.get("user-vote-counts", {}))
+        with self._pg.transaction() as connection:
+            # The tick upsert locks this (zid, math_env) until all three writes
+            # commit. Other zids use independent connections on the shared client.
+            math_tick = self._pg.increment_math_tick(zid, connection=connection)
+            self._pg.write_math_main(
+                zid, data, last_vote_timestamp=last_vote_timestamp,
+                math_tick=math_tick, connection=connection,
+            )
+            self._pg.write_math_bidtopid(
+                zid, data=bidtopid, math_tick=math_tick, connection=connection,
+            )
+            self._pg.write_participant_stats(
+                zid, data=ptptstats, math_tick=math_tick, connection=connection,
+            )
 
         logger.info(
             "Wrote math results for zid=%s math_tick=%s (main+bidtopid+ptptstats)",

--- a/delphi/polismath/poller/math_writer.py
+++ b/delphi/polismath/poller/math_writer.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
+from polismath.database.postgres import encode_math_blob
 from polismath.utils.clj_hash import clojure_hash_map_key_order
 
 logger = logging.getLogger(__name__)
@@ -234,22 +235,33 @@ class MathWriter:
         if last_vote_timestamp is None:
             last_vote_timestamp = getattr(conv, "last_updated", None)
 
-        # Derive blobs before opening the transaction/holding any row locks.
+        # Derive AND encode all three blobs before opening the transaction, so
+        # neither derivation nor json.dumps of the (large) math_main blob runs
+        # while the (zid, math_env) row locks are held.
         bidtopid = derive_bidtopid(conv, zid)
         ptptstats = derive_ptptstats(conv, zid, data.get("user-vote-counts", {}))
+        main_json = encode_math_blob(data)
+        bidtopid_json = encode_math_blob(bidtopid)
+        ptptstats_json = encode_math_blob(ptptstats)
         with self._pg.transaction() as connection:
             # The tick upsert locks this (zid, math_env) until all three writes
             # commit. Other zids use independent connections on the shared client.
             math_tick = self._pg.increment_math_tick(zid, connection=connection)
-            self._pg.write_math_main(
-                zid, data, last_vote_timestamp=last_vote_timestamp,
-                math_tick=math_tick, connection=connection,
-            )
+            # math_main is written LAST, and deliberately so: it is the statement
+            # that allocates caching_tick with MAX(caching_tick)+1, and that
+            # allocation is not serializable (R12). Keeping it adjacent to the
+            # COMMIT keeps the allocate -> commit window as short as it was when
+            # each write autocommitted; the companions carry only the tick that
+            # was already minted above, so moving them earlier is free.
             self._pg.write_math_bidtopid(
-                zid, data=bidtopid, math_tick=math_tick, connection=connection,
+                zid, data=bidtopid_json, math_tick=math_tick, connection=connection,
             )
             self._pg.write_participant_stats(
-                zid, data=ptptstats, math_tick=math_tick, connection=connection,
+                zid, data=ptptstats_json, math_tick=math_tick, connection=connection,
+            )
+            self._pg.write_math_main(
+                zid, main_json, last_vote_timestamp=last_vote_timestamp,
+                math_tick=math_tick, connection=connection,
             )
 
         logger.info(

--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -282,7 +282,12 @@ class MathPollerService:
         self._stop = threading.Event()
         self._vote_wm: Optional[int] = None
         self._mod_wm: Optional[int] = None
+        # Set ONLY on a scan that completed without raising. Until then the
+        # parked-zid reconciler retries it every cycle (see _reconcile_once);
+        # the lock serialises start()/poll_once()/reconciler so a retry cannot
+        # run concurrently with the scan it is retrying and double-submit.
         self._startup_repair_done = False
+        self._startup_repair_lock = threading.Lock()
 
     @property
     def _parked(self) -> set:
@@ -316,9 +321,13 @@ class MathPollerService:
         # A boot-time database blip must not abort startup. Before the startup
         # scan existed, start() touched no database at all and a blip was
         # absorbed by the poll loops' own try/except; keep that property. The
-        # scan leaves _startup_repair_done False on failure, so the first poll
-        # cycle retries it. poll_once() deliberately still propagates — the
-        # --once contract and test_startup_scan_failure_is_retried depend on it.
+        # scan leaves _startup_repair_done False on failure, and the parked-zid
+        # reconciler thread started just below retries it every cycle until it
+        # succeeds — swallowing the error here must NOT strand dormant mixed
+        # generations for the process lifetime, and no vote/moderation traffic
+        # is required to trigger the retry. poll_once() deliberately still
+        # propagates — the --once contract and
+        # test_startup_scan_failure_is_retried depend on it.
         try:
             self._repair_incomplete_snapshots()
         except Exception:
@@ -382,10 +391,16 @@ class MathPollerService:
     def _repair_incomplete_snapshots(self) -> None:
         """Schedule legacy partial generations even outside the boot lookback.
 
-        A scan failure must propagate, leaving the scan pending for the next
-        poll_once/start attempt. Once submitted, ordinary worker retry/park
+        IDEMPOTENT and re-entrant-safe: it is a no-op once it has completed
+        successfully, and the flag is set ONLY after the whole scan+submit pass
+        returns. A scan failure must propagate, leaving the scan pending; the
+        caller decides. ``start()`` catches it so a boot-time blip cannot abort
+        startup, and ``_reconcile_once`` — the one daemon path that runs
+        without any vote/moderation traffic — retries it every cycle until it
+        succeeds. ``poll_once`` still propagates. The lock serialises those
+        three entry points so a retry cannot overlap the scan it is retrying
+        and submit each zid twice. Once submitted, ordinary worker retry/park
         reconciliation owns recovery, including a failed rebuild with no votes.
-        start() catches it so a boot-time blip cannot abort startup.
 
         TODO(review E4 - startup REBUILD burst cap): this submits an UNBOUNDED
         number of REBUILDs (each a full vote-history recompute), logs one
@@ -408,18 +423,21 @@ class MathPollerService:
         if self._startup_repair_done:
             return
         assert self._pool is not None
-        for zid in self._pg.find_incomplete_math_snapshots():
-            if should_process_zid(
-                zid, self.config.allowlist, self.config.blocklist,
-                self.config.shard_index, self.config.shard_count,
-            ):
-                logger.warning(
-                    "Startup repair: incomplete math snapshot for zid=%s "
-                    "math_env=%s (missing rows or mismatched math_tick); "
-                    "scheduling full rebuild", zid, self.config.math_env,
-                )
-                self._pool.submit(zid, REBUILD, [])
-        self._startup_repair_done = True
+        with self._startup_repair_lock:
+            if self._startup_repair_done:  # won by another entry point
+                return
+            for zid in self._pg.find_incomplete_math_snapshots():
+                if should_process_zid(
+                    zid, self.config.allowlist, self.config.blocklist,
+                    self.config.shard_index, self.config.shard_count,
+                ):
+                    logger.warning(
+                        "Startup repair: incomplete math snapshot for zid=%s "
+                        "math_env=%s (missing rows or mismatched math_tick); "
+                        "scheduling full rebuild", zid, self.config.math_env,
+                    )
+                    self._pool.submit(zid, REBUILD, [])
+            self._startup_repair_done = True
 
     def _vote_loop(self) -> None:
         while not self._stop.is_set():
@@ -457,8 +475,33 @@ class MathPollerService:
         unparks each parked zid (which invalidates its cache) and enqueues a
         REBUILD so the worker reloads the full vote history from Postgres and
         re-persists — reprocessing the interval that was skipped when the global
-        watermark advanced past the failure."""
+        watermark advanced past the failure.
+
+        It ALSO retries the startup repair scan until that has completed
+        successfully once. This is the only daemon path that runs without new
+        votes or moderation, so it is the only place a dormant zid with mixed
+        math_tick generations can be rediscovered after a boot-time DB error;
+        without it, swallowing that error in start() would strand the zid for
+        the process lifetime (start() runs no other scan, and the vote/mod
+        loops never look outside the watermark lookback). The retry is bounded
+        by the reconciler's own cadence, so a persistently failing scan retries
+        once per interval rather than hot-looping."""
         assert self._pool is not None
+        if not self._startup_repair_done:
+            logger.warning(
+                "Startup repair scan still pending; retrying it from the "
+                "parked-zid reconciler"
+            )
+            # Swallowed like the parked-zid work below: a still-broken database
+            # must not kill the reconciler thread, and the flag stays False so
+            # the next cycle retries again.
+            try:
+                self._repair_incomplete_snapshots()
+            except Exception:
+                logger.exception(
+                    "Startup repair scan retry failed; the next reconcile "
+                    "cycle retries"
+                )
         for zid in sorted(self._pool.parked_zids()):
             logger.info("Reconciler recovering parked zid=%s (M1)", zid)
             self._unpark(zid)  # clears park + invalidates cache

--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -313,7 +313,19 @@ class MathPollerService:
 
     def start(self) -> None:
         self._ensure_runtime()
-        self._repair_incomplete_snapshots()
+        # A boot-time database blip must not abort startup. Before the startup
+        # scan existed, start() touched no database at all and a blip was
+        # absorbed by the poll loops' own try/except; keep that property. The
+        # scan leaves _startup_repair_done False on failure, so the first poll
+        # cycle retries it. poll_once() deliberately still propagates — the
+        # --once contract and test_startup_scan_failure_is_retried depend on it.
+        try:
+            self._repair_incomplete_snapshots()
+        except Exception:
+            logger.exception(
+                "Startup repair scan failed; continuing without it "
+                "(the next poll cycle retries)"
+            )
         self._stop.clear()
         self._threads = [
             threading.Thread(target=self._vote_loop, name="vote-poller", daemon=True),
@@ -373,6 +385,25 @@ class MathPollerService:
         A scan failure must propagate, leaving the scan pending for the next
         poll_once/start attempt. Once submitted, ordinary worker retry/park
         reconciliation owns recovery, including a failed rebuild with no votes.
+        start() catches it so a boot-time blip cannot abort startup.
+
+        TODO(review E4 - startup REBUILD burst cap): this submits an UNBOUNDED
+        number of REBUILDs (each a full vote-history recompute), logs one
+        WARNING per zid, and runs before the poll threads start. The scan is
+        three seq scans (math_env is unindexed on all three tables) and the
+        burst on a large production namespace has not been benchmarked. Wants a
+        cap, a summary count log instead of per-zid warnings, an env kill
+        switch, and a benchmark. Note R10: poll_once's join(timeout=120)
+        result is discarded, so with a backlog `--once` reports success with
+        work still pending.
+
+        TODO(review E5 - rebuild-thrash metering): _load_or_init's mismatch
+        path discards warm state and re-reads full vote history every time it
+        fires, unthrottled. A second writer (Clojure during dual-run) holding
+        one table at a different tick would make that zid full-rebuild every
+        cycle. Wants a counter/metric so it is visible.
+
+        Both are deliberate follow-ups, not part of this change.
         """
         if self._startup_repair_done:
             return

--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -282,6 +282,7 @@ class MathPollerService:
         self._stop = threading.Event()
         self._vote_wm: Optional[int] = None
         self._mod_wm: Optional[int] = None
+        self._startup_repair_done = False
 
     @property
     def _parked(self) -> set:
@@ -312,6 +313,7 @@ class MathPollerService:
 
     def start(self) -> None:
         self._ensure_runtime()
+        self._repair_incomplete_snapshots()
         self._stop.clear()
         self._threads = [
             threading.Thread(target=self._vote_loop, name="vote-poller", daemon=True),
@@ -357,12 +359,36 @@ class MathPollerService:
         Used by ``--once`` and the integration test.
         """
         self._ensure_runtime()
+        self._repair_incomplete_snapshots()
         self._poll_votes_once()
         self._poll_moderation_once()
         # Recover any zids parked in earlier cycles even if they got no new votes.
         self._reconcile_once()
         assert self._pool is not None
         self._pool.join(timeout=120.0)
+
+    def _repair_incomplete_snapshots(self) -> None:
+        """Schedule legacy partial generations even outside the boot lookback.
+
+        A scan failure must propagate, leaving the scan pending for the next
+        poll_once/start attempt. Once submitted, ordinary worker retry/park
+        reconciliation owns recovery, including a failed rebuild with no votes.
+        """
+        if self._startup_repair_done:
+            return
+        assert self._pool is not None
+        for zid in self._pg.find_incomplete_math_snapshots():
+            if should_process_zid(
+                zid, self.config.allowlist, self.config.blocklist,
+                self.config.shard_index, self.config.shard_count,
+            ):
+                logger.warning(
+                    "Startup repair: incomplete math snapshot for zid=%s "
+                    "math_env=%s (missing rows or mismatched math_tick); "
+                    "scheduling full rebuild", zid, self.config.math_env,
+                )
+                self._pool.submit(zid, REBUILD, [])
+        self._startup_repair_done = True
 
     def _vote_loop(self) -> None:
         while not self._stop.is_set():
@@ -569,6 +595,14 @@ class MathPollerService:
             row = self._pg.load_math_main(zid)
         except Exception:
             logger.exception("load_math_main failed for zid=%s; cold start", zid)
+            row = None
+
+        if row and row.get("snapshot_complete") is False:
+            logger.warning(
+                "load-or-init: incomplete math snapshot for zid=%s math_env=%s "
+                "(missing rows or mismatched math_tick); discarding persisted "
+                "state and rebuilding full history", zid, self.config.math_env,
+            )
             row = None
 
         if row and row.get("data"):

--- a/delphi/pyproject.toml
+++ b/delphi/pyproject.toml
@@ -146,6 +146,7 @@ markers = [
     "local_dataset: mark test as using local (non-committed) datasets from real_data/.local/",
     "clojure_comparison: mark test as comparing with Clojure reference implementation (can be excluded with '-m \"not clojure_comparison\"')",
     "integration: mark test as an opt-in integration test needing a real Postgres (self-skips if docker/port unavailable)",
+    "recovery: P-022 §C poller recovery matrix (R01-R12); REQUIRES a real Postgres via POLIS_TEST_POSTGRES_URL and FAILS (never skips) without one — run via `make test-recovery`",
 ]
 
 [tool.coverage.run]

--- a/delphi/tests/poller/recovery/__init__.py
+++ b/delphi/tests/poller/recovery/__init__.py
@@ -1,0 +1,1 @@
+"""P-022 §C recovery matrix (R01-R12) against a REAL Postgres."""

--- a/delphi/tests/poller/recovery/conftest.py
+++ b/delphi/tests/poller/recovery/conftest.py
@@ -432,6 +432,18 @@ def drain(svc, timeout: float = 60.0) -> None:
     )
 
 
+def pool_pending(pool, zid: int) -> bool:
+    """Queued-or-active work for one zid, read under the pool's OWN lock.
+
+    Used to assert that no queued request was dropped and that no handler is
+    still in flight.  Reads the pool's private bookkeeping deliberately: the
+    point IS the pool's internal accounting, and taking ``_lock`` means the
+    snapshot cannot tear against a concurrent submit/park.
+    """
+    with pool._lock:
+        return bool(pool._queues.get(zid)) or zid in pool._active
+
+
 def eventually(
     predicate: Callable[[], bool],
     *,

--- a/delphi/tests/poller/recovery/conftest.py
+++ b/delphi/tests/poller/recovery/conftest.py
@@ -76,6 +76,30 @@ non-required runs only.
 """
 
 
+@pytest.fixture(autouse=True)
+def _quiet_engine_logs():
+    """The engine logs a paragraph per compute at INFO; recovery tests run many
+    computes each.  Nothing here asserts on log output."""
+    import logging
+
+    # conversation.py:91 sets its OWN logger to INFO explicitly, so raising the
+    # parent's level is not enough — every already-created polismath logger has
+    # to be quieted individually.
+    import polismath.conversation.conversation  # noqa: F401  (force creation)
+
+    names = [n for n in logging.root.manager.loggerDict
+             if n == "polismath" or n.startswith(("polismath.", "sqlalchemy"))]
+    loggers = [logging.getLogger("polismath")] + [
+        logging.getLogger(n) for n in names
+    ]
+    previous = [(lg, lg.level) for lg in loggers]
+    for lg in loggers:
+        lg.setLevel(logging.WARNING)
+    yield
+    for lg, level in previous:
+        lg.setLevel(level)
+
+
 # --------------------------------------------------------------------------- #
 # Postgres plumbing
 # --------------------------------------------------------------------------- #

--- a/delphi/tests/poller/recovery/conftest.py
+++ b/delphi/tests/poller/recovery/conftest.py
@@ -1,0 +1,586 @@
+"""Shared fixtures for the P-022 §C recovery matrix (R01-R12).
+
+Postgres policy
+---------------
+Every scenario in which DB behaviour matters runs against a REAL Postgres with
+the REAL ``server/postgres/migrations/*.sql`` applied — never the hand-maintained
+equivalence schema, and never sqlite.  Per P-022 §C "Acceptance":
+
+    Missing Postgres is a failing required job, not pytest skip.
+
+so :func:`recovery_postgres_url` **fails** (loudly, with the command that fixes
+it) when ``POLIS_TEST_POSTGRES_URL`` is unset or unreachable.  There is one
+deliberate exception: ``POLIS_RECOVERY_ALLOW_NO_PG=1`` turns the failure into a
+skip, for a developer running an unrelated part of the suite.  CI must not set
+it, and the required job asserts it is unset.
+
+Schema freshness
+----------------
+The migrations are applied ONCE per session into a template database; each test
+then gets its own database created with ``CREATE DATABASE ... TEMPLATE``.  That
+is a genuinely fresh migrated schema per test (no cross-test residue in
+math_main / math_ticks / votes) at roughly the cost of a file copy.
+
+Fault injection
+---------------
+All hooks live in the tests.  They monkeypatch the WRITER/ENGINE boundary
+(``PostgresClient`` methods, ``MathWriter.write_conv_updates``,
+``MathPollerService._load_or_init``) rather than editing production code, so the
+code under test is byte-for-byte the deployed code.  :class:`FaultInjector`
+provides one-shot and persistent variants and records what it fired.
+
+No fixed sleep is ever used as evidence of an interleaving: ordering comes from
+``threading.Event``/``threading.Barrier`` latches at named boundaries and from
+``ConversationWorkerPool.join`` (which blocks until the pool is idle).
+:func:`eventually` exists only for genuinely asynchronous *progress* assertions,
+and is always bounded.
+"""
+
+import os
+import re
+import subprocess
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import pytest
+import sqlalchemy as sa
+
+# Every module in this package is part of the required recovery job.
+pytestmark = pytest.mark.recovery
+
+_MIGRATIONS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..",
+                 "server", "postgres", "migrations")
+)
+
+_MISSING_PG_MESSAGE = """
+P-022 §C requires a REAL Postgres; POLIS_TEST_POSTGRES_URL is {why}.
+
+This is a REQUIRED job, so it FAILS rather than skipping (P-022 §C Acceptance:
+"Missing Postgres is a failing required job, not pytest skip").
+
+Start the compose test Postgres and run the suite with:
+
+    make test-recovery                 # from the repository root
+
+or, to point at an existing database:
+
+    POLIS_TEST_POSTGRES_URL=postgresql://user:pw@host:port/db \\
+        uv run pytest tests/poller/recovery
+
+Set POLIS_RECOVERY_ALLOW_NO_PG=1 to downgrade this to a skip for local,
+non-required runs only.
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Postgres plumbing
+# --------------------------------------------------------------------------- #
+def _fail_or_skip(why: str) -> None:
+    message = _MISSING_PG_MESSAGE.format(why=why)
+    if os.environ.get("POLIS_RECOVERY_ALLOW_NO_PG") == "1":
+        pytest.skip(message)
+    pytest.fail(message, pytrace=False)
+
+
+def _split_url(url: str):
+    """(server-url-without-database, database-name)."""
+    match = re.match(r"^(?P<head>.*?)/(?P<db>[^/?]+)(?P<tail>\?.*)?$", url)
+    if not match:
+        raise ValueError(f"cannot parse a database name out of {url!r}")
+    return match.group("head"), match.group("db"), match.group("tail") or ""
+
+
+@pytest.fixture(scope="session")
+def recovery_postgres_url() -> str:
+    """The base Postgres server URL, verified reachable.  FAILS if missing."""
+    url = os.environ.get("POLIS_TEST_POSTGRES_URL")
+    if not url:
+        _fail_or_skip("not set")
+    import psycopg2
+
+    try:
+        conn = psycopg2.connect(url, connect_timeout=5)
+    except Exception as exc:  # pragma: no cover - infra guard
+        _fail_or_skip(f"set to {url!r} but unreachable: {exc}")
+    else:
+        conn.close()
+    return url
+
+
+@pytest.fixture(scope="session")
+def migrated_template(recovery_postgres_url: str) -> str:
+    """Name of a session-scoped template database carrying the REAL migrations.
+
+    Built by applying every ``server/postgres/migrations/*.sql`` in filename
+    order, so schema constraints/types under test are the migrated ones (P-022
+    §C: "Test schema constraints/types against migrations, not only the
+    hand-maintained equivalence schema").
+    """
+    import psycopg2
+
+    head, admin_db, tail = _split_url(recovery_postgres_url)
+    template = f"polis_recovery_tmpl_{os.getpid()}"
+
+    files = sorted(
+        f for f in os.listdir(_MIGRATIONS_DIR)
+        if f.endswith(".sql") and os.path.isfile(os.path.join(_MIGRATIONS_DIR, f))
+    )
+    if not files:  # pragma: no cover - infra guard
+        pytest.fail(f"no migrations found in {_MIGRATIONS_DIR}", pytrace=False)
+
+    admin = psycopg2.connect(recovery_postgres_url, connect_timeout=5)
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(f'DROP DATABASE IF EXISTS "{template}"')
+            cur.execute(f'CREATE DATABASE "{template}"')
+    finally:
+        admin.close()
+
+    tmpl_url = f"{head}/{template}{tail}"
+    conn = psycopg2.connect(tmpl_url, connect_timeout=5)
+    conn.autocommit = True
+    try:
+        for name in files:
+            with open(os.path.join(_MIGRATIONS_DIR, name), "r") as fh:
+                sql = fh.read()
+            with conn.cursor() as cur:
+                cur.execute(sql)
+    finally:
+        conn.close()
+
+    yield template
+
+    admin = psycopg2.connect(recovery_postgres_url, connect_timeout=5)
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(f'DROP DATABASE IF EXISTS "{template}" WITH (FORCE)')
+    finally:
+        admin.close()
+
+
+@pytest.fixture
+def pg_url(recovery_postgres_url: str, migrated_template: str) -> str:
+    """A FRESH migrated database for this one test, dropped afterwards."""
+    import psycopg2
+
+    head, _admin_db, tail = _split_url(recovery_postgres_url)
+    name = f"rec_{uuid.uuid4().hex[:12]}"
+
+    admin = psycopg2.connect(recovery_postgres_url, connect_timeout=5)
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(f'CREATE DATABASE "{name}" TEMPLATE "{migrated_template}"')
+    finally:
+        admin.close()
+
+    url = f"{head}/{name}{tail}"
+    try:
+        yield url
+    finally:
+        admin = psycopg2.connect(recovery_postgres_url, connect_timeout=5)
+        admin.autocommit = True
+        try:
+            with admin.cursor() as cur:
+                cur.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        finally:
+            admin.close()
+
+
+@pytest.fixture
+def engine(pg_url: str):
+    eng = sa.create_engine(pg_url, poolclass=sa.pool.NullPool)
+    try:
+        yield eng
+    finally:
+        eng.dispose()
+
+
+# --------------------------------------------------------------------------- #
+# Seeding (plain SQL; no polismath code involved)
+# --------------------------------------------------------------------------- #
+@dataclass
+class SeededConversation:
+    """What a test committed, so the fold can be built from the test's own
+    knowledge of the input rather than from a re-read of the system's output."""
+
+    zid: int
+    vote_events: List[Dict[str, Any]] = field(default_factory=list)
+    comment_rows: List[Dict[str, Any]] = field(default_factory=list)
+    participant_rows: List[Dict[str, Any]] = field(default_factory=list)
+
+
+def seed_conversation(
+    engine,
+    zid: int = 1,
+    n_ptpts: int = 8,
+    n_cmts: int = 5,
+    base_created: Optional[int] = None,
+    vote_pattern: Optional[Callable[[int, int], int]] = None,
+) -> SeededConversation:
+    """Seed one conversation: conversations/participants/comments/votes rows.
+
+    Raw DB vote signs (AGREE=-1, DISAGREE=+1) are written directly, so the
+    poller's ingress conversion is genuinely exercised.  Two opposing camps by
+    participant parity gives a non-degenerate PCA.
+    """
+    now = int(time.time() * 1000)
+    base_created = now - 60_000 if base_created is None else base_created
+    long_ago = now - 2 * 24 * 60 * 60 * 1000
+    if vote_pattern is None:
+        def vote_pattern(pid: int, tid: int) -> int:  # noqa: ARG001
+            return -1 if pid % 2 == 0 else 1
+
+    seeded = SeededConversation(zid=zid)
+    with engine.begin() as conn:
+        conn.execute(sa.text("SET session_replication_role = replica"))
+        conn.execute(sa.text("INSERT INTO conversations (zid) VALUES (:zid) "
+                             "ON CONFLICT DO NOTHING"), {"zid": zid})
+        for pid in range(n_ptpts):
+            conn.execute(
+                sa.text("INSERT INTO participants (pid, uid, zid, created, mod) "
+                        "VALUES (:pid, :uid, :zid, :created, 0)"),
+                {"pid": pid, "uid": 100000 * zid + pid, "zid": zid,
+                 "created": long_ago},
+            )
+            seeded.participant_rows.append({"pid": pid, "mod": 0})
+        for tid in range(n_cmts):
+            conn.execute(
+                sa.text("INSERT INTO comments (tid, zid, pid, uid, txt, mod, "
+                        "is_meta, created, modified) VALUES (:tid, :zid, 0, "
+                        ":uid, :txt, 0, false, :created, :modified)"),
+                {"tid": tid, "zid": zid, "uid": 100000 * zid,
+                 "txt": f"comment {tid}", "created": long_ago,
+                 "modified": long_ago},
+            )
+            seeded.comment_rows.append(
+                {"tid": tid, "mod": 0, "is_meta": False, "modified": long_ago}
+            )
+        created = base_created
+        for pid in range(n_ptpts):
+            for tid in range(n_cmts):
+                created += 1
+                raw = vote_pattern(pid, tid)
+                conn.execute(
+                    sa.text("INSERT INTO votes (zid, pid, tid, vote, created) "
+                            "VALUES (:zid, :pid, :tid, :vote, :created)"),
+                    {"zid": zid, "pid": pid, "tid": tid, "vote": raw,
+                     "created": created},
+                )
+                seeded.vote_events.append(
+                    {"pid": pid, "tid": tid, "vote": raw, "created": created}
+                )
+        conn.execute(sa.text("SET session_replication_role = DEFAULT"))
+    return seeded
+
+
+def commit_vote(engine_or_conn, zid: int, pid: int, tid: int, raw_vote: int,
+                created: int) -> Dict[str, Any]:
+    """Commit ONE vote row (raw storage sign) and return the fold event."""
+    stmt = sa.text("INSERT INTO votes (zid, pid, tid, vote, created) "
+                   "VALUES (:zid, :pid, :tid, :vote, :created)")
+    params = {"zid": zid, "pid": pid, "tid": tid, "vote": raw_vote,
+              "created": created}
+    if isinstance(engine_or_conn, sa.engine.Engine):
+        with engine_or_conn.begin() as conn:
+            conn.execute(sa.text("SET session_replication_role = replica"))
+            conn.execute(stmt, params)
+    else:
+        # An OPEN connection/transaction the caller controls — this is how the
+        # two-real-connections tests keep one commit pending while another lands.
+        engine_or_conn.execute(sa.text("SET session_replication_role = replica"))
+        engine_or_conn.execute(stmt, params)
+    return {"pid": pid, "tid": tid, "vote": raw_vote, "created": created}
+
+
+def read_vote_events(engine, zid: int) -> List[Dict[str, Any]]:
+    """Read back every committed vote EVENT with a plain SELECT, in the poller's
+    own load order.  Used to build the fold from the DB rather than from the
+    test's bookkeeping, so the fold checks what was really committed."""
+    with engine.connect() as conn:
+        rows = conn.execute(
+            sa.text("SELECT pid, tid, vote, created FROM votes WHERE zid = :zid "
+                    "ORDER BY zid, tid, pid, created"),
+            {"zid": zid},
+        ).mappings().all()
+    return [dict(r) for r in rows]
+
+
+def read_math_tables(engine, zid: int, math_env: str) -> Dict[str, Any]:
+    """Read the three published tables + math_ticks for one (zid, math_env)."""
+    out: Dict[str, Any] = {}
+    with engine.connect() as conn:
+        out["main"] = _one(conn,
+            "SELECT zid, math_env, caching_tick, math_tick, last_vote_timestamp, "
+            "data FROM math_main WHERE zid=:z AND math_env=:e", zid, math_env)
+        out["bidtopid"] = _one(conn,
+            "SELECT zid, math_tick, data FROM math_bidtopid "
+            "WHERE zid=:z AND math_env=:e", zid, math_env)
+        out["ptptstats"] = _one(conn,
+            "SELECT zid, math_tick, data FROM math_ptptstats "
+            "WHERE zid=:z AND math_env=:e", zid, math_env)
+        out["ticks"] = _one(conn,
+            "SELECT zid, math_tick, caching_tick FROM math_ticks "
+            "WHERE zid=:z AND math_env=:e", zid, math_env)
+    return out
+
+
+def _one(conn, sql: str, zid: int, math_env: str) -> Optional[Dict[str, Any]]:
+    row = conn.execute(sa.text(sql), {"z": zid, "e": math_env}).mappings().first()
+    return dict(row) if row else None
+
+
+def tables_are_coherent(tables: Dict[str, Any]) -> List[str]:
+    """Return the reasons a published generation is INCOHERENT (empty == fine).
+
+    "Coherent" here is the contract a reader needs: all three data rows exist and
+    carry the SAME math_tick, i.e. one complete generation.
+    """
+    problems = []
+    for name in ("main", "bidtopid", "ptptstats"):
+        if tables.get(name) is None:
+            problems.append(f"{name} row missing")
+    if problems:
+        return problems
+    ticks = {name: tables[name]["math_tick"]
+             for name in ("main", "bidtopid", "ptptstats")}
+    if len(set(ticks.values())) != 1:
+        problems.append(f"mixed generations: math_tick per table = {ticks}")
+    return problems
+
+
+# --------------------------------------------------------------------------- #
+# Service construction
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def make_service(tmp_path):
+    """Build real ``MathPollerService`` instances against the real Postgres
+    client.  Cleans up pools/engines afterwards."""
+    from polismath.database.postgres import PostgresClient, PostgresConfig
+    from polismath.poller.service import MathPollerService, PollerConfig
+
+    built = []
+
+    def _make(url: str, math_env: str = "recovery", **cfg_kwargs):
+        pg = PostgresClient(
+            PostgresConfig(url=url, math_env=math_env, ssl_mode="disable")
+        )
+        pg.initialize()
+        kwargs = dict(
+            database_url=url,
+            math_env=math_env,
+            poll_from_days_ago=1,
+            worker_pool_size=2,
+            dump_dir=str(tmp_path / "errorconv"),
+        )
+        kwargs.update(cfg_kwargs)
+        svc = MathPollerService(pg, PollerConfig(**kwargs))
+        svc._ensure_runtime()
+        built.append((svc, pg))
+        return svc
+
+    yield _make
+
+    for svc, pg in built:
+        try:
+            if svc._pool is not None:
+                svc._pool.shutdown(wait=False)
+        except Exception:  # pragma: no cover - teardown best effort
+            pass
+        try:
+            pg.shutdown()
+        except Exception:  # pragma: no cover - teardown best effort
+            pass
+
+
+def drain(svc, timeout: float = 60.0) -> None:
+    """Block until the pool is idle — a latch on the pool's own condition
+    variable, NOT a sleep."""
+    assert svc._pool is not None
+    assert svc._pool.join(timeout=timeout), (
+        "worker pool did not drain within the bound; work is stuck"
+    )
+
+
+def eventually(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 30.0,
+    interval: float = 0.05,
+    message: str = "bounded eventual-progress assertion failed",
+) -> None:
+    """Bounded eventual-progress assertion.
+
+    Used ONLY where progress is genuinely asynchronous and no latch exists; the
+    passing evidence is the predicate, never elapsed time, and the bound makes a
+    stall a failure rather than a hang.
+    """
+    deadline = time.monotonic() + timeout
+    last = False
+    while time.monotonic() < deadline:
+        last = bool(predicate())
+        if last:
+            return
+        time.sleep(interval)
+    raise AssertionError(f"{message} (bound {timeout}s)")
+
+
+# --------------------------------------------------------------------------- #
+# Fault injection
+# --------------------------------------------------------------------------- #
+class InjectedFault(RuntimeError):
+    """Raised by a :class:`FaultInjector` hook.  A distinct type so a test can
+    assert it saw the injected failure and not an unrelated one."""
+
+
+@dataclass
+class FaultInjector:
+    """One-shot / persistent failure injection at a NAMED boundary.
+
+    ``mode='once'`` fires exactly once (the transient-blip case); ``'always'``
+    fires forever (the persistent-outage case); ``'nth'`` fires on the n-th call.
+    Every call is recorded so a test can assert how many attempts were made
+    (bounded retries, no hot loop).
+    """
+
+    name: str
+    mode: str = "once"
+    nth: int = 1
+    calls: int = 0
+    fired: int = 0
+    exception: Callable[[], BaseException] = lambda: InjectedFault("injected")
+
+    def should_fire(self) -> bool:
+        self.calls += 1
+        if self.mode == "always":
+            hit = True
+        elif self.mode == "once":
+            hit = self.fired == 0
+        elif self.mode == "nth":
+            hit = self.calls == self.nth
+        elif self.mode == "never":
+            hit = False
+        else:  # pragma: no cover - programming error
+            raise ValueError(f"unknown fault mode {self.mode!r}")
+        if hit:
+            self.fired += 1
+        return hit
+
+    def maybe_raise(self) -> None:
+        if self.should_fire():
+            raise self.exception()
+
+
+def fail_stage(target: Any, method: str, injector: FaultInjector,
+               *, after: bool = False) -> Callable[[], None]:
+    """Wrap ``target.method`` so ``injector`` can fail BEFORE (default) or AFTER
+    the real call.  Returns an undo callable.
+
+    ``after=True`` is the committed-write / lost-ack case: the DB work really
+    happened and committed, but the caller sees an exception.
+    """
+    original = getattr(target, method)
+
+    def wrapper(*args, **kwargs):
+        if not after:
+            injector.maybe_raise()
+            return original(*args, **kwargs)
+        result = original(*args, **kwargs)
+        injector.maybe_raise()
+        return result
+
+    setattr(target, method, wrapper)
+    return lambda: setattr(target, method, original)
+
+
+class Latch:
+    """A named boundary latch: the hooked call announces arrival and blocks
+    until released.  Used instead of sleeps to pin an interleaving."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.arrived = threading.Event()
+        self.release = threading.Event()
+        self.arrivals = 0
+
+    def wait_arrival(self, timeout: float = 30.0) -> None:
+        assert self.arrived.wait(timeout), (
+            f"latch {self.name!r} was never reached within {timeout}s"
+        )
+
+    def let_go(self) -> None:
+        self.release.set()
+
+    def block(self, timeout: float = 30.0) -> None:
+        self.arrivals += 1
+        self.arrived.set()
+        assert self.release.wait(timeout), (
+            f"latch {self.name!r} was never released within {timeout}s"
+        )
+
+
+def latch_method(target: Any, method: str, latch: Latch,
+                 predicate: Optional[Callable[..., bool]] = None
+                 ) -> Callable[[], None]:
+    """Block inside ``target.method`` at ``latch`` (optionally only when
+    ``predicate(*args)`` holds).  Returns an undo callable."""
+    original = getattr(target, method)
+
+    def wrapper(*args, **kwargs):
+        if predicate is None or predicate(*args, **kwargs):
+            latch.block()
+        return original(*args, **kwargs)
+
+    setattr(target, method, wrapper)
+    return lambda: setattr(target, method, original)
+
+
+# --------------------------------------------------------------------------- #
+# Misc
+# --------------------------------------------------------------------------- #
+def terminate_backends(admin_url: str, dbname: str) -> int:
+    """Kill every server-side backend on ``dbname`` — a REAL connection loss."""
+    import psycopg2
+
+    conn = psycopg2.connect(admin_url, connect_timeout=5)
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (dbname,),
+            )
+            return len(cur.fetchall())
+    finally:
+        conn.close()
+
+
+def dbname_of(url: str) -> str:
+    return _split_url(url)[1]
+
+
+def run_child(script_args: List[str], env_extra: Dict[str, str],
+              cwd: Optional[str] = None) -> subprocess.Popen:
+    """Start a child Python process (used by R05's real process kills)."""
+    import sys
+
+    env = dict(os.environ)
+    env.update(env_extra)
+    return subprocess.Popen(
+        [sys.executable, *script_args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        env=env,
+        cwd=cwd or os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..")
+        ),
+    )

--- a/delphi/tests/poller/recovery/fold.py
+++ b/delphi/tests/poller/recovery/fold.py
@@ -1,0 +1,244 @@
+"""An INDEPENDENT reference fold of the raw input stream (P-022 §C).
+
+The recovery matrix requires "a small independent fold of the input votes to
+check final state (not the engine's own methods)".  Everything in this module
+is therefore deliberately dumb, plain-stdlib Python:
+
+* no ``numpy``/``pandas``,
+* **nothing** imported from ``polismath`` — not even the vote-sign converter or
+  the moderation reader, which are themselves under test,
+* no knowledge of ``Conversation`` internals.
+
+It folds the rows a test committed to Postgres (or read back out of it with a
+plain ``SELECT``) into the state the poller must eventually publish, and exposes
+that state in the two shapes ``math_main.data`` actually carries:
+
+``user-vote-counts``
+    per-pid count of cells with a latest vote (``conversation.py``'s
+    ``_compute_user_vote_counts`` = non-missing cells of ``raw_rating_mat``).
+``votes-base``
+    per-tid A/D/S counts, per base-cluster bucket; summing the buckets for one
+    tid gives that comment's agree/disagree/observed totals over the
+    **clustered** participants.  The fold's per-tid totals are over ALL
+    participants, so they are an upper bound that is exact whenever every voter
+    is clustered — which is the case for the small generated fixtures here, and
+    is asserted explicitly rather than assumed.
+
+Vote-sign convention is spelled out locally instead of imported:
+Postgres stores AGREE=-1 / DISAGREE=+1 / PASS=0; the math engine uses
+AGREE=+1 / DISAGREE=-1 / PASS=0.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+# --- raw Postgres storage polarity (P-023 `storage_agree_value`) ------------ #
+RAW_AGREE = -1
+RAW_DISAGREE = 1
+RAW_PASS = 0
+
+# --- engine polarity -------------------------------------------------------- #
+ENGINE_AGREE = 1
+ENGINE_DISAGREE = -1
+ENGINE_PASS = 0
+
+Cell = Tuple[Any, Any]  # (pid, tid)
+
+
+def raw_to_engine(raw_vote: int, storage_agree_value: int = RAW_AGREE) -> int:
+    """Convert a stored vote to the engine convention, given the storage
+    polarity.  ``storage_agree_value`` is the value the DB uses for AGREE
+    (-1 today).  Written out here rather than imported from
+    ``polismath.utils.general`` so the fold cannot inherit a sign bug from the
+    code it is checking."""
+    if raw_vote == RAW_PASS:
+        return ENGINE_PASS
+    return ENGINE_AGREE if raw_vote == storage_agree_value else ENGINE_DISAGREE
+
+
+@dataclass
+class VoteFold:
+    """The authoritative latest-cell state derived from an ordered vote stream."""
+
+    #: (pid, tid) -> engine-convention vote of the winning event
+    cells: Dict[Cell, int] = field(default_factory=dict)
+    #: (pid, tid) -> ``created`` of the winning event
+    cell_created: Dict[Cell, int] = field(default_factory=dict)
+    #: cells whose winner is ambiguous: two or more events tie on max(created)
+    #: with different vote values.  The DB's ``ORDER BY zid, tid, pid, created``
+    #: does not break that tie, so no test may assert a single winner there.
+    ambiguous: Set[Cell] = field(default_factory=set)
+    #: total number of vote EVENTS folded (not cells) — the raw event counter
+    event_count: int = 0
+    #: max(created) over every folded event; 0 for an empty stream (Clojure's
+    #: floor, conversation.clj:161-165)
+    last_vote_timestamp: int = 0
+
+    # -- derived views ------------------------------------------------------ #
+    @property
+    def participants(self) -> Set[Any]:
+        return {pid for pid, _ in self.cells}
+
+    @property
+    def comments(self) -> Set[Any]:
+        return {tid for _, tid in self.cells}
+
+    def user_vote_counts(self) -> Dict[Any, int]:
+        """pid -> number of cells this participant has a latest vote in."""
+        counts: Dict[Any, int] = {}
+        for pid, _tid in self.cells:
+            counts[pid] = counts.get(pid, 0) + 1
+        return counts
+
+    def per_comment_totals(self) -> Dict[Any, Dict[str, int]]:
+        """tid -> {'A': agrees, 'D': disagrees, 'S': observed cells}."""
+        totals: Dict[Any, Dict[str, int]] = {}
+        for (_pid, tid), vote in self.cells.items():
+            entry = totals.setdefault(tid, {"A": 0, "D": 0, "S": 0})
+            entry["S"] += 1
+            if vote == ENGINE_AGREE:
+                entry["A"] += 1
+            elif vote == ENGINE_DISAGREE:
+                entry["D"] += 1
+        return totals
+
+
+def fold_votes(
+    events: List[Dict[str, Any]],
+    storage_agree_value: int = RAW_AGREE,
+) -> VoteFold:
+    """Fold raw vote rows into latest-cell state.
+
+    ``events`` are dicts with ``pid``/``tid``/``vote`` (RAW storage sign) and
+    ``created`` (epoch millis), in the order the DB returns them.  The winner of
+    a cell is the event with the greatest ``created``; a tie on ``created``
+    between DIFFERENT vote values is recorded in :attr:`VoteFold.ambiguous`
+    rather than silently resolved, because the poller's load ordering
+    (``ORDER BY zid, tid, pid, created``) does not define it either.
+    """
+    fold = VoteFold()
+    for ev in events:
+        cell: Cell = (ev["pid"], ev["tid"])
+        created = int(ev["created"])
+        value = raw_to_engine(int(ev["vote"]), storage_agree_value)
+        fold.event_count += 1
+        if created > fold.last_vote_timestamp:
+            fold.last_vote_timestamp = created
+        prior = fold.cell_created.get(cell)
+        if prior is None or created > prior:
+            fold.cells[cell] = value
+            fold.cell_created[cell] = created
+            fold.ambiguous.discard(cell)
+        elif created == prior:
+            if fold.cells[cell] != value:
+                fold.ambiguous.add(cell)
+            # later row of an equal-created pair wins in payload order, which is
+            # what the engine's stable sort + keep='last' does — but the DB row
+            # order between them is arbitrary, hence `ambiguous`.
+            fold.cells[cell] = value
+    return fold
+
+
+@dataclass
+class ModerationFold:
+    mod_out_tids: Set[Any] = field(default_factory=set)
+    mod_in_tids: Set[Any] = field(default_factory=set)
+    meta_tids: Set[Any] = field(default_factory=set)
+    mod_out_ptpts: Set[Any] = field(default_factory=set)
+    last_mod_timestamp: int = 0
+
+
+def fold_moderation(
+    comment_rows: List[Dict[str, Any]],
+    participant_rows: Optional[List[Dict[str, Any]]] = None,
+) -> ModerationFold:
+    """Fold current comment/participant rows into the moderation state.
+
+    A comments snapshot is CURRENT STATE, not a history of moderation actions
+    (P-022 §A) — so this folds the rows as they stand, exactly like a plain
+    ``SELECT``, and never tries to reconstruct a timeline.
+    """
+    fold = ModerationFold()
+    for row in comment_rows:
+        tid = row["tid"]
+        mod = row["mod"]
+        if mod in (1, "1"):
+            fold.mod_in_tids.add(tid)
+        elif mod in (-1, "-1"):
+            fold.mod_out_tids.add(tid)
+        if row.get("is_meta"):
+            fold.meta_tids.add(tid)
+        modified = row.get("modified")
+        if modified is not None and int(modified) > fold.last_mod_timestamp:
+            fold.last_mod_timestamp = int(modified)
+    for row in participant_rows or []:
+        if row.get("mod") in (-1, "-1"):
+            fold.mod_out_ptpts.add(row["pid"])
+    return fold
+
+
+# --------------------------------------------------------------------------- #
+# Comparing the fold against a published math_main blob
+# --------------------------------------------------------------------------- #
+def votes_base_totals(data: Dict[str, Any]) -> Dict[int, Dict[str, int]]:
+    """Sum ``math_main.data['votes-base']``'s per-base-cluster buckets into
+    per-tid A/D/S totals.  ``votes-base`` is ``{tid: {'A': [...], 'D': [...],
+    'S': [...]}}`` — one entry per base cluster, sorted by cluster id."""
+    out: Dict[int, Dict[str, int]] = {}
+    for tid, buckets in (data.get("votes-base") or {}).items():
+        out[int(tid)] = {
+            key: int(sum(buckets.get(key) or []))
+            for key in ("A", "D", "S")
+        }
+    return out
+
+
+def check_published_against_fold(
+    data: Dict[str, Any],
+    fold: VoteFold,
+    *,
+    require_all_clustered: bool = True,
+) -> List[str]:
+    """Return a list of human-readable mismatches between a published
+    ``math_main.data`` blob and the independent fold.  Empty list == agreement.
+
+    Deliberately returns problems instead of asserting, so a caller can use the
+    same routine for a positive assertion and for a negative control.
+    """
+    problems: List[str] = []
+
+    published_ts = data.get("lastVoteTimestamp")
+    if published_ts != fold.last_vote_timestamp:
+        problems.append(
+            f"lastVoteTimestamp: published {published_ts!r} != "
+            f"folded {fold.last_vote_timestamp!r}"
+        )
+
+    expected_counts = {int(k): v for k, v in fold.user_vote_counts().items()}
+    published_counts = {
+        int(k): int(v) for k, v in (data.get("user-vote-counts") or {}).items()
+    }
+    if published_counts != expected_counts:
+        problems.append(
+            f"user-vote-counts: published {published_counts!r} != "
+            f"folded {expected_counts!r}"
+        )
+
+    if data.get("n") != len(fold.participants):
+        problems.append(
+            f"n: published {data.get('n')!r} != folded "
+            f"{len(fold.participants)!r} participants"
+        )
+
+    if require_all_clustered:
+        expected_totals = {
+            int(t): v for t, v in fold.per_comment_totals().items()
+        }
+        published_totals = votes_base_totals(data)
+        if published_totals != expected_totals:
+            problems.append(
+                f"votes-base totals: published {published_totals!r} != "
+                f"folded {expected_totals!r}"
+            )
+
+    return problems

--- a/delphi/tests/poller/recovery/restart_child.py
+++ b/delphi/tests/poller/recovery/restart_child.py
@@ -14,10 +14,10 @@ Stages (the P-022 §C R05 list):
     after the poll cycle advanced the watermark, before any compute
 ``during_compute``
     inside ``Conversation.recompute``
-``after_main_commit``
-    after ``write_math_main`` committed, before the other two tables
-``before_final_table_commit``
-    after main+bidtopid committed, before ``write_participant_stats``
+``after_main_write``
+    after ``write_math_main`` executed, before the other two tables (uncommitted)
+``before_final_table_write``
+    after main+bidtopid executed, before ``write_participant_stats`` (uncommitted)
 ``after_all_writes_before_cache``
     after all three writes committed, before the conversation is cached
 ``none``
@@ -43,6 +43,8 @@ def _block_forever() -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--legacy-writes", action="store_true",
+                        help="Test-only negative control: commit each write separately")
     parser.add_argument("--pg-url", required=True)
     parser.add_argument("--math-env", required=True)
     parser.add_argument("--kill-stage", default="none")
@@ -63,6 +65,19 @@ def main() -> int:
                        ssl_mode="disable")
     )
     pg.initialize()
+    if args.legacy_writes:
+        # None tells each table writer to own/commit its transaction. Only the
+        # victim uses this: survivors always run the production atomic writer.
+        from contextlib import nullcontext
+        pg.transaction = lambda: nullcontext(None)
+        # Standalone _write_returning also uses transaction(), so provide its
+        # original implementation bound to the engine rather than recurse.
+        def legacy_returning(sql, params=None, *, connection=None):
+            from sqlalchemy import text
+            with pg.engine.begin() as conn:
+                result = conn.execute(text(sql), params or {})
+                return [dict(row) for row in result.mappings().all()]
+        pg._write_returning = legacy_returning
     svc = MathPollerService(
         pg,
         PollerConfig(
@@ -97,7 +112,7 @@ def main() -> int:
 
         Conversation.recompute = hooked_recompute
 
-    elif stage == "after_main_commit":
+    elif stage == "after_main_write":
         real_main = pg.write_math_main
 
         def hooked_main(*a, **kw):
@@ -107,7 +122,7 @@ def main() -> int:
 
         pg.write_math_main = hooked_main
 
-    elif stage == "before_final_table_commit":
+    elif stage == "before_final_table_write":
         real_stats = pg.write_participant_stats
 
         def hooked_stats(*a, **kw):

--- a/delphi/tests/poller/recovery/restart_child.py
+++ b/delphi/tests/poller/recovery/restart_child.py
@@ -14,10 +14,15 @@ Stages (the P-022 §C R05 list):
     after the poll cycle advanced the watermark, before any compute
 ``during_compute``
     inside ``Conversation.recompute``
-``after_main_write``
-    after ``write_math_main`` executed, before the other two tables (uncommitted)
+``after_first_table_write``
+    after the FIRST of the three table writes (``write_math_bidtopid``)
+    executed, before the other two.  Under the production writer nothing is
+    committed yet; under ``--legacy-writes`` that first table committed alone,
+    which is the mixed generation the old writer could leave behind.
 ``before_final_table_write``
-    after main+bidtopid executed, before ``write_participant_stats`` (uncommitted)
+    after tick+bidtopid+ptptstats executed, before ``write_math_main`` — which
+    is deliberately the LAST statement in the publication transaction, so this
+    is the widest uncommitted window the writer ever has
 ``after_all_writes_before_cache``
     after all three writes committed, before the conversation is cached
 ``none``
@@ -76,6 +81,11 @@ def main() -> int:
             from sqlalchemy import text
             with pg.engine.begin() as conn:
                 result = conn.execute(text(sql), params or {})
+                # Mirror the real _write_returning: .mappings() on a statement
+                # with no result set raises. Every writer uses RETURNING today,
+                # so this only keeps the stand-in from drifting.
+                if not result.returns_rows:
+                    return []
                 return [dict(row) for row in result.mappings().all()]
         pg._write_returning = legacy_returning
     svc = MathPollerService(
@@ -112,24 +122,24 @@ def main() -> int:
 
         Conversation.recompute = hooked_recompute
 
-    elif stage == "after_main_write":
+    elif stage == "after_first_table_write":
+        real_bidtopid = pg.write_math_bidtopid
+
+        def hooked_bidtopid(*a, **kw):
+            result = real_bidtopid(*a, **kw)
+            _emit(stage)
+            _block_forever()
+
+        pg.write_math_bidtopid = hooked_bidtopid
+
+    elif stage == "before_final_table_write":
         real_main = pg.write_math_main
 
         def hooked_main(*a, **kw):
-            result = real_main(*a, **kw)
             _emit(stage)
             _block_forever()
 
         pg.write_math_main = hooked_main
-
-    elif stage == "before_final_table_write":
-        real_stats = pg.write_participant_stats
-
-        def hooked_stats(*a, **kw):
-            _emit(stage)
-            _block_forever()
-
-        pg.write_participant_stats = hooked_stats
 
     elif stage == "after_all_writes_before_cache":
         real_remember = svc._remember

--- a/delphi/tests/poller/recovery/restart_child.py
+++ b/delphi/tests/poller/recovery/restart_child.py
@@ -1,0 +1,139 @@
+"""A REAL poller process, killable at a NAMED stage — the R05 subject.
+
+Run as a subprocess by ``test_r05_mid_batch_restart.py``.  It builds a real
+``PostgresClient`` + ``MathPollerService`` against the test database, installs a
+single hook at the requested stage, and — when that stage is reached — prints
+``STAGE <name>`` on stdout and then blocks forever so the PARENT can deliver the
+kill.  The kill is therefore genuinely external (SIGKILL from the test), which
+is what P-022 §G requires: "A process kill is driven externally.  Stdin-only
+crash simulations do not replace kill/restart tests."
+
+Stages (the P-022 §C R05 list):
+
+``after_poll``
+    after the poll cycle advanced the watermark, before any compute
+``during_compute``
+    inside ``Conversation.recompute``
+``after_main_commit``
+    after ``write_math_main`` committed, before the other two tables
+``before_final_table_commit``
+    after main+bidtopid committed, before ``write_participant_stats``
+``after_all_writes_before_cache``
+    after all three writes committed, before the conversation is cached
+``none``
+    no kill: run one poll cycle and exit 0 (the restart process)
+"""
+
+import argparse
+import os
+import sys
+import threading
+import time
+
+
+def _emit(stage: str) -> None:
+    sys.stdout.write(f"STAGE {stage}\n")
+    sys.stdout.flush()
+
+
+def _block_forever() -> None:
+    """Park this process so the parent's SIGKILL lands at exactly this point."""
+    threading.Event().wait()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pg-url", required=True)
+    parser.add_argument("--math-env", required=True)
+    parser.add_argument("--kill-stage", default="none")
+    parser.add_argument("--poll-from-days-ago", type=float, default=1.0)
+    parser.add_argument("--reconcile-interval-ms", type=int, default=60000)
+    args = parser.parse_args()
+
+    import logging
+
+    logging.disable(logging.CRITICAL)
+
+    from polismath.conversation.conversation import Conversation
+    from polismath.database.postgres import PostgresClient, PostgresConfig
+    from polismath.poller.service import MathPollerService, PollerConfig
+
+    pg = PostgresClient(
+        PostgresConfig(url=args.pg_url, math_env=args.math_env,
+                       ssl_mode="disable")
+    )
+    pg.initialize()
+    svc = MathPollerService(
+        pg,
+        PollerConfig(
+            database_url=args.pg_url,
+            math_env=args.math_env,
+            poll_from_days_ago=args.poll_from_days_ago,
+            worker_pool_size=1,
+            retry_cap=0,
+            reconcile_interval_ms=args.reconcile_interval_ms,
+            dump_dir=os.environ.get("POLIS_RECOVERY_DUMP_DIR", "/tmp/errorconv"),
+        ),
+    )
+    svc._ensure_runtime()
+
+    stage = args.kill_stage
+
+    if stage == "after_poll":
+        real = svc._run_engine
+
+        def hooked(zid, coalesced):
+            _emit(stage)
+            _block_forever()
+
+        svc._run_engine = hooked
+
+    elif stage == "during_compute":
+        real_recompute = Conversation.recompute
+
+        def hooked_recompute(self, *a, **kw):
+            _emit(stage)
+            _block_forever()
+
+        Conversation.recompute = hooked_recompute
+
+    elif stage == "after_main_commit":
+        real_main = pg.write_math_main
+
+        def hooked_main(*a, **kw):
+            result = real_main(*a, **kw)
+            _emit(stage)
+            _block_forever()
+
+        pg.write_math_main = hooked_main
+
+    elif stage == "before_final_table_commit":
+        real_stats = pg.write_participant_stats
+
+        def hooked_stats(*a, **kw):
+            _emit(stage)
+            _block_forever()
+
+        pg.write_participant_stats = hooked_stats
+
+    elif stage == "after_all_writes_before_cache":
+        real_remember = svc._remember
+
+        def hooked_remember(zid, conv):
+            _emit(stage)
+            _block_forever()
+
+        svc._remember = hooked_remember
+
+    elif stage != "none":
+        raise SystemExit(f"unknown --kill-stage {stage!r}")
+
+    _emit("READY")
+    svc.poll_once()
+    _emit("DONE")
+    svc.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/delphi/tests/poller/recovery/test_atomic_publish.py
+++ b/delphi/tests/poller/recovery/test_atomic_publish.py
@@ -128,6 +128,28 @@ def test_startup_scan_failure_is_retried(pg_url, make_service):
     assert svc._startup_repair_done
 
 
+def test_start_survives_a_boot_time_scan_failure(pg_url, make_service, caplog):
+    """A database blip at boot must not abort startup. Before the startup scan
+    existed, start() touched no database at all; a scan failure now has to be
+    logged and swallowed there (poll_once still propagates, above), leaving the
+    scan pending so the first poll cycle retries it."""
+    svc = make_service(pg_url, math_env=MATH_ENV)
+    scan = svc._pg.find_incomplete_math_snapshots
+    with patch.object(svc._pg, "find_incomplete_math_snapshots",
+                      side_effect=RuntimeError("boot scan failed")):
+        svc.start()
+    try:
+        assert not svc._startup_repair_done
+        assert "Startup repair scan failed" in caplog.text
+        assert svc._threads and all(t.is_alive() for t in svc._threads)
+    finally:
+        svc.stop()
+    with patch.object(svc._pg, "find_incomplete_math_snapshots", wraps=scan) as called:
+        svc.poll_once()
+        called.assert_called_once_with()
+    assert svc._startup_repair_done
+
+
 def test_blocked_zid_does_not_block_other_zid_transactions(
     engine, pg_url, make_service, monkeypatch
 ):

--- a/delphi/tests/poller/recovery/test_atomic_publish.py
+++ b/delphi/tests/poller/recovery/test_atomic_publish.py
@@ -2,6 +2,7 @@
 
 from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
+import threading
 import time
 
 import pytest
@@ -9,8 +10,8 @@ import sqlalchemy as sa
 
 from polismath.conversation.conversation import Conversation
 from .conftest import (
-    FaultInjector, Latch, fail_stage, read_math_tables, read_vote_events,
-    seed_conversation, tables_are_coherent,
+    FaultInjector, Latch, drain, eventually, fail_stage, read_math_tables,
+    read_vote_events, seed_conversation, tables_are_coherent,
 )
 from . import fold as F
 
@@ -148,6 +149,88 @@ def test_start_survives_a_boot_time_scan_failure(pg_url, make_service, caplog):
         svc.poll_once()
         called.assert_called_once_with()
     assert svc._startup_repair_done
+
+
+def test_running_daemon_retries_a_failed_boot_scan_and_repairs_a_dormant_zid(
+    engine, pg_url, make_service, caplog
+):
+    """The daemon itself must recover from a boot-time scan failure.
+
+    ``test_start_survives_a_boot_time_scan_failure`` only proves start() does not
+    abort; it then stops the daemon and drives ``poll_once`` by hand, which the
+    long-running ``start``/``run_forever`` path never calls.  Nothing there shows
+    a RUNNING process ever retrying.  This test never calls ``poll_once``: it
+    starts the real threads, fails exactly the boot scan, heals the database, and
+    requires the daemon's own reconciler loop to rediscover a DORMANT zid whose
+    math_tick generations are mixed — a zid no vote or moderation cycle can ever
+    reach, because it is 10 days old and the lookback is 1 day.  Without the
+    reconciler retry the scan is never re-run and the zid stays broken for the
+    process lifetime.
+    """
+    old = int(time.time() * 1000) - 10 * 24 * 60 * 60 * 1000
+    seed_conversation(engine, zid=2, n_ptpts=6, n_cmts=4, base_created=old)
+    # Publish one real coherent generation (no poll cycle involved), then damage
+    # it into UNEQUAL generations across the three tables.
+    setup = make_service(pg_url, math_env=MATH_ENV, poll_from_days_ago=30)
+    setup._writer.write_conv_updates(2, setup._load_or_init(2))
+    assert tables_are_coherent(read_math_tables(engine, 2, MATH_ENV)) == []
+    with engine.begin() as conn:
+        conn.execute(sa.text("UPDATE math_ptptstats SET math_tick = math_tick + 7 "
+                             "WHERE zid=2 AND math_env=:e"), {"e": MATH_ENV})
+        # A mixed main must not seed an incorrect watermark into the rebuild.
+        conn.execute(sa.text("UPDATE math_main SET last_vote_timestamp=:t "
+                             "WHERE zid=2 AND math_env=:e"),
+                     {"t": old + 99999999, "e": MATH_ENV})
+    assert setup._pg.find_incomplete_math_snapshots() == [2]
+    before = read_math_tables(engine, 2, MATH_ENV)
+
+    svc = make_service(
+        pg_url, math_env=MATH_ENV, poll_from_days_ago=1, worker_pool_size=1,
+        vote_interval_ms=50, mod_interval_ms=50, reconcile_interval_ms=25,
+    )
+    real_scan = svc._pg.find_incomplete_math_snapshots
+    calls = []
+    lock = threading.Lock()
+    boot_scan_failed = threading.Event()
+
+    def scan():
+        """Fail exactly the first scan (the boot one), then the database is healthy."""
+        with lock:
+            calls.append(1)
+            first = len(calls) == 1
+        if first:
+            boot_scan_failed.set()
+            raise RuntimeError("boot scan failed")
+        return real_scan()
+
+    with patch.object(svc._pg, "find_incomplete_math_snapshots", side_effect=scan):
+        svc.start()
+        try:
+            # start() ran the scan synchronously before spawning the threads, so
+            # this is deterministic rather than a race with the reconciler.
+            assert boot_scan_failed.is_set()
+            assert "Startup repair scan failed" in caplog.text
+            assert svc._threads and all(t.is_alive() for t in svc._threads)
+            # The ONLY thing that can flip this now is a daemon loop.
+            eventually(
+                lambda: svc._startup_repair_done,
+                message="no daemon loop ever retried the failed startup scan",
+            )
+            assert len(calls) >= 2, "the scan was never re-run"
+            drain(svc)
+        finally:
+            svc.stop()
+
+    assert "retrying it from the parked-zid reconciler" in caplog.text
+    assert "Startup repair: incomplete math snapshot for zid=2" in caplog.text
+    # Rebuilt from authoritative history, not restored from the mixed state.
+    assert "discarding persisted state and rebuilding full history" in caplog.text
+    tables = read_math_tables(engine, 2, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    assert tables["main"]["math_tick"] > before["main"]["math_tick"]
+    fold = F.fold_votes(read_vote_events(engine, 2))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    assert svc._pg.find_incomplete_math_snapshots() == []
 
 
 def test_blocked_zid_does_not_block_other_zid_transactions(

--- a/delphi/tests/poller/recovery/test_atomic_publish.py
+++ b/delphi/tests/poller/recovery/test_atomic_publish.py
@@ -1,0 +1,196 @@
+"""R05/R09: transaction rollback, legacy repair and concurrent zid isolation."""
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+import time
+
+import pytest
+import sqlalchemy as sa
+
+from polismath.conversation.conversation import Conversation
+from .conftest import (
+    FaultInjector, Latch, fail_stage, read_math_tables, read_vote_events,
+    seed_conversation, tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+MATH_ENV = "recovery"
+
+
+@pytest.mark.parametrize("published_before", [False, True])
+@pytest.mark.parametrize("stage", [
+    "increment_math_tick", "write_math_main", "write_math_bidtopid",
+    "write_participant_stats",
+])
+@pytest.mark.parametrize("after", [False, True])
+def test_failure_rolls_back_whole_snapshot(
+    engine, pg_url, make_service, stage, after, published_before
+):
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV)
+    conv = svc._load_or_init(1)
+    if published_before:
+        svc._writer.write_conv_updates(1, conv)
+    before = read_math_tables(engine, 1, MATH_ENV)
+    fault = FaultInjector(name=stage, mode="once")
+    undo = fail_stage(svc._pg, stage, fault, after=after)
+    try:
+        with pytest.raises(RuntimeError):
+            svc._writer.write_conv_updates(1, conv)
+    finally:
+        undo()
+    assert fault.fired == 1
+    # This includes the allocation row, not only the three published blobs.
+    assert read_math_tables(engine, 1, MATH_ENV) == before
+    svc._writer.write_conv_updates(1, conv)
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    expected = before["main"]["math_tick"] + 1 if published_before else 0
+    assert tables["main"]["math_tick"] == expected
+    assert tables["main"]["caching_tick"] == (2 if published_before else 1)
+
+
+@pytest.mark.parametrize("table", ["math_main", "math_bidtopid", "math_ptptstats"])
+@pytest.mark.parametrize("damage", ["missing", "different_tick"])
+def test_dormant_partial_snapshot_rebuilds_without_restoring_mixed_state(
+    engine, pg_url, make_service, caplog, table, damage
+):
+    old = int(time.time() * 1000) - 10 * 24 * 60 * 60 * 1000
+    seed_conversation(engine, zid=2, n_ptpts=6, n_cmts=4, base_created=old)
+    svc = make_service(pg_url, math_env=MATH_ENV, poll_from_days_ago=30)
+    svc.poll_once()
+    with engine.begin() as conn:
+        if damage == "missing":
+            conn.execute(sa.text(f"DELETE FROM {table} WHERE zid=2 AND math_env=:e"),
+                         {"e": MATH_ENV})
+        else:
+            conn.execute(sa.text(f"UPDATE {table} SET math_tick=math_tick + 7 "
+                                 "WHERE zid=2 AND math_env=:e"), {"e": MATH_ENV})
+        # A mixed main must not seed an incorrect watermark into the rebuild.
+        conn.execute(sa.text("UPDATE math_main SET last_vote_timestamp=:t "
+                             "WHERE zid=2 AND math_env=:e"),
+                     {"t": old + 99999999, "e": MATH_ENV})
+    assert svc._pg.find_incomplete_math_snapshots() == [2]
+    fresh = make_service(pg_url, math_env=MATH_ENV, poll_from_days_ago=1)
+    with patch.object(Conversation, "from_dict", wraps=Conversation.from_dict) as restore:
+        fresh.poll_once()
+        restore.assert_not_called()
+    tables = read_math_tables(engine, 2, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    fold = F.fold_votes(read_vote_events(engine, 2))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    assert fresh._pg.find_incomplete_math_snapshots() == []
+    assert "Startup repair: incomplete math snapshot for zid=2" in caplog.text
+    if table != "math_main" or damage != "missing":
+        assert "discarding persisted state and rebuilding full history" in caplog.text
+
+
+@pytest.mark.parametrize("config,expected", [
+    ({"allowlist": [1, 2], "shard_index": 0, "shard_count": 2}, [2]),
+    ({"blocklist": [2, 3]}, [1]),
+    ({"allowlist": [3], "blocklist": [3]}, [3]),
+])
+def test_startup_repair_obeys_namespace_and_routing(
+    engine, pg_url, make_service, config, expected
+):
+    old = int(time.time() * 1000) - 10 * 24 * 60 * 60 * 1000
+    for zid in (1, 2, 3, 4):
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3, base_created=old)
+        with engine.begin() as conn:
+            conn.execute(sa.text("INSERT INTO math_main "
+                                 "(zid, math_env, data, math_tick, last_vote_timestamp) "
+                                 "VALUES (:z, :e, '{}'::jsonb, 7, 0)"),
+                         {"z": zid, "e": "other" if zid == 4 else MATH_ENV})
+    other_before = read_math_tables(engine, 4, "other")
+    svc = make_service(pg_url, math_env=MATH_ENV, **config)
+    assert svc._pg.find_incomplete_math_snapshots() == [1, 2, 3]
+    svc.poll_once()
+    for zid in (1, 2, 3):
+        tables = read_math_tables(engine, zid, MATH_ENV)
+        assert (tables_are_coherent(tables) == []) == (zid in expected)
+    assert read_math_tables(engine, 4, "other") == other_before
+    assert read_math_tables(engine, 4, MATH_ENV)["main"] is None
+
+
+def test_startup_scan_failure_is_retried(pg_url, make_service):
+    svc = make_service(pg_url, math_env=MATH_ENV)
+    scan = svc._pg.find_incomplete_math_snapshots
+    with patch.object(svc._pg, "find_incomplete_math_snapshots",
+                      side_effect=RuntimeError("scan failed")):
+        with pytest.raises(RuntimeError, match="scan failed"):
+            svc.poll_once()
+    assert not svc._startup_repair_done
+    with patch.object(svc._pg, "find_incomplete_math_snapshots", wraps=scan) as called:
+        svc.poll_once()
+        svc.poll_once()
+        called.assert_called_once_with()
+    assert svc._startup_repair_done
+
+
+def test_blocked_zid_does_not_block_other_zid_transactions(
+    engine, pg_url, make_service, monkeypatch
+):
+    for zid in (1, 2, 3, 4):
+        seed_conversation(engine, zid=zid, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=4)
+    svc.poll_once()
+    before = read_math_tables(engine, 1, MATH_ENV)
+    latch = Latch("zid 1 before bidtopid")
+    real = svc._pg.write_math_bidtopid
+
+    def blocked(zid, *args, **kwargs):
+        if zid == 1:
+            latch.block()
+        return real(zid, *args, **kwargs)
+
+    monkeypatch.setattr(svc._pg, "write_math_bidtopid", blocked)
+    # Same client, four explicit connections. Holding zid 1's transaction open
+    # must neither commit its main/tick nor stop the other three transactions.
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        first = pool.submit(svc._writer.write_conv_updates, 1, svc._convs[1])
+        try:
+            latch.wait_arrival()
+            others = [pool.submit(svc._writer.write_conv_updates, z, svc._convs[z])
+                      for z in (2, 3, 4)]
+            for future in others:
+                future.result(timeout=20)
+            assert not first.done()
+            assert read_math_tables(engine, 1, MATH_ENV) == before
+            for zid in (2, 3, 4):
+                tables = read_math_tables(engine, zid, MATH_ENV)
+                assert tables_are_coherent(tables) == []
+                assert tables["main"]["math_tick"] == 1
+        finally:
+            latch.let_go()
+        first.result(timeout=20)
+    assert tables_are_coherent(read_math_tables(engine, 1, MATH_ENV)) == []
+
+
+def test_lost_ack_after_snapshot_commit_recovers(engine, pg_url, make_service):
+    """The commit succeeded, but the worker sees failure before caching. Retry
+    must preserve all inputs and coherence even though a generation committed."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1, worker_pool_size=1)
+    committed = []
+    real = svc._writer.write_conv_updates
+
+    def lose_first_ack(zid, conv):
+        tick = real(zid, conv)
+        if not committed:
+            tables = read_math_tables(engine, zid, MATH_ENV)
+            assert tables_are_coherent(tables) == []
+            assert tables["main"]["math_tick"] == tick
+            committed.append(tables)
+            raise RuntimeError("lost acknowledgement after commit")
+        return tick
+
+    with patch.object(svc._writer, "write_conv_updates", side_effect=lose_first_ack):
+        svc.poll_once()
+    assert len(committed) == 1
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    assert tables["main"]["math_tick"] == committed[0]["main"]["math_tick"] + 1
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    assert 1 not in svc._parked

--- a/delphi/tests/poller/recovery/test_r01_stage_failures.py
+++ b/delphi/tests/poller/recovery/test_r01_stage_failures.py
@@ -1,0 +1,408 @@
+"""R01 — stage failures (REAL Postgres, real engine, real writer).
+
+P-022 §C required matrix:
+
+    Fail before/after tick allocation, main write, bidtopid write and ptptstats
+    write; include serialization failure, DB rollback, connection loss and
+    committed-write/lost-ack.  Check final latest vote values, unchanged prior
+    cached object on failed write, no extra temporal advancement from replaying
+    an uncommitted computation, coherent recovered tables.  Tick gaps may occur;
+    gaps are not lost votes.
+
+Every failure is injected at the ``PostgresClient`` boundary that
+``MathWriter.write_conv_updates`` calls (``math_writer.py:238`` — three separate
+calls, each committing on its own ``engine.begin()``), so the code under test is
+the deployed code.  Three of the failures are genuine Postgres failures, not
+Python stand-ins:
+
+* **DB rollback** — a real ``NOT NULL`` violation inside the real upsert.
+* **connection loss** — ``pg_terminate_backend`` on the poller's own backend.
+* **serialization failure** — two real ``SERIALIZABLE`` transactions touching
+  the same math_main row, one of which the server aborts with 40001.
+
+Final state is checked against the INDEPENDENT fold in ``fold.py``.
+"""
+
+import threading
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    FaultInjector,
+    InjectedFault,
+    dbname_of,
+    drain,
+    fail_stage,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+    terminate_backends,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+def _publish_and_check(engine, svc, zid=1):
+    """Poll until quiet, then assert the published generation is coherent and
+    agrees with the independent fold."""
+    svc.poll_once()
+    tables = read_math_tables(engine, zid, MATH_ENV)
+    assert tables_are_coherent(tables) == [], (
+        f"published generation is incoherent: {tables_are_coherent(tables)}"
+    )
+    fold = F.fold_votes(read_vote_events(engine, zid))
+    problems = F.check_published_against_fold(tables["main"]["data"], fold)
+    assert problems == [], problems
+    return tables, fold
+
+
+# --------------------------------------------------------------------------- #
+# Stage-by-stage one-shot failures
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "stage,after",
+    [
+        ("increment_math_tick", False),   # before tick allocation
+        ("increment_math_tick", True),    # after tick allocation
+        ("write_math_main", False),       # before the main write
+        ("write_math_main", True),        # after the main write (lost ack)
+        ("write_math_bidtopid", False),   # before the bidtopid write
+        ("write_math_bidtopid", True),    # after the bidtopid write
+        ("write_participant_stats", False),   # before the ptptstats write
+        ("write_participant_stats", True),    # after all three writes
+    ],
+)
+def test_one_shot_stage_failure_recovers(engine, pg_url, make_service, stage, after):
+    """A transient failure at ANY write stage must recover to a coherent
+    generation whose contents match the independent fold.  Tick GAPS are
+    permitted (a failed cycle may have already minted a tick); lost votes are
+    not."""
+    seeded = seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
+
+    injector = FaultInjector(name=f"{stage}:{'after' if after else 'before'}")
+    undo = fail_stage(svc._pg, stage, injector, after=after)
+    try:
+        svc.poll_once()          # the injected failure fires inside this cycle
+    finally:
+        undo()
+    assert injector.fired == 1, "the fault must actually have fired"
+
+    # Bounded eventual progress: one more quiet cycle with no new votes.
+    tables, fold = _publish_and_check(engine, svc, zid=1)
+
+    # No extra temporal advancement: the published watermark is exactly the
+    # folded max(created) — replaying a computation that never committed must
+    # not push last_vote_timestamp past the real input.
+    assert tables["main"]["last_vote_timestamp"] == fold.last_vote_timestamp
+    assert fold.event_count == len(seeded.vote_events)
+
+
+def test_persistent_stage_failure_parks_then_recovers(engine, pg_url, make_service):
+    """A PERSISTENT main-write failure must park the zid with bounded retries
+    (visible unhealthy state, no hot loop, no phantom publication); once the DB
+    stage is restored the reconciler recovers it with no new votes."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1)
+
+    injector = FaultInjector(name="write_math_main", mode="always")
+    undo = fail_stage(svc._pg, "write_math_main", injector)
+    svc.poll_once()
+    assert 1 in svc._parked, "a persistently failing zid must become visibly parked"
+    assert injector.calls == 2, (
+        f"retries must be bounded to retry_cap+1=2 attempts, saw {injector.calls}"
+    )
+    assert read_math_tables(engine, 1, MATH_ENV)["main"] is None, (
+        "a failing write must never publish"
+    )
+
+    undo()  # DB stage restored; no new votes
+    svc._reconcile_once()
+    drain(svc)
+    tables, fold = _publish_and_check(engine, svc, zid=1)
+    assert 1 not in svc._parked
+
+
+# --------------------------------------------------------------------------- #
+# Real Postgres failures
+# --------------------------------------------------------------------------- #
+def test_real_db_rollback_leaves_no_partial_main_row(engine, pg_url, make_service):
+    """A REAL Postgres error rolls the write back.
+
+    The failure is a genuine ``math_main_zid_fkey`` violation from the real
+    migration (a zid with no ``conversations`` row), raised inside the real
+    upsert on the real ``engine.begin()`` transaction — so the rollback is
+    Postgres's, not a Python stand-in.  Afterwards nothing partial is left and
+    the retry publishes a coherent generation.
+    """
+    GHOST_ZID = 987654321  # deliberately absent from `conversations`
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
+
+    original = svc._pg.write_math_main
+    state = {"fired": 0, "error": None}
+
+    def broken_write(zid, data, **kwargs):
+        if state["fired"] == 0:
+            state["fired"] = 1
+            try:
+                original(GHOST_ZID, data, **kwargs)
+            except Exception as exc:
+                state["error"] = exc
+                raise
+        return original(zid, data, **kwargs)
+
+    svc._pg.write_math_main = broken_write
+    svc.poll_once()
+    svc._pg.write_math_main = original
+
+    assert state["fired"] == 1
+    assert isinstance(state["error"], sa.exc.DBAPIError), (
+        f"expected a real Postgres DBAPI error, got {state['error']!r}"
+    )
+    assert getattr(state["error"].orig, "pgcode", None) == "23503", (
+        "expected a foreign_key_violation (23503) from the real migration's "
+        f"math_main_zid_fkey, saw {state['error']!r}"
+    )
+    # The rolled-back statement left nothing behind.
+    with engine.connect() as conn:
+        ghost = conn.execute(
+            sa.text("SELECT count(*) FROM math_main WHERE zid = :z"),
+            {"z": GHOST_ZID},
+        ).scalar()
+    assert ghost == 0, "a rolled-back write must leave no row"
+
+    _publish_and_check(engine, svc, zid=1)
+
+
+def test_real_connection_loss_recovers(engine, pg_url, recovery_postgres_url,
+                                       make_service):
+    """Terminate the poller's server-side backend mid-cycle (a REAL connection
+    loss), then require bounded eventual recovery with no lost votes."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
+
+    original = svc._pg.write_math_bidtopid
+    state = {"fired": 0}
+
+    def kill_then_write(zid, data, **kwargs):
+        if state["fired"] == 0:
+            state["fired"] = 1
+            terminate_backends(recovery_postgres_url, dbname_of(pg_url))
+        return original(zid, data, **kwargs)
+
+    svc._pg.write_math_bidtopid = kill_then_write
+    svc.poll_once()
+    svc._pg.write_math_bidtopid = original
+    assert state["fired"] == 1
+
+    _publish_and_check(engine, svc, zid=1)
+
+
+def test_real_serialization_failure_recovers(engine, pg_url, make_service):
+    """A REAL 40001 serialization failure (two SERIALIZABLE transactions on the
+    same math_main row) must be a retryable blip, not lost work."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
+
+    # Publish once so a math_main row exists for two transactions to contend on.
+    svc.poll_once()
+    baseline = read_math_tables(engine, 1, MATH_ENV)
+    assert baseline["main"] is not None
+
+    original = svc._pg.write_math_main
+    seen = {"code": None, "fired": 0}
+
+    def contended_write(zid, data, **kwargs):
+        if seen["fired"] == 0:
+            seen["fired"] = 1
+            a = engine.connect().execution_options(isolation_level="SERIALIZABLE")
+            b = engine.connect().execution_options(isolation_level="SERIALIZABLE")
+            try:
+                a.begin()
+                b.begin()
+                # Both read the same row, then both write it: the second commit
+                # must abort with a real serialization failure.
+                a.execute(sa.text("SELECT caching_tick FROM math_main "
+                                  "WHERE zid=:z AND math_env=:e"),
+                          {"z": zid, "e": MATH_ENV}).all()
+                b.execute(sa.text("SELECT caching_tick FROM math_main "
+                                  "WHERE zid=:z AND math_env=:e"),
+                          {"z": zid, "e": MATH_ENV}).all()
+                a.execute(sa.text("UPDATE math_main SET modified = modified + 1 "
+                                  "WHERE zid=:z AND math_env=:e"),
+                          {"z": zid, "e": MATH_ENV})
+                a.commit()
+                try:
+                    b.execute(sa.text("UPDATE math_main SET modified = modified + 2 "
+                                      "WHERE zid=:z AND math_env=:e"),
+                              {"z": zid, "e": MATH_ENV})
+                    b.commit()
+                except sa.exc.DBAPIError as exc:
+                    seen["code"] = getattr(exc.orig, "pgcode", None)
+                    raise
+            finally:
+                a.close()
+                b.close()
+        return original(zid, data, **kwargs)
+
+    svc._pg.write_math_main = contended_write
+    # Force another cycle by committing one more vote.
+    from .conftest import commit_vote
+    events = read_vote_events(engine, 1)
+    commit_vote(engine, 1, 0, 0, 1, max(e["created"] for e in events) + 10)
+    svc._vote_wm = 0
+    svc.poll_once()
+    svc._pg.write_math_main = original
+
+    assert seen["fired"] == 1
+    assert seen["code"] == "40001", (
+        f"expected a REAL serialization failure (40001), saw pgcode {seen['code']!r}"
+    )
+    _publish_and_check(engine, svc, zid=1)
+
+
+# --------------------------------------------------------------------------- #
+# Cache / temporal invariants around a failed write
+# --------------------------------------------------------------------------- #
+def test_failed_write_leaves_prior_cached_object_unchanged(engine, pg_url,
+                                                           make_service):
+    """Write-before-cache (M2): on a failed write the in-memory cache must still
+    hold the LAST PERSISTED conversation object — never an unpersisted one."""
+    from .conftest import commit_vote
+
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0)
+    svc.poll_once()
+    cached_before = svc._convs.get(1)
+    assert cached_before is not None
+    ts_before = cached_before.last_updated
+
+    events = read_vote_events(engine, 1)
+    newer = max(e["created"] for e in events) + 1000
+    commit_vote(engine, 1, 0, 0, 1, newer)
+
+    injector = FaultInjector(name="write_math_main", mode="always")
+    undo = fail_stage(svc._pg, "write_math_main", injector)
+    svc._vote_wm = 0
+    svc.poll_once()
+    undo()
+
+    assert injector.fired >= 1
+    cached_after = svc._convs.get(1)
+    assert cached_after is cached_before, (
+        "a failed write must leave the PREVIOUS cached object in place"
+    )
+    assert cached_after.last_updated == ts_before, (
+        "no temporal advancement from a computation that never committed"
+    )
+    # And the persisted row is still the last good one.
+    main = read_math_tables(engine, 1, MATH_ENV)["main"]
+    assert main["last_vote_timestamp"] == ts_before
+
+    # Bounded eventual progress once the stage is healthy again.
+    svc._vote_wm = 0
+    svc.poll_once()
+    tables, fold = _publish_and_check(engine, svc, zid=1)
+    assert tables["main"]["last_vote_timestamp"] == newer == fold.last_vote_timestamp
+
+
+def test_tick_gap_is_allowed_but_votes_are_not_lost(engine, pg_url, make_service):
+    """A failure AFTER tick allocation burns a math_tick.  P-022: "Tick gaps may
+    occur; gaps are not lost votes." — assert the gap AND the intact input."""
+    from .conftest import commit_vote
+
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0)
+    svc.poll_once()
+    first = read_math_tables(engine, 1, MATH_ENV)["main"]["math_tick"]
+
+    injector = FaultInjector(name="write_math_main", mode="once")
+    undo = fail_stage(svc._pg, "write_math_main", injector)
+    events = read_vote_events(engine, 1)
+    newer = max(e["created"] for e in events) + 1000
+    commit_vote(engine, 1, 1, 1, -1, newer)
+    svc._vote_wm = 0
+    svc.poll_once()          # mints a tick, then fails
+    undo()
+    svc._vote_wm = 0
+    svc.poll_once()          # succeeds
+
+    tables, fold = _publish_and_check(engine, svc, zid=1)
+    assert tables["main"]["math_tick"] > first + 1, (
+        "the failed cycle should have burned a tick (a GAP), which is allowed"
+    )
+    assert tables["main"]["last_vote_timestamp"] == fold.last_vote_timestamp
+    assert fold.cells[(1, 1)] == F.ENGINE_AGREE, (
+        "the vote committed during the failing cycle must survive"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the write-stage failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    """An intentionally broken variant must FAIL, proving the R01 assertions can
+    actually see a stage failure rather than passing vacuously."""
+
+    def test_broken_variant_swallows_the_failure_and_is_caught(
+        self, engine, pg_url, make_service
+    ):
+        """The broken variant is a writer that silently SKIPS the bidtopid and
+        ptptstats writes when the main write fails — i.e. it "recovers" by
+        publishing a partial generation.  The R01 coherence assertion must go
+        red on it."""
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0)
+
+        # Publish a good generation first, then advance only math_main so the
+        # tables disagree — exactly the state a "swallow the error" writer leaves.
+        svc.poll_once()
+        with engine.begin() as conn:
+            conn.execute(
+                sa.text("UPDATE math_main SET math_tick = math_tick + 1 "
+                        "WHERE zid=:z AND math_env=:e"),
+                {"z": 1, "e": MATH_ENV},
+            )
+        problems = tables_are_coherent(read_math_tables(engine, 1, MATH_ENV))
+        assert problems, (
+            "NEGATIVE CONTROL FAILED: a mixed generation was reported coherent"
+        )
+        assert "mixed generations" in problems[0]
+
+    def test_fold_check_detects_a_lost_vote(self, engine, pg_url, make_service):
+        """Drop one vote from the fold's input and the published blob must no
+        longer match — proof the fold comparison is load-bearing."""
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV)
+        svc.poll_once()
+        data = read_math_tables(engine, 1, MATH_ENV)["main"]["data"]
+
+        events = read_vote_events(engine, 1)
+        assert F.check_published_against_fold(
+            data, F.fold_votes(events)
+        ) == []
+        mutilated = F.fold_votes([e for e in events if not (e["pid"] == 0)])
+        assert F.check_published_against_fold(data, mutilated) != [], (
+            "NEGATIVE CONTROL FAILED: the fold check accepted a stream that is "
+            "missing a whole participant"
+        )
+
+    def test_injector_that_never_fires_is_detected(self, engine, pg_url,
+                                                   make_service):
+        """A fault that never fires must not be mistaken for a passed recovery."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV)
+        injector = FaultInjector(name="never", mode="never")
+        undo = fail_stage(svc._pg, "write_math_main", injector)
+        svc.poll_once()
+        undo()
+        assert injector.calls > 0
+        assert injector.fired == 0
+        with pytest.raises(AssertionError):
+            assert injector.fired == 1, "the fault must actually have fired"

--- a/delphi/tests/poller/recovery/test_r01_stage_failures.py
+++ b/delphi/tests/poller/recovery/test_r01_stage_failures.py
@@ -313,14 +313,17 @@ def test_failed_write_leaves_prior_cached_object_unchanged(engine, pg_url,
 
 
 def test_tick_gap_is_allowed_but_votes_are_not_lost(engine, pg_url, make_service):
-    """A failure AFTER tick allocation burns a math_tick.  P-022: "Tick gaps may
-    occur; gaps are not lost votes." — assert the gap AND the intact input."""
+    """A legacy standalone allocation can leave a tick gap. Atomic publication
+    must tolerate that existing gap and preserve the final authoritative input.
+    New transaction rollback is checked separately in test_atomic_publish."""
     from .conftest import commit_vote
 
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0)
     svc.poll_once()
     first = read_math_tables(engine, 1, MATH_ENV)["main"]["math_tick"]
+    # Explicit legacy negative control: commit an allocation without a snapshot.
+    assert svc._pg.increment_math_tick(1) == first + 1
 
     injector = FaultInjector(name="write_math_main", mode="once")
     undo = fail_stage(svc._pg, "write_math_main", injector)

--- a/delphi/tests/poller/recovery/test_r01_stage_failures.py
+++ b/delphi/tests/poller/recovery/test_r01_stage_failures.py
@@ -10,10 +10,11 @@ P-022 §C required matrix:
     gaps are not lost votes.
 
 Every failure is injected at the ``PostgresClient`` boundary that
-``MathWriter.write_conv_updates`` calls (``math_writer.py:238`` — three separate
-calls, each committing on its own ``engine.begin()``), so the code under test is
-the deployed code.  Three of the failures are genuine Postgres failures, not
-Python stand-ins:
+``MathWriter.write_conv_updates`` calls (``math_writer.py:227`` — the tick
+allocation and all three table writes now share ONE ``engine.begin()``, so a
+failure at any stage rolls the whole snapshot back, including the tick), so the
+code under test is the deployed code.  Three of the failures are genuine
+Postgres failures, not Python stand-ins:
 
 * **DB rollback** — a real ``NOT NULL`` violation inside the real upsert.
 * **connection loss** — ``pg_terminate_backend`` on the poller's own backend.
@@ -67,14 +68,15 @@ def _publish_and_check(engine, svc, zid=1):
 @pytest.mark.parametrize(
     "stage,after",
     [
+        # Writer order is tick -> bidtopid -> ptptstats -> main -> COMMIT.
         ("increment_math_tick", False),   # before tick allocation
         ("increment_math_tick", True),    # after tick allocation
-        ("write_math_main", False),       # before the main write
-        ("write_math_main", True),        # after the main write (lost ack)
         ("write_math_bidtopid", False),   # before the bidtopid write
         ("write_math_bidtopid", True),    # after the bidtopid write
         ("write_participant_stats", False),   # before the ptptstats write
-        ("write_participant_stats", True),    # after all three writes
+        ("write_participant_stats", True),    # after the ptptstats write
+        ("write_math_main", False),       # before the main write
+        ("write_math_main", True),        # after all three writes (lost ack)
     ],
 )
 def test_one_shot_stage_failure_recovers(engine, pg_url, make_service, stage, after):

--- a/delphi/tests/poller/recovery/test_r02_newer_revote_during_retry.py
+++ b/delphi/tests/poller/recovery/test_r02_newer_revote_during_retry.py
@@ -205,7 +205,7 @@ def test_late_older_batch_does_not_regress_the_watermark(engine, pg_url,
     reason=(
         "DEFECT (latent, retained regression): merging an OLDER batch into "
         "already-newer conversation state overwrites the newer cell. "
-        "polismath/conversation/conversation.py:387 sorts by `created` WITHIN "
+        "polismath/conversation/conversation.py:396 sorts by `created` WITHIN "
         "one payload, but the merge into existing state at "
         "polismath/conversation/conversation.py:470 has NO per-cell timestamp "
         "guard, so a batch whose events are all older than the stored cell "

--- a/delphi/tests/poller/recovery/test_r02_newer_revote_during_retry.py
+++ b/delphi/tests/poller/recovery/test_r02_newer_revote_during_retry.py
@@ -1,0 +1,313 @@
+"""R02 — a newer revote arrives while the older one is being retried.
+
+P-022 §C required matrix:
+
+    Old agree fails; newer disagree is queued while worker is blocked; include
+    pass and equal-time controlled-order variants.  Exercise coalesced and
+    separately scheduled batches with real Conversation.  Final cell is the
+    authoritative winner, timestamp agrees, counters use correct event/cell
+    semantics.
+
+P-019's review flagged that the existing M2 test used a fake conversation which
+"retains per-cell timestamps that the actual merge does not
+(``conversation.py:470``)".  These tests therefore drive the REAL
+``Conversation`` against a REAL Postgres, and cover BOTH shapes:
+
+* **coalesced** — the newer revote lands in the pool queue while the worker is
+  latched inside the failing write, so the retry and the new batch merge into
+  ONE ``CoalescedBatch`` and are resolved by ``update_votes``'s created-sort;
+* **separately scheduled** — the retry batch runs alone to completion and the
+  newer revote arrives in a LATER cycle, so the winner has to survive the
+  cross-batch merge into already-newer state (``conversation.py:470``, the path
+  with no per-cell timestamp guard).
+
+The deterministic interleaving comes from a latch at the ``write_conv_updates``
+boundary, never from a sleep.
+"""
+
+import threading
+
+import pytest
+
+from .conftest import (
+    FaultInjector,
+    InjectedFault,
+    Latch,
+    commit_vote,
+    drain,
+    fail_stage,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+from polismath.poller.worker_pool import VOTES
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+RAW_AGREE = F.RAW_AGREE          # -1 in storage
+RAW_DISAGREE = F.RAW_DISAGREE    # +1 in storage
+RAW_PASS = F.RAW_PASS            # 0
+
+
+def _final_state(engine, zid=1):
+    tables = read_math_tables(engine, zid, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, zid))
+    problems = F.check_published_against_fold(tables["main"]["data"], fold)
+    assert problems == [], problems
+    return tables, fold
+
+
+@pytest.mark.parametrize(
+    "old_raw,new_raw,label",
+    [
+        (RAW_AGREE, RAW_DISAGREE, "agree-then-disagree"),
+        (RAW_DISAGREE, RAW_AGREE, "disagree-then-agree"),
+        (RAW_AGREE, RAW_PASS, "agree-then-pass"),
+        (RAW_PASS, RAW_DISAGREE, "pass-then-disagree"),
+    ],
+)
+def test_coalesced_newer_revote_wins_over_retried_older(
+    engine, pg_url, make_service, old_raw, new_raw, label
+):
+    """The newer revote is queued WHILE the worker is latched inside the failing
+    write of the older one.  Retry + new batch coalesce; the newer value must
+    win, the timestamp must be the newer one, and counters must use cell (not
+    event) semantics."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=2, worker_pool_size=1)
+    svc.poll_once()  # warm the cache with a published, good generation
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    t_old, t_new = base + 1000, base + 2000
+    commit_vote(engine, 1, 0, 0, old_raw, t_old)
+
+    at_write = Latch("write_conv_updates(old)")
+    fault = FaultInjector(name="write(old)", mode="once")
+    real_write = svc._writer.write_conv_updates
+
+    def latched_write(zid, conv):
+        if fault.should_fire():
+            at_write.block()          # hold the worker here, batch in hand
+            raise InjectedFault("old revote write failed")
+        return real_write(zid, conv)
+
+    svc._writer.write_conv_updates = latched_write
+
+    svc._vote_wm = t_old - 1
+    poller = threading.Thread(target=svc._poll_votes_once, daemon=True)
+    poller.start()
+    at_write.wait_arrival()
+
+    # Worker is frozen INSIDE the failing write. Commit + enqueue the newer
+    # revote; the pool queues it behind the in-flight cycle for this zid.
+    commit_vote(engine, 1, 0, 0, new_raw, t_new)
+    svc._pool.submit(1, VOTES, [{"zid": 1, "pid": 0, "tid": 0,
+                                 "vote": F.raw_to_engine(new_raw),
+                                 "created": t_new}])
+    at_write.let_go()
+    poller.join(timeout=30)
+    svc._writer.write_conv_updates = real_write
+    drain(svc)
+
+    # Bounded eventual progress, no new input.
+    svc._vote_wm = 0
+    svc.poll_once()
+
+    tables, fold = _final_state(engine, 1)
+    expected = F.raw_to_engine(new_raw)
+    assert fold.cells[(0, 0)] == expected, "fold disagrees with its own input"
+    assert (0, 0) not in fold.ambiguous
+    assert tables["main"]["last_vote_timestamp"] == t_new == fold.last_vote_timestamp
+
+    # Cell semantics, not event semantics: participant 0 revoted the SAME cell
+    # three times, so their count is unchanged from the seeded 4 cells.
+    counts = {int(k): int(v)
+              for k, v in tables["main"]["data"]["user-vote-counts"].items()}
+    assert counts[0] == 4, f"{label}: revotes must not inflate the cell count"
+    assert fold.event_count == 24 + 2, "both revote EVENTS are in the stream"
+
+
+def test_separately_scheduled_older_retry_then_newer_batch(engine, pg_url,
+                                                           make_service):
+    """The retry of the older vote completes in its OWN batch, and the newer
+    revote arrives in a LATER cycle merged into already-newer state — the
+    cross-batch path (``conversation.py:470``) that has no per-cell timestamp
+    guard."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=2, worker_pool_size=1)
+    svc.poll_once()
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    t_old, t_new = base + 1000, base + 2000
+
+    # Cycle 1: the older agree fails once, then its retry succeeds ALONE.
+    commit_vote(engine, 1, 0, 0, RAW_AGREE, t_old)
+    fault = FaultInjector(name="write(old)", mode="once")
+    undo = fail_stage(svc._writer, "write_conv_updates", fault)
+    svc._vote_wm = t_old - 1
+    svc.poll_once()
+    undo()
+    assert fault.fired == 1
+    assert read_math_tables(engine, 1, MATH_ENV)["main"][
+        "last_vote_timestamp"] == t_old
+
+    # Cycle 2: the newer disagree, as a separate batch.
+    commit_vote(engine, 1, 0, 0, RAW_DISAGREE, t_new)
+    svc._vote_wm = t_new - 1
+    svc.poll_once()
+
+    tables, fold = _final_state(engine, 1)
+    assert fold.cells[(0, 0)] == F.ENGINE_DISAGREE
+    assert tables["main"]["last_vote_timestamp"] == t_new
+
+
+def _apply_new_then_old(engine, svc, t_old, t_new):
+    """Apply the NEWER revote as its own batch, then replay the OLDER one as a
+    separate, later batch."""
+    svc._pool.submit(1, VOTES, [{"zid": 1, "pid": 0, "tid": 0,
+                                 "vote": F.ENGINE_DISAGREE, "created": t_new}])
+    drain(svc)
+    assert read_math_tables(engine, 1, MATH_ENV)["main"][
+        "last_vote_timestamp"] == t_new
+    svc._pool.submit(1, VOTES, [{"zid": 1, "pid": 0, "tid": 0,
+                                 "vote": F.ENGINE_AGREE, "created": t_old}])
+    drain(svc)
+
+
+def test_late_older_batch_does_not_regress_the_watermark(engine, pg_url,
+                                                         make_service):
+    """The watermark half of the new-then-old ordering: ``advance_watermark``'s
+    monotonic max means a late OLDER batch can never pull
+    ``last_vote_timestamp`` backwards.  This part holds today."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=1)
+    svc.poll_once()
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    t_old, t_new = base + 1000, base + 2000
+    commit_vote(engine, 1, 0, 0, RAW_AGREE, t_old)
+    commit_vote(engine, 1, 0, 0, RAW_DISAGREE, t_new)
+    _apply_new_then_old(engine, svc, t_old, t_new)
+
+    main = read_math_tables(engine, 1, MATH_ENV)["main"]
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert main["last_vote_timestamp"] == t_new == fold.last_vote_timestamp, (
+        "a late older batch must never regress the watermark"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (latent, retained regression): merging an OLDER batch into "
+        "already-newer conversation state overwrites the newer cell. "
+        "polismath/conversation/conversation.py:387 sorts by `created` WITHIN "
+        "one payload, but the merge into existing state at "
+        "polismath/conversation/conversation.py:470 has NO per-cell timestamp "
+        "guard, so a batch whose events are all older than the stored cell "
+        "still wins. Observed here: with the newer DISAGREE published first, a "
+        "later OLDER-AGREE batch flips tid 0 back to A=3/D=3 where the "
+        "independent fold says A=2/D=4. The published watermark is unaffected "
+        "(advance_watermark is a monotonic max), so nothing else signals the "
+        "regression. REACHABILITY: the current pool cannot produce this "
+        "ordering on its own — _requeue runs on the worker thread before it "
+        "re-checks the queue (poller/service.py:664), so a retry always "
+        "coalesces with any newer batch instead of following it. This is "
+        "therefore a hardening gap and a retained regression test, not a "
+        "presently-triggerable production bug; any future change that lets a "
+        "stale batch be scheduled separately (a second writer, a queue "
+        "reorder, a cross-process replay) turns it into one."
+    ),
+)
+def test_late_older_batch_must_not_overwrite_the_newer_cell(engine, pg_url,
+                                                            make_service):
+    """The cell-value half of the new-then-old ordering — the authoritative
+    winner must still be the newer value."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=1)
+    svc.poll_once()
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    t_old, t_new = base + 1000, base + 2000
+    commit_vote(engine, 1, 0, 0, RAW_AGREE, t_old)
+    commit_vote(engine, 1, 0, 0, RAW_DISAGREE, t_new)
+    _apply_new_then_old(engine, svc, t_old, t_new)
+
+    tables, fold = _final_state(engine, 1)
+    assert fold.cells[(0, 0)] == F.ENGINE_DISAGREE
+
+
+def test_equal_time_controlled_order_is_flagged_ambiguous(engine, pg_url,
+                                                          make_service):
+    """Equal-``created`` opposite votes on one cell: the DB's
+    ``ORDER BY zid, tid, pid, created`` does not break the tie, so no single
+    winner may be asserted.  The published value must be ONE of the two, the
+    watermark must be the shared timestamp, and the cell count must still be 1.
+
+    P-022 §A: "Ambiguous equal-time opposite votes need a separately specified
+    contract/test; do not invent historical order."
+    """
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    tie = base + 1000
+    commit_vote(engine, 1, 0, 0, RAW_AGREE, tie)
+    commit_vote(engine, 1, 0, 0, RAW_DISAGREE, tie)
+
+    svc._vote_wm = tie - 1
+    svc.poll_once()
+
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert (0, 0) in fold.ambiguous, (
+        "the fold must REFUSE to pick a winner for an equal-time opposite pair"
+    )
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    data = tables["main"]["data"]
+    assert data["lastVoteTimestamp"] == tie == fold.last_vote_timestamp
+    counts = {int(k): int(v) for k, v in data["user-vote-counts"].items()}
+    assert counts[0] == 4, "an ambiguous tie is still ONE cell"
+    totals = F.votes_base_totals(data)
+    assert totals[0]["S"] == 6, "six participants have an observed cell on tid 0"
+    assert totals[0]["A"] + totals[0]["D"] == 6
+    # Exactly one of the two possible resolutions, and nothing else.
+    assert (totals[0]["A"], totals[0]["D"]) in {(3, 3), (4, 2), (2, 4)}
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the retry-ordering failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_stale_older_value_would_be_caught(self, engine, pg_url,
+                                               make_service):
+        """Intentionally broken variant: publish the state produced by applying
+        ONLY the older vote, and check that the R02 assertions go red.  This
+        proves the suite would notice a retry that overwrote a newer revote."""
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        svc.poll_once()
+
+        base = max(e["created"] for e in read_vote_events(engine, 1))
+        t_old, t_new = base + 1000, base + 2000
+        commit_vote(engine, 1, 0, 0, RAW_AGREE, t_old)
+        commit_vote(engine, 1, 0, 0, RAW_DISAGREE, t_new)
+
+        # The BROKEN behaviour: only the older batch is ever applied.
+        svc._pool.submit(1, VOTES, [{"zid": 1, "pid": 0, "tid": 0,
+                                     "vote": F.ENGINE_AGREE, "created": t_old}])
+        drain(svc)
+
+        tables = read_math_tables(engine, 1, MATH_ENV)
+        fold = F.fold_votes(read_vote_events(engine, 1))
+        problems = F.check_published_against_fold(tables["main"]["data"], fold)
+        assert problems, (
+            "NEGATIVE CONTROL FAILED: publishing only the OLDER revote was "
+            "accepted as matching the input fold"
+        )
+        assert tables["main"]["last_vote_timestamp"] != fold.last_vote_timestamp

--- a/delphi/tests/poller/recovery/test_r03_park_then_silence.py
+++ b/delphi/tests/poller/recovery/test_r03_park_then_silence.py
@@ -1,0 +1,205 @@
+"""R03 — park, then silence (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Exhaust retries, no new traffic, reconcile, and fail the first rebuild once.
+    Require eventual successful publication and all park/retry markers cleared.
+    Repeat with persistent failure: visible unhealthy/parked state and bounded
+    retries, not silent loss or a hot loop.
+
+``tests/poller/test_park_rebuild_recovery.py`` already covers this control flow
+with an in-process pool and a fake loader (the R03/R04 fix's regression suite).
+This module re-runs the same scenarios end-to-end against a real migrated
+Postgres with the real ``Conversation``, real ``MathWriter`` and real rows, so
+the recovery is proved to actually re-derive and re-publish authoritative state
+rather than merely to call the right methods.
+"""
+
+import pytest
+
+from .conftest import (
+    FaultInjector,
+    commit_vote,
+    drain,
+    fail_stage,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+def test_transient_rebuild_failure_eventually_publishes(engine, pg_url,
+                                                        make_service):
+    """Retries exhausted -> parked; NO new traffic; the reconciler's first
+    rebuild fails once and its retry succeeds.  Require eventual publication
+    matching the fold and all park/retry markers cleared."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1, worker_pool_size=1)
+
+    # 2 failures park the zid (attempt + 1 retry); the 3rd is the reconciler's
+    # first rebuild, which also fails; the 4th (its retry) wins.
+    injector = FaultInjector(name="write_conv_updates", mode="nth", nth=1)
+    injector.mode = "always"
+
+    undo = fail_stage(svc._writer, "write_conv_updates", injector)
+    svc.poll_once()
+    assert 1 in svc._parked, "exhausting retries must park the zid"
+    assert injector.calls == 2, f"bounded retries, saw {injector.calls} attempts"
+    assert read_math_tables(engine, 1, MATH_ENV)["main"] is None
+
+    # One more transient failure on the reconciler's rebuild, then health.
+    undo()
+    once = FaultInjector(name="write_conv_updates", mode="once")
+    undo2 = fail_stage(svc._writer, "write_conv_updates", once)
+    svc._reconcile_once()
+    drain(svc)
+    undo2()
+    assert once.fired == 1, "the reconciler's first rebuild must have failed once"
+
+    # The retry of a REBUILD must preserve the rebuild kind (service.py:672),
+    # so this already published without any further reconcile pass.
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    assert 1 not in svc._parked
+    assert svc._retry_counts.get(1) is None, "retry markers must be cleared"
+
+
+def test_parked_zid_recovers_the_interval_the_watermark_skipped(engine, pg_url,
+                                                                make_service):
+    """The point of the reconciler: the global watermark advanced PAST the votes
+    that failed, so only a full-history rebuild can recover them.  Assert the
+    published state contains the skipped interval, with no new votes at all."""
+    seeded = seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=1)
+
+    injector = FaultInjector(name="write_conv_updates", mode="always")
+    undo = fail_stage(svc._writer, "write_conv_updates", injector)
+    svc.poll_once()
+    undo()
+    assert 1 in svc._parked
+    # The watermark has moved past every seeded vote even though none published.
+    assert svc._vote_wm >= max(e["created"] for e in seeded.vote_events)
+
+    svc._reconcile_once()
+    drain(svc)
+
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == [], (
+        "the reconciler must recover the interval the watermark skipped"
+    )
+    assert fold.event_count == len(seeded.vote_events)
+
+
+def test_persistent_failure_stays_parked_with_bounded_retries(engine, pg_url,
+                                                              make_service):
+    """A persistent failure must leave a VISIBLE parked state, retry a bounded
+    number of times per cycle (no hot loop), and never publish."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1, worker_pool_size=1)
+
+    injector = FaultInjector(name="write_conv_updates", mode="always")
+    undo = fail_stage(svc._writer, "write_conv_updates", injector)
+    svc.poll_once()
+    assert 1 in svc._parked
+    assert injector.calls == 2
+
+    for cycle in range(3):
+        svc._reconcile_once()
+        drain(svc)
+        assert 1 in svc._parked, f"still visibly parked after cycle {cycle}"
+    assert injector.calls == 2 + 3 * 2, (
+        f"each reconcile must retry a BOUNDED 2 times, saw {injector.calls} total"
+    )
+    assert read_math_tables(engine, 1, MATH_ENV)["main"] is None, (
+        "a persistently failing rebuild must never publish"
+    )
+
+    # And once the fault clears, the very next reconcile recovers it.
+    undo()
+    svc._reconcile_once()
+    drain(svc)
+    assert 1 not in svc._parked
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+
+
+def test_a_healthy_conversation_is_never_parked_by_a_neighbours_failure(
+    engine, pg_url, make_service
+):
+    """Parking is per-zid: a persistently failing zid must not park a healthy
+    one that shares the pool."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    seed_conversation(engine, zid=2, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=2)
+
+    real_write = svc._writer.write_conv_updates
+
+    def poison_zid_1(zid, conv):
+        if zid == 1:
+            raise RuntimeError("poison zid")
+        return real_write(zid, conv)
+
+    svc._writer.write_conv_updates = poison_zid_1
+    svc.poll_once()
+    svc._writer.write_conv_updates = real_write
+
+    assert svc._parked == {1}
+    healthy = read_math_tables(engine, 2, MATH_ENV)
+    assert tables_are_coherent(healthy) == []
+    fold2 = F.fold_votes(read_vote_events(engine, 2))
+    assert F.check_published_against_fold(healthy["main"]["data"], fold2) == []
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the park/rebuild failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_dropping_the_rebuild_on_retry_loses_the_zid(self, engine, pg_url,
+                                                         make_service):
+        """Intentionally broken variant: restore the pre-fix ``_requeue`` that
+        drops the REBUILD kind.  The reconciler has ALREADY cleared the parked
+        marker, so a single transient rebuild failure leaves the zid neither
+        parked nor queued — silently lost.  This is the R03 defect, and it must
+        reproduce on the broken variant."""
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1,
+                           worker_pool_size=1)
+
+        always = FaultInjector(name="write_conv_updates", mode="always")
+        undo = fail_stage(svc._writer, "write_conv_updates", always)
+        svc.poll_once()
+        undo()
+        assert 1 in svc._parked
+
+        # The PRE-FIX _requeue: votes/moderation only, rebuild dropped.
+        from polismath.poller.worker_pool import VOTES, MODERATION
+
+        def broken_requeue(zid, coalesced):
+            if coalesced.votes:
+                svc._pool.submit(zid, VOTES, list(coalesced.votes))
+            if coalesced.moderation:
+                svc._pool.submit(zid, MODERATION, list(coalesced.moderation))
+
+        svc._requeue = broken_requeue
+        once = FaultInjector(name="write_conv_updates", mode="once")
+        undo2 = fail_stage(svc._writer, "write_conv_updates", once)
+        svc._reconcile_once()
+        drain(svc)
+        undo2()
+
+        assert once.fired == 1
+        assert 1 not in svc._parked, "the reconciler already cleared the marker"
+        assert read_math_tables(engine, 1, MATH_ENV)["main"] is None, (
+            "NEGATIVE CONTROL FAILED: the broken _requeue still published, so "
+            "the R03 test would pass even with the defect present"
+        )

--- a/delphi/tests/poller/recovery/test_r04_park_unpark_races.py
+++ b/delphi/tests/poller/recovery/test_r04_park_unpark_races.py
@@ -28,6 +28,7 @@ from .conftest import (
     commit_vote,
     drain,
     fail_stage,
+    pool_pending as _pool_pending,
     read_math_tables,
     read_vote_events,
     seed_conversation,
@@ -136,22 +137,52 @@ def test_overlapping_reconciliation_triggers_run_one_handler_per_zid(
                 conc["cur"] -= 1
 
     svc._load_or_init = latched_load
+    writes = []
+    real_write = svc._writer.write_conv_updates
+
+    def counting_write(zid, conv):
+        writes.append(zid)
+        return real_write(zid, conv)
+
+    svc._writer.write_conv_updates = counting_write
 
     svc._pool.park(1)
     svc._reconcile_once()                    # trigger 1: unpark + REBUILD
-    assert entered.wait(timeout=30)
-    svc._pool.park(1)                        # re-park under the in-flight handler
-    svc._reconcile_once()                    # trigger 2, overlapping
-    svc._reconcile_once()                    # trigger 3, overlapping
+    assert entered.wait(timeout=30), "the first rebuild never started"
+
+    # Two more triggers arrive while the first handler is PROVABLY in flight.
+    # Neither may run now (per-zid serialization) and neither may be dropped:
+    # the pool must coalesce them into exactly one further cycle.
+    svc._pool.submit(1, REBUILD, [])
+    svc._pool.submit(1, REBUILD, [])
     proceed.set()
     drain(svc)
     svc._load_or_init = real_load
+    svc._writer.write_conv_updates = real_write
 
+    # --- handler accounting (exact, not ">= 1") ---------------------------- #
     assert conc["max"] == 1, (
         f"at most one active handler per zid, saw {conc['max']} concurrent"
     )
-    assert conc["n"] >= 1, "the rebuild ran; nothing silently dropped"
-    assert 1 not in svc._parked
+    assert conc["n"] == 2, (
+        "expected EXACTLY two rebuild executions — the in-flight one plus one "
+        f"coalesced cycle for the two overlapping triggers — but saw {conc['n']}. "
+        "A count of 1 means the queued rebuilds were DROPPED; more than 2 means "
+        "per-zid serialization or coalescing broke."
+    )
+    assert conc["cur"] == 0, "no handler left in flight"
+
+    # --- final state ------------------------------------------------------- #
+    assert writes == [1, 1], (
+        f"each executed rebuild must publish exactly once, saw {writes!r}"
+    )
+    assert not _pool_pending(svc._pool, 1), (
+        "the pool must have no queued or active work left for the zid"
+    )
+    assert 1 not in svc._parked and not svc._pool.is_parked(1), (
+        "a successful rebuild must leave the zid quiet and unparked"
+    )
+    assert svc._retry_counts.get(1) is None, "retry markers must be cleared"
     _assert_published(engine, 1)
 
 

--- a/delphi/tests/poller/recovery/test_r04_park_unpark_races.py
+++ b/delphi/tests/poller/recovery/test_r04_park_unpark_races.py
@@ -1,0 +1,256 @@
+"""R04 — park/unpark races (REAL Postgres, real pool threads).
+
+P-022 §C required matrix:
+
+    Barrier between service marker and pool park; trigger both reconciler and
+    new-vote unpark while worker is in flight.  Also overlap two reconciliation
+    triggers.  Require one active handler per zid, no dropped rebuild, and
+    eventual quiet recovery.
+
+The park/rebuild-ownership fix made the worker pool the SINGLE owner of parked
+truth (``worker_pool.py:114`` ``parked_zids()``; ``service.py`` ``_parked`` is a
+read-only property over it), so the "service marker then pool park" gap the
+P-022 probe exploited is no longer expressible.  These tests pin the
+interleaving with latches at the ``pool.park`` and ``_load_or_init`` boundaries
+and assert the invariant directly — the two views must agree at EVERY observed
+instant — then require a real published generation at the end.
+
+Deterministic schedules; run repeatedly (>=20x) by
+``make test-recovery-races``.
+"""
+
+import threading
+
+import pytest
+
+from .conftest import (
+    FaultInjector,
+    commit_vote,
+    drain,
+    fail_stage,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+from polismath.poller.worker_pool import REBUILD, VOTES
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+def _assert_published(engine, zid=1):
+    tables = read_math_tables(engine, zid, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, zid))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    return tables
+
+
+def test_reconcile_and_new_vote_while_worker_parks_never_diverges(
+    engine, pg_url, make_service
+):
+    """Freeze the worker exactly AT the ``pool.park`` boundary, then fire BOTH a
+    reconciliation and a new-vote unpark.  Service and pool views must agree at
+    every instant, no rebuild may be dropped, and recovery must complete."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=2)
+
+    fail_once = FaultInjector(name="write_conv_updates", mode="once")
+    undo = fail_stage(svc._writer, "write_conv_updates", fail_once)
+
+    at_park = threading.Event()
+    release = threading.Event()
+    real_park = svc._pool.park
+
+    def hooked_park(zid):
+        at_park.set()
+        assert release.wait(timeout=30)
+        real_park(zid)
+
+    svc._pool.park = hooked_park
+
+    svc._pool.submit(1, VOTES, [])   # empty batch: has_work() is False
+    svc._pool.submit(1, REBUILD, [])
+    assert at_park.wait(timeout=30), "the worker never reached the park boundary"
+
+    # Worker frozen mid-park. Fire a reconcile AND a new-vote poll.
+    observations = []
+    svc._reconcile_once()
+    observations.append((set(svc._parked), svc._pool.parked_zids()))
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
+    svc._vote_wm = base
+    svc._poll_votes_once()
+    observations.append((set(svc._parked), svc._pool.parked_zids()))
+
+    release.set()
+    drain(svc)
+    svc._pool.park = real_park
+    undo()
+    observations.append((set(svc._parked), svc._pool.parked_zids()))
+
+    for i, (service_view, pool_view) in enumerate(observations):
+        assert service_view == pool_view, (
+            f"observation {i}: service view {service_view} != pool view "
+            f"{pool_view} — parked truth has diverged"
+        )
+
+    # Bounded eventual quiet recovery: reconcile until it publishes.
+    for _ in range(3):
+        svc._reconcile_once()
+        drain(svc)
+        if read_math_tables(engine, 1, MATH_ENV)["main"] is not None:
+            break
+    assert 1 not in svc._parked
+    _assert_published(engine, 1)
+
+
+def test_overlapping_reconciliation_triggers_run_one_handler_per_zid(
+    engine, pg_url, make_service
+):
+    """Two reconciliation triggers overlap while a rebuild is in flight.  At
+    most ONE handler may be active for the zid, and no rebuild may be lost."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1, worker_pool_size=4)
+
+    entered = threading.Event()
+    proceed = threading.Event()
+    lock = threading.Lock()
+    conc = {"cur": 0, "max": 0, "n": 0}
+    real_load = svc._load_or_init
+
+    def latched_load(zid):
+        with lock:
+            conc["n"] += 1
+            conc["cur"] += 1
+            conc["max"] = max(conc["max"], conc["cur"])
+        entered.set()
+        assert proceed.wait(timeout=30)
+        try:
+            return real_load(zid)
+        finally:
+            with lock:
+                conc["cur"] -= 1
+
+    svc._load_or_init = latched_load
+
+    svc._pool.park(1)
+    svc._reconcile_once()                    # trigger 1: unpark + REBUILD
+    assert entered.wait(timeout=30)
+    svc._pool.park(1)                        # re-park under the in-flight handler
+    svc._reconcile_once()                    # trigger 2, overlapping
+    svc._reconcile_once()                    # trigger 3, overlapping
+    proceed.set()
+    drain(svc)
+    svc._load_or_init = real_load
+
+    assert conc["max"] == 1, (
+        f"at most one active handler per zid, saw {conc['max']} concurrent"
+    )
+    assert conc["n"] >= 1, "the rebuild ran; nothing silently dropped"
+    assert 1 not in svc._parked
+    _assert_published(engine, 1)
+
+
+def test_reconcile_racing_a_new_vote_converges_once(engine, pg_url,
+                                                    make_service):
+    """The reconciler and a new-vote unpark fire simultaneously on a parked zid
+    (a two-thread barrier).  Both funnel through the pool-owned parked state, so
+    the outcome is a single quiet recovery with the views in agreement."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0, worker_pool_size=2)
+
+    svc._pool.park(1)
+    assert 1 in svc._parked
+
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
+    svc._vote_wm = base
+
+    barrier = threading.Barrier(2)
+    errors = []
+
+    def reconcile():
+        try:
+            barrier.wait(timeout=30)
+            svc._reconcile_once()
+        except Exception as exc:  # pragma: no cover - surfaced by the assert
+            errors.append(exc)
+
+    def poll():
+        try:
+            barrier.wait(timeout=30)
+            svc._poll_votes_once()
+        except Exception as exc:  # pragma: no cover
+            errors.append(exc)
+
+    threads = [threading.Thread(target=reconcile), threading.Thread(target=poll)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    drain(svc)
+
+    assert errors == []
+    assert 1 not in svc._parked
+    assert set(svc._parked) == svc._pool.parked_zids()
+    _assert_published(engine, 1)
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the park/unpark race failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_second_parked_set_diverges_from_the_pool(self, engine, pg_url,
+                                                        make_service):
+        """Intentionally broken variant: reinstate the pre-fix two-step park
+        (service-side marker first, ``pool.park`` second) and let a
+        reconciliation land in the gap.  The two views MUST diverge — proof the
+        divergence assertion above is load-bearing rather than trivially true.
+        """
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0,
+                           worker_pool_size=2)
+
+        # The pre-fix design: a SECOND parked set the service keeps itself.
+        service_parked = set()
+        at_gap = threading.Event()
+        release = threading.Event()
+        real_park = svc._pool.park
+
+        def two_step_park(zid):
+            service_parked.add(zid)      # step 1: the service's own marker
+            at_gap.set()
+            assert release.wait(timeout=30)
+            real_park(zid)               # step 2: the pool, much later
+
+        def broken_on_error(zid, coalesced, error):
+            two_step_park(zid)
+
+        svc._on_engine_error = broken_on_error
+
+        fail_once = FaultInjector(name="write_conv_updates", mode="once")
+        undo = fail_stage(svc._writer, "write_conv_updates", fail_once)
+        svc._pool.submit(1, REBUILD, [])
+        assert at_gap.wait(timeout=30)
+
+        # A reconciliation lands in the gap: it clears the SERVICE marker (the
+        # pre-fix _unpark) while the pool has not parked yet.
+        service_parked.discard(1)
+        divergent = (set(service_parked), svc._pool.parked_zids())
+        release.set()
+        drain(svc)
+        undo()
+        after = (set(service_parked), svc._pool.parked_zids())
+
+        assert divergent[0] != divergent[1] or after[0] != after[1], (
+            "NEGATIVE CONTROL FAILED: the two-set design did not diverge, so "
+            "the R04 agreement assertion proves nothing"
+        )
+        assert after == (set(), {1}), (
+            f"expected the classic divergence (service unparked, pool parked), "
+            f"saw {after}"
+        )

--- a/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
+++ b/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
@@ -16,6 +16,12 @@ The production writer now commits all three rows together. The legacy-writes
 child option intentionally restores separate commits ONLY for negative controls
 and the dormant-zid repair regression: old partial rows still need repair even
 though new publications can no longer produce them.
+
+P-022's "after main commit / before final table commit" stages are expressed as
+``after_first_table_write`` and ``before_final_table_write``, because the writer
+now emits ``math_main`` LAST (it is the statement that allocates caching_tick,
+so it is kept adjacent to the COMMIT — see math_writer.py). The two stages still
+bracket the same seam: one table written, and all-but-the-last written.
 """
 
 import os
@@ -49,7 +55,7 @@ _MS_PER_DAY = 24 * 60 * 60 * 1000
 STAGES = [
     "after_poll",
     "during_compute",
-    "after_main_write",
+    "after_first_table_write",
     "before_final_table_write",
     "after_all_writes_before_cache",
 ]
@@ -162,23 +168,23 @@ def test_kill_at_stage_then_restart_recovers(engine, pg_url, children,
     assert fold.event_count == len(seeded.vote_events)
 
 
-def test_legacy_kill_after_main_write_leaves_a_mixed_generation(
+def test_legacy_kill_after_first_table_write_leaves_a_mixed_generation(
     engine, pg_url, children, tmp_path
 ):
     """The seam itself, asserted directly: a kill between the three writes DOES
-    leave math_main ahead of the other two tables.  (Recovery is the test
+    leave the first table ahead of the other two.  (Recovery is the test
     above; this one pins the intermediate state so the defect is documented
     rather than inferred.)"""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
 
-    victim = _spawn(children, pg_url, "after_main_write", tmp_path=tmp_path,
+    victim = _spawn(children, pg_url, "after_first_table_write", tmp_path=tmp_path,
                     legacy_writes=True)
-    victim.await_stage("after_main_write")
+    victim.await_stage("after_first_table_write")
     victim.kill()
 
     tables = read_math_tables(engine, 1, MATH_ENV)
-    assert tables["main"] is not None, "math_main committed on its own"
-    assert tables["bidtopid"] is None and tables["ptptstats"] is None, (
+    assert tables["bidtopid"] is not None, "math_bidtopid committed on its own"
+    assert tables["main"] is None and tables["ptptstats"] is None, (
         "the other two tables must not exist yet — that is the non-atomic "
         "three-table write (math_writer.py:238)"
     )
@@ -214,17 +220,18 @@ def test_dormant_zid_is_outside_the_lookback(engine, pg_url, children,
 def test_dormant_zid_partial_write_is_repaired_after_restart(
     engine, pg_url, children, tmp_path
 ):
-    """Kill the process after the main commit for a DORMANT conversation using the legacy writer, then
-    restart the production writer with no new votes. It must discover and repair
-    the preexisting mixed generation outside its lookback."""
+    """Kill the process after the first table commit for a DORMANT conversation
+    using the legacy writer, then restart the production writer with no new
+    votes. It must discover and repair the preexisting mixed generation outside
+    its lookback."""
     _seed_dormant(engine, zid=2)
 
     # The conversation was active when the poller last ran (wide lookback).
-    victim = _spawn(children, pg_url, "after_main_write", days=30.0,
+    victim = _spawn(children, pg_url, "after_first_table_write", days=30.0,
                     tmp_path=tmp_path, legacy_writes=True)
-    victim.await_stage("after_main_write")
+    victim.await_stage("after_first_table_write")
     victim.kill()
-    assert read_math_tables(engine, 2, MATH_ENV)["main"] is not None
+    assert read_math_tables(engine, 2, MATH_ENV)["bidtopid"] is not None
 
     # It has since gone quiet for longer than the boot lookback.
     survivor = _spawn(children, pg_url, "none", days=1.0, tmp_path=tmp_path)
@@ -244,9 +251,9 @@ def test_dormant_zid_partial_write_is_repaired_with_a_wide_lookback(
     durable repair path rather than to the write seam alone."""
     _seed_dormant(engine, zid=2)
 
-    victim = _spawn(children, pg_url, "after_main_write", days=30.0,
+    victim = _spawn(children, pg_url, "after_first_table_write", days=30.0,
                     tmp_path=tmp_path, legacy_writes=True)
-    victim.await_stage("after_main_write")
+    victim.await_stage("after_first_table_write")
     victim.kill()
 
     survivor = _spawn(children, pg_url, "none", days=30.0, tmp_path=tmp_path)
@@ -270,7 +277,7 @@ class TestNegativeControl:
         seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
         child = _spawn(children, pg_url, "none", tmp_path=tmp_path)
         with pytest.raises(AssertionError):
-            child.await_stage("after_main_write", timeout=5.0)
+            child.await_stage("after_first_table_write", timeout=5.0)
 
     def test_the_kill_is_real(self, engine, pg_url, children, tmp_path):
         """The victim must die by signal, not exit cleanly — otherwise the
@@ -286,7 +293,7 @@ class TestNegativeControl:
         )
 
 
-@pytest.mark.parametrize("stage", ["after_main_write", "before_final_table_write"])
+@pytest.mark.parametrize("stage", ["after_first_table_write", "before_final_table_write"])
 @pytest.mark.parametrize("published_before", [False, True])
 def test_atomic_publish_kill_rolls_back_every_table(
     engine, pg_url, children, tmp_path, stage, published_before

--- a/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
+++ b/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
@@ -1,0 +1,305 @@
+"""R05 — mid-batch restart of the ACTUAL Python process (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Kill the actual Python process after poll/watermark advance, during compute,
+    after main commit, before final table commit and after all writes before
+    cache publication.  Restart with no new vote; recover from DB, complete the
+    missing work and serve coherent state.  Include a dormant zid older than
+    lookback.
+
+The subject is ``restart_child.py``: a real ``MathPollerService`` in a real
+subprocess, which announces the named stage on stdout and then blocks so the
+TEST delivers ``SIGKILL``.  Nothing is simulated in-process.
+
+Two of these scenarios expose the seam P-022 predicted
+(``math_writer.py:238`` issues three separate calls, each committing on its own
+``engine.begin()`` — ``database/postgres.py:413``, ``:432``): a process killed
+between them leaves math_main published at a generation the other two tables
+never reach, and there is no parked marker to reconcile because the marker only
+ever lived in the dead process's memory.  With a recent conversation the next
+poll happens to repair it; with a DORMANT one (older than the boot lookback) it
+never does.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    dbname_of,
+    eventually,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+_CHILD = os.path.join(os.path.dirname(__file__), "restart_child.py")
+_DELPHI_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                            "..", "..", ".."))
+_MS_PER_DAY = 24 * 60 * 60 * 1000
+
+STAGES = [
+    "after_poll",
+    "during_compute",
+    "after_main_commit",
+    "before_final_table_commit",
+    "after_all_writes_before_cache",
+]
+
+
+class Child:
+    """A real poller subprocess whose stdout stage markers the test can await."""
+
+    def __init__(self, pg_url, stage, days=1.0, tmp_path=None):
+        env = dict(os.environ)
+        env["PYTHONPATH"] = _DELPHI_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+        if tmp_path is not None:
+            env["POLIS_RECOVERY_DUMP_DIR"] = str(tmp_path / "errorconv")
+        self.proc = subprocess.Popen(
+            [sys.executable, _CHILD, "--pg-url", pg_url,
+             "--math-env", MATH_ENV, "--kill-stage", stage,
+             "--poll-from-days-ago", str(days)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            bufsize=1, env=env, cwd=_DELPHI_ROOT,
+        )
+        self.stages = []
+        self._reader = threading.Thread(target=self._read, daemon=True)
+        self._reader.start()
+
+    def _read(self):
+        for line in self.proc.stdout:
+            line = line.strip()
+            if line.startswith("STAGE "):
+                self.stages.append(line.split(" ", 1)[1])
+
+    def await_stage(self, stage, timeout=90.0):
+        eventually(
+            lambda: stage in self.stages,
+            timeout=timeout,
+            message=(f"child never reported stage {stage!r} "
+                     f"(saw {self.stages}); stderr:\n{self._peek_stderr()}"),
+        )
+
+    def _peek_stderr(self):
+        try:
+            self.proc.stderr.flush()
+        except Exception:  # pragma: no cover
+            pass
+        return "(see child stderr on failure)"
+
+    def kill(self):
+        """A genuinely EXTERNAL, uncatchable kill."""
+        self.proc.send_signal(signal.SIGKILL)
+        self.proc.wait(timeout=30)
+        assert self.proc.returncode in (-signal.SIGKILL, 137), (
+            f"child exited {self.proc.returncode}, expected a SIGKILL"
+        )
+
+    def wait_done(self, timeout=180.0):
+        rc = self.proc.wait(timeout=timeout)
+        assert rc == 0, (
+            f"restart child exited {rc}; stderr:\n{self.proc.stderr.read()}"
+        )
+        assert "DONE" in self.stages
+
+    def cleanup(self):
+        if self.proc.poll() is None:  # pragma: no cover - safety net
+            self.proc.kill()
+            self.proc.wait(timeout=10)
+
+
+@pytest.fixture
+def children():
+    made = []
+    yield made
+    for c in made:
+        c.cleanup()
+
+
+def _spawn(children, pg_url, stage, days=1.0, tmp_path=None):
+    c = Child(pg_url, stage, days=days, tmp_path=tmp_path)
+    children.append(c)
+    return c
+
+
+# --------------------------------------------------------------------------- #
+# Recent conversation: a restart within the lookback recovers
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("stage", STAGES)
+def test_kill_at_stage_then_restart_recovers(engine, pg_url, children,
+                                             tmp_path, stage):
+    """Kill the real process at each named stage, then restart it with NO new
+    vote.  The restarted process must recover from the DB and serve a coherent
+    generation that matches the independent fold."""
+    seeded = seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+
+    victim = _spawn(children, pg_url, stage, tmp_path=tmp_path)
+    victim.await_stage(stage)
+    victim.kill()
+
+    # Restart. No new votes are committed between the kill and the restart.
+    survivor = _spawn(children, pg_url, "none", tmp_path=tmp_path)
+    survivor.wait_done()
+
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    problems = tables_are_coherent(tables)
+    assert problems == [], (
+        f"after a kill at {stage!r} and a restart, the published generation is "
+        f"still incoherent: {problems}"
+    )
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    assert fold.event_count == len(seeded.vote_events)
+
+
+def test_kill_after_main_commit_leaves_a_mixed_generation_before_restart(
+    engine, pg_url, children, tmp_path
+):
+    """The seam itself, asserted directly: a kill between the three writes DOES
+    leave math_main ahead of the other two tables.  (Recovery is the test
+    above; this one pins the intermediate state so the defect is documented
+    rather than inferred.)"""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+
+    victim = _spawn(children, pg_url, "after_main_commit", tmp_path=tmp_path)
+    victim.await_stage("after_main_commit")
+    victim.kill()
+
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables["main"] is not None, "math_main committed on its own"
+    assert tables["bidtopid"] is None and tables["ptptstats"] is None, (
+        "the other two tables must not exist yet — that is the non-atomic "
+        "three-table write (math_writer.py:238)"
+    )
+    assert tables_are_coherent(tables) != []
+
+
+# --------------------------------------------------------------------------- #
+# Dormant zid older than the lookback — the predicted defect
+# --------------------------------------------------------------------------- #
+def _seed_dormant(engine, zid=2):
+    """A conversation whose newest vote is 10 days old: outside a 1-day boot
+    lookback, so a restarted poller never polls it."""
+    now = int(time.time() * 1000)
+    return seed_conversation(
+        engine, zid=zid, n_ptpts=6, n_cmts=4,
+        base_created=now - 10 * _MS_PER_DAY,
+    )
+
+
+def test_dormant_zid_is_outside_the_lookback(engine, pg_url, children,
+                                             tmp_path):
+    """Control: with a 1-day lookback a dormant conversation is genuinely never
+    polled, so the xfail below is about repair and not about a mis-seeded
+    fixture."""
+    _seed_dormant(engine, zid=2)
+    child = _spawn(children, pg_url, "none", days=1.0, tmp_path=tmp_path)
+    child.wait_done()
+    assert read_math_tables(engine, 2, MATH_ENV)["main"] is None, (
+        "a dormant zid must not be polled with a 1-day lookback"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (predicted by P-022 §C): a process killed between the three "
+        "non-atomic table writes leaves a permanently mixed generation for a "
+        "DORMANT conversation. polismath/poller/math_writer.py:238 issues "
+        "write_math_main / write_math_bidtopid / write_participant_stats as "
+        "three separate calls, each committing on its own engine.begin() "
+        "(polismath/database/postgres.py:413, :432), so a main-row watermark "
+        "is not proof of all-table completion. The only repair path is the "
+        "parked-zid reconciler (polismath/poller/service.py:393), which "
+        "iterates the pool's in-memory parked set — that set died with the "
+        "process, and the conversation's newest vote is older than the boot "
+        "lookback (service.py:55 initial_watermark), so nothing ever revisits "
+        "it. math_main stays published at math_tick N while math_bidtopid and "
+        "math_ptptstats are absent, indefinitely. Fixing this needs either a "
+        "transaction spanning all three writes or a durable "
+        "table-generation-completeness scan; both are a separate decision."
+    ),
+)
+def test_dormant_zid_partial_write_is_repaired_after_restart(
+    engine, pg_url, children, tmp_path
+):
+    """Kill the process after the main commit for a DORMANT conversation, then
+    restart with the production-like lookback and no new votes.  A correct
+    system repairs the mixed generation; this one cannot."""
+    _seed_dormant(engine, zid=2)
+
+    # The conversation was active when the poller last ran (wide lookback).
+    victim = _spawn(children, pg_url, "after_main_commit", days=30.0,
+                    tmp_path=tmp_path)
+    victim.await_stage("after_main_commit")
+    victim.kill()
+    assert read_math_tables(engine, 2, MATH_ENV)["main"] is not None
+
+    # It has since gone quiet for longer than the boot lookback.
+    survivor = _spawn(children, pg_url, "none", days=1.0, tmp_path=tmp_path)
+    survivor.wait_done()
+
+    tables = read_math_tables(engine, 2, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+
+
+def test_dormant_zid_partial_write_is_repaired_with_a_wide_lookback(
+    engine, pg_url, children, tmp_path
+):
+    """The same partial write DOES repair when the restarted process's lookback
+    still covers the conversation — isolating the defect above to the missing
+    durable repair path rather than to the write seam alone."""
+    _seed_dormant(engine, zid=2)
+
+    victim = _spawn(children, pg_url, "after_main_commit", days=30.0,
+                    tmp_path=tmp_path)
+    victim.await_stage("after_main_commit")
+    victim.kill()
+
+    survivor = _spawn(children, pg_url, "none", days=30.0, tmp_path=tmp_path)
+    survivor.wait_done()
+
+    tables = read_math_tables(engine, 2, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, 2))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the restart failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_child_that_never_reaches_the_stage_is_detected(self, engine,
+                                                              pg_url, children,
+                                                              tmp_path):
+        """If the stage hook silently failed to fire, the R05 tests must not
+        pass vacuously: awaiting a stage that cannot happen has to time out."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        child = _spawn(children, pg_url, "none", tmp_path=tmp_path)
+        with pytest.raises(AssertionError):
+            child.await_stage("after_main_commit", timeout=5.0)
+
+    def test_the_kill_is_real(self, engine, pg_url, children, tmp_path):
+        """The victim must die by signal, not exit cleanly — otherwise the
+        'restart' would just be a graceful shutdown."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        victim = _spawn(children, pg_url, "during_compute", tmp_path=tmp_path)
+        victim.await_stage("during_compute")
+        victim.kill()
+        assert victim.proc.returncode in (-signal.SIGKILL, 137)
+        assert "DONE" not in victim.stages, (
+            "NEGATIVE CONTROL FAILED: the victim completed its poll cycle, so "
+            "the kill did not interrupt anything"
+        )

--- a/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
+++ b/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
@@ -12,14 +12,10 @@ The subject is ``restart_child.py``: a real ``MathPollerService`` in a real
 subprocess, which announces the named stage on stdout and then blocks so the
 TEST delivers ``SIGKILL``.  Nothing is simulated in-process.
 
-Two of these scenarios expose the seam P-022 predicted
-(``math_writer.py:238`` issues three separate calls, each committing on its own
-``engine.begin()`` — ``database/postgres.py:413``, ``:432``): a process killed
-between them leaves math_main published at a generation the other two tables
-never reach, and there is no parked marker to reconcile because the marker only
-ever lived in the dead process's memory.  With a recent conversation the next
-poll happens to repair it; with a DORMANT one (older than the boot lookback) it
-never does.
+The production writer now commits all three rows together. The legacy-writes
+child option intentionally restores separate commits ONLY for negative controls
+and the dormant-zid repair regression: old partial rows still need repair even
+though new publications can no longer produce them.
 """
 
 import os
@@ -53,8 +49,8 @@ _MS_PER_DAY = 24 * 60 * 60 * 1000
 STAGES = [
     "after_poll",
     "during_compute",
-    "after_main_commit",
-    "before_final_table_commit",
+    "after_main_write",
+    "before_final_table_write",
     "after_all_writes_before_cache",
 ]
 
@@ -62,7 +58,7 @@ STAGES = [
 class Child:
     """A real poller subprocess whose stdout stage markers the test can await."""
 
-    def __init__(self, pg_url, stage, days=1.0, tmp_path=None):
+    def __init__(self, pg_url, stage, days=1.0, tmp_path=None, legacy_writes=False):
         env = dict(os.environ)
         env["PYTHONPATH"] = _DELPHI_ROOT + os.pathsep + env.get("PYTHONPATH", "")
         if tmp_path is not None:
@@ -70,7 +66,8 @@ class Child:
         self.proc = subprocess.Popen(
             [sys.executable, _CHILD, "--pg-url", pg_url,
              "--math-env", MATH_ENV, "--kill-stage", stage,
-             "--poll-from-days-ago", str(days)],
+             "--poll-from-days-ago", str(days)] +
+            (["--legacy-writes"] if legacy_writes else []),
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
             bufsize=1, env=env, cwd=_DELPHI_ROOT,
         )
@@ -128,8 +125,9 @@ def children():
         c.cleanup()
 
 
-def _spawn(children, pg_url, stage, days=1.0, tmp_path=None):
-    c = Child(pg_url, stage, days=days, tmp_path=tmp_path)
+def _spawn(children, pg_url, stage, days=1.0, tmp_path=None, legacy_writes=False):
+    c = Child(pg_url, stage, days=days, tmp_path=tmp_path,
+              legacy_writes=legacy_writes)
     children.append(c)
     return c
 
@@ -164,7 +162,7 @@ def test_kill_at_stage_then_restart_recovers(engine, pg_url, children,
     assert fold.event_count == len(seeded.vote_events)
 
 
-def test_kill_after_main_commit_leaves_a_mixed_generation_before_restart(
+def test_legacy_kill_after_main_write_leaves_a_mixed_generation(
     engine, pg_url, children, tmp_path
 ):
     """The seam itself, asserted directly: a kill between the three writes DOES
@@ -173,8 +171,9 @@ def test_kill_after_main_commit_leaves_a_mixed_generation_before_restart(
     rather than inferred.)"""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
 
-    victim = _spawn(children, pg_url, "after_main_commit", tmp_path=tmp_path)
-    victim.await_stage("after_main_commit")
+    victim = _spawn(children, pg_url, "after_main_write", tmp_path=tmp_path,
+                    legacy_writes=True)
+    victim.await_stage("after_main_write")
     victim.kill()
 
     tables = read_math_tables(engine, 1, MATH_ENV)
@@ -202,7 +201,7 @@ def _seed_dormant(engine, zid=2):
 def test_dormant_zid_is_outside_the_lookback(engine, pg_url, children,
                                              tmp_path):
     """Control: with a 1-day lookback a dormant conversation is genuinely never
-    polled, so the xfail below is about repair and not about a mis-seeded
+    polled, so the regression below is about repair and not about a mis-seeded
     fixture."""
     _seed_dormant(engine, zid=2)
     child = _spawn(children, pg_url, "none", days=1.0, tmp_path=tmp_path)
@@ -212,38 +211,18 @@ def test_dormant_zid_is_outside_the_lookback(engine, pg_url, children,
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "DEFECT (predicted by P-022 §C): a process killed between the three "
-        "non-atomic table writes leaves a permanently mixed generation for a "
-        "DORMANT conversation. polismath/poller/math_writer.py:238 issues "
-        "write_math_main / write_math_bidtopid / write_participant_stats as "
-        "three separate calls, each committing on its own engine.begin() "
-        "(polismath/database/postgres.py:413, :432), so a main-row watermark "
-        "is not proof of all-table completion. The only repair path is the "
-        "parked-zid reconciler (polismath/poller/service.py:393), which "
-        "iterates the pool's in-memory parked set — that set died with the "
-        "process, and the conversation's newest vote is older than the boot "
-        "lookback (service.py:55 initial_watermark), so nothing ever revisits "
-        "it. math_main stays published at math_tick N while math_bidtopid and "
-        "math_ptptstats are absent, indefinitely. Fixing this needs either a "
-        "transaction spanning all three writes or a durable "
-        "table-generation-completeness scan; both are a separate decision."
-    ),
-)
 def test_dormant_zid_partial_write_is_repaired_after_restart(
     engine, pg_url, children, tmp_path
 ):
-    """Kill the process after the main commit for a DORMANT conversation, then
-    restart with the production-like lookback and no new votes.  A correct
-    system repairs the mixed generation; this one cannot."""
+    """Kill the process after the main commit for a DORMANT conversation using the legacy writer, then
+    restart the production writer with no new votes. It must discover and repair
+    the preexisting mixed generation outside its lookback."""
     _seed_dormant(engine, zid=2)
 
     # The conversation was active when the poller last ran (wide lookback).
-    victim = _spawn(children, pg_url, "after_main_commit", days=30.0,
-                    tmp_path=tmp_path)
-    victim.await_stage("after_main_commit")
+    victim = _spawn(children, pg_url, "after_main_write", days=30.0,
+                    tmp_path=tmp_path, legacy_writes=True)
+    victim.await_stage("after_main_write")
     victim.kill()
     assert read_math_tables(engine, 2, MATH_ENV)["main"] is not None
 
@@ -253,6 +232,8 @@ def test_dormant_zid_partial_write_is_repaired_after_restart(
 
     tables = read_math_tables(engine, 2, MATH_ENV)
     assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, 2))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
 
 
 def test_dormant_zid_partial_write_is_repaired_with_a_wide_lookback(
@@ -263,9 +244,9 @@ def test_dormant_zid_partial_write_is_repaired_with_a_wide_lookback(
     durable repair path rather than to the write seam alone."""
     _seed_dormant(engine, zid=2)
 
-    victim = _spawn(children, pg_url, "after_main_commit", days=30.0,
-                    tmp_path=tmp_path)
-    victim.await_stage("after_main_commit")
+    victim = _spawn(children, pg_url, "after_main_write", days=30.0,
+                    tmp_path=tmp_path, legacy_writes=True)
+    victim.await_stage("after_main_write")
     victim.kill()
 
     survivor = _spawn(children, pg_url, "none", days=30.0, tmp_path=tmp_path)
@@ -289,7 +270,7 @@ class TestNegativeControl:
         seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
         child = _spawn(children, pg_url, "none", tmp_path=tmp_path)
         with pytest.raises(AssertionError):
-            child.await_stage("after_main_commit", timeout=5.0)
+            child.await_stage("after_main_write", timeout=5.0)
 
     def test_the_kill_is_real(self, engine, pg_url, children, tmp_path):
         """The victim must die by signal, not exit cleanly — otherwise the
@@ -303,3 +284,23 @@ class TestNegativeControl:
             "NEGATIVE CONTROL FAILED: the victim completed its poll cycle, so "
             "the kill did not interrupt anything"
         )
+
+
+@pytest.mark.parametrize("stage", ["after_main_write", "before_final_table_write"])
+@pytest.mark.parametrize("published_before", [False, True])
+def test_atomic_publish_kill_rolls_back_every_table(
+    engine, pg_url, children, tmp_path, stage, published_before
+):
+    """SIGKILL inside the shared transaction preserves ALL prior rows, including
+    both ticks; a first publication leaves no partial rows at all."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    if published_before:
+        initial = _spawn(children, pg_url, "none", tmp_path=tmp_path)
+        initial.wait_done()
+    before = read_math_tables(engine, 1, MATH_ENV)
+    victim = _spawn(children, pg_url, stage, tmp_path=tmp_path)
+    victim.await_stage(stage)
+    # Uncommitted writes are invisible even before the backend notices the kill.
+    assert read_math_tables(engine, 1, MATH_ENV) == before
+    victim.kill()
+    assert read_math_tables(engine, 1, MATH_ENV) == before

--- a/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
+++ b/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
@@ -165,7 +165,7 @@ def test_cache_stays_bounded_under_pool_concurrency(engine, pg_url,
         "DEFECT (P-019 should-fix #5, unaddressed): the conversation cache is "
         "an unsynchronized OrderedDict. polismath/poller/service.py:497 reads "
         "`conv = self._convs.get(zid)` and then, as a separate step, calls "
-        "`self._convs.move_to_end(zid)`; polismath/poller/service.py:488 "
+        "`self._convs.move_to_end(zid)`; polismath/poller/service.py:489 "
         "concurrently evicts with `self._convs.popitem(last=False)` from "
         "another pool thread. With the key evicted in that window, move_to_end "
         "raises KeyError, which escapes _run_engine into _handle_zid's blanket "

--- a/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
+++ b/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
@@ -1,0 +1,271 @@
+"""R06 — LRU eviction while work is in flight (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Cap=1/2, >=4 worker threads, barriers between cache get/touch/store while
+    other zids evict.  Repeat touches/restarts, inspect final outputs and peak
+    memory.  No KeyError, dropped handler or lost input; cache bookkeeping
+    synchronized.  Compare restart geometry against a reference using the same
+    restore seam, not an uninterrupted smoother trajectory.
+
+The conversation cache is a bare ``OrderedDict`` mutated from pool threads with
+no lock (``poller/service.py:278``; ``_remember`` at ``:479``, the LRU touch at
+``:497``).  The barrier here sits at the named "cache get" boundary and holds
+one worker between its ``self._convs.get(zid)`` and its
+``self._convs.move_to_end(zid)`` while another worker's ``_remember`` evicts
+that very key — P-019's unaddressed should-fix #5.
+"""
+
+import threading
+from collections import OrderedDict
+
+import pytest
+
+from .conftest import (
+    drain,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+from polismath.poller.worker_pool import VOTES
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+class LatchedCache(OrderedDict):
+    """An ``OrderedDict`` that can block INSIDE ``get`` for one named zid.
+
+    This is the "barrier between cache get / touch / store" the matrix asks
+    for: it freezes a worker at the exact instant between
+    ``self._convs.get(zid)`` returning a conversation and the following
+    ``self._convs.move_to_end(zid)`` LRU touch.
+    """
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.latch_zid = None
+        self.arrived = threading.Event()
+        self.release = threading.Event()
+
+    def get(self, key, default=None):
+        value = super().get(key, default)
+        if key == self.latch_zid and value is not None:
+            self.arrived.set()
+            self.release.wait(timeout=30)
+        return value
+
+
+def _assert_all_published(engine, zids):
+    for zid in zids:
+        tables = read_math_tables(engine, zid, MATH_ENV)
+        problems = tables_are_coherent(tables)
+        assert problems == [], f"zid {zid}: {problems}"
+        fold = F.fold_votes(read_vote_events(engine, zid))
+        assert F.check_published_against_fold(
+            tables["main"]["data"], fold
+        ) == [], f"zid {zid} disagrees with the fold"
+
+
+# --------------------------------------------------------------------------- #
+# Churn: a tiny cap with many zids must not lose anything
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("cap", [1, 2])
+def test_cap_smaller_than_the_working_set_loses_nothing(engine, pg_url,
+                                                        make_service, cap):
+    """cap-1/cap-2 with 4 workers and 5 conversations, repeatedly touched: every
+    zid must end with a coherent generation matching its own fold.  Eviction is
+    a memory/latency trade, never a correctness one."""
+    zids = [1, 2, 3, 4, 5]
+    for zid in zids:
+        seed_conversation(engine, zid=zid, n_ptpts=6, n_cmts=4)
+
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=4,
+                       conv_cache_cap=cap)
+    for _ in range(3):          # repeat touches: every zid cycles through the LRU
+        svc._vote_wm = 0
+        svc.poll_once()
+
+    assert len(svc._convs) <= cap, (
+        f"cache grew past its cap: {len(svc._convs)} > {cap}"
+    )
+    _assert_all_published(engine, zids)
+
+
+def test_evicted_conversation_reloads_identically_via_the_same_restore_seam(
+    engine, pg_url, make_service
+):
+    """"Compare restart geometry against a reference using the SAME restore
+    seam": a zid evicted and reloaded must publish the same blob as a cold
+    service that loaded it through ``_load_or_init`` — not the same blob as an
+    uninterrupted warm trajectory."""
+    zids = [1, 2, 3]
+    for zid in zids:
+        seed_conversation(engine, zid=zid, n_ptpts=6, n_cmts=4)
+
+    # Reference: a cold service, restoring zid 1 through _load_or_init.
+    reference_svc = make_service(pg_url, math_env=MATH_ENV + "_ref",
+                                 worker_pool_size=1, conv_cache_cap=0)
+    reference_svc.poll_once()
+    reference = read_math_tables(engine, 1, MATH_ENV + "_ref")["main"]["data"]
+
+    # Subject: cap=1, so zid 1 is evicted by 2 and 3, then reloaded.
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       conv_cache_cap=1)
+    svc.poll_once()
+    assert list(svc._convs) == [3], "zid 1 must have been evicted"
+    svc._vote_wm = 0
+    svc.poll_once()             # zid 1 reloads through the same restore seam
+    subject = read_math_tables(engine, 1, MATH_ENV)["main"]["data"]
+
+    for key in ("user-vote-counts", "votes-base", "lastVoteTimestamp", "n",
+                "n-cmts", "base-clusters", "group-clusters"):
+        assert subject[key] == reference[key], (
+            f"reloaded zid 1 differs from the cold reference at {key!r}"
+        )
+
+
+def test_cache_stays_bounded_under_pool_concurrency(engine, pg_url,
+                                                    make_service):
+    """Peak cache occupancy — the memory proxy this suite can actually measure —
+    must respect the cap even while four workers store concurrently."""
+    zids = list(range(1, 9))
+    for zid in zids:
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=4,
+                       conv_cache_cap=2)
+    peak = {"n": 0}
+    real_remember = svc._remember
+
+    def watched_remember(zid, conv):
+        real_remember(zid, conv)
+        peak["n"] = max(peak["n"], len(svc._convs))
+
+    svc._remember = watched_remember
+    svc.poll_once()
+    drain(svc)
+
+    assert peak["n"] <= 2 + 1, (
+        f"cache peaked at {peak['n']} entries with cap=2; the eviction loop is "
+        "not keeping up with concurrent stores"
+    )
+    _assert_all_published(engine, zids)
+
+
+# --------------------------------------------------------------------------- #
+# The in-flight race itself
+# --------------------------------------------------------------------------- #
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (P-019 should-fix #5, unaddressed): the conversation cache is "
+        "an unsynchronized OrderedDict. polismath/poller/service.py:497 reads "
+        "`conv = self._convs.get(zid)` and then, as a separate step, calls "
+        "`self._convs.move_to_end(zid)`; polismath/poller/service.py:488 "
+        "concurrently evicts with `self._convs.popitem(last=False)` from "
+        "another pool thread. With the key evicted in that window, move_to_end "
+        "raises KeyError, which escapes _run_engine into _handle_zid's blanket "
+        "except (:476) and is treated as an ENGINE error: the batch is retried "
+        "or the healthy zid is PARKED, and an errorconv dump is written — a "
+        "spurious failure caused purely by cache bookkeeping. P-022 §C R06 "
+        "requires 'No KeyError, dropped handler or lost input; cache "
+        "bookkeeping synchronized.' The fix is a lock (or a thread-safe cache) "
+        "around get/touch/store/evict; that is a separate decision."
+    ),
+)
+def test_lru_touch_racing_an_eviction_does_not_park_a_healthy_zid(
+    engine, pg_url, make_service
+):
+    """Barrier at the cache-get boundary: hold worker A between its cache read
+    and its LRU touch while another worker's ``_remember`` evicts that key.
+
+    Worker A is doing perfectly healthy work on real, valid input; only the
+    cache bookkeeping is racing.  It must not fail, and it must not park.
+    """
+    from polismath.poller.worker_pool import CoalescedBatch
+
+    seeded = seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=4,
+                       conv_cache_cap=1, retry_cap=0)
+    svc.poll_once()
+    assert 1 in svc._convs, "zid 1 must be warm before the race can be staged"
+
+    cache = LatchedCache(svc._convs)
+    svc._convs = cache
+    cache.latch_zid = 1
+
+    errors = []
+    newer = max(e["created"] for e in seeded.vote_events) + 1000
+    batch = CoalescedBatch(votes=[{"zid": 1, "pid": 0, "tid": 0,
+                                   "vote": F.ENGINE_DISAGREE,
+                                   "created": newer}])
+
+    def worker_a():
+        try:
+            svc._handle_zid(1, batch)
+        except BaseException as exc:  # pragma: no cover - _handle_zid catches
+            errors.append(exc)
+
+    real_error_handler = svc._on_engine_error
+
+    def recording_error(zid, coalesced, error):
+        errors.append(error)
+        return real_error_handler(zid, coalesced, error)
+
+    svc._on_engine_error = recording_error
+
+    thread = threading.Thread(target=worker_a, daemon=True)
+    thread.start()
+    assert cache.arrived.wait(timeout=30), "worker A never reached cache-get"
+
+    # Worker A is frozen between get() and move_to_end(). Evict zid 1 from
+    # another thread, exactly as a concurrent _remember for zid 2 would.
+    svc._remember(2, object())
+    assert 1 not in cache, "the eviction must have removed zid 1"
+    cache.release.set()
+    thread.join(timeout=30)
+    assert not thread.is_alive()
+
+    assert errors == [] and 1 not in svc._parked, (
+        f"a healthy zid failed purely because of cache bookkeeping: "
+        f"errors={errors!r} parked={set(svc._parked)!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the cache/LRU failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_cache_that_never_evicts_is_detected(self, engine, pg_url,
+                                                   make_service):
+        """Intentionally broken variant: disable eviction and check that the
+        bound assertion goes red — proving it is not vacuous."""
+        for zid in (1, 2, 3):
+            seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                           conv_cache_cap=1)
+
+        def never_evicts(zid, conv):
+            svc._convs[zid] = conv
+
+        svc._remember = never_evicts
+        svc.poll_once()
+        with pytest.raises(AssertionError):
+            assert len(svc._convs) <= 1, "cache grew past its cap"
+
+    def test_eviction_is_lossless_control(self, engine, pg_url, make_service):
+        """Positive counterpart: with eviction ENABLED the same workload still
+        publishes every zid correctly, so the bound above is not being met by
+        dropping work."""
+        zids = (1, 2, 3)
+        for zid in zids:
+            seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                           conv_cache_cap=1)
+        svc.poll_once()
+        assert len(svc._convs) <= 1
+        _assert_all_published(engine, zids)

--- a/delphi/tests/poller/recovery/test_r07_overlapping_shards.py
+++ b/delphi/tests/poller/recovery/test_r07_overlapping_shards.py
@@ -1,0 +1,273 @@
+"""R07 — overlapping shards / duplicate writers (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Two processes, same shard index and math env; then partially overlapping
+    allowlists and a rolling shard-count change.  Require startup refusal or
+    demonstrable exclusive/fenced ownership.  For this cutover, deployment
+    enforces one replica; duplicate-start must be prevented/observable.  Do not
+    claim modulus filtering alone prevents duplicate writers.  Disjoint valid
+    shards must cover every selected zid exactly once.
+
+The partitioning arithmetic (``should_process_zid``,
+``polismath/poller/service.py:62``) is correct and is asserted here as a pure
+property.  Ownership is a different question: nothing in the poller takes a
+lease, advisory lock or fence before writing, and ``ConversationWorkerPool``
+serialises per zid only WITHIN a process (``worker_pool.py:5``).  Two processes
+that both accept a zid therefore both write it, with no mutual exclusion — which
+is what the duplicate-writer tests below establish, on real processes against
+real rows.
+"""
+
+import os
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+from polismath.poller.service import PollerConfig, should_process_zid
+from .test_r05_mid_batch_restart import Child, _DELPHI_ROOT
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+# --------------------------------------------------------------------------- #
+# Partition arithmetic — a pure property, no DB needed
+# --------------------------------------------------------------------------- #
+def test_disjoint_shards_cover_every_zid_exactly_once():
+    """For every shard count, the shards partition the zid space: each zid is
+    accepted by exactly one shard index."""
+    zids = list(range(0, 500))
+    for count in (1, 2, 3, 4, 7, 8, 16):
+        owners = {}
+        for zid in zids:
+            accepting = [
+                idx for idx in range(count)
+                if should_process_zid(zid, [], [], idx, count)
+            ]
+            assert len(accepting) == 1, (
+                f"zid {zid} accepted by {accepting} of {count} shards"
+            )
+            owners[zid] = accepting[0]
+        assert set(owners.values()) <= set(range(count))
+
+
+def test_shard_test_precedes_the_allowlist():
+    """A shard must never process a zid outside its slice, even one an
+    allowlist names — the allowlist cannot widen ownership."""
+    assert not should_process_zid(3, [3], [], shard_index=0, shard_count=2)
+    assert should_process_zid(3, [3], [], shard_index=1, shard_count=2)
+
+
+def test_out_of_range_shard_is_a_startup_refusal():
+    """An unusable shard slice must crash at construction, not start healthy and
+    silently process nothing."""
+    with pytest.raises(ValueError, match="shard_index must be in"):
+        PollerConfig(shard_index=2, shard_count=2)
+    with pytest.raises(ValueError, match="shard_index must be in"):
+        PollerConfig(shard_index=-1, shard_count=2)
+    with pytest.raises(ValueError, match="shard_count must be >= 1"):
+        PollerConfig(shard_count=0)
+
+
+def test_rolling_shard_count_change_leaves_no_zid_unowned(engine, pg_url,
+                                                          make_service):
+    """A rolling shard-count change (2 -> 3) may DOUBLE-cover a zid mid-roll,
+    but it must never leave one unowned.  Assert both halves explicitly."""
+    zids = list(range(1, 61))
+    old, new = 2, 3
+    unowned, double = [], []
+    for zid in zids:
+        owners = [("old", i) for i in range(old)
+                  if should_process_zid(zid, [], [], i, old)]
+        owners += [("new", i) for i in range(new)
+                   if should_process_zid(zid, [], [], i, new)]
+        if not owners:
+            unowned.append(zid)
+        if len(owners) > 1:
+            double.append(zid)
+    assert unowned == [], f"zids with no owner during a rolling change: {unowned}"
+    assert double, (
+        "a rolling shard-count change necessarily double-covers some zids; "
+        "that is exactly why ownership needs a fence, not just a modulus"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Duplicate writers — the ownership question
+# --------------------------------------------------------------------------- #
+def _run_two_children(pg_url, tmp_path, days=1.0):
+    """Start two identical poller processes at once (same shard, same math_env)
+    and wait for both to finish one cycle."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _DELPHI_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+    env["POLIS_RECOVERY_DUMP_DIR"] = str(tmp_path / "errorconv")
+    child = os.path.join(os.path.dirname(__file__), "restart_child.py")
+    procs = [
+        subprocess.Popen(
+            [sys.executable, child, "--pg-url", pg_url, "--math-env", MATH_ENV,
+             "--kill-stage", "none", "--poll-from-days-ago", str(days)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            env=env, cwd=_DELPHI_ROOT,
+        )
+        for _ in range(2)
+    ]
+    outs = []
+    for p in procs:
+        out, err = p.communicate(timeout=180)
+        outs.append((p.returncode, out, err))
+    return outs
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (P-022 §C R07): nothing prevents or fences a duplicate writer. "
+        "Two poller processes with the SAME POLL_SHARD_INDEX/POLL_SHARD_COUNT "
+        "and the same MATH_ENV both start cleanly and both write the same "
+        "zid's math_main / math_bidtopid / math_ptptstats rows. There is no "
+        "startup refusal, no advisory lock, no lease and no fencing token "
+        "anywhere in polismath/poller/service.py or "
+        "polismath/database/postgres.py; ConversationWorkerPool serialises per "
+        "zid only WITHIN one process (polismath/poller/worker_pool.py:5). "
+        "P-022 §C requires 'startup refusal or demonstrable exclusive/fenced "
+        "ownership' and warns not to claim modulus filtering alone prevents "
+        "duplicate writers. Today the only control is the deployment promising "
+        "one replica, which is not observable from the database. A fix (a "
+        "pg_advisory_lock lease per (math_env, shard) held for the process "
+        "lifetime, or a fencing token checked in the writes) is a separate "
+        "decision."
+    ),
+)
+def test_duplicate_shard_start_is_refused_or_fenced(engine, pg_url, tmp_path):
+    """Two identical processes, same shard index and math env: one must refuse
+    to start, or ownership must be demonstrably exclusive."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    results = _run_two_children(pg_url, tmp_path)
+    exit_codes = [rc for rc, _out, _err in results]
+    refusals = [rc for rc in exit_codes if rc != 0]
+    assert refusals, (
+        "both duplicate processes started and completed a full write cycle "
+        f"(exit codes {exit_codes}); neither refused, and nothing fenced them"
+    )
+
+
+def test_duplicate_writers_both_write_the_same_rows(engine, pg_url, tmp_path):
+    """The observable consequence, asserted directly so the defect above is
+    documented rather than inferred: two duplicate processes both advance the
+    same zid's math_tick.  (Both write authoritative full-history state, so the
+    CONTENT stays correct here — the hazard is unfenced concurrent ownership,
+    not a demonstrated corruption on this fixture.)"""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    results = _run_two_children(pg_url, tmp_path)
+    assert [rc for rc, _o, _e in results] == [0, 0], (
+        f"both duplicates were expected to run to completion: {results}"
+    )
+    with engine.connect() as conn:
+        tick = conn.execute(
+            sa.text("SELECT math_tick FROM math_ticks WHERE zid=:z AND "
+                    "math_env=:e"), {"z": 1, "e": MATH_ENV},
+        ).scalar()
+    assert tick is not None and tick >= 1, (
+        f"two writers must have advanced the shared math_tick at least twice "
+        f"(saw math_tick={tick})"
+    )
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+
+
+def test_partially_overlapping_allowlists_both_accept_the_shared_zid(engine,
+                                                                     pg_url,
+                                                                     make_service):
+    """Two configurations whose allowlists overlap on zid 2: both accept it.
+    Allowlists are a selection mechanism, not an ownership mechanism."""
+    for zid in (1, 2, 3):
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+
+    a = make_service(pg_url, math_env=MATH_ENV, allowlist=[1, 2],
+                     worker_pool_size=1)
+    b = make_service(pg_url, math_env=MATH_ENV, allowlist=[2, 3],
+                     worker_pool_size=1)
+    for zid in (1, 2, 3):
+        accepted_by = [
+            name for name, svc in (("a", a), ("b", b))
+            if should_process_zid(zid, svc.config.allowlist, svc.config.blocklist,
+                                  svc.config.shard_index, svc.config.shard_count)
+        ]
+        expected = {1: ["a"], 2: ["a", "b"], 3: ["b"]}[zid]
+        assert accepted_by == expected
+
+    a.poll_once()
+    b.poll_once()
+    for zid in (1, 2, 3):
+        tables = read_math_tables(engine, zid, MATH_ENV)
+        assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+        fold = F.fold_votes(read_vote_events(engine, zid))
+        assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+
+
+def test_disjoint_shards_cover_every_seeded_zid_exactly_once_on_real_pg(
+    engine, pg_url, make_service
+):
+    """End-to-end partitioning: shard 0/2 and shard 1/2 together publish every
+    seeded conversation, and neither touches the other's zids."""
+    zids = [1, 2, 3, 4, 5, 6]
+    for zid in zids:
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+
+    shard0 = make_service(pg_url, math_env=MATH_ENV + "_s0", shard_index=0,
+                          shard_count=2, worker_pool_size=1)
+    shard1 = make_service(pg_url, math_env=MATH_ENV + "_s1", shard_index=1,
+                          shard_count=2, worker_pool_size=1)
+    shard0.poll_once()
+    shard1.poll_once()
+
+    for zid in zids:
+        owner = MATH_ENV + ("_s0" if zid % 2 == 0 else "_s1")
+        other = MATH_ENV + ("_s1" if zid % 2 == 0 else "_s0")
+        assert read_math_tables(engine, zid, owner)["main"] is not None, (
+            f"zid {zid} was not published by its owning shard"
+        )
+        assert read_math_tables(engine, zid, other)["main"] is None, (
+            f"zid {zid} was published by the NON-owning shard"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the shard-ownership failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_broken_partition_is_detected(self):
+        """Intentionally broken variant: a filter that ignores the shard index.
+        The exactly-once partition assertion must go red on it."""
+        def broken(zid, allowlist, blocklist, shard_index, shard_count):
+            return True  # every shard accepts every zid
+
+        accepting = [idx for idx in range(4) if broken(7, [], [], idx, 4)]
+        assert len(accepting) != 1, (
+            "NEGATIVE CONTROL FAILED: a shard filter that accepts everything "
+            "still looked like an exactly-once partition"
+        )
+
+    def test_a_shard_that_owns_nothing_would_be_caught(self):
+        """A shard index outside its count owns no zid at all — the failure
+        mode ``_validate_shard`` exists to prevent.  Assert the arithmetic
+        really would go silent, so the startup refusal is load-bearing."""
+        owned = [z for z in range(200)
+                 if should_process_zid(z, [], [], shard_index=5, shard_count=2)]
+        assert owned == [], (
+            "an out-of-range shard owns nothing; without the constructor's "
+            "ValueError such a process would start and look healthy"
+        )

--- a/delphi/tests/poller/recovery/test_r08_timestamp_boundary.py
+++ b/delphi/tests/poller/recovery/test_r08_timestamp_boundary.py
@@ -1,0 +1,309 @@
+"""R08 — strict ``>`` watermark boundary (REAL Postgres, two real connections).
+
+P-022 §C required matrix:
+
+    Commit vote A at t; poll/advance; commit B with created=t and then one with
+    created<t on another connection.  Repeat for moderation, timestamp ties and
+    clock skew.  Without a later vote, all committed input must eventually be
+    represented.  Strict ``>`` plus max timestamp is insufficient.  Test
+    overlap/dedup or durable scan/reconciliation repair; a lookback needs a
+    proven bound or a repair path for older commits.
+
+The poll queries are ``WHERE created > :since`` / ``WHERE modified > :since``
+(``polismath/database/postgres.py:572``, ``:606``) and the watermark advances to
+``max(created)`` (``polismath/poller/service.py:40``).  Two real connections are
+used so the "committed later, timestamped earlier" case is a genuine commit-order
+event and not a Python-side reordering: ``votes.created`` defaults to
+``now_as_millis()`` but is explicitly supplied here, which is exactly what a
+client-supplied or clock-skewed timestamp looks like.
+"""
+
+import time
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    commit_vote,
+    drain,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+def _published_fold_problems(engine, zid=1):
+    tables = read_math_tables(engine, zid, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, zid))
+    return F.check_published_against_fold(tables["main"]["data"], fold), tables, fold
+
+
+# --------------------------------------------------------------------------- #
+# The boundary itself
+# --------------------------------------------------------------------------- #
+def test_watermark_advances_to_exactly_the_max_created(engine, pg_url,
+                                                       make_service):
+    """Control: after a poll, the vote watermark is exactly ``max(created)``, so
+    the next poll's ``created > watermark`` excludes that row."""
+    seeded = seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    assert svc._vote_wm == max(e["created"] for e in seeded.vote_events)
+
+    with engine.connect() as conn:
+        rows = conn.execute(
+            sa.text("SELECT count(*) FROM votes WHERE created > :w"),
+            {"w": svc._vote_wm},
+        ).scalar()
+    assert rows == 0, "the strict > boundary excludes the row it advanced onto"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (predicted by P-022 §C): a vote committed with created EXACTLY "
+        "equal to the current watermark is never delivered. "
+        "polismath/database/postgres.py:572 polls `WHERE created > :since` and "
+        "polismath/poller/service.py:40 advances the watermark to max(created) "
+        "of the rows it just saw, so the boundary row is skipped by the very "
+        "poll that moved onto it. Nothing repairs it: the parked-zid "
+        "reconciler (polismath/poller/service.py:393) only visits zids that "
+        "FAILED, and a never-polled late commit creates no parked marker. "
+        "Without a later vote on the same conversation the input is silently "
+        "absent from math_main indefinitely. P-022 §C: 'Without a later vote, "
+        "all committed input must eventually be represented. Strict > plus max "
+        "timestamp is insufficient.' The fix is an overlap/dedup window or a "
+        "durable scan; that is a separate decision."
+    ),
+)
+def test_equal_timestamp_commit_is_eventually_represented(engine, pg_url,
+                                                          make_service):
+    """Commit A at t, poll (watermark -> t), then commit B with created == t on
+    ANOTHER connection.  With no later vote, B must still be represented."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    t = svc._vote_wm
+
+    # Second, independent connection — a genuinely separate committer.
+    with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as conn:
+        with conn.begin():
+            commit_vote(conn, 1, 0, 0, F.RAW_DISAGREE, t)
+
+    for _ in range(3):          # bounded eventual progress: repeated cycles
+        svc.poll_once()
+
+    problems, _tables, _fold = _published_fold_problems(engine, 1)
+    assert problems == [], problems
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (same root cause, clock-skew / late-commit variant): a vote "
+        "COMMITTED after the poll but TIMESTAMPED before the watermark is never "
+        "delivered either. votes.created is a client/server-supplied bigint "
+        "(server/postgres/migrations/000000_initial.sql: `created bigint "
+        "default now_as_millis()`), so commit order and timestamp order are "
+        "independent; polismath/database/postgres.py:572's `created > :since` "
+        "keys on the timestamp alone. There is no repair path for a "
+        "never-polled commit — see the equal-timestamp case above."
+    ),
+)
+def test_late_commit_with_earlier_timestamp_is_eventually_represented(
+    engine, pg_url, make_service
+):
+    """Commit-order vs timestamp-order: B commits AFTER the poll but carries
+    ``created < watermark``.
+
+    B targets cell (0, 0), whose seeded event is the OLDEST in the stream, and
+    carries a timestamp strictly between that event and the watermark — so B is
+    unambiguously the cell's new winner and its absence is observable.
+    """
+    seeded = seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    t = svc._vote_wm
+    oldest = min(e["created"] for e in seeded.vote_events)
+    late = (oldest + t) // 2
+    assert oldest < late < t
+
+    with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as conn:
+        with conn.begin():
+            commit_vote(conn, 1, 0, 0, F.RAW_DISAGREE, late)
+
+    for _ in range(3):
+        svc.poll_once()
+
+    problems, _tables, _fold = _published_fold_problems(engine, 1)
+    assert problems == [], problems
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (moderation variant of the same boundary): "
+        "polismath/database/postgres.py:606 polls comments with `WHERE "
+        "modified > :since` and polismath/poller/service.py:465 advances the "
+        "moderation watermark to max(modified), so a moderation change whose "
+        "`modified` equals the watermark is never delivered. The per-zid worker "
+        "re-derives FULL moderation state once it is woken "
+        "(polismath/poller/service.py:533), so the damage is bounded to 'the "
+        "conversation is never woken' — but with no later vote or later "
+        "moderation change, nothing wakes it."
+    ),
+)
+def test_equal_timestamp_moderation_change_is_eventually_represented(
+    engine, pg_url, make_service
+):
+    """The moderation loop has the same strict boundary."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    # Move the moderation watermark onto a real modified value.
+    now = int(time.time() * 1000)
+    with engine.begin() as conn:
+        conn.execute(sa.text("SET session_replication_role = replica"))
+        conn.execute(
+            sa.text("UPDATE comments SET modified = :m WHERE zid=1 AND tid=0"),
+            {"m": now},
+        )
+    svc.poll_once()
+    assert svc._mod_wm == now
+
+    # A second moderation action lands with modified EXACTLY on the watermark.
+    with engine.begin() as conn:
+        conn.execute(sa.text("SET session_replication_role = replica"))
+        conn.execute(
+            sa.text("UPDATE comments SET mod = -1, modified = :m "
+                    "WHERE zid=1 AND tid=1"),
+            {"m": now},
+        )
+    for _ in range(3):
+        svc.poll_once()
+
+    data = read_math_tables(engine, 1, MATH_ENV)["main"]["data"]
+    with engine.connect() as conn:
+        comment_rows = [dict(r) for r in conn.execute(
+            sa.text("SELECT tid, mod, is_meta, modified FROM comments "
+                    "WHERE zid = 1")).mappings()]
+    expected = F.fold_moderation(comment_rows)
+    assert set(data["moderation"]["mod_out_tids"]) == expected.mod_out_tids, (
+        "the moderated-out comment must eventually be represented"
+    )
+
+
+def test_a_later_vote_repairs_the_skipped_boundary_row(engine, pg_url,
+                                                       make_service):
+    """The bound on the damage: ANY later vote on the same conversation wakes
+    it, and the per-zid worker's full-history rebuild subsumes the skipped row.
+    So the defect is 'no repair without further traffic', not 'lost forever
+    under traffic' — asserted so the xfails above are correctly scoped."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       conv_cache_cap=0)
+    svc.poll_once()
+    t = svc._vote_wm
+
+    with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as conn:
+        with conn.begin():
+            commit_vote(conn, 1, 0, 0, F.RAW_DISAGREE, t)      # skipped
+    svc.poll_once()
+    assert _published_fold_problems(engine, 1)[0] != [], (
+        "precondition: the boundary row must indeed be missing at this point"
+    )
+
+    # Any later vote wakes the conversation. The cached conv is warm, so the
+    # skipped row is only recovered via a full rebuild — force the rebuild path
+    # the reconciler would use.
+    commit_vote(engine, 1, 2, 2, F.RAW_AGREE, t + 1000)
+    svc._convs.pop(1, None)
+    svc.poll_once()
+
+    problems, tables, fold = _published_fold_problems(engine, 1)
+    assert problems == [], problems
+    assert tables["main"]["last_vote_timestamp"] == fold.last_vote_timestamp
+
+
+def test_a_warm_cached_conversation_does_not_recover_the_skipped_row(
+    engine, pg_url, make_service
+):
+    """Scope the repair claim honestly: with a WARM cache the later vote is
+    applied incrementally, so the skipped boundary row stays missing even under
+    traffic.  Only a full-history rebuild (eviction, restart, reconcile)
+    recovers it."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       conv_cache_cap=0)
+    svc.poll_once()
+    t = svc._vote_wm
+
+    with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as conn:
+        with conn.begin():
+            commit_vote(conn, 1, 0, 0, F.RAW_DISAGREE, t)
+    commit_vote(engine, 1, 2, 2, F.RAW_AGREE, t + 1000)
+    svc.poll_once()             # warm cache: incremental update only
+
+    problems, _tables, _fold = _published_fold_problems(engine, 1)
+    assert problems != [], (
+        "a warm incremental update cannot recover a row the poll never "
+        "delivered; if this passes, the scoping of the R08 xfails is wrong"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the timestamp-boundary failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_an_inclusive_boundary_would_deliver_the_row(self, engine, pg_url,
+                                                         make_service):
+        """Intentionally 'fixed' variant: poll with an OVERLAP window
+        (``created > watermark - overlap``).  The same scenario then passes,
+        proving the xfails above are caused by the strict boundary and not by
+        the fixture."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                           conv_cache_cap=0)
+        svc.poll_once()
+        t = svc._vote_wm
+
+        with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as c:
+            with c.begin():
+                commit_vote(c, 1, 0, 0, F.RAW_DISAGREE, t)
+
+        real_poll = svc._pg.poll_votes_since
+        svc._pg.poll_votes_since = lambda since: real_poll(since - 1)
+        svc._convs.pop(1, None)
+        svc.poll_once()
+        svc._pg.poll_votes_since = real_poll
+
+        problems, _tables, _fold = _published_fold_problems(engine, 1)
+        assert problems == [], (
+            "NEGATIVE CONTROL FAILED: even an overlapping poll window did not "
+            f"deliver the boundary row ({problems})"
+        )
+
+    def test_the_row_really_is_committed(self, engine, pg_url, make_service):
+        """Guard against a vacuous xfail: the boundary row must actually be in
+        the votes table."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        svc.poll_once()
+        t = svc._vote_wm
+        with sa.create_engine(pg_url, poolclass=sa.pool.NullPool).connect() as c:
+            with c.begin():
+                commit_vote(c, 1, 0, 0, F.RAW_DISAGREE, t)
+        events = read_vote_events(engine, 1)
+        assert any(e["created"] == t and e["pid"] == 0 and e["tid"] == 0
+                   and e["vote"] == F.RAW_DISAGREE for e in events), (
+            "the boundary vote was never committed; the R08 xfails would be "
+            "vacuous"
+        )

--- a/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
+++ b/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
@@ -1,0 +1,369 @@
+"""R09 — partial tables and concurrent readers (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Pause after main but before bidtopid/ptptstats; continuously query through
+    Node.  No response may combine incompatible generations.  Prefer a
+    transaction spanning all three writes or a reader-visible completed
+    generation.  Eventual repair alone does not make a mixed mapping safe.  Seed
+    preexisting partial rows, restart and repair; fail on absent/mismatched
+    required rows.
+
+The reader here is a Python transcription of the TWO server queries that
+together produce a participant mapping —
+``server/src/utils/pca.ts:360`` (``select * from math_main where zid = $1 and
+math_env = $2``) and ``server/src/utils/participants.ts:10``
+(``select * from math_bidtopid where zid = $1 and math_env = $2``) — plus
+``getPidsForGid``'s positional join of ``base-clusters.id`` ->
+``bidToPid[index]`` (``participants.ts:25-60``).  Running the real Node server
+is D's job (see the notes file); what R09 needs is the exact query pair and the
+exact join, which is what is reproduced.
+"""
+
+import json
+import threading
+import time
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    Latch,
+    eventually,
+    latch_method,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+# --------------------------------------------------------------------------- #
+# The server's reader, transcribed
+# --------------------------------------------------------------------------- #
+def read_generation(engine, zid: int, math_env: str):
+    """One SNAPSHOT of the reader's two queries, taken inside a single
+    REPEATABLE READ transaction so any incoherence is the writer's, not a
+    torn read of the test's own making."""
+    conn = engine.connect().execution_options(isolation_level="REPEATABLE READ")
+    try:
+        with conn.begin():
+            main = conn.execute(
+                sa.text("select * from math_main where zid = :z and "
+                        "math_env = :e"), {"z": zid, "e": math_env},
+            ).mappings().first()
+            bid = conn.execute(
+                sa.text("select * from math_bidtopid where zid = :z and "
+                        "math_env = :e"), {"z": zid, "e": math_env},
+            ).mappings().first()
+            pts = conn.execute(
+                sa.text("select * from math_ptptstats where zid = :z and "
+                        "math_env = :e"), {"z": zid, "e": math_env},
+            ).mappings().first()
+    finally:
+        conn.close()
+    return (dict(main) if main else None,
+            dict(bid) if bid else None,
+            dict(pts) if pts else None)
+
+
+def response_problems(main, bid, pts):
+    """Everything wrong with the response a reader would build from this
+    snapshot.  Empty list == a usable, single-generation response."""
+    problems = []
+    if main is None:
+        return ["no math_main row: nothing to serve"]
+    if bid is None:
+        problems.append("math_bidtopid row absent while math_main is published")
+    if pts is None:
+        problems.append("math_ptptstats row absent while math_main is published")
+    if bid is not None and bid["math_tick"] != main["math_tick"]:
+        problems.append(
+            f"MIXED GENERATIONS: math_main math_tick={main['math_tick']} vs "
+            f"math_bidtopid math_tick={bid['math_tick']}"
+        )
+    if pts is not None and pts["math_tick"] != main["math_tick"]:
+        problems.append(
+            f"MIXED GENERATIONS: math_main math_tick={main['math_tick']} vs "
+            f"math_ptptstats math_tick={pts['math_tick']}"
+        )
+    if bid is not None:
+        problems.extend(_mapping_problems(main["data"], bid["data"]))
+    return problems
+
+
+def _mapping_problems(main_data, bid_data):
+    """``getPidsForGid``'s positional join (participants.ts:25-60): index a
+    group's base-cluster ids through ``base-clusters.id`` into ``bidToPid``."""
+    problems = []
+    ids = (main_data.get("base-clusters") or {}).get("id") or []
+    bid_to_pid = bid_data.get("bidToPid") or []
+    if len(ids) != len(bid_to_pid):
+        problems.append(
+            f"positional contract broken: base-clusters.id has {len(ids)} "
+            f"entries, bidToPid has {len(bid_to_pid)}"
+        )
+        return problems
+    bid_to_index = {b: i for i, b in enumerate(ids)}
+    known_pids = set()
+    for members in bid_to_pid:
+        known_pids.update(members)
+    for group in main_data.get("group-clusters") or []:
+        for member in group.get("members", []):
+            # group-clusters members are already unfolded to pids by the writer;
+            # the base-cluster ids are the ones that must resolve.
+            if member not in known_pids:
+                problems.append(
+                    f"group {group.get('id')} references pid {member!r} that "
+                    "no base cluster in this bidToPid contains"
+                )
+    for bid_id in ids:
+        if bid_id not in bid_to_index:
+            problems.append(f"base cluster {bid_id} has no bidToPid index")
+    return problems
+
+
+# --------------------------------------------------------------------------- #
+# Continuous reader while a write is paused mid-way
+# --------------------------------------------------------------------------- #
+class ContinuousReader(threading.Thread):
+    """Polls the reader's query pair until stopped, recording every snapshot."""
+
+    def __init__(self, engine, zid, math_env):
+        super().__init__(daemon=True)
+        self.engine = engine
+        self.zid = zid
+        self.math_env = math_env
+        self.snapshots = []
+        self._halt = threading.Event()
+
+    def run(self):
+        while not self._halt.is_set():
+            self.snapshots.append(read_generation(self.engine, self.zid,
+                                                  self.math_env))
+            self._halt.wait(0.01)
+
+    def stop(self):
+        self._halt.set()
+        self.join(timeout=30)
+
+    def incoherent(self):
+        return [response_problems(*s) for s in self.snapshots
+                if s[0] is not None and response_problems(*s)]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (predicted by P-022 §C): the three tables are published "
+        "NON-ATOMICALLY, so a reader can observe math_main at generation N "
+        "together with math_bidtopid/math_ptptstats at N-1 or absent. "
+        "polismath/poller/math_writer.py:238 makes three separate client "
+        "calls and each commits on its own engine.begin() "
+        "(polismath/database/postgres.py:413, :432). The consumer joins the "
+        "two blobs POSITIONALLY — server/src/utils/participants.ts:33-51 maps "
+        "base-clusters.id -> index -> bidToPid[index] — so a mixed pair is a "
+        "wrong participant mapping, not merely a stale one. P-022 §C: 'No "
+        "response may combine incompatible generations... Eventual repair "
+        "alone does not make a mixed mapping safe.' The fix is a transaction "
+        "spanning all three writes, or a reader-visible completed-generation "
+        "marker; that is a separate decision."
+    ),
+)
+def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service):
+    """Pause the writer after the main commit and before the bidtopid commit,
+    while a reader polls continuously."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()          # generation 1: complete
+
+    reader = ContinuousReader(engine, 1, MATH_ENV)
+    reader.start()
+
+    latch = Latch("write_math_bidtopid")
+    undo = latch_method(svc._pg, "write_math_bidtopid", latch)
+    from .conftest import commit_vote
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
+    svc._vote_wm = base
+
+    worker = threading.Thread(target=svc.poll_once, daemon=True)
+    worker.start()
+    latch.wait_arrival()
+    # The reader is running while math_main is committed and bidtopid is not.
+    eventually(lambda: len(reader.snapshots) > 3, timeout=10,
+               message="the reader took no snapshots during the pause")
+    latch.let_go()
+    worker.join(timeout=60)
+    undo()
+    reader.stop()
+
+    bad = reader.incoherent()
+    assert bad == [], (
+        f"{len(bad)} of {len(reader.snapshots)} reader snapshots combined "
+        f"incompatible generations, e.g. {bad[0]}"
+    )
+
+
+def test_the_mixed_window_is_real_and_observable(engine, pg_url, make_service):
+    """Companion to the xfail: assert the incoherent window EXISTS, so the
+    defect is documented directly rather than only as a failing expectation."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    first_tick = read_math_tables(engine, 1, MATH_ENV)["main"]["math_tick"]
+
+    latch = Latch("write_math_bidtopid")
+    undo = latch_method(svc._pg, "write_math_bidtopid", latch)
+    from .conftest import commit_vote
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
+    svc._vote_wm = base
+    worker = threading.Thread(target=svc.poll_once, daemon=True)
+    worker.start()
+    latch.wait_arrival()
+
+    main, bid, pts = read_generation(engine, 1, MATH_ENV)
+    assert main["math_tick"] > first_tick, "math_main advanced on its own"
+    assert bid["math_tick"] == first_tick, "math_bidtopid is a generation behind"
+    assert pts["math_tick"] == first_tick
+    problems = response_problems(main, bid, pts)
+    assert any("MIXED GENERATIONS" in p for p in problems), problems
+
+    latch.let_go()
+    worker.join(timeout=60)
+    undo()
+    assert tables_are_coherent(read_math_tables(engine, 1, MATH_ENV)) == []
+
+
+# --------------------------------------------------------------------------- #
+# Preexisting partial rows: repair on restart
+# --------------------------------------------------------------------------- #
+def test_preexisting_partial_rows_are_repaired(engine, pg_url, make_service):
+    """Seed a math_main row with NO bidtopid/ptptstats (the state a crash
+    between writes leaves) and require a subsequent cycle to repair it into a
+    single coherent generation matching the fold."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text("insert into math_main (zid, math_env, data, "
+                    "last_vote_timestamp, caching_tick, math_tick) values "
+                    "(:z, :e, cast(:d as jsonb), 0, 1, 7)"),
+            {"z": 1, "e": MATH_ENV, "d": json.dumps({"zid": 1})},
+        )
+    main, bid, pts = read_generation(engine, 1, MATH_ENV)
+    assert response_problems(main, bid, pts), "precondition: partial rows"
+
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    main, bid, pts = read_generation(engine, 1, MATH_ENV)
+    assert response_problems(main, bid, pts) == [], (
+        response_problems(main, bid, pts)
+    )
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(main["data"], fold) == []
+
+
+def test_absent_required_rows_fail_the_reader_check(engine, pg_url,
+                                                    make_service):
+    """"fail on absent/mismatched required rows": deleting either companion row
+    must make the reader check go red."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    assert response_problems(*read_generation(engine, 1, MATH_ENV)) == []
+
+    for table in ("math_bidtopid", "math_ptptstats"):
+        with engine.begin() as conn:
+            conn.execute(
+                sa.text(f"delete from {table} where zid=:z and math_env=:e"),
+                {"z": 1, "e": MATH_ENV},
+            )
+        problems = response_problems(*read_generation(engine, 1, MATH_ENV))
+        assert any(table in p for p in problems), (
+            f"deleting {table} was not detected: {problems}"
+        )
+
+
+def test_positional_bidtopid_contract_holds_for_a_complete_generation(
+    engine, pg_url, make_service
+):
+    """The contract the server relies on (``math_writer.py:42``): every base
+    cluster id has a positionally aligned bidToPid entry, and every group
+    member resolves."""
+    seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    main, bid, _pts = read_generation(engine, 1, MATH_ENV)
+    assert _mapping_problems(main["data"], bid["data"]) == []
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the partial-table / reader failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_an_atomic_three_table_write_is_never_observed_mixed(self, engine,
+                                                                 pg_url,
+                                                                 make_service):
+        """Intentionally 'fixed' variant: write all three rows inside ONE
+        transaction and show the continuous reader never observes a split.
+        This proves the observer above can distinguish atomic from non-atomic
+        publication — the xfail is about the writer, not about the check."""
+        seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        svc.poll_once()
+        tables = read_math_tables(engine, 1, MATH_ENV)
+        blob = tables["main"]["data"]
+        bid_blob = tables["bidtopid"]["data"]
+        pts_blob = tables["ptptstats"]["data"]
+
+        reader = ContinuousReader(engine, 1, MATH_ENV)
+        reader.start()
+        for tick in range(50, 55):
+            with engine.begin() as conn:      # ONE transaction for all three
+                conn.execute(
+                    sa.text("update math_main set math_tick=:t, data=cast(:d as "
+                            "jsonb) where zid=:z and math_env=:e"),
+                    {"t": tick, "d": json.dumps(blob), "z": 1, "e": MATH_ENV})
+                conn.execute(
+                    sa.text("update math_bidtopid set math_tick=:t, "
+                            "data=cast(:d as jsonb) where zid=:z and "
+                            "math_env=:e"),
+                    {"t": tick, "d": json.dumps(bid_blob), "z": 1,
+                     "e": MATH_ENV})
+                conn.execute(
+                    sa.text("update math_ptptstats set math_tick=:t, "
+                            "data=cast(:d as jsonb) where zid=:z and "
+                            "math_env=:e"),
+                    {"t": tick, "d": json.dumps(pts_blob), "z": 1,
+                     "e": MATH_ENV})
+        reader.stop()
+
+        assert len(reader.snapshots) > 1
+        assert reader.incoherent() == [], (
+            "NEGATIVE CONTROL FAILED: an ATOMIC three-table write was still "
+            "observed as a mixed generation, so the reader check has a false "
+            f"positive: {reader.incoherent()[:1]}"
+        )
+
+    def test_a_deliberately_misaligned_mapping_is_caught(self, engine, pg_url,
+                                                         make_service):
+        """Break the positional contract on purpose; the mapping check must
+        detect it."""
+        seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        svc.poll_once()
+        main, bid, _pts = read_generation(engine, 1, MATH_ENV)
+        broken = dict(bid["data"])
+        broken["bidToPid"] = broken["bidToPid"][:-1]      # drop one bucket
+        problems = _mapping_problems(main["data"], broken)
+        assert problems, (
+            "NEGATIVE CONTROL FAILED: a truncated bidToPid was accepted as "
+            "positionally aligned"
+        )

--- a/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
+++ b/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
@@ -157,26 +157,8 @@ class ContinuousReader(threading.Thread):
                 if s[0] is not None and response_problems(*s)]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "DEFECT (predicted by P-022 §C): the three tables are published "
-        "NON-ATOMICALLY, so a reader can observe math_main at generation N "
-        "together with math_bidtopid/math_ptptstats at N-1 or absent. "
-        "polismath/poller/math_writer.py:238 makes three separate client "
-        "calls and each commits on its own engine.begin() "
-        "(polismath/database/postgres.py:413, :432). The consumer joins the "
-        "two blobs POSITIONALLY — server/src/utils/participants.ts:33-51 maps "
-        "base-clusters.id -> index -> bidToPid[index] — so a mixed pair is a "
-        "wrong participant mapping, not merely a stale one. P-022 §C: 'No "
-        "response may combine incompatible generations... Eventual repair "
-        "alone does not make a mixed mapping safe.' The fix is a transaction "
-        "spanning all three writes, or a reader-visible completed-generation "
-        "marker; that is a separate decision."
-    ),
-)
 def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service):
-    """Pause the writer after the main commit and before the bidtopid commit,
+    """Pause the writer after the main write and before the bidtopid write,
     while a reader polls continuously."""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
@@ -195,7 +177,7 @@ def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service):
     worker = threading.Thread(target=svc.poll_once, daemon=True)
     worker.start()
     latch.wait_arrival()
-    # The reader is running while math_main is committed and bidtopid is not.
+    # Main has executed, but the full snapshot is still uncommitted.
     eventually(lambda: len(reader.snapshots) > 3, timeout=10,
                message="the reader took no snapshots during the pause")
     latch.let_go()
@@ -210,13 +192,25 @@ def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service):
     )
 
 
-def test_the_mixed_window_is_real_and_observable(engine, pg_url, make_service):
-    """Companion to the xfail: assert the incoherent window EXISTS, so the
-    defect is documented directly rather than only as a failing expectation."""
+def test_legacy_mixed_window_is_real_and_observable(engine, pg_url, make_service,
+                                                    monkeypatch):
+    """Negative control: the intentionally non-atomic legacy writer MUST expose
+    a mixed window. Keep the original defect assertions load-bearing."""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
     svc.poll_once()
     first_tick = read_math_tables(engine, 1, MATH_ENV)["main"]["math_tick"]
+
+    from contextlib import nullcontext
+    real_transaction = svc._pg.transaction
+    real_returning = svc._pg._write_returning
+
+    def legacy_returning(sql, params=None, *, connection=None):
+        with real_transaction() as conn:
+            return real_returning(sql, params, connection=conn)
+
+    monkeypatch.setattr(svc._pg, "transaction", lambda: nullcontext(None))
+    monkeypatch.setattr(svc._pg, "_write_returning", legacy_returning)
 
     latch = Latch("write_math_bidtopid")
     undo = latch_method(svc._pg, "write_math_bidtopid", latch)
@@ -314,7 +308,7 @@ class TestNegativeControl:
         """Intentionally 'fixed' variant: write all three rows inside ONE
         transaction and show the continuous reader never observes a split.
         This proves the observer above can distinguish atomic from non-atomic
-        publication — the xfail is about the writer, not about the check."""
+        publication — the regression is about the writer, not about the check."""
         seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
         svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
         svc.poll_once()

--- a/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
+++ b/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
@@ -158,8 +158,10 @@ class ContinuousReader(threading.Thread):
 
 
 def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service):
-    """Pause the writer after the main write and before the bidtopid write,
-    while a reader polls continuously."""
+    """Pause the writer between the table writes — after bidtopid and ptptstats
+    have executed and before math_main, which the writer now emits last — while
+    a reader polls continuously. That is the widest window in which a reader
+    could observe a mixed generation."""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
     svc.poll_once()          # generation 1: complete
@@ -167,8 +169,8 @@ def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service):
     reader = ContinuousReader(engine, 1, MATH_ENV)
     reader.start()
 
-    latch = Latch("write_math_bidtopid")
-    undo = latch_method(svc._pg, "write_math_bidtopid", latch)
+    latch = Latch("write_math_main")
+    undo = latch_method(svc._pg, "write_math_main", latch)
     from .conftest import commit_vote
     base = max(e["created"] for e in read_vote_events(engine, 1))
     commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
@@ -177,7 +179,7 @@ def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service):
     worker = threading.Thread(target=svc.poll_once, daemon=True)
     worker.start()
     latch.wait_arrival()
-    # Main has executed, but the full snapshot is still uncommitted.
+    # Both companions have executed, but the full snapshot is still uncommitted.
     eventually(lambda: len(reader.snapshots) > 3, timeout=10,
                message="the reader took no snapshots during the pause")
     latch.let_go()
@@ -212,8 +214,10 @@ def test_legacy_mixed_window_is_real_and_observable(engine, pg_url, make_service
     monkeypatch.setattr(svc._pg, "transaction", lambda: nullcontext(None))
     monkeypatch.setattr(svc._pg, "_write_returning", legacy_returning)
 
-    latch = Latch("write_math_bidtopid")
-    undo = latch_method(svc._pg, "write_math_bidtopid", latch)
+    # Pause after the FIRST table write commits on its own: with separate
+    # commits, whichever table goes first is a generation ahead of the rest.
+    latch = Latch("write_participant_stats")
+    undo = latch_method(svc._pg, "write_participant_stats", latch)
     from .conftest import commit_vote
     base = max(e["created"] for e in read_vote_events(engine, 1))
     commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
@@ -223,8 +227,8 @@ def test_legacy_mixed_window_is_real_and_observable(engine, pg_url, make_service
     latch.wait_arrival()
 
     main, bid, pts = read_generation(engine, 1, MATH_ENV)
-    assert main["math_tick"] > first_tick, "math_main advanced on its own"
-    assert bid["math_tick"] == first_tick, "math_bidtopid is a generation behind"
+    assert bid["math_tick"] > first_tick, "math_bidtopid advanced on its own"
+    assert main["math_tick"] == first_tick, "math_main is a generation behind"
     assert pts["math_tick"] == first_tick
     problems = response_problems(main, bid, pts)
     assert any("MIXED GENERATIONS" in p for p in problems), problems

--- a/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
+++ b/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
@@ -106,7 +106,7 @@ def test_failing_math_main_load_cold_starts_without_a_false_empty(engine,
                                                                   pg_url,
                                                                   make_service):
     """``_load_or_init`` swallows a ``load_math_main`` failure and cold-starts
-    (``service.py:568``).  That is safe ONLY because the rebuild then reads the
+    (``service.py:570``).  That is safe ONLY because the rebuild then reads the
     full authoritative vote history — assert the published result is the full
     fold, not an empty conversation."""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)

--- a/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
+++ b/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
@@ -1,0 +1,336 @@
+"""R10 — poll/load failure and fairness (REAL Postgres).
+
+P-022 §C required matrix:
+
+    Fail vote/mod SELECT, math_main load and full-history load; verify no false
+    empty publication or inappropriate watermark advancement, and subsequent
+    quiet recovery.  One poison zid must not starve healthy zids.  Exhaust a
+    join timeout: ``poll_once`` must surface failure, not successful completion
+    (``service.py:350``).
+"""
+
+import threading
+import time
+
+import pytest
+
+from .conftest import (
+    FaultInjector,
+    InjectedFault,
+    commit_vote,
+    drain,
+    fail_stage,
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+
+def _assert_published(engine, zid):
+    tables = read_math_tables(engine, zid, MATH_ENV)
+    assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, zid))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    return tables
+
+
+# --------------------------------------------------------------------------- #
+# Poll SELECT failures
+# --------------------------------------------------------------------------- #
+def test_failing_vote_select_does_not_advance_the_watermark(engine, pg_url,
+                                                            make_service):
+    """A failed vote poll must leave the watermark untouched (so nothing is
+    skipped) and must recover on the next cycle."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    before = svc._vote_wm
+
+    injector = FaultInjector(name="poll_votes_since", mode="always")
+    undo = fail_stage(svc._pg, "poll_votes_since", injector)
+    with pytest.raises(InjectedFault):
+        svc._poll_votes_once()
+    undo()
+
+    assert svc._vote_wm == before, "a failed poll must not advance the watermark"
+    assert read_math_tables(engine, 1, MATH_ENV)["main"] is None
+
+    svc.poll_once()
+    _assert_published(engine, 1)
+
+
+def test_failing_moderation_select_does_not_advance_the_watermark(engine,
+                                                                  pg_url,
+                                                                  make_service):
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    before = svc._mod_wm
+
+    injector = FaultInjector(name="poll_moderation_since", mode="always")
+    undo = fail_stage(svc._pg, "poll_moderation_since", injector)
+    with pytest.raises(InjectedFault):
+        svc._poll_moderation_once()
+    undo()
+
+    assert svc._mod_wm == before
+    svc.poll_once()
+    _assert_published(engine, 1)
+
+
+def test_vote_loop_survives_a_failing_poll_and_recovers(engine, pg_url,
+                                                        make_service):
+    """The running loop swallows and logs the poll failure (``_vote_loop``,
+    ``service.py:367``) and the very next cycle publishes correctly."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    injector = FaultInjector(name="poll_votes_since", mode="once")
+    undo = fail_stage(svc._pg, "poll_votes_since", injector)
+    try:
+        svc._poll_votes_once()
+    except InjectedFault:
+        pass
+    undo()
+    svc.poll_once()
+    _assert_published(engine, 1)
+
+
+# --------------------------------------------------------------------------- #
+# Load failures
+# --------------------------------------------------------------------------- #
+def test_failing_math_main_load_cold_starts_without_a_false_empty(engine,
+                                                                  pg_url,
+                                                                  make_service):
+    """``_load_or_init`` swallows a ``load_math_main`` failure and cold-starts
+    (``service.py:568``).  That is safe ONLY because the rebuild then reads the
+    full authoritative vote history — assert the published result is the full
+    fold, not an empty conversation."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+    svc.poll_once()
+    _assert_published(engine, 1)
+
+    injector = FaultInjector(name="load_math_main", mode="always")
+    undo = fail_stage(svc._pg, "load_math_main", injector)
+    svc._convs.pop(1, None)
+    base = max(e["created"] for e in read_vote_events(engine, 1))
+    commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
+    svc._vote_wm = base
+    svc.poll_once()
+    undo()
+
+    assert injector.fired >= 1, "the load failure must have fired"
+    tables = _assert_published(engine, 1)
+    assert tables["main"]["data"]["n"] == 6, (
+        "a swallowed load failure must not publish an EMPTY conversation"
+    )
+
+
+def test_failing_full_history_load_never_publishes(engine, pg_url,
+                                                   make_service):
+    """A failing full-history ``poll_votes`` is NOT swallowed: it must abort the
+    cycle (retry/park) rather than publish an empty or partial conversation."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       retry_cap=0)
+
+    injector = FaultInjector(name="poll_votes", mode="always")
+    undo = fail_stage(svc._pg, "poll_votes", injector)
+    svc.poll_once()
+    undo()
+
+    assert injector.fired >= 1
+    assert 1 in svc._parked, "the zid must park rather than publish"
+    assert read_math_tables(engine, 1, MATH_ENV)["main"] is None, (
+        "a failed full-history load must never publish a false empty result"
+    )
+
+    svc._reconcile_once()
+    drain(svc)
+    _assert_published(engine, 1)
+
+
+def test_an_existing_row_is_never_replaced_by_an_empty_one(engine, pg_url,
+                                                           make_service):
+    """The worst false-empty shape: a good math_main row must never be
+    overwritten by an empty conversation because a load failed."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       retry_cap=0)
+    svc.poll_once()
+    good = read_math_tables(engine, 1, MATH_ENV)["main"]
+
+    load_fault = FaultInjector(name="load_math_main", mode="always")
+    hist_fault = FaultInjector(name="poll_votes", mode="always")
+    undo1 = fail_stage(svc._pg, "load_math_main", load_fault)
+    undo2 = fail_stage(svc._pg, "poll_votes", hist_fault)
+    svc._convs.pop(1, None)
+    svc._pool.submit(1, "rebuild", [])
+    drain(svc)
+    undo1()
+    undo2()
+
+    after = read_math_tables(engine, 1, MATH_ENV)["main"]
+    assert after["data"] == good["data"], (
+        "the previously published row was replaced while both loads were "
+        "failing"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Fairness
+# --------------------------------------------------------------------------- #
+def test_one_poison_zid_does_not_starve_healthy_zids(engine, pg_url,
+                                                     make_service):
+    """A permanently failing zid must not stop healthy conversations from
+    making progress, across repeated cycles."""
+    zids = [1, 2, 3, 4]
+    for zid in zids:
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=2,
+                       retry_cap=1)
+
+    real_write = svc._writer.write_conv_updates
+    attempts = {"poison": 0}
+
+    def poison(zid, conv):
+        if zid == 1:
+            attempts["poison"] += 1
+            raise InjectedFault("poison zid")
+        return real_write(zid, conv)
+
+    svc._writer.write_conv_updates = poison
+
+    for cycle in range(3):
+        svc._vote_wm = 0
+        svc.poll_once()
+        for zid in zids[1:]:
+            assert read_math_tables(engine, zid, MATH_ENV)["main"] is not None, (
+                f"healthy zid {zid} starved on cycle {cycle}"
+            )
+    svc._writer.write_conv_updates = real_write
+
+    assert 1 in svc._parked, "the poison zid must be visibly parked"
+    for zid in zids[1:]:
+        _assert_published(engine, zid)
+    # Bounded, not a hot loop: 2 attempts to park + 2 per later reconcile pass.
+    assert attempts["poison"] <= 2 + 2 * 3, (
+        f"the poison zid consumed {attempts['poison']} attempts — unbounded "
+        "retrying starves the pool"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The join timeout
+# --------------------------------------------------------------------------- #
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (P-022 §C R10): poll_once IGNORES the pool join result. "
+        "polismath/poller/service.py:365 calls `self._pool.join(timeout=120.0)` "
+        "and discards its boolean; ConversationWorkerPool.join returns False on "
+        "timeout (polismath/poller/worker_pool.py:156). So a cycle whose work "
+        "never drained returns NORMALLY and looks like a completed poll — the "
+        "`--once` CLI exits 0, and the integration harness treats a stuck "
+        "conversation as a successful cycle. P-022 §C: 'Exhaust a join timeout: "
+        "poll_once must surface failure, not successful completion.' The fix is "
+        "to raise (or return a status) when join() is False; that is a separate "
+        "decision."
+    ),
+)
+def test_poll_once_surfaces_a_join_timeout(engine, pg_url, make_service):
+    """Stall a worker past the join bound and require ``poll_once`` to surface
+    the failure instead of returning as if the cycle completed."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+
+    stalled = threading.Event()
+    release = threading.Event()
+    real_load = svc._load_or_init
+
+    def stalling_load(zid):
+        stalled.set()
+        release.wait(timeout=60)
+        return real_load(zid)
+
+    svc._load_or_init = stalling_load
+
+    # Shrink the join bound so the timeout is reached deterministically, and
+    # observe what poll_once does with it.
+    real_join = svc._pool.join
+    svc._pool.join = lambda timeout=120.0: real_join(timeout=0.5)
+
+    result = {"returned": False, "raised": None}
+
+    def run():
+        try:
+            svc.poll_once()
+            result["returned"] = True
+        except BaseException as exc:
+            result["raised"] = exc
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    assert stalled.wait(timeout=30), "the worker never stalled"
+    thread.join(timeout=30)
+
+    try:
+        assert result["raised"] is not None or not result["returned"], (
+            "poll_once returned normally after its pool join timed out with "
+            "work still in flight — a stuck cycle is indistinguishable from a "
+            "successful one"
+        )
+    finally:
+        release.set()
+        svc._pool.join = real_join
+        svc._load_or_init = real_load
+        drain(svc)
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the poll/load failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_watermark_that_advances_on_failure_is_caught(self, engine,
+                                                            pg_url,
+                                                            make_service):
+        """Intentionally broken variant: advance the watermark BEFORE the
+        (failing) poll.  The R10 assertion must go red, proving it can see an
+        inappropriate advancement."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        before = svc._vote_wm
+
+        def broken_poll(since):
+            svc._vote_wm = since + 1_000_000   # advance first, then fail
+            raise InjectedFault("poll failed after advancing")
+
+        svc._pg.poll_votes_since = broken_poll
+        with pytest.raises(InjectedFault):
+            svc._poll_votes_once()
+
+        with pytest.raises(AssertionError):
+            assert svc._vote_wm == before, "a failed poll must not advance"
+
+    def test_a_false_empty_publication_is_caught(self, engine, pg_url,
+                                                 make_service):
+        """Publish an EMPTY conversation on purpose; the fold check must reject
+        it."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        real_history = svc._pg.poll_votes
+        svc._pg.poll_votes = lambda zid, since=None: []
+        svc.poll_once()
+        svc._pg.poll_votes = real_history
+
+        tables = read_math_tables(engine, 1, MATH_ENV)
+        fold = F.fold_votes(read_vote_events(engine, 1))
+        problems = F.check_published_against_fold(tables["main"]["data"], fold)
+        assert problems, (
+            "NEGATIVE CONTROL FAILED: an EMPTY publication was accepted as "
+            "matching a conversation with 12 votes"
+        )

--- a/delphi/tests/poller/recovery/test_r11_namespace_config.py
+++ b/delphi/tests/poller/recovery/test_r11_namespace_config.py
@@ -1,0 +1,321 @@
+"""R11 — math_env namespace isolation and effective configuration (REAL PG).
+
+P-022 §C required matrix:
+
+    Assert all reads, writes and restore operations stay in the selected math
+    env; validate negative/zero cap policy, shard bounds and effective container
+    settings.  A shadow job cannot mutate prod math rows.
+
+The write side holds: every writer and ``load_math_main`` is scoped by
+``math_env`` and ``UNIQUE(zid, math_env)`` keeps the namespaces apart.  The
+READER side does not: the server's prefetch query is not math_env-scoped, so a
+shadow row still reaches the server's in-process PCA cache.  That is asserted
+below against the server's own SQL.
+"""
+
+import json
+import os
+import re
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+from polismath.poller.service import PollerConfig
+
+pytestmark = pytest.mark.recovery
+
+PROD_ENV = "prod"
+SHADOW_ENV = "python"
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
+
+
+def _seed_prod_rows(engine, zid: int):
+    """A pre-existing, complete prod generation the shadow job must not touch."""
+    blob = {"zid": zid, "sentinel": "PROD-ROW-DO-NOT-TOUCH", "n": 999}
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text("insert into math_main (zid, math_env, data, "
+                    "last_vote_timestamp, caching_tick, math_tick) values "
+                    "(:z, :e, cast(:d as jsonb), 42, 5, 5)"),
+            {"z": zid, "e": PROD_ENV, "d": json.dumps(blob)},
+        )
+        conn.execute(
+            sa.text("insert into math_bidtopid (zid, math_env, math_tick, data) "
+                    "values (:z, :e, 5, cast(:d as jsonb))"),
+            {"z": zid, "e": PROD_ENV, "d": json.dumps({"bidToPid": [[0]]})},
+        )
+        conn.execute(
+            sa.text("insert into math_ptptstats (zid, math_env, math_tick, data) "
+                    "values (:z, :e, 5, cast(:d as jsonb))"),
+            {"z": zid, "e": PROD_ENV, "d": json.dumps({"ptptstats": {}})},
+        )
+        conn.execute(
+            sa.text("insert into math_ticks (zid, math_env, math_tick, "
+                    "caching_tick) values (:z, :e, 5, 5)"),
+            {"z": zid, "e": PROD_ENV},
+        )
+    return blob
+
+
+def _prod_snapshot(engine, zid: int):
+    with engine.connect() as conn:
+        return {
+            name: [dict(r) for r in conn.execute(
+                sa.text(f"select * from {name} where zid=:z and math_env=:e "
+                        "order by zid"), {"z": zid, "e": PROD_ENV}).mappings()]
+            for name in ("math_main", "math_bidtopid", "math_ptptstats",
+                         "math_ticks")
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Write / restore isolation
+# --------------------------------------------------------------------------- #
+def test_shadow_job_never_mutates_prod_math_rows(engine, pg_url, make_service):
+    """A full shadow cycle must leave every prod row byte-identical."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    _seed_prod_rows(engine, 1)
+    before = _prod_snapshot(engine, 1)
+
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    assert _prod_snapshot(engine, 1) == before, (
+        "the shadow job mutated prod math rows"
+    )
+    shadow = read_math_tables(engine, 1, SHADOW_ENV)
+    assert tables_are_coherent(shadow) == [], tables_are_coherent(shadow)
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(shadow["main"]["data"], fold) == []
+
+
+def test_restore_never_reads_another_math_env(engine, pg_url, make_service):
+    """``load_math_main`` (``database/postgres.py:763``) filters by math_env, so
+    a cold shadow start must NOT restore the prod blob."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    sentinel = _seed_prod_rows(engine, 1)["sentinel"]
+
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    assert svc._pg.load_math_main(1) is None, (
+        "a shadow client must not see the prod row"
+    )
+    svc.poll_once()
+    published = json.dumps(read_math_tables(engine, 1, SHADOW_ENV)["main"]["data"])
+    assert sentinel not in published, (
+        "prod state leaked into the shadow namespace's published blob"
+    )
+
+
+def test_math_tick_counters_are_per_math_env(engine, pg_url, make_service):
+    """``increment_math_tick`` upserts on (zid, math_env), so the two namespaces
+    keep independent counters."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    _seed_prod_rows(engine, 1)
+
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    for _ in range(3):
+        svc._vote_wm = 0
+        svc.poll_once()
+
+    with engine.connect() as conn:
+        rows = {r["math_env"]: r["math_tick"] for r in conn.execute(
+            sa.text("select math_env, math_tick from math_ticks where zid=1")
+        ).mappings()}
+    assert rows[PROD_ENV] == 5, "the prod counter must not move"
+    assert rows[SHADOW_ENV] >= 2, f"the shadow counter must advance: {rows}"
+
+
+def test_caching_tick_is_scoped_to_its_math_env(engine, pg_url, make_service):
+    """``write_math_main``'s caching_tick subquery is
+    ``max(caching_tick)+1 WHERE math_env = ?`` (``database/postgres.py:838``),
+    so each namespace has its OWN cursor sequence — which is why the two
+    sequences overlap numerically (see R12)."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    _seed_prod_rows(engine, 1)          # prod caching_tick = 5
+
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    svc.poll_once()
+    shadow_tick = read_math_tables(engine, 1, SHADOW_ENV)["main"]["caching_tick"]
+    assert shadow_tick == 1, (
+        f"the shadow namespace must start its own cursor at 1, saw {shadow_tick}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The reader side of namespace isolation
+# --------------------------------------------------------------------------- #
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (R11 reader side): the server's PCA PREFETCH is not scoped to "
+        "math_env. server/src/utils/pca.ts:98 runs `select * from math_main "
+        "where caching_tick > ($1) order by caching_tick limit 10` with NO "
+        "math_env predicate, then calls processMathObject/updatePcaCache on "
+        "every row (pca.ts:117-137). Point reads ARE scoped "
+        "(server/src/utils/pca.ts:360, participants.ts:10), so the hazard is "
+        "specific to the prefetch cache: while a shadow poller writes under "
+        "MATH_ENV=python (docker-compose.yml:169) with the server on prod, the "
+        "shadow's rows enter the prod server's in-process PCA cache keyed by "
+        "zid alone. P-022 §C R11: 'Assert all reads, writes and restore "
+        "operations stay in the selected math env.' The writes and restores "
+        "do; this read does not. Fix: add `and math_env = ($2)` to the "
+        "prefetch, which is a server change and a separate decision."
+    ),
+)
+def test_the_server_prefetch_query_is_math_env_scoped(engine, pg_url,
+                                                      make_service):
+    """Run the server's OWN prefetch SQL and require it to return only rows of
+    the server's configured math_env."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    _seed_prod_rows(engine, 1)
+
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    # Verbatim from server/src/utils/pca.ts:98 (the deployed prefetch).
+    with engine.connect() as conn:
+        rows = [dict(r) for r in conn.execute(
+            sa.text("select * from math_main where caching_tick > :last "
+                    "order by caching_tick limit 10"), {"last": -1},
+        ).mappings()]
+    envs = sorted({r["math_env"] for r in rows})
+    assert envs == [PROD_ENV], (
+        f"the prefetch returned rows from {envs}; a server on {PROD_ENV!r} "
+        "would cache the shadow namespace's PCA blob"
+    )
+
+
+def test_the_server_point_reads_are_math_env_scoped(engine, pg_url,
+                                                    make_service):
+    """The scoping that DOES hold, asserted so the xfail above is narrow: the
+    per-zid reads used by getPca and getBidIndexToPidMapping filter on
+    math_env."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    sentinel = _seed_prod_rows(engine, 1)["sentinel"]
+    svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+    svc.poll_once()
+
+    with engine.connect() as conn:
+        main = conn.execute(
+            sa.text("select * from math_main where zid = :z and math_env = :e"),
+            {"z": 1, "e": PROD_ENV},
+        ).mappings().first()
+        bid = conn.execute(
+            sa.text("select * from math_bidtopid where zid = :z and "
+                    "math_env = :e"), {"z": 1, "e": PROD_ENV},
+        ).mappings().first()
+    assert main["data"]["sentinel"] == sentinel
+    assert bid["data"] == {"bidToPid": [[0]]}
+
+
+# --------------------------------------------------------------------------- #
+# Configuration policy
+# --------------------------------------------------------------------------- #
+def test_cache_cap_policy(monkeypatch):
+    """0 = unlimited (explicit and documented), positive = a real LRU bound,
+    negative rejected at construction."""
+    assert PollerConfig().conv_cache_cap == 200, "the default must be FINITE"
+    assert PollerConfig(conv_cache_cap=0).conv_cache_cap == 0
+    with pytest.raises(ValueError, match="conv_cache_cap must be >= 0"):
+        PollerConfig(conv_cache_cap=-1)
+
+    monkeypatch.setenv("MATH_CONV_CACHE_CAP", "-5")
+    with pytest.raises(ValueError, match="conv_cache_cap must be >= 0"):
+        PollerConfig.from_env()
+
+
+def test_shard_bounds_policy():
+    with pytest.raises(ValueError):
+        PollerConfig(shard_index=3, shard_count=3)
+    with pytest.raises(ValueError):
+        PollerConfig(shard_count=0)
+    assert PollerConfig(shard_index=2, shard_count=3).shard_index == 2
+
+
+def test_effective_container_settings_reach_the_config(monkeypatch):
+    """"validate ... effective container settings": every env var the compose
+    math-python service sets must actually be consumed by ``from_env``."""
+    monkeypatch.setenv("MATH_ENV", "python")
+    monkeypatch.setenv("MATH_CONV_CACHE_CAP", "37")
+    monkeypatch.setenv("MATH_POLLER_RECONCILE_INTERVAL_MS", "1234")
+    monkeypatch.setenv("POLL_SHARD_INDEX", "1")
+    monkeypatch.setenv("POLL_SHARD_COUNT", "4")
+    monkeypatch.setenv("MATH_WORKER_POOL_SIZE", "3")
+    monkeypatch.setenv("MATH_POLLER_RETRY_CAP", "2")
+    monkeypatch.setenv("POLL_FROM_DAYS_AGO", "7")
+
+    cfg = PollerConfig.from_env()
+    assert cfg.math_env == "python"
+    assert cfg.conv_cache_cap == 37
+    assert cfg.reconcile_interval_ms == 1234
+    assert (cfg.shard_index, cfg.shard_count) == (1, 4)
+    assert cfg.worker_pool_size == 3
+    assert cfg.retry_cap == 2
+    assert cfg.poll_from_days_ago == 7
+
+
+def test_compose_math_python_service_passes_the_required_settings():
+    """The container definition must actually forward the settings above, or
+    the validated defaults never reach the deployed process."""
+    with open(os.path.join(_REPO_ROOT, "docker-compose.yml")) as fh:
+        compose = fh.read()
+    service = compose.split("  math-python:", 1)[1].split("\n  postgres:", 1)[0]
+    for var in ("MATH_ENV", "MATH_CONV_CACHE_CAP",
+                "MATH_POLLER_RECONCILE_INTERVAL_MS", "POLL_SHARD_INDEX",
+                "POLL_SHARD_COUNT", "MATH_WORKER_POOL_SIZE",
+                "MATH_POLLER_RETRY_CAP", "POLL_FROM_DAYS_AGO"):
+        assert re.search(rf"^\s*-\s*{var}=", service, re.M), (
+            f"docker-compose.yml's math-python service does not pass {var}"
+        )
+    assert "MATH_ENV=${MATH_PYTHON_ENV:-python}" in service, (
+        "the shadow service must default to a DISTINCT math_env"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the namespace failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_an_unscoped_writer_is_caught(self, engine, pg_url, make_service):
+        """Intentionally broken variant: a writer that ignores math_env and
+        overwrites the prod row.  The isolation assertion must go red."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        _seed_prod_rows(engine, 1)
+        before = _prod_snapshot(engine, 1)
+
+        with engine.begin() as conn:      # the broken write
+            conn.execute(
+                sa.text("update math_main set data = cast(:d as jsonb) "
+                        "where zid = :z"),
+                {"d": json.dumps({"zid": 1, "sentinel": "SHADOW"}), "z": 1},
+            )
+        assert _prod_snapshot(engine, 1) != before, (
+            "NEGATIVE CONTROL FAILED: an unscoped write to math_main did not "
+            "change the prod snapshot, so the isolation assertion is vacuous"
+        )
+
+    def test_the_prefetch_control_would_pass_when_scoped(self, engine, pg_url,
+                                                         make_service):
+        """The 'fixed' prefetch (with a math_env predicate) returns only prod
+        rows — proving the xfail above is about the missing predicate."""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        _seed_prod_rows(engine, 1)
+        svc = make_service(pg_url, math_env=SHADOW_ENV, worker_pool_size=1)
+        svc.poll_once()
+
+        with engine.connect() as conn:
+            rows = [dict(r) for r in conn.execute(
+                sa.text("select * from math_main where caching_tick > :last "
+                        "and math_env = :e order by caching_tick limit 10"),
+                {"last": -1, "e": PROD_ENV},
+            ).mappings()]
+        assert sorted({r["math_env"] for r in rows}) == [PROD_ENV]

--- a/delphi/tests/poller/recovery/test_r12_publication_cursor.py
+++ b/delphi/tests/poller/recovery/test_r12_publication_cursor.py
@@ -10,9 +10,18 @@ P-022 §C required matrix:
 
 Two halves, both real:
 
-* the WRITER's cursor allocation — ``polismath/database/postgres.py:838``'s
-  ``COALESCE((select max(caching_tick) + 1 from math_main where math_env = ?), 1)``,
-  evaluated inside each write's own transaction;
+* the WRITER's cursor allocation — ``polismath/database/postgres.py:878``'s
+  ``COALESCE((select max(caching_tick) + 1 from math_main where math_env = ?), 1)``.
+  It is now evaluated inside the ONE publication transaction that also mints the
+  math_tick and writes all three tables (``math_writer.py:227``), not inside a
+  per-table transaction — the R05/R09 fix.  That makes the snapshot atomic but
+  changes nothing here: the allocation is still a non-serializable read at READ
+  COMMITTED with no uniqueness constraint on ``caching_tick``, so two zids
+  publishing concurrently can still allocate the same value and still commit out
+  of cursor order.  ``write_math_main`` is deliberately the last statement
+  before the COMMIT so the allocate -> commit window stays as short as it was
+  when each write autocommitted;
+
 * the READER's cursor consumption — ``server/src/utils/pca.ts:98``'s
   ``select * from math_main where caching_tick > ($1) order by caching_tick
   limit 10``, with ``lastPrefetchedMathTick`` advanced to the largest
@@ -151,10 +160,15 @@ def test_two_concurrent_publications_allocate_the_SAME_cursor(engine, pg_url):
     strict=True,
     reason=(
         "DEFECT (predicted by P-022 §C): MAX(caching_tick)+1 is not a safe "
-        "global change cursor. polismath/database/postgres.py:838 allocates "
+        "global change cursor. polismath/database/postgres.py:878 allocates "
         "`COALESCE((select max(caching_tick)+1 from math_main where math_env = "
-        "?), 1)` INSIDE each write's own transaction, so two conversations "
-        "publishing concurrently allocate the SAME value; the consumer "
+        "?), 1)` inside the single publication transaction that mints the "
+        "math_tick and writes all three tables (math_writer.py:227). That "
+        "transaction made the SNAPSHOT atomic (R05/R09) but does not serialize "
+        "the allocation: it is still a plain read at READ COMMITTED with no "
+        "predicate lock and no uniqueness constraint on caching_tick, so two "
+        "conversations publishing concurrently allocate the SAME value; the "
+        "consumer "
         "(server/src/utils/pca.ts:98, :130-132) polls `caching_tick > "
         "lastPrefetchedMathTick` and advances the cursor to the largest value "
         "it saw. If the reader advances past a value between the two commits, "

--- a/delphi/tests/poller/recovery/test_r12_publication_cursor.py
+++ b/delphi/tests/poller/recovery/test_r12_publication_cursor.py
@@ -1,0 +1,364 @@
+"""R12 — the concurrent publication cursor (REAL Postgres, two real connections).
+
+P-022 §C required matrix:
+
+    Two different zids publish concurrently; hold one transaction while the
+    other commits and the Node prefetcher advances.  Require both conversations
+    to become visible without a later update.  Exercise equal caching ticks and
+    out-of-order commits; do not assume ``MAX(caching_tick)+1`` is a safe global
+    change cursor.
+
+Two halves, both real:
+
+* the WRITER's cursor allocation — ``polismath/database/postgres.py:838``'s
+  ``COALESCE((select max(caching_tick) + 1 from math_main where math_env = ?), 1)``,
+  evaluated inside each write's own transaction;
+* the READER's cursor consumption — ``server/src/utils/pca.ts:98``'s
+  ``select * from math_main where caching_tick > ($1) order by caching_tick
+  limit 10``, with ``lastPrefetchedMathTick`` advanced to the largest
+  ``caching_tick`` seen (``pca.ts:130-132``).
+
+The writer SQL is reproduced verbatim in :func:`allocate_and_write` so a
+transaction can be HELD open across the allocation; a companion test proves the
+production client produces the same allocation, so the transcription is not
+drifting from the code under test.
+"""
+
+import json
+import threading
+
+import pytest
+import sqlalchemy as sa
+
+from .conftest import (
+    read_math_tables,
+    read_vote_events,
+    seed_conversation,
+    tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+
+MATH_ENV = "recovery"
+
+# Verbatim from polismath/database/postgres.py:834-847 (write_math_main).
+_WRITE_MAIN_SQL = sa.text("""
+    insert into math_main
+        (zid, math_env, last_vote_timestamp, math_tick, data, caching_tick)
+    values
+        (:zid, :math_env, :last_vote_timestamp, :math_tick,
+         cast(:data as jsonb),
+         COALESCE((select max(caching_tick) + 1 from math_main
+                   where math_env = :math_env), 1))
+    on conflict (zid, math_env)
+    do update set modified = now_as_millis(),
+                  data = excluded.data,
+                  last_vote_timestamp = excluded.last_vote_timestamp,
+                  math_tick = excluded.math_tick,
+                  caching_tick = excluded.caching_tick
+    returning caching_tick;
+""")
+
+
+def allocate_and_write(conn, zid: int, math_env: str = MATH_ENV) -> int:
+    """Run the production upsert on an OPEN transaction and return the
+    caching_tick it allocated (without committing)."""
+    return conn.execute(_WRITE_MAIN_SQL, {
+        "zid": zid, "math_env": math_env, "last_vote_timestamp": 0,
+        "math_tick": 1, "data": json.dumps({"zid": zid}),
+    }).scalar()
+
+
+class Prefetcher:
+    """The server's prefetch cursor (``pca.ts:98``, ``:130-132``)."""
+
+    def __init__(self, engine):
+        self.engine = engine
+        self.last = -1
+        self.seen = []
+
+    def poll(self):
+        with self.engine.connect() as conn:
+            rows = [dict(r) for r in conn.execute(
+                sa.text("select * from math_main where caching_tick > :last "
+                        "order by caching_tick limit 10"),
+                {"last": self.last},
+            ).mappings()]
+        for row in rows:
+            self.seen.append(row["zid"])
+            if row["caching_tick"] > self.last:
+                self.last = row["caching_tick"]
+        return rows
+
+
+# --------------------------------------------------------------------------- #
+# The transcription matches the production client
+# --------------------------------------------------------------------------- #
+def test_transcribed_sql_allocates_the_same_cursor_as_the_client(engine, pg_url,
+                                                                 make_service):
+    """Guard against the reproduction drifting from ``write_math_main``."""
+    for zid in (1, 2, 3):
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1,
+                       allowlist=[1, 2])
+    svc.poll_once()
+    ticks = {zid: read_math_tables(engine, zid, MATH_ENV)["main"]["caching_tick"]
+             for zid in (1, 2)}
+    assert sorted(ticks.values()) == [1, 2], (
+        f"the production client allocates a strictly increasing cursor: {ticks}"
+    )
+
+    with engine.connect() as conn:
+        with conn.begin():
+            allocated = allocate_and_write(conn, 3)
+    assert allocated == max(ticks.values()) + 1, (
+        "the transcribed SQL must allocate exactly what the client would"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The concurrent cursor
+# --------------------------------------------------------------------------- #
+def test_two_concurrent_publications_allocate_the_SAME_cursor(engine, pg_url):
+    """The root observation: with A's transaction still open, B's
+    ``max(caching_tick)+1`` cannot see A's row, so both allocate the same
+    value."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    seed_conversation(engine, zid=2, n_ptpts=4, n_cmts=3)
+
+    conn_a = engine.connect()
+    conn_b = engine.connect()
+    try:
+        tx_a = conn_a.begin()
+        tick_a = allocate_and_write(conn_a, 1)      # NOT committed
+        tx_b = conn_b.begin()
+        tick_b = allocate_and_write(conn_b, 2)
+        tx_b.commit()
+        tx_a.commit()
+    finally:
+        conn_a.close()
+        conn_b.close()
+
+    assert tick_a == tick_b == 1, (
+        f"two concurrent publications allocated {tick_a} and {tick_b}; "
+        "MAX+1 is not a globally unique change cursor"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "DEFECT (predicted by P-022 §C): MAX(caching_tick)+1 is not a safe "
+        "global change cursor. polismath/database/postgres.py:838 allocates "
+        "`COALESCE((select max(caching_tick)+1 from math_main where math_env = "
+        "?), 1)` INSIDE each write's own transaction, so two conversations "
+        "publishing concurrently allocate the SAME value; the consumer "
+        "(server/src/utils/pca.ts:98, :130-132) polls `caching_tick > "
+        "lastPrefetchedMathTick` and advances the cursor to the largest value "
+        "it saw. If the reader advances past a value between the two commits, "
+        "the later-committing row is NEVER prefetched: its conversation stays "
+        "invisible to the server's PCA cache until some unrelated later update "
+        "allocates a higher tick. P-022 §C: 'Require both conversations to "
+        "become visible without a later update... an earlier allocated value "
+        "can commit after a reader has advanced past it.' A replacement "
+        "sequence alone does not fix this — it also needs a commit-order or "
+        "reader-recovery argument. Separate decision."
+    ),
+)
+def test_both_zids_become_visible_to_the_prefetcher(engine, pg_url):
+    """Hold A's transaction, let B commit, let the prefetcher advance, THEN
+    commit A.  Both conversations must still become visible with no later
+    update."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    seed_conversation(engine, zid=2, n_ptpts=4, n_cmts=3)
+    prefetcher = Prefetcher(engine)
+
+    conn_a = engine.connect()
+    conn_b = engine.connect()
+    try:
+        tx_a = conn_a.begin()
+        allocate_and_write(conn_a, 1)          # allocated, uncommitted
+        tx_b = conn_b.begin()
+        allocate_and_write(conn_b, 2)
+        tx_b.commit()                          # zid 2 lands first
+        prefetcher.poll()                      # the reader advances past it
+        tx_a.commit()                          # zid 1 lands, out of order
+    finally:
+        conn_a.close()
+        conn_b.close()
+
+    for _ in range(5):                         # bounded eventual visibility
+        prefetcher.poll()
+
+    assert set(prefetcher.seen) == {1, 2}, (
+        f"the prefetcher only ever saw {sorted(set(prefetcher.seen))}; "
+        f"cursor is at {prefetcher.last}"
+    )
+
+
+def test_the_invisible_row_is_present_and_correct_in_the_table(engine, pg_url):
+    """Scope the defect: the row IS committed and correct — the loss is purely
+    in the change cursor, so a point read still serves it while the prefetch
+    cache never learns about it."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    seed_conversation(engine, zid=2, n_ptpts=4, n_cmts=3)
+    prefetcher = Prefetcher(engine)
+
+    conn_a = engine.connect()
+    conn_b = engine.connect()
+    try:
+        tx_a = conn_a.begin()
+        allocate_and_write(conn_a, 1)
+        tx_b = conn_b.begin()
+        allocate_and_write(conn_b, 2)
+        tx_b.commit()
+        prefetcher.poll()
+        tx_a.commit()
+    finally:
+        conn_a.close()
+        conn_b.close()
+
+    assert set(prefetcher.seen) == {2}, "precondition: zid 1 was skipped"
+    with engine.connect() as conn:
+        row = conn.execute(
+            sa.text("select zid, caching_tick from math_main where zid = 1 and "
+                    "math_env = :e"), {"e": MATH_ENV},
+        ).mappings().first()
+    assert row is not None and row["caching_tick"] == prefetcher.last, (
+        "the skipped row is committed with a caching_tick the cursor has "
+        f"already passed: {dict(row) if row else None}, cursor={prefetcher.last}"
+    )
+
+
+def test_a_later_update_makes_the_skipped_row_visible_again(engine, pg_url,
+                                                            make_service):
+    """The bound on the damage: any LATER publication for that zid allocates a
+    higher tick and the prefetcher picks it up.  So the defect is 'invisible
+    until further traffic', which is exactly what P-022 forbids for a quiet
+    conversation."""
+    seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+    seed_conversation(engine, zid=2, n_ptpts=4, n_cmts=3)
+    prefetcher = Prefetcher(engine)
+
+    conn_a = engine.connect()
+    conn_b = engine.connect()
+    try:
+        tx_a = conn_a.begin()
+        allocate_and_write(conn_a, 1)
+        tx_b = conn_b.begin()
+        allocate_and_write(conn_b, 2)
+        tx_b.commit()
+        prefetcher.poll()
+        tx_a.commit()
+    finally:
+        conn_a.close()
+        conn_b.close()
+    assert set(prefetcher.seen) == {2}
+
+    with engine.connect() as conn:              # a later publication for zid 1
+        with conn.begin():
+            allocate_and_write(conn, 1)
+    prefetcher.poll()
+    assert set(prefetcher.seen) == {1, 2}
+
+
+def test_out_of_order_commits_of_equal_ticks_across_many_zids(engine, pg_url):
+    """Three concurrent publications allocating equal ticks, committed in
+    reverse order: count how many the strict cursor can ever deliver."""
+    for zid in (1, 2, 3):
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+    prefetcher = Prefetcher(engine)
+
+    conns = [engine.connect() for _ in range(3)]
+    txs = []
+    try:
+        for conn, zid in zip(conns, (1, 2, 3)):
+            txs.append(conn.begin())
+            allocate_and_write(conn, zid)
+        for tx in reversed(txs):                # commit in reverse order
+            tx.commit()
+            prefetcher.poll()
+    finally:
+        for conn in conns:
+            conn.close()
+
+    with engine.connect() as conn:
+        ticks = {r["zid"]: r["caching_tick"] for r in conn.execute(
+            sa.text("select zid, caching_tick from math_main where math_env=:e"),
+            {"e": MATH_ENV}).mappings()}
+    assert len(set(ticks.values())) == 1, (
+        f"all three publications allocated the same cursor value: {ticks}"
+    )
+    assert set(prefetcher.seen) == {3}, (
+        "only the FIRST committer of an equal-tick group is ever prefetched; "
+        f"saw {sorted(set(prefetcher.seen))}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Negative control for the publication-cursor failure class
+# --------------------------------------------------------------------------- #
+class TestNegativeControl:
+    def test_a_sequence_allocated_cursor_is_unique(self, engine, pg_url):
+        """Intentionally 'fixed' variant: allocate from a real Postgres
+        SEQUENCE instead of MAX+1.  Concurrent transactions then get DISTINCT
+        values, proving the collision above is caused by the MAX+1 allocation.
+
+        (It does NOT make the scenario safe: the out-of-order-commit half of
+        the defect survives, which is why P-022 says a replacement sequence
+        alone still needs a commit-order/reader-recovery argument — asserted
+        below.)"""
+        seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
+        seed_conversation(engine, zid=2, n_ptpts=4, n_cmts=3)
+        with engine.begin() as conn:
+            conn.execute(sa.text("create sequence caching_tick_seq"))
+
+        sql = sa.text(
+            "insert into math_main (zid, math_env, last_vote_timestamp, "
+            "math_tick, data, caching_tick) values (:zid, :e, 0, 1, "
+            "cast(:d as jsonb), nextval('caching_tick_seq')) returning "
+            "caching_tick"
+        )
+        prefetcher = Prefetcher(engine)
+        conn_a, conn_b = engine.connect(), engine.connect()
+        try:
+            tx_a = conn_a.begin()
+            tick_a = conn_a.execute(
+                sql, {"zid": 1, "e": MATH_ENV, "d": json.dumps({})}).scalar()
+            tx_b = conn_b.begin()
+            tick_b = conn_b.execute(
+                sql, {"zid": 2, "e": MATH_ENV, "d": json.dumps({})}).scalar()
+            tx_b.commit()
+            prefetcher.poll()
+            tx_a.commit()
+        finally:
+            conn_a.close()
+            conn_b.close()
+
+        assert tick_a != tick_b, (
+            "NEGATIVE CONTROL FAILED: even a sequence produced colliding "
+            "cursor values, so the MAX+1 finding would be misattributed"
+        )
+        for _ in range(3):
+            prefetcher.poll()
+        assert set(prefetcher.seen) == {2}, (
+            "a sequence alone does NOT fix visibility: zid 1's smaller value "
+            "committed after the reader advanced past it, so it is still "
+            f"never delivered (saw {sorted(set(prefetcher.seen))})"
+        )
+
+    def test_the_prefetcher_model_can_see_a_normal_publication(self, engine,
+                                                               pg_url,
+                                                               make_service):
+        """Guard against a vacuous xfail: in the ordinary (serial) case the
+        prefetcher model does deliver every zid."""
+        for zid in (1, 2, 3):
+            seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3)
+        svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
+        svc.poll_once()
+        prefetcher = Prefetcher(engine)
+        for _ in range(3):
+            prefetcher.poll()
+        assert set(prefetcher.seen) == {1, 2, 3}

--- a/delphi/tests/poller/test_integration_postgres.py
+++ b/delphi/tests/poller/test_integration_postgres.py
@@ -45,6 +45,18 @@ def _seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5):
     old_modified = now - 2 * 24 * 60 * 60 * 1000  # 2 days ago
     with engine.begin() as conn:
         conn.execute(sa.text("SET session_replication_role = replica"))
+        # Make the seed RE-RUNNABLE. When POLIS_TEST_POSTGRES_URL points at a
+        # long-lived service database (the compose `postgres` service, and now
+        # `make test-recovery`), rows from a previous run survive: the INSERT
+        # below hit conversations_zid_key, and the caching_tick == 1 assertion
+        # below additionally requires this math_env to have no prior math_main
+        # row. Clear this zid's own rows first rather than depending on a
+        # freshly-initialised database.
+        for table in ("votes", "votes_latest_unique", "comments",
+                      "participants", "math_main", "math_bidtopid",
+                      "math_ptptstats", "math_ticks", "conversations"):
+            conn.execute(sa.text(f"DELETE FROM {table} WHERE zid = :zid"),
+                         {"zid": zid})
         conn.execute(sa.text("INSERT INTO conversations (zid) VALUES (:zid)"),
                      {"zid": zid})
         for p in range(n_ptpts):

--- a/delphi/tests/poller/test_math_writer.py
+++ b/delphi/tests/poller/test_math_writer.py
@@ -38,6 +38,13 @@ def _fake_conv(zid=42, base_clusters=None, last_updated=1234567,
     return conv
 
 
+def _decoded(data):
+    """``write_conv_updates`` pre-encodes each blob before opening the
+    transaction (so json.dumps never runs under the row locks), so the writers
+    receive a JSON string from the poller and a dict from every other caller."""
+    return json.loads(data) if isinstance(data, str) else data
+
+
 class TestDeriveBidToPid:
     def test_shape_is_list_of_member_lists_sorted_by_id(self):
         # base_clusters intentionally out of id order to prove sorting.
@@ -298,13 +305,14 @@ class TestMathWriterSharedTick:
         conv = _fake_conv(zid=42, base_clusters=[{"id": 0, "members": ["1", "2"]}])
         MathWriter(client).write_conv_updates(42, conv)
 
-        # Find the data dict passed to write_math_bidtopid.
+        # Find the data blob passed to write_math_bidtopid.
         call = client.write_math_bidtopid.call_args
         data = call.kwargs.get("data")
         if data is None:
             # positional: (zid, data, math_tick)
             data = call.args[1]
-        assert data["bidToPid"] == [["1", "2"]]
+        # The writer pre-encodes the blob before opening the transaction.
+        assert _decoded(data)["bidToPid"] == [["1", "2"]]
 
     def test_ptptstats_written_uses_user_vote_counts_from_to_dict(self):
         """write_conv_updates must thread data["user-vote-counts"] (already
@@ -329,7 +337,7 @@ class TestMathWriterSharedTick:
         data = call.kwargs.get("data")
         if data is None:
             data = call.args[1]
-        assert data["ptptstats"]["n-votes"] == [42]
+        assert _decoded(data)["ptptstats"]["n-votes"] == [42]
 
 
 class TestWriterSQLFidelity:

--- a/delphi/tests/poller/test_math_writer.py
+++ b/delphi/tests/poller/test_math_writer.py
@@ -277,7 +277,12 @@ class TestMathWriterSharedTick:
         writer.write_conv_updates(42, conv)
 
         # tick incremented exactly once for the zid
-        client.increment_math_tick.assert_called_once_with(42)
+        connection = client.transaction.return_value.__enter__.return_value
+        client.increment_math_tick.assert_called_once_with(42, connection=connection)
+        client.transaction.assert_called_once_with()
+        for method in (client.write_math_main, client.write_math_bidtopid,
+                       client.write_participant_stats):
+            assert method.call_args.kwargs["connection"] is connection
 
         # all three data writes carry the SAME tick value returned above
         assert client.write_math_main.call_args.kwargs.get("math_tick") == 77 \
@@ -338,7 +343,7 @@ class TestWriterSQLFidelity:
         client = PostgresClient(cfg)
         calls = []
 
-        def recorder(sql, params=None):
+        def recorder(sql, params=None, *, connection=None):
             calls.append((sql, params or {}))
             # increment_math_tick reads [0]["math_tick"] off the result
             return [{"math_tick": 5, "zid": 1}]

--- a/delphi/tests/poller/test_park_rebuild_recovery.py
+++ b/delphi/tests/poller/test_park_rebuild_recovery.py
@@ -93,6 +93,18 @@ def _drain(svc, timeout=5.0):
     assert svc._pool.join(timeout=timeout), "worker pool did not drain in time"
 
 
+def _pool_pending(pool, zid):
+    """Queued-or-active work for one zid, read under the pool's OWN lock.
+
+    Used to assert that no queued request was dropped and that no handler is
+    still in flight.  Reads the pool's private bookkeeping deliberately: the
+    point is to check the pool's internal accounting, and taking ``_lock``
+    means the snapshot cannot tear against a concurrent submit/park.
+    """
+    with pool._lock:
+        return bool(pool._queues.get(zid)) or zid in pool._active
+
+
 # --------------------------------------------------------------------------- #
 # Retry-preserves-rebuild unit test (the R03 root-cause fix)
 # --------------------------------------------------------------------------- #
@@ -267,13 +279,38 @@ class TestR04ParkUnparkRaces:
 
         svc._pool.submit(1, REBUILD, [])  # worker A enters loader and freezes
         assert entered.wait(timeout=5)
-        svc._pool.submit(1, REBUILD, [])  # overlapping trigger: must NOT run now
+        # Two overlapping triggers arrive while worker A is provably in flight.
+        # Neither may run NOW (per-zid serialization) and neither may be
+        # DROPPED: the pool must coalesce them into exactly one further cycle
+        # once worker A finishes.
+        svc._pool.submit(1, REBUILD, [])
+        svc._pool.submit(1, REBUILD, [])
         proceed.set()
         _drain(svc)
 
+        # --- handler accounting (exact, not ">= 1") ------------------------ #
         assert conc["max"] == 1, "at most one active handler per zid"
-        assert conc["n"] >= 1, "the rebuild ran; nothing silently dropped"
-        assert svc._writer.writes and svc._writer.writes[0] == 1
+        assert conc["n"] == 2, (
+            "expected EXACTLY two rebuild executions — the in-flight one plus "
+            "one coalesced cycle for the two overlapping triggers — but saw "
+            f"{conc['n']}. A count of 1 means the queued rebuilds were "
+            "DROPPED; more than 2 means per-zid serialization or coalescing "
+            "broke."
+        )
+        assert conc["cur"] == 0, "no handler left in flight"
+
+        # --- final state --------------------------------------------------- #
+        assert svc._writer.writes == [1, 1], (
+            f"each executed rebuild must publish exactly once, saw "
+            f"{svc._writer.writes!r}"
+        )
+        assert not _pool_pending(svc._pool, 1), (
+            "the pool must have no queued or active work left for the zid"
+        )
+        assert 1 not in svc._parked and not svc._pool.is_parked(1), (
+            "a successful rebuild must leave the zid unparked"
+        )
+        assert svc._retry_counts.get(1) is None, "retry markers must be cleared"
 
     def test_reconcile_and_new_vote_unpark_converge(self, make_svc):
         """Trigger the reconciler and a new-vote unpark concurrently on a parked

--- a/delphi/tests/poller/test_recovery.py
+++ b/delphi/tests/poller/test_recovery.py
@@ -83,6 +83,9 @@ class FakePg:
     def poll_moderation(self, zid, since):
         return []
 
+    def find_incomplete_math_snapshots(self):
+        return []
+
     def load_math_main(self, zid):
         return None
 

--- a/delphi/tests/test_math_writer_numpy_serialization.py
+++ b/delphi/tests/test_math_writer_numpy_serialization.py
@@ -61,7 +61,7 @@ def _client_capturing():
     client = PostgresClient(PostgresConfig(url="postgresql://ignored/db", math_env="t3"))
     captured = {}
 
-    def _fake_write_returning(sql, params=None):
+    def _fake_write_returning(sql, params=None, *, connection=None):
         captured["params"] = params
         return []
 

--- a/delphi/uv.lock
+++ b/delphi/uv.lock
@@ -1,0 +1,3663 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "docstring-parser" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/6d/793f5cfe2cd444c43b4eeb4cb7c3cc55ebcb38929fdfe81aa1f2fced7326/anthropic-1.4.0.tar.gz", hash = "sha256:f0d017e901e48b343520b5d458f8240c283c8d850bf6d119834c622207e0a74c", size = 1150831, upload-time = "2026-09-04T22:20:31.355Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/e3/34a88f0e1e854022a352d67f72ca9baa8b952d4541315088411ba2bfbc2a/anthropic-1.4.0-py3-none-any.whl", hash = "sha256:590e85bff75b713a123b03f586d68f02266b5fdc49f70dd75f721ced93a4716c", size = 1300390, upload-time = "2026-09-04T22:20:33.078Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/d2/f4d173e22df740bc37b1db102b386ba719b66e95b0f0d751f556b387e6d2/anyio-4.15.1.tar.gz", hash = "sha256:9f28306018cbd6d329e64a36d58256edff76dd996fe423bc957326e578b82a94", size = 276966, upload-time = "2026-09-05T10:42:39.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b8/4bd346e22b28902df4d651910f5242c28d84e4a5c2435ca5c3f797ed7e2e/anyio-4.15.1-py3-none-any.whl", hash = "sha256:6152fdbbf9a77fdec97731721bebf7c4c44f7c29b424b0065826173efc7ed101", size = 132079, upload-time = "2026-09-05T10:42:37.923Z" },
+]
+
+[[package]]
+name = "appnope"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/f7/a82489c2b6ebe32d3e2831895ae19c77861f0eadf3bb16034484d965dbb2/appnope-1.0.0.tar.gz", hash = "sha256:685db59cb6043c3c2e528adc0b3bce3a5f8d09bcf7492c6ea650d1b7421f3c49", size = 5454, upload-time = "2026-08-20T21:36:13.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/c7/6b687cb0f83d2a51017d47953f2ee430ffad6fec2a8ebc964e0718a33eb1/appnope-1.0.0-py3-none-any.whl", hash = "sha256:6fe0c04218aab65c54c4ff81638cdbf848d89f5653b74d68638a137f200dd16e", size = 4158, upload-time = "2026-08-20T21:36:12.444Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/43/bb8b6e8708d49a5ab36781333af092d9f483b198a2710d01281204640055/argon2_cffi_bindings-26.1.0.tar.gz", hash = "sha256:63505c71542a44b68b1e38060450fb006404170da375feb31af153e7f9c6205d", size = 1790807, upload-time = "2026-08-20T07:44:22.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/d2/0ae991f1b2181e5be49007c574710a800ad36c2978683addb3e67c474e55/argon2_cffi_bindings-26.1.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:21ca0396fe5ec995dd54431c32698189666f9224810acfa752e50d2bd94d9df2", size = 25521, upload-time = "2026-08-20T07:32:43.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e4/ad91d8297638aa2258aad4501c306aca99480dfe76ccd638173fa3702db9/argon2_cffi_bindings-26.1.0-cp310-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78de2d65e0b9ea7ce9d1b1c3e87297b2d7305a02c266ee2a2d6910daddd7ee69", size = 27177, upload-time = "2026-08-20T07:32:44.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/86/5363df11b86d02cf3662208e7406496327649cc90eb365bf6f4e8a54a41f/argon2_cffi_bindings-26.1.0-cp310-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27f1821903e2ceadcb88ec2b45ef190897b7682449c772f4d9b53e42c520cf29", size = 26597, upload-time = "2026-08-20T07:32:45.172Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b5/a14dcc592652347dad23ee93b278a4da5d2a25c9ed3ebd10d68eea823a4f/argon2_cffi_bindings-26.1.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d88e5f7e60f28ae0b0cc6b2f16c43e87cd642a196a86f85e0d8bb6fe016fc16d", size = 27403, upload-time = "2026-08-20T07:32:46.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/b4a20d4902af7f796390bf9245ff83c5217dfa7367efa1d14986956c482b/argon2_cffi_bindings-26.1.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:34b7d9c24a4165a2c61cc8ae11d44d48c9ce2830fb536cb7914e11fdd9962728", size = 27132, upload-time = "2026-08-20T07:32:47.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/1b/c8de358af07b1c490e0fcb863ef98e46ddb486e45567aca5a60bd68d9daa/argon2_cffi_bindings-26.1.0-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:224865cbbcb7a2bd1356741dff12b0134df726b6d44bb7b500df8e303cbd9e81", size = 27588, upload-time = "2026-08-20T07:32:48.087Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2f/7ee62a6e79f9309f9d9982d301b22a00010adb580c05c8109b94d7b33de0/argon2_cffi_bindings-26.1.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ffff613aaa9ce6236766e2fc6dc560bb5abde7a2e2416e3db1f9ae395a2b4dd4", size = 26785, upload-time = "2026-08-20T07:32:48.977Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/10/960d0ee93d4897741bcaf4799c697dae2d81499f66fd1ed042a7dd54c1f4/argon2_cffi_bindings-26.1.0-cp310-abi3-win32.whl", hash = "sha256:a86c069c91a747a2c4e5c51473590aeb48172fff9b2130d23729a42d98665ecb", size = 23898, upload-time = "2026-08-20T07:32:50.114Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/3a/0cc14a05810e6add9bce5e87693334baa2222de5f647fa31781885b6573f/argon2_cffi_bindings-26.1.0-cp310-abi3-win_amd64.whl", hash = "sha256:2c36ff87b5dfaa477d0bd51e9d7f6abdae7c8955d2983c97419085d842154b3e", size = 25730, upload-time = "2026-08-20T07:32:51.091Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/db/d83cf2af140547f0b9cdaece05b2dc2dcbf991be4667331d073eff771435/argon2_cffi_bindings-26.1.0-cp310-abi3-win_arm64.whl", hash = "sha256:f9c4420a7a864fe1b86ce35befc95b8e39fb852493b81cf798671ddc265de638", size = 24478, upload-time = "2026-08-20T07:32:52.111Z" },
+]
+
+[[package]]
+name = "arrow"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/1e/faf0f247f6f881b98fc4d6d07e14085cb89d13665084e6d6ac1dc2c03d0b/asttokens-3.0.2.tar.gz", hash = "sha256:3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2", size = 63136, upload-time = "2026-07-12T03:31:49.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl", hash = "sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933", size = 28702, upload-time = "2026-07-12T03:31:47.542Z" },
+]
+
+[[package]]
+name = "async-lru"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "aws-lambda-powertools"
+version = "3.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/d2/ead05769a42baf2c01e9e8909b5b7a0a42b0798ab2d0eccacdef3d1f009d/aws_lambda_powertools-3.34.0.tar.gz", hash = "sha256:75f2c65a5997630666c9c3c495002c1f9d1e9defd3cb6d5d9fc7272b7dc9ef54", size = 800151, upload-time = "2026-08-10T11:26:10.742Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/d1/9e9433f99d8c9084d3bc831900f1ce7a99b0a2c153d9223e46839d8cc665/aws_lambda_powertools-3.34.0-py3-none-any.whl", hash = "sha256:ab1354c58085ccecf92e9c548b1336ad5bae72c7ae23e61d2aa0ff15520d679c", size = 957321, upload-time = "2026-08-10T11:26:09.002Z" },
+]
+
+[[package]]
+name = "aws-xray-sdk"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/25/0cbd7a440080def5e6f063720c3b190a25f8aa2938c1e34415dc18241596/aws_xray_sdk-2.15.0.tar.gz", hash = "sha256:794381b96e835314345068ae1dd3b9120bd8b4e21295066c37e8814dbb341365", size = 76315, upload-time = "2025-10-29T20:59:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/c3/f30a7a63e664acc7c2545ca0491b6ce8264536e0e5cad3965f1d1b91e960/aws_xray_sdk-2.15.0-py2.py3-none-any.whl", hash = "sha256:422d62ad7d52e373eebb90b642eb1bb24657afe03b22a8df4a8b2e5108e278a3", size = 103228, upload-time = "2025-10-29T21:00:24.12Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "bleach"
+version = "6.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
+]
+
+[package.optional-dependencies]
+css = [
+    { name = "tinycss2" },
+]
+
+[[package]]
+name = "bokeh"
+version = "3.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyyaml" },
+    { name = "tornado", marker = "sys_platform != 'emscripten'" },
+    { name = "xyzservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/e8/93d270023eb987348f9b5a2aef0103f903511b934519cd2bbefde451868d/bokeh-3.10.0.tar.gz", hash = "sha256:73f0b0c06d7925ca2b6d52b2dc51c2533a11f667cc6944f1f06c039ccc57c5ce", size = 5982193, upload-time = "2026-08-18T17:47:09.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/0a/1423bb61b5f06376fe6ccf79c8781e2bb5e36c78c1814c78913b7425950f/bokeh-3.10.0-py3-none-any.whl", hash = "sha256:6bb8dbd4a555f71a921be5bd45c3bfaa15b390257fbadae76901927bd58629b7", size = 6649702, upload-time = "2026-08-18T17:47:07.287Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.34.70"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/b4/e00615f5848a9e4ec4ba28cda591035497a4dbd22d1cfb4114a02cfcb3da/boto3-1.34.70.tar.gz", hash = "sha256:54150a52eb93028b8e09df00319e8dcb68be7459333d5da00d706d75ba5130d6", size = 108288, upload-time = "2024-03-25T19:20:53.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2c/4b87fe046ad059c7ede17fa402a0658d131e31413d12942c6d3c72d60805/boto3-1.34.70-py3-none-any.whl", hash = "sha256:8d7902e2c0c62837457ba18146e3feaf1dec62018617edc5c0336b65b305b682", size = 139322, upload-time = "2024-03-25T19:20:00.973Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.34.162"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/17d672eac6725da49bd5832e3bd2f74c4d212311cd393fd56b59f51a4e86/botocore-1.34.162.tar.gz", hash = "sha256:adc23be4fb99ad31961236342b7cbf3c0bfc62532cd02852196032e8c0d682f3", size = 12676693, upload-time = "2024-08-15T19:25:25.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/47/e35f788047c91110f48703a6254e5c84e33111b3291f7b57a653ca00accf/botocore-1.34.162-py3-none-any.whl", hash = "sha256:2d918b02db88d27a75b48275e6fb2506e9adaaddbec1ffa6a8a0898b34e769be", size = 12468049, upload-time = "2024-08-15T19:25:18.301Z" },
+]
+
+[[package]]
+name = "build"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/b7/1db48a9ce2984842c8c886432ec8a2719613322e868a966ba82a28862f25/build-1.6.0.tar.gz", hash = "sha256:bd2c8afc603e7a2e0ce70e2ea85f0a6d02043bafbd307f5bada0f98669eca5af", size = 113825, upload-time = "2026-08-27T21:01:16.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/e5/aa1e81b21aea0ce0ba435311837a37d4cb936e7461f9fecac08580073ba9/build-1.6.0-py3-none-any.whl", hash = "sha256:f7aaf1ebbb79178a02ba248bb524f2176b256017e17e8e4bd4289c7b38cc2bad", size = 31187, upload-time = "2026-08-27T21:01:14.957Z" },
+]
+
+[[package]]
+name = "bytecode"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/e9/9f355e80d57fc271d35631883778564aeea02c35b4cfb4b64d84cb653aed/bytecode-0.19.0.tar.gz", hash = "sha256:fb733957396cb82301f3f79cd320aef262cd0592c93d6b4fd656771506999624", size = 106372, upload-time = "2026-08-21T21:17:40.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/38/c8397880426bb56b139a0b53f69a4e54cf770c358b8c1ad872b3c88430d3/bytecode-0.19.0-py3-none-any.whl", hash = "sha256:7b32811d4a574f5ebcdc84ae8d37af928d980f31d6aa5aea2cab9f6d364489d1", size = 43277, upload-time = "2026-08-21T21:17:38.589Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/27/78873dc8b6a56357517b74b6bb9568b80450e7bb4f6ef7e3fa9d22aa0bd7/charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b6d1386bf0096d26d3a863dc0a487a5b4eb9aa93cf5ba69683d29dde6b9d60f", size = 344456, upload-time = "2026-08-15T08:17:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/be49ada26b1f0232d57aa89bbebf997a5cc2332a5616b6eca26ff680044d/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa", size = 238530, upload-time = "2026-08-15T08:17:11.563Z" },
+    { url = "https://files.pythonhosted.org/packages/76/84/6f1290fa07ae6978d3960caa3eb1b8019bf9284ab7c2297b00c099ef4250/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1d1c7a53a6c2103925cdd6d7229f8c567379f211c869793df679f2e9f738c369", size = 230200, upload-time = "2026-08-15T08:17:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a0/47b18adeed31c8f16ba9700f32c1b18594cfa09f47eb672a488c273c22bf/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e6621fb2a4988d6e53eedc455e5903e2679f3967b8acb3d639f1b63c14a2e893", size = 262222, upload-time = "2026-08-15T08:17:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fe/341861ac118dae06f3ec0eb487488af52128f2ef2faf0b11003944d22259/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c0c10730342b0c9b35dd1d619beb8214e520bd96a1f870f452680b238aab3e0", size = 258951, upload-time = "2026-08-15T08:17:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08", size = 248801, upload-time = "2026-08-15T08:17:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/ef83ae3aca816393decfa3530976f38a79812d707b80b580ac33b83f9877/charset_normalizer-3.5.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9f8405c2c758532c74fed975dbee57be1f31a6e865c031870c79a6ed3212ada", size = 244070, upload-time = "2026-08-15T08:17:19.191Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0b/c5292a2462d69b7378ea89793bbb5b2b6fcf6f7dd6d1667f9619094ad553/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:96fef3e886d6a9874b14f27fc193fbdc69d5d8035783d86aa4e1cea594e695f9", size = 240110, upload-time = "2026-08-15T08:17:20.547Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/111e5be3b740d5c2a5bfcedb3d237b6591e5c2e82ae9d6ffcb121fe0909c/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5d8531a6569d025f68e2321e7638fb7978f23db58e5f69f56913837aae03816e", size = 232836, upload-time = "2026-08-15T08:17:21.895Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d2/d2aad6fe0dbb44b194bf3becb60f5a0ac48446ade999a47fe7bb41eb09a7/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:aae2ee51122d3ae968a3837d97dc24a0aeebb0dea23694422cd172bd30017cd6", size = 262712, upload-time = "2026-08-15T08:17:23.727Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/337e4663a5eae6de99db940ee8066d4145caafb61327db62deda15313cce/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7235dc28fc6dd9d832ac7c7bce95367dedb85929f17368a0c2bee1e080b9acbf", size = 242977, upload-time = "2026-08-15T08:17:25.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/85/f82f8a92e31c7519410e2e1afdc630f28ec47490ce2c09a11c1a43cbb459/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4abdc5f9ad448c1ecbfae2974b820535d6bc6e7eef63babbab3d81cf46968c71", size = 260207, upload-time = "2026-08-15T08:17:26.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/52/643d11ffd60e9ac2fd1fb87e167a19285b9eefeff4a40e63c87cbfbeab36/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba501e667c17d8411f98e67a022d9604ef179aff0e459b7e292c796837c13573", size = 250562, upload-time = "2026-08-15T08:17:27.971Z" },
+    { url = "https://files.pythonhosted.org/packages/62/16/46556278c2168d12df9da7fede5dc6fc70e60301b26a82bbeec238c9cfe3/charset_normalizer-3.5.1-cp312-cp312-win32.whl", hash = "sha256:cfa1c0cc3a8f9f53f1243a5a99ac36fd003880199383b37672e86ddda9cb07e2", size = 178507, upload-time = "2026-08-15T08:17:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/4c6c298171e6b3e745633180ff59350fc0ca0db1ffd28df1e369e0579f71/charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3617ac3cfd8b9888f145ad89dd6e692285834b0201c6074a5eeaad3fd4d668c2", size = 200551, upload-time = "2026-08-15T08:17:30.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d7/eb95a042f0dd22e304b0b6472b154f3546a1a039a9ee89ccb2a7f61591fc/charset_normalizer-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:88e85ab89cb822c1e635f51d6d32e488f94e002e70e2f492bdb8b945543f345a", size = 180700, upload-time = "2026-08-15T08:17:32.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorcet"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/af/b969f541242b84cbbacabdf20862e487689e352bf0f02f90df2795d29da5/colorcet-3.2.1.tar.gz", hash = "sha256:48d9a67e6e59dc5c0a965aa1b46fe5d59cdc95cc36a95949f29313f950ac59f7", size = 2202958, upload-time = "2026-04-28T16:25:37.43Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl", hash = "sha256:3f6fde13cef2169222dd5fe2a2bf847c02d644470fdf167ed566f6421df470f7", size = 262291, upload-time = "2026-04-28T16:25:35.365Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/55/ba79756cb90c8d69d599d57785398ac87bba7b19c80e87f4e8a562197c93/colorlog-6.12.0.tar.gz", hash = "sha256:2a7924c1dadf18b22a0eb8b06d1c7b01d5341707ec1641eb6fcc4fde0c3e8e5f", size = 18151, upload-time = "2026-07-23T13:40:40.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/19/0b6647bf5e331521e55d2b63bfbdc210bd9cd605189273f03614a05f702d/colorlog-6.12.0-py3-none-any.whl", hash = "sha256:30d392604e9110045a2c2aeefc27d7a017abbab63f3a8aee594eac0801df784e", size = 12239, upload-time = "2026-07-23T13:40:39.562Z" },
+]
+
+[[package]]
+name = "colorspacious"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/e4/aa41ae14c5c061205715006c8834496d86ec7500f1edda5981f0f0190cc6/colorspacious-1.1.2.tar.gz", hash = "sha256:5e9072e8cdca889dac445c35c9362a22ccf758e97b00b79ff0d5a7ba3e11b618", size = 688573, upload-time = "2018-04-08T04:27:30.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/a1/318b9aeca7b9856410ededa4f52d6f82174d1a41e64bdd70d951e532675a/colorspacious-1.1.2-py2.py3-none-any.whl", hash = "sha256:c78befa603cea5dccb332464e7dd29e96469eebf6cd5133029153d1e69e3fd6f", size = 37735, upload-time = "2018-04-08T04:27:22.143Z" },
+]
+
+[[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/45/adfee365d9ea3d853550b2e735f9d66366701c65db7855cd07621732ccfc/contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb", size = 293419, upload-time = "2025-07-26T12:01:21.16Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6", size = 273979, upload-time = "2025-07-26T12:01:22.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/a12359b9b2ca3a845e8f7f9ac08bdf776114eb931392fcad91743e2ea17b/contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7", size = 332653, upload-time = "2025-07-26T12:01:24.155Z" },
+    { url = "https://files.pythonhosted.org/packages/63/12/897aeebfb475b7748ea67b61e045accdfcf0d971f8a588b67108ed7f5512/contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8", size = 379536, upload-time = "2025-07-26T12:01:25.91Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8a/a8c584b82deb248930ce069e71576fc09bd7174bbd35183b7943fb1064fd/contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea", size = 384397, upload-time = "2025-07-26T12:01:27.152Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1", size = 362601, upload-time = "2025-07-26T12:01:28.808Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0a/a3fe3be3ee2dceb3e615ebb4df97ae6f3828aa915d3e10549ce016302bd1/contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7", size = 1331288, upload-time = "2025-07-26T12:01:31.198Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1d/acad9bd4e97f13f3e2b18a3977fe1b4a37ecf3d38d815333980c6c72e963/contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411", size = 1403386, upload-time = "2025-07-26T12:01:33.947Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8f/5847f44a7fddf859704217a99a23a4f6417b10e5ab1256a179264561540e/contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69", size = 185018, upload-time = "2025-07-26T12:01:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b", size = 226567, upload-time = "2025-07-26T12:01:36.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e2/f05240d2c39a1ed228d8328a78b6f44cd695f7ef47beb3e684cf93604f86/contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc", size = 193655, upload-time = "2025-07-26T12:01:37.999Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/f5/deb1a27aa20746c0278ac998c4179e272004699b2d33959ce020c5ac1615/coverage-7.16.0.tar.gz", hash = "sha256:077f0964087883176ff6ab9b074694cae29f8c708273b13ca62c183c6ed716cd", size = 945620, upload-time = "2026-08-28T21:54:37.74Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/9c/8d2688694f53dc0b0f0e4783c7eb3c4bb1e79beaf1411879f6dabedf4607/coverage-7.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d1c77c3579ac42798f8b7eed6d3dd258debacca32c8753fc8a1f6eaf1db644f5", size = 223194, upload-time = "2026-08-28T21:51:27.767Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/11/f002163dd688aa3fa49ac6a424b7c2705c7fcf80fba18ec9f586d77827ca/coverage-7.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1f81cb1554c3712e41649ed5dc98656b50b958e4da12f0f5adb681ce3db92831", size = 223553, upload-time = "2026-08-28T21:51:29.46Z" },
+    { url = "https://files.pythonhosted.org/packages/81/65/f9d469e97c4554372a710650a109004a2434dfc56f577142e5d6057fa0cc/coverage-7.16.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e701938ec9081d3e400a0c9a9a8ae0f7ca44214741daeac4454b1c6ef6dbd19", size = 255054, upload-time = "2026-08-28T21:51:31.54Z" },
+    { url = "https://files.pythonhosted.org/packages/95/29/dd89fd39af1a3b6e9a9c3eddeaf03f6376ba517d43d6cbf8b519177e2a10/coverage-7.16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:719a3feb6220dd32ed932d4c3676d17fb8739e2643b29c0e7c3af400ff80ac44", size = 257790, upload-time = "2026-08-28T21:51:33.374Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/64/208d26cedc525d6b5db9c492cf9130784c42d9eb08d22badaa7b806005ad/coverage-7.16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:87771ecf986cff55e87413238cd5e4f54d949c2074bd6fc1657d26a56314ee24", size = 258904, upload-time = "2026-08-28T21:51:35.096Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/98/28e2752aa9a8baee5798edade9c95602ca200f4e7eeb503eb64df42e5921/coverage-7.16.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:47d5e1fc0b321c8308a2aacee0497c435b08acaa629b7059798fdf6fc3006352", size = 261165, upload-time = "2026-08-28T21:51:36.744Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/77/fa6ae699a0ea2bc12acb38a85d96b786fea0f833c12b5756056350e0e547/coverage-7.16.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01b18b8a6c9cec8d5f45550e2501426ed982cf2c35016b0acd2ba9b5d8b2fb06", size = 255416, upload-time = "2026-08-28T21:51:38.495Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c8/5ee46d1de7d34cb00ba08b5c50da1971114dbc09ca9898ccc32975ec74dd/coverage-7.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:32c56b5b47c50635081445ac404dd08c2d591b9c837c22570aa9e182c3b42cd4", size = 256825, upload-time = "2026-08-28T21:51:40.27Z" },
+    { url = "https://files.pythonhosted.org/packages/15/f6/d59e1c0693ad48855fe20169fbf6ee5befefe5887a7fabf5f0bcb464a2dc/coverage-7.16.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6ad3bbad240ab937512156bc944fdee63ac4dd34a7558a3094548fd4c1150c02", size = 254970, upload-time = "2026-08-28T21:51:43.136Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7b/b51bbe05b3a7565927fccfb1be42b8b3c1f4ab15e53d91b303e9923969aa/coverage-7.16.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4c1f16d5555a195295d0dc9c902612270e3dfed6a11f3bf7bc470b7b6a79ed3c", size = 259039, upload-time = "2026-08-28T21:51:44.983Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/04/d513f816456a8a43c1859abe88a37d01d7d2515b6c3e24ebb3c9b1dd44ec/coverage-7.16.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f6c9c21a8bf0d19788f3c5f3e020c90317a0a63ef60521b376003801e21250fb", size = 254539, upload-time = "2026-08-28T21:51:46.733Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/54/5542190ceb97e0d1333a4ce0c8f95b2ef2efe790f1ad018a4b61766f849e/coverage-7.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:06f20145a9eb5bf1fd1dde3c0bc2af2e7c22135ab07ca6284d6ada7cc3904c4e", size = 256410, upload-time = "2026-08-28T21:51:48.363Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/28/78643f361ff6bb5b2ade90f8bfc8395fe9ca367a18c101f8991215b4c65b/coverage-7.16.0-cp312-cp312-win32.whl", hash = "sha256:916cf8d25c1ce148f7eceb1d45afc9724841200110adc4e53250391852debd91", size = 225239, upload-time = "2026-08-28T21:51:50.22Z" },
+    { url = "https://files.pythonhosted.org/packages/67/61/8e76b36c36b1a033dc933dd2480db96b04ce3be975793ce3fad122e7174d/coverage-7.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:78f8b56261d608be102c62edd3a60b66bcd0b581f3f86fdcabaf8b8d95adc950", size = 225775, upload-time = "2026-08-28T21:51:51.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f3/bb4787a4b81c1792ca69b502f5f730dbbb609f73fed552ab074c6b92cb8b/coverage-7.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:577c2ac8c0036f6f8edd3a7783a9e67302b17771d1abf0fd2ed246e3158be51b", size = 225159, upload-time = "2026-08-28T21:51:53.667Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5a/234e8fadf85c3cc48cb31c247b9e8e0c7f06ece80f5b29f9b8c241f9da4c/coverage-7.16.0-py3-none-any.whl", hash = "sha256:245f7de6d023a5bba375dbec9f2e0869bfa26ac0cc639bbb7b4c814884000b73", size = 214977, upload-time = "2026-08-28T21:54:35.189Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "dask"
+version = "2024.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "fsspec" },
+    { name = "packaging" },
+    { name = "partd" },
+    { name = "pyyaml" },
+    { name = "toolz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/19/1d1e57c0fa24dfd241bbec46d4b70c37ec15e8071a7e06d43d327c8dafbb/dask-2024.12.1.tar.gz", hash = "sha256:bac809af21c2dd7eb06827bccbfc612504f3ee6435580e548af912828f823195", size = 10693689, upload-time = "2024-12-17T20:26:53.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/5a/cdc78a77bb1c7290fd1ccfe6001437f99a2af63e28343299abd09336236e/dask-2024.12.1-py3-none-any.whl", hash = "sha256:1f32acddf1a6994e3af6734756f0a92467c47050bc29f3555bb9b140420e8e19", size = 1269300, upload-time = "2024-12-17T20:26:41.118Z" },
+]
+
+[package.optional-dependencies]
+complete = [
+    { name = "bokeh" },
+    { name = "dask-expr" },
+    { name = "distributed" },
+    { name = "jinja2" },
+    { name = "lz4" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+]
+
+[[package]]
+name = "dask-expr"
+version = "1.1.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dask" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d3/50af8a5826231a804b0286704ed7be494d685337e159bf600cb396fcfcf9/dask_expr-1.1.21.tar.gz", hash = "sha256:eb45de8e6fea1ce2608a431b4e03a484592defb1796665530c91386ffac581d3", size = 223929, upload-time = "2024-12-17T20:26:49.519Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/60c73ccb5a272ff396bc766bfa3c9caa71484424983f0334070263a16581/dask_expr-1.1.21-py3-none-any.whl", hash = "sha256:2c2a9a0b0e66b26cf918679988f97e947bc936544f3a106102055adb9a9edeba", size = 244297, upload-time = "2024-12-17T20:26:47.647Z" },
+]
+
+[[package]]
+name = "datamapplot"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorcet" },
+    { name = "colorspacious" },
+    { name = "dask", extra = ["complete"] },
+    { name = "datashader" },
+    { name = "importlib-resources" },
+    { name = "jinja2" },
+    { name = "matplotlib" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "platformdirs" },
+    { name = "pyarrow" },
+    { name = "pylabeladjust" },
+    { name = "rcssmin" },
+    { name = "requests" },
+    { name = "rjsmin" },
+    { name = "scikit-image" },
+    { name = "scikit-learn" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/de/b77e80c8626b08f0180a97aa711e550e7b935d5cbdb9327cfff5347f01d7/datamapplot-0.6.4.tar.gz", hash = "sha256:aa25301ab0a08aeca11c05400d8e9ad94cceb26f84a4d95183026e37ddfdaaaf", size = 163024, upload-time = "2025-09-02T13:22:10.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/d3/5aa973250662089aed615e885007d6d89192bf774978785d057bc2241290/datamapplot-0.6.4-py3-none-any.whl", hash = "sha256:d1c538a830a48029b1a1a74e8f74a2e458918db439a047b6fdb26924049ddab4", size = 168520, upload-time = "2025-09-02T13:22:08.501Z" },
+]
+
+[[package]]
+name = "datashader"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorcet" },
+    { name = "multipledispatch" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "param" },
+    { name = "pyct" },
+    { name = "requests" },
+    { name = "scipy" },
+    { name = "toolz" },
+    { name = "xarray" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/4b/a9141f286f0c01685e9715ba3404769a6138e74575c4d5ccbaa95a22c3bd/datashader-0.19.1.tar.gz", hash = "sha256:f62d880a4a431813f9bb3959e565feda79c1634f889aaadcf948cb0d0c114cdd", size = 10581968, upload-time = "2026-05-19T07:53:06.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/41/247627c8b9fef5c605d00546b85771a8fe42975b9616a557cead5468789b/datashader-0.19.1-py3-none-any.whl", hash = "sha256:7ce7154ff3ed070607f429355f57002fee5a17964e47c0b6447eeafe8cef9c82", size = 10715897, upload-time = "2026-05-19T07:53:03.431Z" },
+]
+
+[[package]]
+name = "ddtrace"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bytecode" },
+    { name = "envier" },
+    { name = "opentelemetry-api" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/cf/b9a1a809a38973731c23e41a75a84e4d0118134bb09278a865ef84e89b18/ddtrace-4.14.0.tar.gz", hash = "sha256:030699f46e0330b4bfd23bedb94d7a07a588638bed27490851f732f045bf96fe", size = 2678446, upload-time = "2026-08-26T10:57:13.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/8c/602d4b71addbdaf75a8737d183a399d2dfce5c430ec51a34f954059197cd/ddtrace-4.14.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:287b1bfe9b697dcd9634d9d516b9e6cead69fde8d365022f80d081164e8fe037", size = 7646820, upload-time = "2026-08-26T10:55:25.017Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c1/80136ca39ff2c0823b93fd83faaf43348547941f6ffe0a51c6aa4458afef/ddtrace-4.14.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:ee1c73e5d4c1dd68c9bf87ceabc22fd4b4458e807a21c8d44c03aa4919eeb5c4", size = 8006663, upload-time = "2026-08-26T10:55:27.439Z" },
+    { url = "https://files.pythonhosted.org/packages/62/80/a760097adbf01909ae352417af40415199b475d5186b3768c083700a2832/ddtrace-4.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b42e8aee08be314e93f5ac7a64d9a95a7e9115ad5276dd19ea579f6eb19dbb0", size = 9029345, upload-time = "2026-08-26T10:55:29.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ea/11ea0a7351a538ab8ed60a3bb5707e115db08bef385b008ec6518ff06b4f/ddtrace-4.14.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:eb08155d5bac19ac16e65ff544bea528818f9b7f2b0f4a80a523a923f2cb4480", size = 9279301, upload-time = "2026-08-26T10:55:32.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/04/aaa7b156f122c3d1635633591c87ab82bde8d550c99f58615807e166191e/ddtrace-4.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:132f8e3801b0711a737583c5e6dac206cb7ab1366b7aec552fdd729f1a6be86e", size = 9937577, upload-time = "2026-08-26T10:55:35.079Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/db/9be90f89ee9fd4e6dcd40faefa89c05eaf3822c680b879c678886e03a259/ddtrace-4.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:159fc0082b2c2317048fce3eb00d27fdce8f59ff0cde9f3d011246906dacdfa9", size = 10229919, upload-time = "2026-08-26T10:55:37.983Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/01/0363f16415a4be63f1a8af621be2b7e68398b6bed023ae8cd8d9e8282883/ddtrace-4.14.0-cp312-cp312-win32.whl", hash = "sha256:d01e99ecb90632d012eeb6adf5e82b3b7235497939d3a87d999b2be3ddcf8a94", size = 6790895, upload-time = "2026-08-26T10:55:40.467Z" },
+    { url = "https://files.pythonhosted.org/packages/89/52/41798133a77ea94e8f26c317c4ef90773cd96ff8c5d8ad3f889b55066caa/ddtrace-4.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:be34c4528ad3f9bc2d7a6364430083801c6d97f9f2eb14dddc2895ff2f4d523d", size = 7394837, upload-time = "2026-08-26T10:55:42.888Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/49/8de6573f6ee47c525904fdf33a32910c73cbc3719ed43032dd336d31909d/ddtrace-4.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:2601046956619e78e15237a6c32ddb68b1780464fa1d12f267e0303643d4ba0f", size = 7401983, upload-time = "2026-08-26T10:55:45.317Z" },
+]
+
+[[package]]
+name = "debugpy"
+version = "1.8.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/aa/12037145b7a56eaa5b29b41872f7a21b538e807e13f32c4d3c46e59be084/debugpy-1.8.21.tar.gz", hash = "sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6", size = 1697577, upload-time = "2026-06-01T19:30:35.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/df/bf625547431a9cadc9f4cbfeda38866e2b17f6aed147b625377e87834449/debugpy-1.8.21-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:9f96713896f39c3dff0ee841f47320c3f2983d33c341e009361bb0ebc79adc4e", size = 2483609, upload-time = "2026-06-01T19:30:50.794Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/59324b903599031ff9faaec1758292409f6561a0ec2492fe4b703327705a/debugpy-1.8.21-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:c193d474f0a211191f2b4449d2d06157c689013035bd952f3b617e0ef422b176", size = 3968900, upload-time = "2026-06-01T19:30:52.341Z" },
+    { url = "https://files.pythonhosted.org/packages/14/cd/27f65b805d7fe005c44e1a36b9183ecdfbcdbf9d3e721a5115d461ecc7ee/debugpy-1.8.21-cp312-cp312-win32.whl", hash = "sha256:4743373c1cac7f9e74a1b9915bf1dbe0e900eca657ffb170ae07ac8363205ae9", size = 5336340, upload-time = "2026-06-01T19:30:54.047Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1d/c84e30c0c674184948b66f076ab271c01d940618a2824c23cd035a27bc20/debugpy-1.8.21-cp312-cp312-win_amd64.whl", hash = "sha256:bd7ba9dd3daa7c2f942c6ca8d4695a16bf9ac16b63615261c7982bc74f7ed20c", size = 5374751, upload-time = "2026-06-01T19:30:55.891Z" },
+    { url = "https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl", hash = "sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92", size = 5352888, upload-time = "2026-06-01T19:31:25.186Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "delphi-polis"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "anthropic" },
+    { name = "aws-lambda-powertools" },
+    { name = "aws-xray-sdk" },
+    { name = "boto3" },
+    { name = "click" },
+    { name = "colorlog" },
+    { name = "datamapplot" },
+    { name = "ddtrace" },
+    { name = "evoc" },
+    { name = "fastapi" },
+    { name = "hdbscan" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "llvmlite" },
+    { name = "matplotlib" },
+    { name = "natsort" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "ollama" },
+    { name = "pandas" },
+    { name = "plotly" },
+    { name = "psycopg2-binary" },
+    { name = "pydantic" },
+    { name = "pynamodb" },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "sentence-transformers" },
+    { name = "sqlalchemy" },
+    { name = "starlette" },
+    { name = "torch" },
+    { name = "torchaudio" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "umap-learn" },
+    { name = "uvicorn" },
+    { name = "xmltodict" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "line-profiler" },
+    { name = "moto" },
+    { name = "pandas-stubs" },
+    { name = "pip-tools" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-check" },
+    { name = "pytest-cov" },
+    { name = "pytest-timestamper" },
+    { name = "pytest-xdist" },
+    { name = "types-psycopg2" },
+    { name = "types-requests" },
+]
+notebook = [
+    { name = "ipython" },
+    { name = "jupyter" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib" },
+    { name = "nbconvert" },
+    { name = "seaborn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", specifier = ">=0.116.0" },
+    { name = "aws-lambda-powertools", specifier = ">=2.15.0" },
+    { name = "aws-xray-sdk", specifier = ">=2.12.0" },
+    { name = "boto3", specifier = "==1.34.70" },
+    { name = "click", specifier = ">=8.0.0" },
+    { name = "click", specifier = ">=8.3.1" },
+    { name = "colorlog", specifier = ">=6.9.0" },
+    { name = "datamapplot", specifier = ">=0.6.4" },
+    { name = "ddtrace", specifier = ">=3.16.2" },
+    { name = "evoc", specifier = ">=0.1.3" },
+    { name = "fastapi", specifier = "==0.115.0" },
+    { name = "hdbscan", specifier = ">=0.8.40" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "ipython", marker = "extra == 'notebook'", specifier = ">=8.0.0" },
+    { name = "itsdangerous", specifier = ">=2.0.0" },
+    { name = "jinja2", specifier = ">=3.0.0" },
+    { name = "jupyter", marker = "extra == 'notebook'", specifier = ">=1.0.0" },
+    { name = "jupyter-client", marker = "extra == 'notebook'", specifier = ">=8.6.3" },
+    { name = "jupyter-core", marker = "extra == 'notebook'", specifier = ">=5.8.1" },
+    { name = "line-profiler", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "llvmlite", specifier = ">=0.44.0" },
+    { name = "matplotlib", specifier = "==3.10.6" },
+    { name = "matplotlib", marker = "extra == 'notebook'", specifier = ">=3.10.6" },
+    { name = "moto", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "natsort", specifier = ">=8.4.0" },
+    { name = "nbconvert", marker = "extra == 'notebook'", specifier = ">=7.16.6" },
+    { name = "numba", specifier = ">=0.61.2" },
+    { name = "numpy", specifier = ">=1.26.4,<2.0" },
+    { name = "ollama", specifier = ">=0.5.1" },
+    { name = "pandas", specifier = ">=2.1.4" },
+    { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=3.0.3.260530" },
+    { name = "pip-tools", marker = "extra == 'dev'", specifier = ">=7.5.2" },
+    { name = "plotly", specifier = ">=6.3.1" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.3.0" },
+    { name = "psycopg2-binary", specifier = "==2.9.10" },
+    { name = "pydantic", specifier = ">=2.11.9" },
+    { name = "pynamodb", specifier = ">=5.4.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "pytest-check", marker = "extra == 'dev'", specifier = ">=2.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "pytest-timestamper", marker = "extra == 'dev'", specifier = ">=0.0.10" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8.0" },
+    { name = "python-dotenv", specifier = ">=0.21.0" },
+    { name = "python-multipart", specifier = ">=0.0.5" },
+    { name = "requests", specifier = ">=2.28.0" },
+    { name = "rich", specifier = ">=13.0.0" },
+    { name = "scikit-learn", specifier = ">=1.4.2" },
+    { name = "scipy", specifier = ">=1.12.0" },
+    { name = "seaborn", marker = "extra == 'notebook'", specifier = ">=0.13.2" },
+    { name = "sentence-transformers", specifier = ">=2.2.0" },
+    { name = "sqlalchemy", specifier = ">=2.0.36" },
+    { name = "starlette", specifier = ">=0.22.0" },
+    { name = "torch", specifier = "==2.8.0" },
+    { name = "torchaudio", specifier = "==2.8.0" },
+    { name = "torchvision", specifier = "==0.23.0" },
+    { name = "tqdm", specifier = "==4.66.2" },
+    { name = "types-psycopg2", marker = "extra == 'dev'" },
+    { name = "types-requests", marker = "extra == 'dev'" },
+    { name = "typing-extensions", specifier = ">=4.0.0" },
+    { name = "umap-learn", specifier = ">=0.5.7" },
+    { name = "uvicorn", specifier = ">=0.20.0" },
+    { name = "xmltodict", specifier = ">=0.13.0" },
+]
+provides-extras = ["dev", "notebook"]
+
+[[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
+name = "distributed"
+version = "2024.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "dask" },
+    { name = "jinja2" },
+    { name = "locket" },
+    { name = "msgpack" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "sortedcontainers" },
+    { name = "tblib" },
+    { name = "toolz" },
+    { name = "tornado" },
+    { name = "urllib3" },
+    { name = "zict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/ce/0ca6d4e1da90f5b3af135b3abbf0487b2602d046cc090b793869928880b5/distributed-2024.12.1.tar.gz", hash = "sha256:438aa3ae48bfac9c2bb2ad03f9d47899286f9cb3db8a627b3b8c0de9e26f53dd", size = 1115786, upload-time = "2024-12-17T20:26:47.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/90/82171cc7fe1c6d10bac57587c7ac012be80412ad06ef8c4952c5f067f869/distributed-2024.12.1-py3-none-any.whl", hash = "sha256:87e31abaa0ee3dc517b44fec4993d4b5d92257f926a8d2a12d52c005227154e7", size = 1022935, upload-time = "2024-12-17T20:26:42.471Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "envier"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/e7/4fe4d3f6e21213cea9bcddc36ba60e6ae4003035f9ce8055e6a9f0322ddb/envier-0.6.1.tar.gz", hash = "sha256:3309a01bb3d8850c9e7a31a5166d5a836846db2faecb79b9cb32654dd50ca9f9", size = 10063, upload-time = "2024-10-22T09:56:47.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/e9/30493b1cc967f7c07869de4b2ab3929151a58e6bb04495015554d24b61db/envier-0.6.1-py3-none-any.whl", hash = "sha256:73609040a76be48bbcb97074d9969666484aa0de706183a6e9ef773156a8a6a9", size = 10638, upload-time = "2024-10-22T09:56:45.968Z" },
+]
+
+[[package]]
+name = "evoc"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/16/f5309a9137e7669489cb9b53a1e52f9ee0f38ae794c2f1a7174fa547d189/evoc-0.3.1.tar.gz", hash = "sha256:e4986174419885479929595eea471593e06afee8a3abd8d6934e1ca7530ec449", size = 55853, upload-time = "2026-03-27T19:12:49.315Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/51/9fae6b38d7cd38b8b030d612943941b4018ddca83c9d6a11731c0dae71cc/evoc-0.3.1-py3-none-any.whl", hash = "sha256:28e4d73d3e991821a722ba8fb0913dd38e1bb52a26a923caf5fc1c218115161e", size = 60684, upload-time = "2026-03-27T19:12:48.05Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.115.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/5e/bf0471f14bf6ebfbee8208148a3396d1a23298531a6cc10776c59f4c0f87/fastapi-0.115.0.tar.gz", hash = "sha256:f93b4ca3529a8ebc6fc3fcf710e5efa8de3df9b41570958abf1d97d843138004", size = 302295, upload-time = "2024-09-17T19:18:12.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/ab/a1f7eed031aeb1c406a6e9d45ca04bff401c8a25a30dd0e4fd2caae767c3/fastapi-0.115.0-py3-none-any.whl", hash = "sha256:17ea427674467486e997206a5ab25760f6b09e069f099b96f5b55a32fb6f1631", size = 94625, upload-time = "2024-09-17T19:18:10.962Z" },
+]
+
+[[package]]
+name = "fastjsonschema"
+version = "2.22.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/a4/9473c7c3b87009d9c1d74034e4a0f6a35ff0d42dd0f9866d0c3ec4e9217b/fastjsonschema-2.22.2.tar.gz", hash = "sha256:72064e12356a7d6ef02165be2946b9abadbdf238536e07eb587e3dbaa33099cf", size = 385171, upload-time = "2026-08-15T19:47:08.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/82/2755c7c982086f00d4dab85bc120ec35045a9fc2191893a6ce79afe94443/fastjsonschema-2.22.2-py3-none-any.whl", hash = "sha256:0fb3915616adac85ccfdd737d26be1089845d2019819505b42d39888458f74d4", size = 27413, upload-time = "2026-08-15T19:47:04.406Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/a0/50c2c0ce5e74d7721bbb1b19a26ebd339aac5878553a6e35308c2f31f935/filelock-3.32.5.tar.gz", hash = "sha256:f6a6a28f743f9b95ce19db5abe0f376f75eb56517dff21e1a4751e2657d3e83d", size = 222838, upload-time = "2026-08-31T18:56:34.729Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/d2/b70a31e13d04456d28493f31d2aa087e99eeb2767ef0293b2625727ccb8c/filelock-3.32.5-py3-none-any.whl", hash = "sha256:142cd9fa77a872c5e78c62329a0d15278fadc686eb89e760017968961a4fd6b2", size = 100003, upload-time = "2026-08-31T18:56:33.078Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.64.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/41/0f072a712dc74496e03710e462a18a4cfd8a258ad055a4e22d28b43a7abd/fonttools-4.64.0.tar.gz", hash = "sha256:ecb2e59a7bc692fee64dda6010deb66222335693b30046f15cccf81233aa715f", size = 3664266, upload-time = "2026-08-31T15:44:33.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/23/4ea251977fef70ed14193785e1b2949355f1f5927dc0ef1dada675c0bbb2/fonttools-4.64.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9ecb2b206b5b2386f6968721a0770226b66bdd54adc4279bfff3ddf62873eed8", size = 3095501, upload-time = "2026-08-31T15:42:44.299Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/32/943e9034f49797e1a25dbbd60c8047ce0c38c3585c5d1b2db38ce64059c5/fonttools-4.64.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8c631303bb1fd7be3067c47536a30ff1fcb4846d6008c112bc52a03f7cd6965", size = 2583091, upload-time = "2026-08-31T15:42:46.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4b/332cb3105d5d550cb5728e669151601c4f7698cbedafd134154eb806ef83/fonttools-4.64.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2763e452b025ee8e990f0462e76052de9bb094ebc21d296f62c6dfe958886b4", size = 5423449, upload-time = "2026-08-31T15:42:48.615Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8f/e5f2906ea833d362916c64a2f6b1922a07b19442744fd3cd89563f429bff/fonttools-4.64.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:66a83f93579fb3493e458c4449d1d566a7b2a1c7b19915cd0fa3c9b8b5a8540b", size = 5400981, upload-time = "2026-08-31T15:42:50.862Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/46/1b325ebb20aef8bb05f803052ea65931d73638ae3e0d02a6658e3d14e0f8/fonttools-4.64.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cf67f96dc0bfe9607f5f2b734cedfbe2f6f995231adee4ccefa12872044d452d", size = 5359588, upload-time = "2026-08-31T15:42:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d3/ac56fa880e01339aa6ad0bcb457cc30bb4d6c5ca79922e1bd650e4a3a396/fonttools-4.64.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6786bed88581e19bc4f28ea7a64ad531e8f54acf50327fddca942688824a60bd", size = 5520698, upload-time = "2026-08-31T15:42:55.919Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/40/1251fef04c308836a3a7db523703a7ca8ab010dc1e3b9a9bf08e0861c7a8/fonttools-4.64.0-cp312-cp312-win32.whl", hash = "sha256:da4c9bdeaf6b06c12d13d0addfc8ef15aa9695d26574a6dc10751258bef72f30", size = 2430689, upload-time = "2026-08-31T15:42:58.48Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1c/ce0e89183c0235ff6cfbf0603d593023a5afa5333efb35ff569cc0be9ce2/fonttools-4.64.0-cp312-cp312-win_amd64.whl", hash = "sha256:06b6409b868494556a831ae33b2d9a090476c37516b38d70f45a9720b460d423", size = 2482071, upload-time = "2026-08-31T15:43:00.598Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f8/7188153c4b265c899cd035de6a062677d51f67118a4ba640902bd9683e90/fonttools-4.64.0-py3-none-any.whl", hash = "sha256:4a05783ff54ce4c7a28f18e5772efdf63c219374bd9ffc55452182e1cef8be60", size = 1195327, upload-time = "2026-08-31T15:44:31.741Z" },
+]
+
+[[package]]
+name = "fqdn"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/7e/9ecd0285e3153532ae07aeb88063c43c72b4221cf0d4d123b02f3682e3ff/greenlet-3.5.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49520f0c95a48b42cf55414b8e8479beb274ea70431afc33e3f79903c71f4380", size = 295809, upload-time = "2026-08-10T13:25:34.023Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/60e4bbcc89252037b18087f2ec16405d5b2d5be42dde191bbf3667e96102/greenlet-3.5.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55272212cbc5f43d1d723725ab931f1939969b7e9523882ca58b55061769d053", size = 611910, upload-time = "2026-08-10T14:14:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/cd5134be659cd4a443e7a61ae670dabec165a814c51162916d637b6dd38e/greenlet-3.5.5-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655bca754a2ef4efcb0eb48a94d3f4593536d0f3d48f8ed44343c01d16a92f95", size = 624198, upload-time = "2026-08-10T14:27:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d", size = 621439, upload-time = "2026-08-10T13:40:49.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8b/6acf112ed8aee499f25b4d6949820fb02ac950ff9c1f3d793bd5be0599f2/greenlet-3.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:27493374cff1d1b7919dc8126547f2aea582737e3046147b434b1e12de56389b", size = 1581342, upload-time = "2026-08-10T14:15:05.653Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e5/4dee4d8d2e603fe5fdd7b444e63219f7b9bd852c60c6214511c7157cbe88/greenlet-3.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:5f1b1ff4828cdc1aba4266aff814085d04a1d07959287219af021b838b265d52", size = 308362, upload-time = "2026-08-10T13:26:46.839Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hdbscan"
+version = "0.8.44"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/51/b476849d27980d1ce5ba0a172891d37441b0112047894350951f6b169266/hdbscan-0.8.44.tar.gz", hash = "sha256:1ac6196fabdd42072284b60c9be7b9b504b5f4f25cf7a551a8af29a3c7963a4d", size = 7094270, upload-time = "2026-06-01T18:56:31.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f0/4f719c1275158a13918124ce7d798be4b4ae2898469b467216fde974e443/hdbscan-0.8.44-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cc4917a57f73984137bc6f14cddd1a140907102522174af8d8add42668a5e196", size = 2590501, upload-time = "2026-06-01T18:55:52.587Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/95/4f08d8adeba894453a057f1b87d24fb155e040601137cb82536d9708ff30/hdbscan-0.8.44-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d67f2b3628a80764a07fff3a994df2c6b2d9a6b9c8024edde7b36c184f6657f6", size = 5868686, upload-time = "2026-06-01T18:56:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a2/959f617dbff9ebe0ef9b55f61c84b7ad00e5eb91b47b838b3a1a2bf0aa95/hdbscan-0.8.44-cp312-cp312-win_amd64.whl", hash = "sha256:29bffe0ef8a8191e6cd5af3dc7fdf5e7f6334eea8fa39ee8488f2f16911c1cdf", size = 1947427, upload-time = "2026-06-01T18:56:14.433Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/97/2eb4abaa5b969ed385066a0496a3823b3ff467fc1082e2202955f1867d60/huggingface_hub-1.30.0.tar.gz", hash = "sha256:e6a6120bc8c8e2723d03648434ee247088cceb55ba7067e7d34d692cad5fdb57", size = 964291, upload-time = "2026-09-03T10:05:14.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/0e/3e45bbe0dd48f4e56b1d46649d342de853cd1c7e815323472ab62687f153/huggingface_hub-1.30.0-py3-none-any.whl", hash = "sha256:96ae0a8e99a234374a6fe43e989ebd21c04640b91ab2927e7e5773ba1131ca59", size = 796795, upload-time = "2026-09-03T10:05:12.21Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "imageio"
+version = "2.37.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/62/aa770a9307508d2a2a2c62d536a49347bffe9e55322db27838d3c93d0b07/imageio-2.37.4.tar.gz", hash = "sha256:e45cbc5e83502047fb138f7f585f7f105a136a57eea5f4b3cfc6ce1b52720bd3", size = 390173, upload-time = "2026-07-20T05:26:11.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/2d/ca050652104bab2cf55e569db2a178b1b61cb041fef28307f2db383f6d9f/imageio-2.37.4-py3-none-any.whl", hash = "sha256:1ab2e22c8debf700f24c3ac43e8f95f3b3a8110c83b93411e97b4b0b2cd1c7e6", size = 318000, upload-time = "2026-07-20T05:26:09.874Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "ipykernel"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio2" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/e4a38f579de4225a561305666f7541cdabb30075def2aa1ac17bd73c1fb5/ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09", size = 184899, upload-time = "2026-06-10T08:41:25.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/02/77b271f5dc58bfbc0b577c877b2365d1ffea2afe66a80c13f2312820348c/ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057", size = 120583, upload-time = "2026-06-10T08:41:23.648Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/32/99451b1283ec5d92ad77073f12e1c667dc10775384d8f15c2914207149dd/ipython-9.17.1.tar.gz", hash = "sha256:8919be8c27f20a6f4423145028063f6637b42a03ce57665bb12015ee1f073529", size = 4539289, upload-time = "2026-09-01T08:29:32.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/1e/65b59cf518c106aa755e7f7da3099027738687a862ec785060702a481320/ipython-9.17.1-py3-none-any.whl", hash = "sha256:6d1645743cfd1a07eb695d85aa2b5fa66721f8cbae9431d4049f7084bbf06509", size = 639038, upload-time = "2026-09-01T08:29:30.673Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "ipywidgets"
+version = "8.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comm" },
+    { name = "ipython" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/7c/6db60eddf38547353b06d57941f5eee22a990640ce30479fd71a810507f2/ipywidgets-8.1.9.tar.gz", hash = "sha256:bcccba38a6ec3253f7a39c943cea5b9ad01999ce071396171adbc51c6a6a8613", size = 117252, upload-time = "2026-08-18T08:54:24.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/55/298e9b3b864a198234997e87a1471c1b17d7f3546ace6d18fb5cf1ce24b2/ipywidgets-8.1.9-py3-none-any.whl", hash = "sha256:f2b8cbcaae10252b809fbe4d7470db75c09b769a32cbf816d20e5ca6d3c5a79d", size = 140101, upload-time = "2026-08-18T08:54:22.339Z" },
+]
+
+[[package]]
+name = "isoduration"
+version = "20.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/1d/537ab090f302b838943a1b56497dd53059b9a9b46a074936470173a2e207/joblib-1.6.0.tar.gz", hash = "sha256:2ccc96785b12046c08fd6d55839c12857831b54a3c1673ffadd2f04bfc4eda03", size = 327903, upload-time = "2026-08-31T09:39:04.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/53/84099323c2ec4be98d935f63c033ac4151ee83836ca1050ede3b3aadf155/joblib-1.6.0-py3-none-any.whl", hash = "sha256:3dbbf9f6e4b592a2357b854608e980fe6390d131d7a82f011a377ef2ebef7aba", size = 306115, upload-time = "2026-08-31T09:39:02.298Z" },
+]
+
+[[package]]
+name = "json5"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[package.optional-dependencies]
+format-nongpl = [
+    { name = "fqdn" },
+    { name = "idna" },
+    { name = "isoduration" },
+    { name = "jsonpointer" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "rfc3987-syntax" },
+    { name = "uri-template" },
+    { name = "webcolors" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "jupyter"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "jupyter-console" },
+    { name = "jupyterlab" },
+    { name = "nbconvert" },
+    { name = "notebook" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/f3/af28ea964ab8bc1e472dba2e82627d36d470c51f5cd38c37502eeffaa25e/jupyter-1.1.1.tar.gz", hash = "sha256:d55467bceabdea49d7e3624af7e33d59c37fff53ed3a350e1ac957bed731de7a", size = 5714959, upload-time = "2024-08-30T07:15:48.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/64/285f20a31679bf547b75602702f7800e74dbabae36ef324f716c02804753/jupyter-1.1.1-py2.py3-none-any.whl", hash = "sha256:7a59533c22af65439b24bbe60373a4e95af8f16ac65a6c00820ad378e3f7cc83", size = 2657, upload-time = "2024-08-30T07:15:47.045Z" },
+]
+
+[[package]]
+name = "jupyter-builder"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/3e/56f593e6a664cd14d441724654ce8243f3cac7d3e45867cf084749c8bc75/jupyter_builder-1.2.3.tar.gz", hash = "sha256:01aba6794eb9b19e0e29ae21137ca60ba4135c70347d4b9f664a586822b8c809", size = 1024218, upload-time = "2026-09-04T18:54:09.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/aa/be79e87c50698673f196d0633fc1664607da2289f9688d1de7a1c9db9e71/jupyter_builder-1.2.3-py3-none-any.whl", hash = "sha256:c5ea5a7190c2a7b082494abade98eece1b2b5bd5dbd7d610606cbcd10a1d08b3", size = 947541, upload-time = "2026-09-04T18:54:07.644Z" },
+]
+
+[[package]]
+name = "jupyter-client"
+version = "8.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/2a/906772148a06e48885039e0250c340b770a55bbf37b08d6ee0449df369c3/jupyter_client-8.10.0.tar.gz", hash = "sha256:9f7116294dca55f1785be880057d44544db9b1567718d92cb33c58886afb9497", size = 360653, upload-time = "2026-08-28T12:17:10.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/88/7c548de1f6c2ade7c931a3282da73f9274fa6a1531091be682f89c85efb9/jupyter_client-8.10.0-py3-none-any.whl", hash = "sha256:5f73f24f22fa25192cfff6b23c051932a2473a797b05734aff495b392103e14e", size = 110184, upload-time = "2026-08-28T12:17:09.028Z" },
+]
+
+[[package]]
+name = "jupyter-console"
+version = "6.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "pyzmq" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2d/e2fd31e2fc41c14e2bcb6c976ab732597e907523f6b2420305f9fc7fdbdb/jupyter_console-6.6.3.tar.gz", hash = "sha256:566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539", size = 34363, upload-time = "2023-03-06T14:13:31.02Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/77/71d78d58f15c22db16328a476426f7ac4a60d3a5a7ba3b9627ee2f7903d4/jupyter_console-6.6.3-py3-none-any.whl", hash = "sha256:309d33409fcc92ffdad25f0bcdf9a4a9daa61b6f341177570fdac03de5352485", size = 24510, upload-time = "2023-03-06T14:13:28.229Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "jupyter-events"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "packaging" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl", hash = "sha256:c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf", size = 19512, upload-time = "2026-04-20T23:17:48.927Z" },
+]
+
+[[package]]
+name = "jupyter-lsp"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6", size = 55677, upload-time = "2026-04-02T08:10:06.749Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/e8/9d61dcbd1dce8ef418f06befd4ac084b4720429c26b0b1222bc218685eff/jupyter_lsp-2.3.1-py3-none-any.whl", hash = "sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81", size = 77513, upload-time = "2026-04-02T08:10:01.753Z" },
+]
+
+[[package]]
+name = "jupyter-server"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "argon2-cffi" },
+    { name = "jinja2" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "jupyter-events" },
+    { name = "jupyter-server-terminals" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "prometheus-client" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pyzmq" },
+    { name = "send2trash" },
+    { name = "terminado" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/e0/63b481d5b21f81fe23173dfc9eb25629fa1bc174fdc4a2c19d09c1ff8124/jupyter_server-2.21.0.tar.gz", hash = "sha256:70d9a1883f57d3576ea17f4ce061ec1a7aad7ef388d00428cfb7f5e4f0022271", size = 760357, upload-time = "2026-08-27T16:06:34.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/8a/cb97c2b353cb46cced413be8f742fa8fcd3cb1659524f27314494aa94968/jupyter_server-2.21.0-py3-none-any.whl", hash = "sha256:2ae2e5ce5e97268553e25aebe040197455673d925b5fc7995477153318160cf7", size = 393961, upload-time = "2026-08-27T16:06:31.814Z" },
+]
+
+[[package]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "terminado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320841fc300911a55143925112a72a883e2ca71fba4c618d/jupyter_server_terminals-0.5.4-py3-none-any.whl", hash = "sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14", size = 13704, upload-time = "2026-01-14T16:53:18.738Z" },
+]
+
+[[package]]
+name = "jupyterlab"
+version = "4.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-lru" },
+    { name = "httpx" },
+    { name = "ipykernel" },
+    { name = "jinja2" },
+    { name = "jupyter-builder" },
+    { name = "jupyter-core" },
+    { name = "jupyter-lsp" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "packaging" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/c0/45934229995d4c6e38192ca118d93185f60808f64157e3df3c5c28f8c5fd/jupyterlab-4.6.3.tar.gz", hash = "sha256:2e3db6e3a12495ebd188276e985bf5ac502fbde3d1e8628819920210008de498", size = 28319771, upload-time = "2026-08-10T18:50:57.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/47/242f46de028074651c9bd6d8000fc340ed0d3cdd1a0eae4387826123413a/jupyterlab-4.6.3-py3-none-any.whl", hash = "sha256:0a1ebc6567186f1eabd99536e94df7ed9e96d1e7c5ddf3e4406ae16e88abacb7", size = 17168312, upload-time = "2026-08-10T18:50:53.044Z" },
+]
+
+[[package]]
+name = "jupyterlab-pygments"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "jupyterlab-server"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "jinja2" },
+    { name = "json5" },
+    { name = "jsonschema" },
+    { name = "jupyter-server" },
+    { name = "packaging" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
+]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/8b/e739cf9066ad5037a2d4b0a403f06da374fdccb9748221661c8b492d3dbc/jupyterlab_widgets-3.0.17.tar.gz", hash = "sha256:6e61fe21ca8a66039180a5cc52a433e07279d2fee79c8be963e00d55193f17a8", size = 213919, upload-time = "2026-08-18T08:52:17.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/ef/6d27fc118f58cb24886da413545a7efb0853d405fddbfd8b2d9ac09fbed4/jupyterlab_widgets-3.0.17-py3-none-any.whl", hash = "sha256:40ac1e9955acf116c4d995d9bfa082d86ad9ec6d91c4f134827cf5e0a5eb75e0", size = 217292, upload-time = "2026-08-18T08:52:15.47Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/07/bd78e6a8fae171ea041ef5bba3ed21a003522fa088834b069b1909981f30/kiwisolver-1.5.1.tar.gz", hash = "sha256:f1303ef2eec81262a4b708c3e858afe58d7c75ad91c1c05266eda7673369859a", size = 104395, upload-time = "2026-08-28T10:28:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/9b/65b302742389c6f96f2956bef5decf26011309feb2fc5d79613af18adea4/kiwisolver-1.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:63fb7294b768f444eb4b068965f2662f28c2fd4161e23bd60fcf3ff27b74c046", size = 123876, upload-time = "2026-08-28T10:25:27.44Z" },
+    { url = "https://files.pythonhosted.org/packages/71/74/c21f339956f6f691b2ed7e31d5f3ae767304df6c460192739fc830853051/kiwisolver-1.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0ebdef3eae5336568147c39a55be6a2036ffde53faa9ca2d978989ae7c2da12c", size = 66487, upload-time = "2026-08-28T10:25:28.728Z" },
+    { url = "https://files.pythonhosted.org/packages/84/e5/bdb34e21523e01dceda064d63713f3bdec91388af24fba1eca7ea5e85864/kiwisolver-1.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1798e83840c3f627246104c4d8a9639c60fa068adf9ce92b61791781fa8a68c1", size = 64660, upload-time = "2026-08-28T10:25:30.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f4/dadfec469313c7f428efa7e84b4aba9732f813c13ea7131a24b7b008ef57/kiwisolver-1.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34633ecf50d16187ab8e5528b7a2530f2feb4e23f300db4672538b51cfc5cd38", size = 1477929, upload-time = "2026-08-28T10:25:31.495Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/35/09c58daac34e6f6ea5c6dee0094b422118e5a7c265586008a95fd135ac5f/kiwisolver-1.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d27c2123977cb9269c30a49ba45f03a4323017ef693e19db4ec9dbe1299a3002", size = 1278499, upload-time = "2026-08-28T10:25:33.375Z" },
+    { url = "https://files.pythonhosted.org/packages/19/32/739765e24fbad29d13f83e546ea4abc215a78cea9d677ca09025b027724d/kiwisolver-1.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6a797a1cefc8b9c93170db580337e1fe3d011ad18b1299943231279406342048", size = 1296677, upload-time = "2026-08-28T10:25:35.059Z" },
+    { url = "https://files.pythonhosted.org/packages/df/32/03304d1010e2cc45e5b3b52cef7e43fed3a2a5cd6c87a89b4a88e1d85b5d/kiwisolver-1.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2551cf9917af48ee7c4b29cc82320489508cf96fd26a51f6fc124de661cd44c7", size = 1346037, upload-time = "2026-08-28T10:25:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/57/4c49377bfd274450dd72ecaa13eaac32ea804a03363e4d1db0c5aa999ceb/kiwisolver-1.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:38f6e0deb4d0a4615efe0c4efc5990b06ae450ab50a0b321c0b078b6d238c083", size = 988248, upload-time = "2026-08-28T10:25:38.299Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c3/38df144a08b6c5d75ca4504e5cc3141bb3bfef64c04f4ef48204f42711b6/kiwisolver-1.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bfd1de989b3330420e29de39352f5c049905c9e3ee67233a50d550e3d652c148", size = 2228722, upload-time = "2026-08-28T10:25:40.038Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/11/3221838a89cd64d9b386353e000cd8a296069a20fbe3584507fdfd5bebae/kiwisolver-1.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1209042a623ddfda5497e4066c7b77651dde8e1d3a9dd97599dc7e97f3b9b78c", size = 2325216, upload-time = "2026-08-28T10:25:41.699Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d4/075c219230697bb5db910d37262b9bacf880f92b4811a02ab81ed073a253/kiwisolver-1.5.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:26e8268480be5061d509e29669d59103c067a26377a56491630ece11762e3858", size = 1977689, upload-time = "2026-08-28T10:25:43.559Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/08/1d219c3c2dd960983d0d4da623d916e9de6385df2b0bab3d1af0e9b8fccc/kiwisolver-1.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:d79308fa689fac89cbcfbd4dbfc80b5f95c54c5a7fd4d194be221f9d33d026e6", size = 2491443, upload-time = "2026-08-28T10:25:45.242Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d3/024208ec1079d273f1047468d1bdffbf38bb75b7b268090fd3a0301b9d9a/kiwisolver-1.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b03af77d77e50edba2030fd5f7c352ff209314b09030a3cba7c14edf9a09a444", size = 2295200, upload-time = "2026-08-28T10:25:46.984Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/7c/7b210498f9f92e1cd7855f260fa69ef056881087b199ee20c208f0e4189a/kiwisolver-1.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:06a6917674de9e0fe3f66f5430787f59a9f2ddb64af9b714eaec547e29ef5c19", size = 70748, upload-time = "2026-08-28T10:25:48.444Z" },
+    { url = "https://files.pythonhosted.org/packages/94/61/ef0daa157c8bb23672f7423e0d14c39db1dc6ef8ed47e6bc54c9c1bef3bf/kiwisolver-1.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:ad8b9671348d7c8716715652ae11f85ed0eb99e265a2df2ca490577d69860b2c", size = 68324, upload-time = "2026-08-28T10:25:49.81Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c4/1407df7512a5b36cc79840e01710dc575733c461b13ab866cae77eaf87f3/kiwisolver-1.5.1-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:482676e5bd48d70ac99d9fc78863469845421e01184fa83f1f9366dc49f7e974", size = 134002, upload-time = "2026-08-28T10:28:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/16/45/c37a21ad5c0ab581a93c55ad544721aaa1f0ae94edb29c6a678a23d013e6/kiwisolver-1.5.1-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:072bdb15a3c19a5b5dbc8f8fb1f4e1884bf4f3507eeb4cc6334401274d37a5c0", size = 194292, upload-time = "2026-08-28T10:28:11.06Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/69f00d627949580e43d57af0aa465df46868d7c29801c137a55374101294/kiwisolver-1.5.1-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:a5a00665d1a0e26763a7338d7e911d4598fbc1d50dd0d6b7919b7dc6c5d6569f", size = 73362, upload-time = "2026-08-28T10:28:12.449Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
+
+[[package]]
+name = "line-profiler"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/b6/6d18ad201417a9c5168995541d0fd7981b5652b2b34f6e46a3a93c0f1beb/line_profiler-5.0.2.tar.gz", hash = "sha256:8d8a990c84c64bcde45af22af502d17bc0ae107be405ce41bba92af5c39c0000", size = 407075, upload-time = "2026-02-23T23:31:20.698Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/92/fb766e6355118d2a681c18525d4c005c146ec44b064ccfd70f4529d8d260/line_profiler-5.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:256c1d5e84a93254dbe656d0486322190cc68f6b517544edef17a9f00167e680", size = 646920, upload-time = "2026-02-23T23:30:14.692Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9d/3583c1cdc740206de9e4734bdcf377d649b89ea876bc36001d95b3dea67d/line_profiler-5.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:892f0cd9967b101ce7528be2d388616037c73cb27830effd7493fa021165c622", size = 505695, upload-time = "2026-02-23T23:30:16.375Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/412476a1d09beac783d11d3bbf85fe6c1e3d50058e3c28967fee59c46649/line_profiler-5.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d2d02735843c14337dae3e80d95a732b4657ef759def75162ef97a1aa7466aac", size = 495859, upload-time = "2026-02-23T23:30:18.036Z" },
+    { url = "https://files.pythonhosted.org/packages/37/75/65028bad08264fd8f9c3f0fd405c539ff552c2d1cf2a00965157ad148973/line_profiler-5.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d2e166a86dc9c78c349ee18b592b98ebfb9dae615f63fc77cce5f5f751a6ad0", size = 1464882, upload-time = "2026-02-23T23:30:19.273Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/6c/2d0286f67e6bb2b00ae23f9af6df18bfc6bb1ac5d803a8f46bd3eb22a8f1/line_profiler-5.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a870b68af1539d718d030f4c4726d35cff4b14ab605147e65222933c5c0e10e", size = 1484331, upload-time = "2026-02-23T23:30:20.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a4/b01359733214a1a85c5f86f3953b07deb61b267efa0328e8d436a1ad80ea/line_profiler-5.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:fe8cd787caa2a02ca7e138832fa4cab1f198377eaf6e5e8263e8b7506157c454", size = 2411802, upload-time = "2026-02-23T23:30:21.995Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f4/1fa91206a6c50091cf614fdd5c9d349eb3a57d23f5eb8be8fffe7e0525b9/line_profiler-5.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:70ff915ade9e3ec38ff043ff093b590bbb3055e6fc8b311e0fe14cd78fb2a7f7", size = 2495790, upload-time = "2026-02-23T23:30:23.448Z" },
+    { url = "https://files.pythonhosted.org/packages/87/18/d389c72dce6c8318c088a7c29ee8961a913c8a1c6469888b517e8f47ddaf/line_profiler-5.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:026779b9dfca0f367174f5d34bcccffce2755db40a4389f0d8a531a2e3ca7cfc", size = 478790, upload-time = "2026-02-23T23:30:24.848Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/54/d171600a4190c07215090a88846ef0093b5bf34a81f8059115592dbb1354/line_profiler-5.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:fe22b927f05a61a0149976bf0d22d8e56fa742ec89f3d72358db71a1f440c77b", size = 462269, upload-time = "2026-02-23T23:30:26.237Z" },
+]
+
+[[package]]
+name = "llvmlite"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/27/72ae94ea5c8f7349ec1c229d4cd058feb799cbd0833ad6d1b47c919b37b7/llvmlite-0.49.0.tar.gz", hash = "sha256:00f16db782f4a13c78c5804aedc434e46794a77e89999a168f9401106270e50a", size = 194467, upload-time = "2026-08-11T16:26:00.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/ae/3f699ebe3590e15e023a6372dd147526fd8ec398aacf9ceb844e854964a8/llvmlite-0.49.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:b541c8fac3450db7574d1f53cf9dff83f285bfed9d69bf81fe71fc2a7d4f97fe", size = 40479231, upload-time = "2026-08-11T16:23:56.773Z" },
+    { url = "https://files.pythonhosted.org/packages/be/3c/e97f69c62a2d972066d9a2612ce1f3de313035ac897a5b9f787cad8b55f7/llvmlite-0.49.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6acba646d88abbc87d5c113a3d62c1fbf8b8fee11c6493f516803e30f21ae870", size = 59890658, upload-time = "2026-08-11T16:24:05.451Z" },
+    { url = "https://files.pythonhosted.org/packages/69/e6/e942ee08605fc0526ff3854260c384d8315a5830e16c4c2a5aebc14dc9bf/llvmlite-0.49.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ec8ad805e7515cb8440a690eb3cef4d34acb29eef80b705ec4e1c1ad3c43c68", size = 58344481, upload-time = "2026-08-11T16:24:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/49/2a44871cac6b5a2fd4aabd68cfdaf6de9a5c7edb36dee5d47b77bda4b50f/llvmlite-0.49.0-cp312-cp312-win_amd64.whl", hash = "sha256:3a9c9e3af4e214acfefa4f73ebe7bc3fb35854a62b654edb3953f5ae33c08ba3", size = 41865543, upload-time = "2026-08-11T16:24:20.41Z" },
+]
+
+[[package]]
+name = "locket"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/83/97b29fe05cb6ae28d2dbd30b81e2e402a3eed5f460c26e9eaa5895ceacf5/locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632", size = 4350, upload-time = "2022-04-20T22:04:44.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3", size = 4398, upload-time = "2022-04-20T22:04:42.23Z" },
+]
+
+[[package]]
+name = "lz4"
+version = "4.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/ac/016e4f6de37d806f7cc8f13add0a46c9a7cfc41a5ddc2bc831d7954cf1ce/lz4-4.4.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:df5aa4cead2044bab83e0ebae56e0944cc7fcc1505c7787e9e1057d6d549897e", size = 207163, upload-time = "2025-11-03T13:01:45.895Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/df/0fadac6e5bd31b6f34a1a8dbd4db6a7606e70715387c27368586455b7fc9/lz4-4.4.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d0bf51e7745484d2092b3a51ae6eb58c3bd3ce0300cf2b2c14f76c536d5697a", size = 207150, upload-time = "2025-11-03T13:01:47.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/17/34e36cc49bb16ca73fb57fbd4c5eaa61760c6b64bce91fcb4e0f4a97f852/lz4-4.4.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7b62f94b523c251cf32aa4ab555f14d39bd1a9df385b72443fd76d7c7fb051f5", size = 1292045, upload-time = "2025-11-03T13:01:48.667Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1c/b1d8e3741e9fc89ed3b5f7ef5f22586c07ed6bb04e8343c2e98f0fa7ff04/lz4-4.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c3ea562c3af274264444819ae9b14dbbf1ab070aff214a05e97db6896c7597e", size = 1279546, upload-time = "2025-11-03T13:01:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/e3867222474f6c1b76e89f3bd914595af69f55bf2c1866e984c548afdc15/lz4-4.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24092635f47538b392c4eaeff14c7270d2c8e806bf4be2a6446a378591c5e69e", size = 1368249, upload-time = "2025-11-03T13:01:51.273Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e7/d667d337367686311c38b580d1ca3d5a23a6617e129f26becd4f5dc458df/lz4-4.4.5-cp312-cp312-win32.whl", hash = "sha256:214e37cfe270948ea7eb777229e211c601a3e0875541c1035ab408fbceaddf50", size = 88189, upload-time = "2025-11-03T13:01:52.605Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/0b/a54cd7406995ab097fceb907c7eb13a6ddd49e0b231e448f1a81a50af65c/lz4-4.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:713a777de88a73425cf08eb11f742cd2c98628e79a8673d6a52e3c5f0c116f33", size = 99497, upload-time = "2025-11-03T13:01:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7e/dc28a952e4bfa32ca16fa2eb026e7a6ce5d1411fcd5986cd08c74ec187b9/lz4-4.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:a88cbb729cc333334ccfb52f070463c21560fca63afcf636a9f160a55fac3301", size = 91279, upload-time = "2025-11-03T13:01:54.419Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.10.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/59/c3e6453a9676ffba145309a73c462bb407f4400de7de3f2b41af70720a3c/matplotlib-3.10.6.tar.gz", hash = "sha256:ec01b645840dd1996df21ee37f208cd8ba57644779fa20464010638013d3203c", size = 34804264, upload-time = "2025-08-30T00:14:25.137Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/1a/7042f7430055d567cc3257ac409fcf608599ab27459457f13772c2d9778b/matplotlib-3.10.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:31ca662df6a80bd426f871105fdd69db7543e28e73a9f2afe80de7e531eb2347", size = 8272404, upload-time = "2025-08-30T00:12:59.112Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5d/1d5f33f5b43f4f9e69e6a5fe1fb9090936ae7bc8e2ff6158e7a76542633b/matplotlib-3.10.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1678bb61d897bb4ac4757b5ecfb02bfb3fddf7f808000fb81e09c510712fda75", size = 8128262, upload-time = "2025-08-30T00:13:01.141Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c3/135fdbbbf84e0979712df58e5e22b4f257b3f5e52a3c4aacf1b8abec0d09/matplotlib-3.10.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:56cd2d20842f58c03d2d6e6c1f1cf5548ad6f66b91e1e48f814e4fb5abd1cb95", size = 8697008, upload-time = "2025-08-30T00:13:03.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/be/c443ea428fb2488a3ea7608714b1bd85a82738c45da21b447dc49e2f8e5d/matplotlib-3.10.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:662df55604a2f9a45435566d6e2660e41efe83cd94f4288dfbf1e6d1eae4b0bb", size = 9530166, upload-time = "2025-08-30T00:13:05.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/35/48441422b044d74034aea2a3e0d1a49023f12150ebc58f16600132b9bbaf/matplotlib-3.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:08f141d55148cd1fc870c3387d70ca4df16dee10e909b3b038782bd4bda6ea07", size = 9593105, upload-time = "2025-08-30T00:13:08.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/c3/994ef20eb4154ab84cc08d033834555319e4af970165e6c8894050af0b3c/matplotlib-3.10.6-cp312-cp312-win_amd64.whl", hash = "sha256:590f5925c2d650b5c9d813c5b3b5fc53f2929c3f8ef463e4ecfa7e052044fb2b", size = 8122784, upload-time = "2025-08-30T00:13:10.367Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b8/5c85d9ae0e40f04e71bedb053aada5d6bab1f9b5399a0937afb5d6b02d98/matplotlib-3.10.6-cp312-cp312-win_arm64.whl", hash = "sha256:f44c8d264a71609c79a78d50349e724f5d5fc3684ead7c2a473665ee63d868aa", size = 7992823, upload-time = "2025-08-30T00:13:12.24Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mistune"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/92/328a294a6de83bacb95bed01f04e0eaff4e3616ee359fc821a5dfc539b02/mistune-3.3.4.tar.gz", hash = "sha256:58b5c96d6fcb61190dfe5fae498d2b2065f99cf61e9649418fd54cf1ada86dfe", size = 121426, upload-time = "2026-07-22T05:22:30.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/e4/288365afae98953bc01de09f686f40d8ee84578135aa7767d5d4e60b5278/mistune-3.3.4-py3-none-any.whl", hash = "sha256:ee015381e955e370962968befe1d729ab60fafb6a715ac6751763fbce38c8d4a", size = 66862, upload-time = "2026-07-22T05:22:29.419Z" },
+]
+
+[[package]]
+name = "moto"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0f/1682c01ca0608c25526afb150246a3c9c1f609caccbd39758de4850e31bc/moto-5.2.3.tar.gz", hash = "sha256:a9e95c3218b6eda18e74571f1ced11cb1bc3151467d562c1da6037b9d19832cb", size = 8785514, upload-time = "2026-08-22T18:46:00.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/80/ee7ace7a49bd525455497fa2ff198111877d6f93b908b657adeb2cf057a4/moto-5.2.3-py3-none-any.whl", hash = "sha256:5ec31b3cdbb383a19d46030157bd82aaaa7a9cc5f564200f995663d347bd4728", size = 6780972, upload-time = "2026-08-22T18:45:55.719Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/ea2100ec54d30c46ee9dba10a3bfb79b655e96c6df237238a3234c75869b/msgpack-1.2.2.tar.gz", hash = "sha256:9eb0b0e602064527a045ea28c4f174ed69383587e29cebe28947e3b84106eb2a", size = 187025, upload-time = "2026-08-27T10:03:47.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/78/90c15bebb1a72667349ca62d4507e9d9369e7f8f76b95f490b823d3622e5/msgpack-1.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a4348705be86e029d04e741cf9ed0dfe03e942d7d3b92e838fa80d3aa2c3ebc", size = 84275, upload-time = "2026-08-27T10:02:07.106Z" },
+    { url = "https://files.pythonhosted.org/packages/88/88/c2b6d8e81571da87aa232c0e34a3f3a0e618e6235892065ec82d1d81fc7a/msgpack-1.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a652ceeededf71d3fa40c303a02a149d42338d310162367b91c539d4bd6e0a3", size = 83970, upload-time = "2026-08-27T10:02:08.488Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c0/d3ede9f5d16acb4c05a9281859f1e99ef9f877a928eb78454c37f70db001/msgpack-1.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90986cc9aab9d7d1d8f38bcbf65d3f7ac83bdd90c35765db7d691b4829698cba", size = 409401, upload-time = "2026-08-27T10:02:09.877Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f0/29f591bea185616cf417645ac03bd3ad9b317483ad8572160e325f7fe777/msgpack-1.2.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:77c2e018417dc1d66f235e383877ee885b60ade9d29e494dd581e08af2cb1923", size = 420619, upload-time = "2026-08-27T10:02:11.526Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8e/c70c8c9180c5ddf4440eb8658ebead98e22e7686fbf84f6b165031430750/msgpack-1.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0e91332144f69bc3018c91232fac26da580ef748fb8eaddd7914d4458001cc4f", size = 379747, upload-time = "2026-08-27T10:02:13.345Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9a/f10ce11fa62700c9ab87a22e65b9ca272f7f673ddd31aeb2de6ae272ad35/msgpack-1.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e915d390d7068b257ca8b62f3fc59fad135c8631d1017ab03b0b924b07c5367", size = 398944, upload-time = "2026-08-27T10:02:15.006Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fe/d7be978456ff8552e69a8e270d882e7530e01513c096b293d83df03753ea/msgpack-1.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c522420d78db2431887d45b518e304d86e27b9ad0b30f24e3806a6ad5d8bdbfc", size = 373979, upload-time = "2026-08-27T10:02:16.618Z" },
+    { url = "https://files.pythonhosted.org/packages/be/af/91b0d8d3fb3063e259daee3ea8515cea6282f68f4b0e5f0b6fea25762c6e/msgpack-1.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4b554d8164ebb526892194f71dcd96ef1fefe0c250087498785d3ffc04a80be3", size = 417781, upload-time = "2026-08-27T10:02:18.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3c/ce8e9efe1fd9e95c78b3705e4300ba7feba3dc6c00fb76259895db155518/msgpack-1.2.2-cp312-cp312-win32.whl", hash = "sha256:0e3315de5a4b2920ccef48d96b4448025e064a10d0f5a250f6584477d839c8d4", size = 65267, upload-time = "2026-08-27T10:02:19.869Z" },
+    { url = "https://files.pythonhosted.org/packages/85/98/a33b8b4af14e3476bb0da1b8c36ef7a0f28dcf95db1c5e68ff88cb89d591/msgpack-1.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:b68614fba0570349833b7dd999ff0aed4e5cc8d9eb6e3a7d4527be33c65e33d3", size = 72275, upload-time = "2026-08-27T10:02:21.141Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5e/2f323a33a6aba5bd4b2d8b430e4fab21d92cd91c093b49ee287bc166ee54/msgpack-1.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:59d5b93efa45fd09f620d0c9ba81cde339a2c9937af3eea42ee9653094ce6640", size = 65488, upload-time = "2026-08-27T10:02:22.575Z" },
+]
+
+[[package]]
+name = "multipledispatch"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/3e/a62c3b824c7dec33c4a1578bcc842e6c30300051033a4e5975ed86cc2536/multipledispatch-1.0.0.tar.gz", hash = "sha256:5c839915465c68206c3e9c473357908216c28383b425361e5d144594bf85a7e0", size = 12385, upload-time = "2023-06-27T16:45:11.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl", hash = "sha256:0c53cd8b077546da4e48869f49b13164bebafd0c2a5afceb6bb6a316e7fb46e4", size = 12818, upload-time = "2023-06-27T16:45:09.418Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7b/6248dada39781db1ab3ebf08943080df0796098515a87f6f8696d14ec744/narwhals-2.25.0.tar.gz", hash = "sha256:62c036c810662bf7820b7737077176313bc59350eeeefb808510f388c743e4b2", size = 677076, upload-time = "2026-08-20T18:10:15.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl", hash = "sha256:1f0f403e8c7e4463cde9bfe78b12fdd809e3ae3dda6d9b2f802934fb9c7a6a8f", size = 467373, upload-time = "2026-08-20T18:10:13.834Z" },
+]
+
+[[package]]
+name = "natsort"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
+]
+
+[[package]]
+name = "nbclient"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "nbformat" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/a5/b3bae4b590c0cbcada2c63a34f7580024e834a8ba213e949a2f906705787/nbclient-0.11.0.tar.gz", hash = "sha256:04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a", size = 62535, upload-time = "2026-06-05T07:52:41.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/c9/94d73e5a01c5b926c3fa2496e97d7a8dc28ed5a77c0b2ed712f1a62e6694/nbclient-0.11.0-py3-none-any.whl", hash = "sha256:ef7fa0d59d6e1d41103933d8a445a18d5de860ca6b613b87b8574accdb3c2895", size = 25288, upload-time = "2026-06-05T07:52:40.115Z" },
+]
+
+[[package]]
+name = "nbconvert"
+version = "7.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "bleach", extra = ["css"] },
+    { name = "defusedxml" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyterlab-pygments" },
+    { name = "markupsafe" },
+    { name = "mistune" },
+    { name = "nbclient" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "pandocfilters" },
+    { name = "pygments" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/b1/708e53fe2e429c103c6e6e159106bcf0357ac41aa4c28772bd8402339051/nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2", size = 865311, upload-time = "2026-04-08T00:44:14.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl", hash = "sha256:aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8", size = 261927, upload-time = "2026-04-08T00:44:12.845Z" },
+]
+
+[[package]]
+name = "nbformat"
+version = "5.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/72/b3446efab8756e7df4b8ec587f8e611cb5a7249e4323db480802f1d3be04/nbformat-5.11.1.tar.gz", hash = "sha256:32d4521c68c6e7d5b29c76defaeed9f42ea733142b9b19f88277ce10390b9c4d", size = 147775, upload-time = "2026-08-17T08:10:51.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/69/ee613f74085ca7103f79cd08d579c4f3177d1d26e5d3d9528d2d6536a707/nbformat-5.11.1-py3-none-any.whl", hash = "sha256:cc6698fa75f4fab8755ead786317815f13a6fee3b53311c0abb1a8b51d52f7ec", size = 79849, upload-time = "2026-08-17T08:10:50.18Z" },
+]
+
+[[package]]
+name = "nest-asyncio2"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "notebook"
+version = "7.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-builder" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/d9/5c76de84e96e1cf8aae3fce930875e0615e14f3557bbcdb634aab52da9d3/notebook-7.6.2.tar.gz", hash = "sha256:cc02b5f0bb972160cccfe44ad8a1a202036206ba3439469c514f03aefa9ae807", size = 5500147, upload-time = "2026-08-11T13:21:16.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fd/3e552ff5b24dd305c6e9a10e8645e29c03091c317429f326ae10dbae1ac6/notebook-7.6.2-py3-none-any.whl", hash = "sha256:5fe9e09c335cb4b7de21627b860f77210e70e54b1fb1276ad942a4a7e1d858d3", size = 5547102, upload-time = "2026-08-11T13:21:13.302Z" },
+]
+
+[[package]]
+name = "notebook-shim"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.67.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/90/2544f4e3a61e501d6c9a5418fd4b905323222693d54a02cab0106a0af865/numba-0.67.0.tar.gz", hash = "sha256:cd75aa535b33fa05d9d930b1ae8af9f97a2881e96d72dfb38ec9b78284d9f851", size = 2836515, upload-time = "2026-08-11T23:04:00.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/58/915cddba90010348ed0444451132fdde9b000bcbaff1582029b5bf115d11/numba-0.67.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6004d8d5f28d4028687fb2d972d629295b13685943bd2ed5cd8810c3b848e219", size = 2745050, upload-time = "2026-08-11T23:03:25.607Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/38/926757caaac18a66f057d7544a63620bf360a07d281c9f7ecadd2aa83963/numba-0.67.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f63d43db06b4756424d6d2484737c902e0ae944a0eec3e8b0b4de2c695b15caa", size = 3884596, upload-time = "2026-08-11T23:03:27.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6d/58291dc58da39d98b32db7f044729f6d8d4920cd9622fbab3179b54ff4c4/numba-0.67.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76d3335aaeffb9dc88309420890e73497a00be08a7530441bc2b58ffe025bfa5", size = 3585290, upload-time = "2026-08-11T23:03:29.684Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/63/ab21828b4056afed71f9ecb40f4de26c2c19de731cc001961aca74b79464/numba-0.67.0-cp312-cp312-win_amd64.whl", hash = "sha256:50e2b72406c18cda5dd7431b0082cb85ea94e06c64c33607248fc8bef92cfb81", size = 2815645, upload-time = "2026-08-11T23:03:31.732Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "1.26.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901, upload-time = "2024-02-05T23:55:32.801Z" },
+    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b", size = 13685868, upload-time = "2024-02-05T23:55:56.28Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b", size = 13925109, upload-time = "2024-02-05T23:56:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed", size = 17950613, upload-time = "2024-02-05T23:56:56.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a", size = 13572172, upload-time = "2024-02-05T23:57:21.56Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643, upload-time = "2024-02-05T23:57:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803, upload-time = "2024-02-05T23:58:08.963Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754, upload-time = "2024-02-05T23:58:36.364Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/5b/4e4fff7bad39adf89f735f2bc87248c81db71205b62bcc0d5ca5b606b3c3/nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adf27ccf4238253e0b826bce3ff5fa532d65fc42322c8bfdfaf28024c0fbe039", size = 322364134, upload-time = "2025-06-03T21:58:04.013Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+]
+
+[[package]]
+name = "ollama"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", size = 53145, upload-time = "2026-04-29T21:21:15.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", size = 15115, upload-time = "2026-04-29T21:21:13.794Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+]
+
+[[package]]
+name = "pandas-stubs"
+version = "3.0.5.260730"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/d2/dea4a3a56b7b5f69c5fbca9f14625fcf28e1a39a657e9833d4a10bcac593/pandas_stubs-3.0.5.260730.tar.gz", hash = "sha256:f70a232c57d93a5a2c81f8a53953e10891a5374bc92652277deb325e2e4d0ff3", size = 114631, upload-time = "2026-07-30T14:31:42.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/c2/959caec5c46f484b5f8bb6def4b0cf7a45ba6acda26f12b75142d98cc5ae/pandas_stubs-3.0.5.260730-py3-none-any.whl", hash = "sha256:60e90e3e1eda6937e337e243cbe6217e151c11137cd7eddf832af537c7310bfd", size = 174807, upload-time = "2026-07-30T14:31:41.17Z" },
+]
+
+[[package]]
+name = "pandocfilters"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/6f/3dd4940bbe001c06a65f88e36bad298bc7a0de5036115639926b0c5c0458/pandocfilters-1.5.1.tar.gz", hash = "sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e", size = 8454, upload-time = "2024-01-18T20:08:13.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl", hash = "sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc", size = 8663, upload-time = "2024-01-18T20:08:11.28Z" },
+]
+
+[[package]]
+name = "param"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/fc/ec34c6fa440c9b5491ee1820874b8776489756820bba16d55b885d07655a/param-2.4.2.tar.gz", hash = "sha256:40ca94b72c97bf1998325738e002d589ce31a7cfb4cc56549f05daa6ccf98043", size = 225945, upload-time = "2026-09-03T11:02:01.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/94/ff5ad5b758c61c1b33755e02c3a653d1d41c36891329e76a8e6b6e69e8b1/param-2.4.2-py3-none-any.whl", hash = "sha256:56f56e991d11cdf9fa8248ca3b1c7d5badfd6b4da3b3886b764b95823d270b07", size = 155563, upload-time = "2026-09-03T11:02:00.069Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
+name = "partd"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "locket" },
+    { name = "toolz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/3a/3f06f34820a31257ddcabdfafc2672c5816be79c7e353b02c1f318daa7d4/partd-1.4.2.tar.gz", hash = "sha256:d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c", size = 21029, upload-time = "2024-05-06T19:51:41.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl", hash = "sha256:978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f", size = 18905, upload-time = "2024-05-06T19:51:39.271Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
+]
+
+[[package]]
+name = "pip-tools"
+version = "7.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "build" },
+    { name = "click" },
+    { name = "pip" },
+    { name = "pyproject-hooks" },
+    { name = "setuptools" },
+    { name = "wheel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/07/a0e89bfdb5ec55b8d6ae28c3edf22a2331909325c9b01c364acc4448f6df/pip_tools-7.6.1.tar.gz", hash = "sha256:695556edeb647eb94ee8345cc7108657fdb7fb16b3876623a399b4f61bbede01", size = 187948, upload-time = "2026-08-12T00:04:08.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/88/3b050c2b3948e8a090cfbd4f04a43359566f9974d66692826d42f4fe5357/pip_tools-7.6.1-py3-none-any.whl", hash = "sha256:6111c8b4b07fd14b7223ca921485b0e96cf66e20bf94da95eeed9845f510cb8f", size = 74661, upload-time = "2026-08-12T00:04:07.367Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/b7/802a56eca9f2fac455b8bab5375a2647b0f0e14a2cd63ef077de3c4a7658/platformdirs-4.11.7.tar.gz", hash = "sha256:4f41487eeeeeb07f3a6625e61d9bc0ae6809f92d3386dbd74392fbb76108104d", size = 35127, upload-time = "2026-09-01T13:35:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/6e/80993e10a0482f630cef528635789233224f36b1ffd11592aa15d13ff9ce/platformdirs-4.11.7-py3-none-any.whl", hash = "sha256:8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6", size = 23938, upload-time = "2026-09-01T13:35:09.02Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/9e/8894e8eae20a5b2a44aa568b1d2d80291e8eea6ce7bc75cdc7a152aef0ac/plotly-7.0.0.tar.gz", hash = "sha256:08b21f1244a97e7a1a699833c4bb2678475aa108b3f1989886ed0b038ebfd849", size = 6218668, upload-time = "2026-08-25T17:47:29.088Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/2f/6f492108d9955bac97979d9949c1b35eab30fc630b1f22bbdd2c7cacbab4/plotly-7.0.0-py3-none-any.whl", hash = "sha256:78cbf7bd06d1b05bb3b8ec1b709864695229b55151b6f7530fbf55517ead6fdd", size = 9052859, upload-time = "2026-08-25T17:47:24.689Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/1f3e8e1fc3e97de0fa963495832f581f025f29471602a309e48808244292/pre_commit-4.6.2.tar.gz", hash = "sha256:8f5d7bfb021ecdbcd9d49d89847082dd24172ccde534390081a679ad046e2441", size = 198670, upload-time = "2026-08-10T22:07:18.421Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/e2/bbb7129c9e7999a6b8ee9cca3b66486c25c423ab5a75f34071798b74ce94/pre_commit-4.6.2-py2.py3-none-any.whl", hash = "sha256:e2dde9a75d3bce11bd3831c26d134df00a2803c1d818be6a0383c3dcda25dc4e", size = 226202, upload-time = "2026-08-10T22:07:16.942Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/bdc8274dc0585090b4e3432267d7be4dfbfd8971c0fa59167c711105a6bf/psycopg2-binary-2.9.10.tar.gz", hash = "sha256:4b3df0e6990aa98acda57d983942eff13d824135fe2250e6522edaa782a06de2", size = 385764, upload-time = "2024-10-16T11:24:58.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/7d/465cc9795cf76f6d329efdafca74693714556ea3891813701ac1fee87545/psycopg2_binary-2.9.10-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:880845dfe1f85d9d5f7c412efea7a08946a46894537e4e5d091732eb1d34d9a0", size = 3044771, upload-time = "2024-10-16T11:20:35.234Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/6d225b7b641a1a2148e3ed65e1aa74fc86ba3fee850545e27be9e1de893d/psycopg2_binary-2.9.10-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9440fa522a79356aaa482aa4ba500b65f28e5d0e63b801abf6aa152a29bd842a", size = 3275336, upload-time = "2024-10-16T11:20:38.742Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b7/a68c2b4bff1cbb1728e3ec864b2d92327c77ad52edcd27922535a8366f68/psycopg2_binary-2.9.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3923c1d9870c49a2d44f795df0c889a22380d36ef92440ff618ec315757e539", size = 2851637, upload-time = "2024-10-16T11:20:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b1/cfedc0e0e6f9ad61f8657fd173b2f831ce261c02a08c0b09c652b127d813/psycopg2_binary-2.9.10-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b2c956c028ea5de47ff3a8d6b3cc3330ab45cf0b7c3da35a2d6ff8420896526", size = 3082097, upload-time = "2024-10-16T11:20:46.185Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ed/0a8e4153c9b769f59c02fb5e7914f20f0b2483a19dae7bf2db54b743d0d0/psycopg2_binary-2.9.10-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f758ed67cab30b9a8d2833609513ce4d3bd027641673d4ebc9c067e4d208eec1", size = 3264776, upload-time = "2024-10-16T11:20:50.879Z" },
+    { url = "https://files.pythonhosted.org/packages/10/db/d09da68c6a0cdab41566b74e0a6068a425f077169bed0946559b7348ebe9/psycopg2_binary-2.9.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cd9b4f2cfab88ed4a9106192de509464b75a906462fb846b936eabe45c2063e", size = 3020968, upload-time = "2024-10-16T11:20:56.819Z" },
+    { url = "https://files.pythonhosted.org/packages/94/28/4d6f8c255f0dfffb410db2b3f9ac5218d959a66c715c34cac31081e19b95/psycopg2_binary-2.9.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dc08420625b5a20b53551c50deae6e231e6371194fa0651dbe0fb206452ae1f", size = 2872334, upload-time = "2024-10-16T11:21:02.411Z" },
+    { url = "https://files.pythonhosted.org/packages/05/f7/20d7bf796593c4fea95e12119d6cc384ff1f6141a24fbb7df5a668d29d29/psycopg2_binary-2.9.10-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d7cd730dfa7c36dbe8724426bf5612798734bff2d3c3857f36f2733f5bfc7c00", size = 2822722, upload-time = "2024-10-16T11:21:09.01Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/e4/0c407ae919ef626dbdb32835a03b6737013c3cc7240169843965cada2bdf/psycopg2_binary-2.9.10-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:155e69561d54d02b3c3209545fb08938e27889ff5a10c19de8d23eb5a41be8a5", size = 2920132, upload-time = "2024-10-16T11:21:16.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/70/aa69c9f69cf09a01da224909ff6ce8b68faeef476f00f7ec377e8f03be70/psycopg2_binary-2.9.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c3cc28a6fd5a4a26224007712e79b81dbaee2ffb90ff406256158ec4d7b52b47", size = 2959312, upload-time = "2024-10-16T11:21:25.584Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/213e59854fafe87ba47814bf413ace0dcee33a89c8c8c814faca6bc7cf3c/psycopg2_binary-2.9.10-cp312-cp312-win32.whl", hash = "sha256:ec8a77f521a17506a24a5f626cb2aee7850f9b69a0afe704586f63a464f3cd64", size = 1025191, upload-time = "2024-10-16T11:21:29.912Z" },
+    { url = "https://files.pythonhosted.org/packages/92/29/06261ea000e2dc1e22907dbbc483a1093665509ea586b29b8986a0e56733/psycopg2_binary-2.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:18c5ee682b9c6dd3696dad6e54cc7ff3a1a9020df6a5c0f861ef8bfd338c3ca0", size = 1164031, upload-time = "2024-10-16T11:21:34.211Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "25.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/e3/27f57f80141379d60defe6703eb50a707325706f07fedfd1312c7a751995/pyarrow-25.0.1.tar.gz", hash = "sha256:9150a83248bfed9813ea3c3af74c3856c1984d444aa28e58bf7733b9750ddf6a", size = 1201653, upload-time = "2026-08-10T12:40:53.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/e2/9ab15b88cbfac28e16419ce5439ec29234c5172cb8259301b4ba639bdec0/pyarrow-25.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:df961f2e7ae9cf496459259d798652c70625f6c080650d6952f8c04053c58ee9", size = 35861559, upload-time = "2026-08-10T12:38:02.567Z" },
+    { url = "https://files.pythonhosted.org/packages/58/79/a0036dbe1eabe1f73127427342f1d99982584c4a2cde2651d6c93499c6f6/pyarrow-25.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:cc4aa407fde9fc660be3939e49ea31f50f3e9fec17c0ec63159f7711edd3efc9", size = 37628383, upload-time = "2026-08-10T12:38:09.083Z" },
+    { url = "https://files.pythonhosted.org/packages/13/49/d93a57d375f4bf0cf82913dd6bb54acafde83dd993be2282c81ac5616cad/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:4340f0ba6c1d2e13f21658de1d7c662ca2545018568d0030a1e9afca159d87e3", size = 46820190, upload-time = "2026-08-10T12:38:15.458Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c9/711ca85d79f1ec98f29a5eae2b051e25b4ecec5de3e3c0e2d5c5dcb15664/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5389cdf79447ed1515c9e31620e6e1e2302249564d603f2ad727d4f6d313e4c3", size = 50102437, upload-time = "2026-08-10T12:38:22.487Z" },
+    { url = "https://files.pythonhosted.org/packages/80/53/8fb8359ff17cfb6263a1cf3ebf7caec9fe197de118719e84fcb1d0618026/pyarrow-25.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d51592cb7561e87877c506113e7adbf1342ab579e6c21f0ef44b8ba41cb74c80", size = 49942424, upload-time = "2026-08-10T12:38:28.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/83/4e5ae02a9341571b18a6fca380ac7a58ce6ddae7ab3c060208c0a1e79f02/pyarrow-25.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6109c94d8b9f3b17a041daca16cacb2f651ad8f1ef70a4232c2c0f37a23da2a8", size = 53144206, upload-time = "2026-08-10T12:38:34.862Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ee/197cbf47e49f83e6ebeb946a5259a48a638dea27ac774db42fe78022179d/pyarrow-25.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:8858d7bfc22e3f51529aeaa4077225029724623e4595dc9eff8c793935c34140", size = 27953934, upload-time = "2026-08-10T12:38:39.808Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pyct"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "param" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c3/78eeacf7cbf478db6bd41de0ee2221cc6769d81e0c10f6c1616c82a25e06/pyct-0.6.0.tar.gz", hash = "sha256:d4e513b2cf35b6165605ae5fce5f2a49985bc67473c579de85134b8c71d374a8", size = 14586, upload-time = "2025-09-26T08:26:19.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/b2/23f4032cd1c9744aa8e9ecda43cd4d755fcb209f7f40fae035248f31a679/pyct-0.6.0-py3-none-any.whl", hash = "sha256:cfaded7289fca72ddf6579b81459e3ec8db323a508e61c49aa318ee3cd6ff160", size = 16630, upload-time = "2025-09-26T08:26:19.092Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/ef/fc4f868f4e2cee79f863883abffceff107875f569b848507319842d2a681/pydantic-2.13.5.tar.gz", hash = "sha256:51a9c5f7b2f8e636f04c6cada605d9b6a3bf1348fdf945a3d8869b19bba0ee08", size = 845750, upload-time = "2026-08-28T14:04:00.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/47/c95ffc2009878c7aac0c5e08528022dcb885933252a88b5f170058014464/pydantic-2.13.5-py3-none-any.whl", hash = "sha256:346a034f080da3755d8e9cb5e00e8b07de1d39e4f6e2c87d8ab7cafa0b269a73", size = 472589, upload-time = "2026-08-28T14:03:59.136Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/f9/8a06bea35ef8daf588f707784c973a7046e0034c8d8cfb08828eeffb8b75/pydantic_core-2.46.5.tar.gz", hash = "sha256:10416c15b8839ecc4ef4d0885da76da6fd0f67333a0eb8aff6d93c4b8f2910fc", size = 472262, upload-time = "2026-08-28T10:01:31.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3f/76358795aa7a8c6d4f36e2cb828ad1c90ee118e1393a9281664f5aade9d4/pydantic_core-2.46.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b9fe6fb92520e3fd61f2e49000b6911b188824f089b75973ea06d6267f0b476d", size = 2076516, upload-time = "2026-08-28T09:58:21.576Z" },
+    { url = "https://files.pythonhosted.org/packages/db/50/26b091836076ce4cb2fac264186936acc069e0595772cfd02a563bc4761a/pydantic_core-2.46.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a39ac25a9a2fa4072efdb429833c4a4c8009a51ff9eea3eeae131713cd27991e", size = 1922874, upload-time = "2026-08-28T09:58:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f0/2a8ce3849e299d44e2d2c196b6082643a3235565a735cb51db7a6261f614/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fdc8b93a41521988916eeaa271173fcca7fa0803d62f87675aac8dcec1c8e29", size = 1951772, upload-time = "2026-08-28T09:58:25.435Z" },
+    { url = "https://files.pythonhosted.org/packages/87/46/ac0dc8bdd9e6048183a14eb127764e7ad9240021c17513074a4711b0e31e/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b98134087d9de723658d17a42c7d0da8d6e2ef08015dee7dc93889047315f5e4", size = 2031832, upload-time = "2026-08-28T09:58:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/339de5bef7be36301a2231eaa52e62163742c2281f11b5f4892bc79785cd/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e652ab17569c94bff5475520f907b7148b8c24036a8ebbe5cf7cf7493d28579a", size = 2208645, upload-time = "2026-08-28T09:58:28.948Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a0/9ff22b797724262da14427abaed4dd1d864a139693fc5e7809114376a716/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d925f3d9afd05a8c0fb3a1031463a8d59ebe5e2afad297e29c78be19e13b4e62", size = 2265935, upload-time = "2026-08-28T09:58:30.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a4/eb9409ec0736e50aa70a412f16c204ed149516846912f7e6724d4c73ee53/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fc5be0abd4a407e200d844b404e33639a554e7bd0d448e7b9ae181be4789ac2", size = 2066284, upload-time = "2026-08-28T09:58:32.289Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/02/7f6156ffc926857f1c37c07d9a388682865a81830ab6a1b637082c25e399/pydantic_core-2.46.5-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:816ff0a6550ffc06c098ccd2e0698600f9aa7da192a79eaa6f9af504a35db869", size = 2105889, upload-time = "2026-08-28T09:58:33.986Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/e781d357ebe09fc929f995700f1b3503e8897f1cece183ecb1300d4d67e9/pydantic_core-2.46.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7ea57fc63aa7da93a1bd2d644e6577befae10c52c4e36377635eea1056a74f5", size = 2158006, upload-time = "2026-08-28T09:58:35.647Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/644597d84ab400e50609c192120b85c9681c22d3a20461b9060a79be0a7a/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:efd62a42486f1bda5d24cb4f63d15a3c7768375fe83d36f9417b4ad7a2fb20b3", size = 2158408, upload-time = "2026-08-28T09:58:37.38Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ee/ca3b7b3a4b3769ffe9ce9432a7c9be755de9593a46d3b0d54d0409323e44/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:2bc9419666990c06d7397831f2126a1ecc3594aaa3ff7de5bf2d066802f4e07b", size = 2309609, upload-time = "2026-08-28T09:58:39.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/52/39fa1f451486019524ca685020390e7ca351832fd874530ba30c8628e6dc/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:18a09e1e1011b462f2e32774f25859ef1223d5c2b0546a633cf56654710721e0", size = 2342618, upload-time = "2026-08-28T09:58:40.89Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5e/468fc630568c61dcef3cd47ad32ffbeed9af643f49208d1ea86ab4f890c4/pydantic_core-2.46.5-cp312-cp312-win32.whl", hash = "sha256:5cb482e9e84c851f4e623fe4acc1ced89168cf1fe18f7089db4548c8f5bbb65b", size = 1939475, upload-time = "2026-08-28T09:58:42.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c9/4c19f41b84cf6b622a72fbeed7665b25d47a187d68d47d0d430c07f23268/pydantic_core-2.46.5-cp312-cp312-win_amd64.whl", hash = "sha256:5e81740c09e310f5aa5cbd3e434a01c154d4bef93241c7877b39f211d2b78ba8", size = 2043140, upload-time = "2026-08-28T09:58:44.272Z" },
+    { url = "https://files.pythonhosted.org/packages/af/dd/0c1a050299147c746e5256db16d645ab5efd4f78c59937d581a0524e74a2/pydantic_core-2.46.5-cp312-cp312-win_arm64.whl", hash = "sha256:f7b0ec93a2893de856652154d73b7ba622f26fa97726487dcac373de5f4c6084", size = 1997729, upload-time = "2026-08-28T09:58:46.13Z" },
+    { url = "https://files.pythonhosted.org/packages/df/dd/053c2e4303f791f3b8f8a14ab0b22008e8eb21d868c0c90b4f9be705b76a/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:013d6f3483d81e02e7c328831808f336c8596ee33b4bd4026b9ffb1e960b8942", size = 2062540, upload-time = "2026-08-28T10:01:00.318Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/dd/a18df751a5e37dd51bfad7f68e766999125bebe68c9e1d10a493ad01bd63/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:e9c134bb666dd54b778b9fc0d2b50cbb7f979b9e3716f26a88c9ab3b6fc1dd0f", size = 1902040, upload-time = "2026-08-28T10:01:02.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/13/01d40f9d07ce8a779fd6e0bd8ad4fba91309500dd67b869e2e219d261a6d/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:347ec774390c87326a2e4929d58d3f7e8763a104d5d35f4cd595a4c952366433", size = 1967479, upload-time = "2026-08-28T10:01:05.004Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/04/c81d4841331c2178b6fb09ae225425e110ed72d990c9fe556c4ec03d1013/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e24d8f05fa2d28513d94e877e9c75ad66175376209b3977f916e240e623193c", size = 2111034, upload-time = "2026-08-28T10:01:07.345Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pylabeladjust"
+version = "0.1.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "pandas" },
+    { name = "pyqtree" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/ec/e60af07f4aae3706d2e9592b462065b2757557aa23300f21edda7b5a6921/pylabeladjust-0.1.13.tar.gz", hash = "sha256:23c1f9f8096c5c7de9fa79678ce729ca3730b88d979997fa24e99c037a48f59b", size = 18275, upload-time = "2024-04-26T23:44:34.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/cd/b706a538a53b5033a86ebfd85621ab0ba78ba3d8a09fd4060e346e0cfb20/pylabeladjust-0.1.13-py3-none-any.whl", hash = "sha256:75f031f9296369dcf72a997076160cce6a504ee7cb23b9ab0b111a286644d495", size = 19190, upload-time = "2024-04-26T23:44:32.309Z" },
+]
+
+[[package]]
+name = "pynamodb"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/0b/35d24cdfe532fd9c774c184fbd09118b0a8c94eb51ca9598c0c5ef21174d/pynamodb-6.1.0.tar.gz", hash = "sha256:c7d09700ace9f428e67ecf73fa867633c632de3acf402b2c7c136be695afda79", size = 96283, upload-time = "2025-06-02T17:32:59.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/86/71e355d232f28adb50c89b806b018548c095a6cf3d631b645918f415212a/pynamodb-6.1.0-py3-none-any.whl", hash = "sha256:9c0f1a0f177208640b2336ed56c557c5187b0012d356e9c7399c3923c5f93c7f", size = 61685, upload-time = "2025-06-02T17:32:57.488Z" },
+]
+
+[[package]]
+name = "pynndescent"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "llvmlite" },
+    { name = "numba" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/fb/7f58c397fb31666756457ee2ac4c0289ef2daad57f4ae4be8dec12f80b03/pynndescent-0.6.0.tar.gz", hash = "sha256:7ffde0fb5b400741e055a9f7d377e3702e02250616834231f6c209e39aac24f5", size = 2992987, upload-time = "2026-01-08T21:29:58.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/e6/94145d714402fd5ade00b5661f2d0ab981219e07f7db9bfa16786cdb9c04/pynndescent-0.6.0-py3-none-any.whl", hash = "sha256:dc8c74844e4c7f5cbd1e0cd6909da86fdc789e6ff4997336e344779c3d5538ef", size = 73511, upload-time = "2026-01-08T21:29:57.306Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pyqtree"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/90/2905247e80944d2ce6b36a69fb995709cef25c409018f7471fd88cc1122a/Pyqtree-1.0.0.tar.gz", hash = "sha256:4f36d5160ddf170d7245e9c7102a45211b85003383dd552b6cd109e50cc3af81", size = 5239, upload-time = "2018-09-14T06:09:23.062Z" }
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-check"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/48/78fb4d9f95e383e81d2a74db1a56fd2f90947cd08e0d585356830e8e2fe8/pytest_check-2.9.1.tar.gz", hash = "sha256:2d8c9f1fe5cceb0b41c480e1454e95e9ed6a3a534bf2c7e3e0f39167b11cf88b", size = 41394, upload-time = "2026-08-01T06:28:06.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/c5/6c9809d27ecc279d2d4591f1317eb099b52fa9a93998fdcb78bc8f614a4f/pytest_check-2.9.1-py3-none-any.whl", hash = "sha256:9c745f50532c2f650f3d0afab78810aa9e0ca25b8ac60986e1590d8819c04562", size = 21350, upload-time = "2026-08-01T06:28:05.191Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-timestamper"
+version = "0.0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/6c/c5e657db26f3716ad533157bb144cd0a5d14528df4c1c8a876c1c908ad84/pytest-timestamper-0.0.10.tar.gz", hash = "sha256:ec283fdefc46a9fdb41c1e9badac144902b89bc292e50b97bcaf880e95647977", size = 5240, upload-time = "2024-03-27T06:31:49.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/c1/484fa642565cfcdc27321de151a4e9edc731042c653fea9f05712a0a8904/pytest_timestamper-0.0.10-py3-none-any.whl", hash = "sha256:6db3507c9fd879e021b87e4516472f97471a5643993bc86dfc2a5e262f6a09c9", size = 4575, upload-time = "2024-03-27T06:31:48.42Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/96/0f93e27c9f60a650838f2118159aa115fd5732c0716247917b7ba7ede665/python_discovery-1.6.0.tar.gz", hash = "sha256:6393b4eae1be8b2182670635e7baff89ac21cb9f8e86fd1ff40c7b1144febb4c", size = 82849, upload-time = "2026-08-28T17:30:02.366Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/5e/21abf578182fb15006a57faf3711a1e659e29d600d19b6e557eae908c81d/python_discovery-1.6.0-py3-none-any.whl", hash = "sha256:d4e244cf17b8b29819ed78003d55fbacf86eda23425b075454fff9271b79377a", size = 38451, upload-time = "2026-08-28T17:30:01.236Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/25/5473e46b179f8e8b4ad3aeeb36773d1701b7770eaf5e5bc2025c7303b598/python_json_logger-4.2.0.tar.gz", hash = "sha256:e371ebe22ec01e289850102091a2b1f6fc9e655c7f1f5f29073936756c290afa", size = 18211, upload-time = "2026-08-15T11:36:38.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/55/6467fde553886cb293e41538f3a8b4e4fd4688c6df242cf982162d8367fb/python_json_logger-4.2.0-py3-none-any.whl", hash = "sha256:158a52126fcd6869e09574d2b66272666f3dc8f468c62637ef9a1fa883719cb9", size = 14988, upload-time = "2026-08-15T11:36:36.821Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.3.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/48/fb042503b6ca6cd271261dc559fd6432f7d8c713153e9ec5c591af4dfc1c/pytz-2026.3.post1.tar.gz", hash = "sha256:2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d", size = 319745, upload-time = "2026-07-25T15:12:07.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl", hash = "sha256:dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815", size = 508283, upload-time = "2026-07-25T15:12:05.782Z" },
+]
+
+[[package]]
+name = "pywinpty"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/2d27f30c59a67be7025b2d7858c8c2d282b74d66544b2384730b82de74fd/pywinpty-3.0.5.tar.gz", hash = "sha256:61db0db063de9865adbea66db294628f8577f608d9764a4c7d3384eeacc4e81b", size = 16223484, upload-time = "2026-06-11T00:11:58.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/34/942cc95ca4e26489875aa8a95192766247a687379ec29543eebe73ec945f/pywinpty-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:d62946adf14b15b54c0b8d785f93fe18b04da23f4ad59e2e8c4612646e9abd23", size = 2090915, upload-time = "2026-06-10T23:43:14.98Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/5b9053004844139ea8bd86209c57ade12b134b2782f383a095784c8531ec/pywinpty-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:e9391c05fbfa7a992a97e831fc6849887b4014a614192e3d984a7ca59592b376", size = 815934, upload-time = "2026-06-10T23:41:42.384Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
+name = "pyzmq"
+version = "27.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/8d/5b3d5631c2f4b4b8862f64cd0c9eb777b5710eeb5125b4be8dd0a200a4c0/pyzmq-27.2.0.tar.gz", hash = "sha256:54d4259d1bfae24ecdb5ca79f7acc2eac6c286a02d6a0ae617797cb45f0726d3", size = 292316, upload-time = "2026-08-20T19:08:21.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/8a/153532fa53db30e116118164f3af269a1f3966b3e2ba32c89b12fe864bd8/pyzmq-27.2.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:591c8de5851c5ea372194469fe97587b97c3b641e9a70f31bb3474acbfde0241", size = 1431074, upload-time = "2026-08-20T19:06:40.601Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ef/c08b91248bb90a9efa81fa00ba81b69c157c74d0c5efbb2c319d91babb62/pyzmq-27.2.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:00e73942ef12cecbc7951c4a9104bb8ffaed742abb13af2da6833d90dd368cef", size = 973915, upload-time = "2026-08-20T19:06:42.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/78/a3a3a86c2b00fadb92ece1ca4f8f028d62b2ce9ac3526097239ab2d6fba9/pyzmq-27.2.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f8079d0521fe94bbb401fe9407578b28f3701627c8be2c9f7e0c5b77dcb0109", size = 697722, upload-time = "2026-08-20T19:06:43.325Z" },
+    { url = "https://files.pythonhosted.org/packages/62/2c/d5828306f795e8d34676d266823b74e2101e0ad3760d12083de3e02abbb2/pyzmq-27.2.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dea74fd65f1fc5f7fe167916a473ebe6ed6174e5e5d9de11ea6583661be6cf43", size = 872258, upload-time = "2026-08-20T19:06:44.627Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/51253b78fd8739293e283407eeecb14215c02c71b6519af21f6eed8e69cd/pyzmq-27.2.0-cp312-abi3-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcc99ca132b667a4ed750afd42db4ea73288f18425a9b2e3c0af095665c491f5", size = 739591, upload-time = "2026-08-20T19:06:46.214Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3e/142c85b67a4c9678629b0cf6d5125b29663d75be69bfaa57a3cac344d780/pyzmq-27.2.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b8d5f66e4a8246cf77f7b8f7902af64f00553368fa0373c89d99b78f0ad79394", size = 1689031, upload-time = "2026-08-20T19:06:47.612Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/ee/0776fb0f98ed1eb74d77240087fef0ab045b6ad15cb09555c6c5134c98ad/pyzmq-27.2.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:d1526b42a2e725b84ed226f37becedc250c6347594e5ed304e4e9aff68c9aec3", size = 2059547, upload-time = "2026-08-20T19:06:49.064Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0e/ec77f691a4aebe29ab6329f996fb0e0270c876a3016086e3ca6ef733bcae/pyzmq-27.2.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f707bcf2c1d007d14d70531d4dd7b41060881c73efa845580bf6faaf9ea24d42", size = 1910457, upload-time = "2026-08-20T19:06:50.783Z" },
+    { url = "https://files.pythonhosted.org/packages/30/97/1f5530ff4fc271b4597048371d5af972c2baab51be132ba15874e0327a6a/pyzmq-27.2.0-cp312-abi3-win32.whl", hash = "sha256:fdaaa4ea3242f6ad298eb5177eb042aea5c73c30e76d20caee7b15af20d24ec2", size = 563450, upload-time = "2026-08-20T19:06:52.307Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8b/b83f7780dad22e0878e4c7bd9158ebd24ed12bc3d5e3a471cd0576f77ded/pyzmq-27.2.0-cp312-abi3-win_amd64.whl", hash = "sha256:2c218c6ab8bc447ba62054b581fd30209689d199c6ecb253f79615ca74a38e12", size = 628633, upload-time = "2026-08-20T19:06:53.809Z" },
+    { url = "https://files.pythonhosted.org/packages/52/aa/3918b5ac7f9987bd9c421b065074fd7409ded88f856f2c704a24341877ec/pyzmq-27.2.0-cp312-abi3-win_arm64.whl", hash = "sha256:348d6fd3e4b81ae4580622ea8c2ea60224e84b2ac1b3be4482e6edc7de06e7a3", size = 556006, upload-time = "2026-08-20T19:06:55.242Z" },
+]
+
+[[package]]
+name = "rcssmin"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/af/c9654b4f9b054ec163ed7cb20d8db0e5ae05e2e9ce99a4c11d91a2180b3f/rcssmin-1.2.2.tar.gz", hash = "sha256:806986eaf7414545edc28a1d29523e9560e49e151ff4a337d9d1f0271d6e1cc4", size = 587012, upload-time = "2025-10-12T10:48:08.932Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/5c/29af37ffb21a3069d108902868262b25fbbf731821cf5c7de76bba986dd1/rcssmin-1.2.2-cp312-cp312-manylinux1_i686.whl", hash = "sha256:78249189d39344a1e9d813c51362831537500e104c5bdce4ff24fe59010e9ee1", size = 48819, upload-time = "2025-10-12T10:48:31.3Z" },
+    { url = "https://files.pythonhosted.org/packages/89/dc/b522a5e1a0a8ef8af50adbb3bdd9f5a059a9890b9fc5ce3f44a37a996a74/rcssmin-1.2.2-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:217efed0dff304d503bf481068ddb13ae72176ed5970f1011fb1a1e379308d9c", size = 49248, upload-time = "2025-10-12T10:48:32.254Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0b/7c0018793080ed26939d9beaf09591cf58fb9cda3253a891137b841a902a/rcssmin-1.2.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:c51aa47b1752ae55ad4cf4332e7316c5206a6a686d65bc15431a6bfea393e665", size = 50723, upload-time = "2025-10-12T10:48:33.398Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b4/c8b0d2588719af2b9c454e6e95f18bd60b0c474da4b65af61bb6457a7555/rcssmin-1.2.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:354215283f32413ced87b358934ebbb7c5529f51f5d316e80bc2889486d388b3", size = 53302, upload-time = "2025-10-12T10:48:34.452Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/cb/1a8d6ace1ff845d57fa31087510a88dc10ac01cea41317e976bbf2413f91/rcssmin-1.2.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:265b57de87949b505bcd658f4f5bbfc1f077390108cd12e288ba2f7824bee52c", size = 53001, upload-time = "2025-10-12T10:48:35.389Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/25/2d97155edb351a28e5a46a35f7b4e54bfe3933847bd2ba6674216a817d9e/rcssmin-1.2.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:83ecd3093640d69f7582839788e012ecf9a85faeb95760032626977a7d3904b2", size = 53285, upload-time = "2025-10-12T10:48:36.513Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/c1/6b30b775c7bcc6cf6506a4d4741c2123e8d99cd50f3fe8cbd731f5fef526/regex-2026.9.3.tar.gz", hash = "sha256:aabd43208e335f4c3f0b56de3464b066dd425983a58f6eeb5738bcd7465403db", size = 416720, upload-time = "2026-09-01T00:53:43.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/cb/cba530bc3b068fc337f8f455c63ef5ee91a4eb4c76ecf5998e5cef5aaa6b/regex-2026.9.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5db80d0b1c8238940b5957dd66b5c818ea40a221f6652fb717c027a562d09c77", size = 496699, upload-time = "2026-09-01T00:50:27.98Z" },
+    { url = "https://files.pythonhosted.org/packages/81/39/f2e9fb6bbbc80f8bf67ad79d7e2e8866f7837d7c24c692f7faf8f1272e7e/regex-2026.9.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:35d48ce3dee087b63b15cd0a7a3110d0a76c29edbe1f2ad0520b8c4adb7cb596", size = 297018, upload-time = "2026-09-01T00:50:29.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/b6/c16ee58840baf7659def27ef6f62f3d9a9909670d3c1b4b98bb8b8ee47e2/regex-2026.9.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1f22e0d21ae7016c77175c139a7fca465b988efc1280df4816c79752068d9e2e", size = 292008, upload-time = "2026-09-01T00:50:30.929Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b4/4987bf0f17604669b4ea5aef219886d0a73188c4716ff3a7d275d4d15c15/regex-2026.9.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:233662cf8cfdfe3c0e58aa8f7bbefc579b5be0ac34546f123c159804179e8687", size = 796101, upload-time = "2026-09-01T00:50:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/95/2a9ab02a68c8a61dc0b4882ed643b1a95740d9dc291dc26c77d19af79691/regex-2026.9.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2eed2e4d231278a2ccab3f4bfa2c1e39855f336475f7756a281d767d2b1753", size = 865435, upload-time = "2026-09-01T00:50:34.171Z" },
+    { url = "https://files.pythonhosted.org/packages/04/92/0570d41559b446c97c1148cb9ebc1df09f2949b03c7c9bfee09976b3465f/regex-2026.9.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5e674cecb61cb160be392da07fd8a71509ef927f437fbf3215432692ed385151", size = 911828, upload-time = "2026-09-01T00:50:35.72Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8b/9cc6d4123033f7cb82df6cd8ce19eb0fc18a964afe060a03c9b26757c9f3/regex-2026.9.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:665207e41bacd435db001099eeab44103197c2c1a729d73ade74688a905ed4ce", size = 801965, upload-time = "2026-09-01T00:50:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/98/39262e91aa87a67c82cbe90a0df4c3d382c7a44811fe80067904085211b4/regex-2026.9.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7a7ddc9a8ca1795166a1ca80364b8ce74187fc210e112d3fb048b711b934f36c", size = 776192, upload-time = "2026-09-01T00:50:39.57Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e9/3bb93fe4ee4b6f8ce7ba69b527c4a63cfa3393fc425ab26486041fe441c8/regex-2026.9.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3037d02425863ce9501afbaa04ba967162810004bacde39a53ea9a5b740eb32", size = 785053, upload-time = "2026-09-01T00:50:41.156Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/05/31d5bc2553a700c0dfc6b5b6a13c61cdcd1210fde1e304cfa18a33f138b2/regex-2026.9.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3de4eab8c763393b75bbb26f81934ab2cc8794f48f79e90622e3ab7ea57f3d14", size = 860546, upload-time = "2026-09-01T00:50:42.746Z" },
+    { url = "https://files.pythonhosted.org/packages/65/a3/2e1e854d80becda0f061093805bbfc037a5849448f46d0a2b71a070d45e2/regex-2026.9.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:98620c9c4c22568ad70f57b80527c780b6f8fd26e36507bf8e2273262a228275", size = 765841, upload-time = "2026-09-01T00:50:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d6/43d02948cedde2e8476ac893ea02755ee5ee1b21c531fda92d80e114f0bc/regex-2026.9.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:0b1ba3aaaf5776de473ee16625ac60ac195abb0343afb273575a8201d99be089", size = 852147, upload-time = "2026-09-01T00:50:46.474Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ff/adb4e2d08afe8f4c6df004d94604257e1f72af7ba328af7715601585aba4/regex-2026.9.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56d8659c65166641d8f1b5efccc391c62c8a899eff4d528b981cc62b7b402a4b", size = 789761, upload-time = "2026-09-01T00:50:48.749Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e1/1490d1351758e87f6e702cf2025036bdc7bc59182e2ff5c7bec004b19aed/regex-2026.9.3-cp312-cp312-win32.whl", hash = "sha256:837c1859913798d8bebcd98d4a037e113f8d79e81733009bf590e449769eecb3", size = 267150, upload-time = "2026-09-01T00:50:50.414Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/49/4c40cf722d84d60e807a08ef4c3f579216bf97df60c4a1b10be49655d302/regex-2026.9.3-cp312-cp312-win_amd64.whl", hash = "sha256:1ba1dbbb93c5c5629c1861763aec5bfa9f05ad24ef450694130e25029ce7bc36", size = 277773, upload-time = "2026-09-01T00:50:51.963Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/af/c48b3b2b4244b4b090554c78d3387e9ae7b859f3dbf7148a27d427e9e5b8/regex-2026.9.3-cp312-cp312-win_arm64.whl", hash = "sha256:d7b3a8a4bbd83ad8b29758f5d24bab10a3f2de87970db36f1e3651c733353136", size = 277122, upload-time = "2026-09-01T00:50:53.778Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/47/f216a33221db8eff328987661cf18371afee89c62a62b434b963d6b509c9/responses-0.26.3.tar.gz", hash = "sha256:b0c11ca8131b8b227b8d5108e6ed39772222bd5aab030ed430e8f99057c4c409", size = 86335, upload-time = "2026-08-26T19:17:24.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/86/ca7958de70cb0752350575e98229368a3a2f746a2942034b3364e17312bb/responses-0.26.3-py3-none-any.whl", hash = "sha256:74474f799334ac4f37d93b6437ecc3bb1bb5c77a8d31780a338643be2dce0af8", size = 36289, upload-time = "2026-08-26T19:17:23.176Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
+name = "rfc3986-validator"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055", size = 6760, upload-time = "2019-10-28T16:00:19.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9", size = 4242, upload-time = "2019-10-28T16:00:13.976Z" },
+]
+
+[[package]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rjsmin"
+version = "1.2.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/16/14288d309d0f42c6586440c47bf6ec1a880218f698f30293fa3782db4008/rjsmin-1.2.5.tar.gz", hash = "sha256:a3f8040b0273dec773e0e807e86a4d0a9535516c0a0a35aa1bb6de6e15bb1f09", size = 427399, upload-time = "2025-10-12T10:50:27.422Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/f3/143727b02b5c5fdc08335be8b2184f19b762ee7d184bb4459e94ed668ae0/rjsmin-1.2.5-cp312-cp312-manylinux1_i686.whl", hash = "sha256:d8b6ddaaa78fd2d3243da11c13033946d211d37729c64814cefe32dba02d9921", size = 31838, upload-time = "2025-10-12T10:50:49.553Z" },
+    { url = "https://files.pythonhosted.org/packages/13/dc/72ca27c526925e88e273c3af6848777b289e4eb0854afcd7c6dbbfd4d196/rjsmin-1.2.5-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:2f46270969613de2292a7f747c31cabd9354cc49f6cd23f9cc8688d3af9f889e", size = 31795, upload-time = "2025-10-12T10:50:50.459Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/f8bfe2f6949b31adb66563ceca84d9d38f32867aad303cf4311b12534487/rjsmin-1.2.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:6e7b1bb52665894d8cba84144ee91723475948d5d1a54d7f0b25a1cdce8c5921", size = 32085, upload-time = "2025-10-12T10:50:51.704Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d0/239d16374e9e3e0aba2e4924175f2401f21126a1c2df83f5fb18af3ec808/rjsmin-1.2.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f68dd62707d62fc1771be4407892cb932d48fa19a51e7a0e35a11b00e427e3f7", size = 35995, upload-time = "2025-10-12T10:50:52.714Z" },
+    { url = "https://files.pythonhosted.org/packages/43/61/179f5ef72a688cf290acdbcdfcbacc4af297751af1b10d4097af03cb31eb/rjsmin-1.2.5-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:73b6b099f8afb8aa7ff9ddfbfd4d6ae6540dfe7630833a04a26f1d9f67528eaf", size = 36200, upload-time = "2025-10-12T10:50:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3b/42bb50ee0bb3a4baa8f435ad6bfca48ed5a5b46e4b614e1f4d320ce729d2/rjsmin-1.2.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:372d57835014a332dbf227b6de284ea3ee052600ab0f176df959c75a33f0690e", size = 36110, upload-time = "2025-10-12T10:50:55.393Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/0a/1cdbabf9edd0ea7747efdf6c9ab4e7061b085aa7f9bfc36bb1601563b069/s3transfer-0.10.4.tar.gz", hash = "sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7", size = 145287, upload-time = "2024-11-20T21:06:05.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl", hash = "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e", size = 83175, upload-time = "2024-11-20T21:06:03.961Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
+]
+
+[[package]]
+name = "scikit-image"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy" },
+    { name = "tifffile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/e8/e13757982264b33a1621628f86b587e9a73a13f5256dad49b19ba7dc9083/scikit_image-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d454b93a6fa770ac5ae2d33570f8e7a321bb80d29511ce4b6b78058ebe176e8c", size = 12376452, upload-time = "2025-12-20T17:10:52.796Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/f8dd17d0510f9911f9f17ba301f7455328bf13dae416560126d428de9568/scikit_image-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3409e89d66eff5734cd2b672d1c48d2759360057e714e1d92a11df82c87cba37", size = 12061567, upload-time = "2025-12-20T17:10:55.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/c70120a6880579fb42b91567ad79feb4772f7be72e8d52fec403a3dde0c6/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c717490cec9e276afb0438dd165b7c3072d6c416709cc0f9f5a4c1070d23a44", size = 13084214, upload-time = "2025-12-20T17:10:57.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df650e79031634ac90b11e64a9eedaf5a5e06fcd09bcd03a34be01745744466", size = 13561683, upload-time = "2025-12-20T17:10:59.49Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/48bdfd92794c5002d664e0910a349d0a1504671ef5ad358150f21643c79a/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cefd85033e66d4ea35b525bb0937d7f42d4cdcfed2d1888e1570d5ce450d3932", size = 14112147, upload-time = "2025-12-20T17:11:02.083Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/ac71694da92f5def5953ca99f18a10fe98eac2dd0a34079389b70b4d0394/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f5bf622d7c0435884e1e141ebbe4b2804e16b2dd23ae4c6183e2ea99233be70", size = 14661625, upload-time = "2025-12-20T17:11:04.528Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4d/a3cc1e96f080e253dad2251bfae7587cf2b7912bcd76fd43fd366ff35a87/scikit_image-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:abed017474593cd3056ae0fe948d07d0747b27a085e92df5474f4955dd65aec0", size = 11911059, upload-time = "2025-12-20T17:11:06.61Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/d1b8055f584acc937478abf4550d122936f420352422a1a625eef2c605d8/scikit_image-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d57e39ef67a95d26860c8caf9b14b8fb130f83b34c6656a77f191fa6d1d04d8", size = 11348740, upload-time = "2025-12-20T17:11:09.118Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+]
+
+[[package]]
+name = "seaborn"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
+]
+
+[[package]]
+name = "send2trash"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "tokenizers" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/ef/87681678d0aa91a1e77f0ffdd2e5d900aaf358aac644dd14bead8d95ec4c/sentence_transformers-6.0.1.tar.gz", hash = "sha256:1c3b8d9403f87ad0c879638554f36cc85744f38a6a70d150fd7e964ca0e9935b", size = 575395, upload-time = "2026-08-31T07:50:43.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/ab/dc6031faf1b6bba08076fbf457b21a5c51ba7928a77916915e093c16b8c7/sentence_transformers-6.0.1-py3-none-any.whl", hash = "sha256:b8888d72c707ba33c63aa30845850702dd5acadf1dd0d051436380bcebe4fd0f", size = 739832, upload-time = "2026-08-31T07:50:41.635Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/99/a6ca3beb3ccacb41fb3321d8a60e5566f9e6467601ef8eba6a17e1b89778/soupsieve-2.9.2.tar.gz", hash = "sha256:4a55d8cf158a9c2e587fa4922f1bbb91d68ac829e2d6f25403a85747c71daf74", size = 122445, upload-time = "2026-08-07T00:57:24.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/dc/ad025c1ee131eba60c69f4dd5779b18fcf1e6b21a343e2162a84d5d133c7/soupsieve-2.9.2-py3-none-any.whl", hash = "sha256:8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823", size = 37370, upload-time = "2026-08-07T00:57:23.524Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/21/77b4c147963073040dc3c3a5cb7a8c3001a1893c0209432cb77f9df836aa/sqlalchemy-2.0.52.tar.gz", hash = "sha256:5e2d46356ac2ccb7d268ab6c2319ac6a2b42f1b8d5fd8bd3d46855cd82abee97", size = 9945637, upload-time = "2026-08-11T19:07:09.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/d5/1b77a026d161f98a08f11af1a5f6c47b98ee7c7e2648af525a1004826c78/sqlalchemy-2.0.52-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:be8c49131665dfe2cc74c498aa1240ffb548d0fd901325dd11c2c7a18956f727", size = 2170940, upload-time = "2026-08-11T20:58:11.25Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bd/f444444adb37b5d53753fb1730ee7a421628e2e3b756c4da461af7e6394a/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b2d9e507a458832adcfbd8af6e2036ddf069b7710b799448542ebccae2dceee", size = 3383415, upload-time = "2026-08-11T21:02:38.534Z" },
+    { url = "https://files.pythonhosted.org/packages/be/57/2eadf93a552568c57e8680b7e58bb5e9770d80942a1bdbaf4f2f63f0d7c8/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8738008376d22f30f411ea3efecf39b51110b6996d80bb73786f30bcfdd5fd3b", size = 3398577, upload-time = "2026-08-11T21:16:59.092Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c3/2887cf9dd111d1fbf05d22165b404c221ef43e029f7a2695e7302f27a7cc/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37a4d548327b6cab9c7d8cdb4e0e82feabee0110c4d150059068e2d1cfbd99ee", size = 3328225, upload-time = "2026-08-11T21:02:40.183Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0f/466bdf9e1feeeef5587f868c187d8687e21ff8c85b1775e9041130181132/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e49f51a5d59857a7a0dcaf9469febf7197d9394bd88f00d69c2c4e848112cdbf", size = 3357374, upload-time = "2026-08-11T21:17:01.076Z" },
+    { url = "https://files.pythonhosted.org/packages/22/20/5c2b4583904af4173076dda1c9e53c9e2ffc7a702d2efde0216bbacbf7cb/sqlalchemy-2.0.52-cp312-cp312-win32.whl", hash = "sha256:afda3ec521d0517d0de783fc70030775841900896d832de5bbd066549290470e", size = 2129366, upload-time = "2026-08-11T21:14:50.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/06/543dab8ef62d4e9fb96fb31a30c2b8b14a8763bccf48d428294d6b3041c0/sqlalchemy-2.0.52-cp312-cp312-win_amd64.whl", hash = "sha256:2d5e53e36e37129fe0be8b9d08b6e4052c10a963ee6cda56c8c10dcc194b99ca", size = 2157344, upload-time = "2026-08-11T21:14:52.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
+]
+
+[[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.38.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/b4/e25c3b688ef703d85e55017c6edd0cbf38e5770ab748234363d54ff0251a/starlette-0.38.6.tar.gz", hash = "sha256:863a1588f5574e70a821dadefb41e4881ea451a47a3cd1b4df359d4ffefe5ead", size = 2569491, upload-time = "2024-09-22T17:01:45.422Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/9c/93f7bc03ff03199074e81974cc148908ead60dcf189f68ba1761a0ee35cf/starlette-0.38.6-py3-none-any.whl", hash = "sha256:4517a1409e2e73ee4951214ba012052b9e16f60e90d73cfb06192c19203bbb05", size = 71451, upload-time = "2024-09-22T17:01:43.076Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tblib"
+version = "3.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8a/14c15ae154895cc131174f858c707790d416c444fc69f93918adfd8c4c0b/tblib-3.2.2.tar.gz", hash = "sha256:e9a652692d91bf4f743d4a15bc174c0b76afc750fe8c7b6d195cc1c1d6d2ccec", size = 35046, upload-time = "2025-11-12T12:21:16.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl", hash = "sha256:26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76", size = 12893, upload-time = "2025-11-12T12:21:14.407Z" },
+]
+
+[[package]]
+name = "terminado"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "os_name != 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/e4/e804505f87627cd8cdae9c010c47c4485fd8c1ce31a7dd0ab7fcc4707377/tifffile-2026.3.3-py3-none-any.whl", hash = "sha256:e8be15c94273113d31ecb7aa3a39822189dd11c4967e3cc88c178f1ad2fd1170", size = 243960, upload-time = "2026-03-03T19:14:35.808Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/1e/bc6587c5ab643b2e17776cace9070a2ae73549c86bffac9934a600bf3c31/tokenizers-0.23.2.tar.gz", hash = "sha256:7f0f085686b9de0d0079e6f874ae053600db64c5d13049e0bbc0119926d25aac", size = 385745, upload-time = "2026-09-03T08:55:42.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/ed/8a443528baa6fac8dfe8c3b75b038c63ac92bb539bcabe311e227c718173/tokenizers-0.23.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:85a9a357a3764aecc904ee76bdaf8cf1ad8e5a67a1b929a487c4a39b49ed0e90", size = 3148852, upload-time = "2026-09-03T08:55:30.874Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/22da045a91732384d3a3771816bf188dc5a1f702c32e635afa7c679c0bef/tokenizers-0.23.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:986670e43691469dcee610ea0f846f91a8f84e91fc6f7a48d4c064414c0ec2bf", size = 3101593, upload-time = "2026-09-03T08:55:28.587Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4d/8f569ed49372a3ed8e57099bd515055fd48d7c95912c4307cda6973c2168/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a37039b5dfc4af84eb3ef0a92f4307e28936c8f9adccba2629d36f652e9bf7a2", size = 3516830, upload-time = "2026-09-03T08:55:14.741Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/de/e2f14c8919d5bf51874051d00d6c7b7e0e8bde6c6a2dbeddda7f642896ff/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7b7e37ba198f24150f523e1242e83c4970de4a525480586be5dcc24d9add32c5", size = 3407975, upload-time = "2026-09-03T08:55:16.842Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bd/93c69152d02ef06ce47aed8b2bf4952dcf733c935a62791873932b2934d9/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43e4f2071e3cc8d5d86421c874aebc82659bb51a68bcdef5a0da75ee89511ccb", size = 3748165, upload-time = "2026-09-03T08:55:24.769Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b7/56b84b80bc96942bba8eb23751a9e8a1fce4faaf4390425e7083f721c98c/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:325fee2e0418a9dc6c9ecf736a5f5f0db7875183ace9549ae339da76f7a1fbb7", size = 4024165, upload-time = "2026-09-03T08:55:18.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/0175e216f005c2fe08238292663aa41e4c802b216e71047a69a0e9fc6fa3/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:950d7c9426fa72406a0ffeacdbc0bb9985f5db20eb8b263f29c79aaf83105703", size = 3591899, upload-time = "2026-09-03T08:55:22.752Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ca/ca6b93c7820df123b2662a9469e8facc826ccc94e98fdd0d615f6431e73a/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41c2f84d172449b4dadb9cdc508e3e364076613c35b16e76ecfe47a60d1e3305", size = 3386843, upload-time = "2026-09-03T08:55:26.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a4/4f9106d317b14a80aefea9f0e3a8d07ef25f856a7607eb7f5ab894281fcb/tokenizers-0.23.2-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:12f0835dc2ee694746a76adf7b1567d4346a4a502ebe93fb1f5f80ea49799b78", size = 3577314, upload-time = "2026-09-03T08:55:20.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/6a/1552b70fb0d9ab074fd3fc961435d01364e79c9058481822c3af6e8d402c/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:eb2f9c8a24da020ea8c11a01a19c1c2547912d92121ae4a01cfbca46125dee40", size = 9967367, upload-time = "2026-09-03T08:55:33.188Z" },
+    { url = "https://files.pythonhosted.org/packages/06/01/3ccb3a956c7528b2507b8a9714155c4baf86af593039db6ea375dd0c96c3/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f486f402f6f9abee5bb032553736813af0c710a86b2e0ca592634c55cea1f835", size = 9811886, upload-time = "2026-09-03T08:55:35.642Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/73/7038e612d48bda1599457f712f6bd3854eae1a9dc9c13aa47f835349db48/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:bef235815a067b2648caf6dcc7a71091b0b0fff9ee8057f6451eb9335fae52ef", size = 10146224, upload-time = "2026-09-03T08:55:38.391Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d8/8e9e4e0b287a338d8f88976729628c9d22e8a54cfaf9777018a7f7cb58a0/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5c56bda1511921587789163e524d196ed8284174ac23abd7685d5ea8da6c4718", size = 10256304, upload-time = "2026-09-03T08:55:40.977Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1f/c79a01f671a49728ebb0b61f7ff9ea45663b66cab40bc0858e9859b25c16/tokenizers-0.23.2-cp310-abi3-win32.whl", hash = "sha256:debf978920d93ba9c219bd67cc4bbfaf912c9039e41e7a28b91ec15e3728c95a", size = 2592809, upload-time = "2026-09-03T08:55:48.02Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f7/0a69ac6b82dbccf3f71add938a161c497952749294b8dd6dfe03a819dc40/tokenizers-0.23.2-cp310-abi3-win_amd64.whl", hash = "sha256:2e96f5699d5249c9c64aa8412e044f727aae3a4098cf830f9901ec1afc361cde", size = 2863236, upload-time = "2026-09-03T08:55:46.193Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b0/dee84cb44175be1b4c35bd2f770727494e78f0bb38e571a623ade94dbebb/tokenizers-0.23.2-cp310-abi3-win_arm64.whl", hash = "sha256:e49c394456dd9985787fec76132438ba3fb8911f857b1bf3d40119f9292d41aa", size = 2729352, upload-time = "2026-09-03T08:55:44.345Z" },
+]
+
+[[package]]
+name = "toolz"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/0c/2fd4df0d83a495bb5e54dca4474c4ec5f9c62db185421563deeb5dabf609/torch-2.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e2fab4153768d433f8ed9279c8133a114a034a61e77a3a104dcdf54388838705", size = 101906089, upload-time = "2025-08-06T14:53:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a8/6acf48d48838fb8fe480597d98a0668c2beb02ee4755cc136de92a0a956f/torch-2.8.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b2aca0939fb7e4d842561febbd4ffda67a8e958ff725c1c27e244e85e982173c", size = 887913624, upload-time = "2025-08-06T14:56:44.33Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8a/5c87f08e3abd825c7dfecef5a0f1d9aa5df5dd0e3fd1fa2f490a8e512402/torch-2.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:2f4ac52f0130275d7517b03a33d2493bab3693c83dcfadf4f81688ea82147d2e", size = 241326087, upload-time = "2025-08-06T14:53:46.503Z" },
+    { url = "https://files.pythonhosted.org/packages/be/66/5c9a321b325aaecb92d4d1855421e3a055abd77903b7dab6575ca07796db/torch-2.8.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:619c2869db3ada2c0105487ba21b5008defcc472d23f8b80ed91ac4a380283b0", size = 73630478, upload-time = "2025-08-06T14:53:57.144Z" },
+]
+
+[[package]]
+name = "torchaudio"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/cc/c2e2a3eb6ee956f73c68541e439916f8146170ea9cc61e72adea5c995312/torchaudio-2.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ddef94bf181e6447cbb05f38beaca8f6c5bb8d2b9ddced1aa3452025b9fc70d3", size = 1856736, upload-time = "2025-08-06T14:58:36.3Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/24dad878784f1edd62862f27173781669f0c71eb46368636787d1e364188/torchaudio-2.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:862e2e40bf09d865e5df080a84c1a39bbcef40e43140f4b1737eb3a389d3b38f", size = 1692930, upload-time = "2025-08-06T14:58:41.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a6/84d80f34472503e9eb82245d7df501c59602d75d7360e717fb9b84f91c5e/torchaudio-2.8.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:93a8583f280fe83ba021aa713319381ea71362cc87b67ee38e97a43cb2254aee", size = 4014607, upload-time = "2025-08-06T14:58:47.234Z" },
+    { url = "https://files.pythonhosted.org/packages/43/ab/96ad33afa320738a7cfb4b51ba97e2f3cfb1e04ae3115d5057655103ba4f/torchaudio-2.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:4b82cacd1b8ccd543b1149d8cab257a40dfda8119023d2e3a96c66349c84bffb", size = 2499890, upload-time = "2025-08-06T14:58:55.066Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/1d/0ea0b34bde92a86d42620f29baa6dcbb5c2fc85990316df5cb8f7abb8ea2/torchvision-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0e2c04a91403e8dd3af9756c6a024a1d9c0ed9c0d592a8314ded8f4fe30d440", size = 1856885, upload-time = "2025-08-06T14:58:06.503Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/00/2f6454decc0cd67158c7890364e446aad4b91797087a57a78e72e1a8f8bc/torchvision-0.23.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6dd7c4d329a0e03157803031bc856220c6155ef08c26d4f5bbac938acecf0948", size = 2396614, upload-time = "2025-08-06T14:58:03.116Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b5/3e580dcbc16f39a324f3dd71b90edbf02a42548ad44d2b4893cc92b1194b/torchvision-0.23.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4e7d31c43bc7cbecbb1a5652ac0106b436aa66e26437585fc2c4b2cf04d6014c", size = 8627108, upload-time = "2025-08-06T14:58:12.956Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c1/c2fe6d61e110a8d0de2f94276899a2324a8f1e6aee559eb6b4629ab27466/torchvision-0.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2e45272abe7b8bf0d06c405e78521b5757be1bd0ed7e5cd78120f7fdd4cbf35", size = 1600723, upload-time = "2025-08-06T14:57:57.986Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/d3/343e5bb989d6515b1646cf3d40135d73f3d5e45339bded401b56cdac24dd/tornado-6.5.8.tar.gz", hash = "sha256:9452e1b208a8bd771e2cb1f2ff564985b9b214bdebbe622793e1799e0a6bd23f", size = 520493, upload-time = "2026-08-07T02:12:42.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/d5/007086fd8df5489338e204f65adce33fd4f21a4999dbb2b9cff2f897b5f4/tornado-6.5.8-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:cc6aa787d7cfab7c3d35189dc7a56fbd2399a569624c730c6b55b3d6531d0403", size = 449487, upload-time = "2026-08-07T02:12:28.682Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c8/5a24a99495903f594f6a199dd7beead1cbc0a13e2cb9102727bcaaf2a997/tornado-6.5.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9715b5eb79735b2bcd454ce216a9275b7c0470e64ea1bf5742f78b2f72b26eeb", size = 447649, upload-time = "2026-08-07T02:12:30.306Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/de/f2e733f386b85962d1b1dc82cd63d169b5b4580062b35397eac9244a41fe/tornado-6.5.8-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:547d63f450d570c14fe0e8db2cfb14c9bbd1c2503b4a6612586267955aa47b58", size = 450707, upload-time = "2026-08-07T02:12:31.95Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/94/20efeee9a01c141e9ac47c397f81679dfda24b32768fc4fff24e76d36c2c/tornado-6.5.8-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e2360a0ffbe145eca8af0b19cb7203d79b1a98dd4cccdd6b368f6f49c2e3808", size = 451677, upload-time = "2026-08-07T02:12:33.512Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ec/a96ccb8ccf0de2b7bc2c5fa1608a4803735018242e90c4882365a9fd418f/tornado-6.5.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5d242290bdf7ab3151bc1065fdd75c0dcc21cbc7b49f22a4c56329c2d6566d22", size = 451510, upload-time = "2026-08-07T02:12:35.346Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b5/93185859245ad3f00e62175f29607346788b696369347f0146e0421286bb/tornado-6.5.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7b94ff0e128fe0542f3bd331fb44d06260fc4ac16881545159f34ef08aad4195", size = 450917, upload-time = "2026-08-07T02:12:36.963Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cf/fe33cf062834487d34d1559746a4a12521033c22645b6d74d4bca702e018/tornado-6.5.8-cp39-abi3-win32.whl", hash = "sha256:67832909c4779c64942380cb5f044a5c6163d00831472d80e25e115de9917836", size = 451952, upload-time = "2026-08-07T02:12:38.512Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e1/468ad54333e92ccb62627e62cb88e5fc14a2171daa67ed47b1b8542d5b86/tornado-6.5.8-cp39-abi3-win_amd64.whl", hash = "sha256:11881db6b7c168494be2c2d12e65931451bdf7ee718535418ae1d8855dd5a0ee", size = 452391, upload-time = "2026-08-07T02:12:39.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3e/cd5e4f06e34cde33b8ef66cf36aa2b5ad46354cc1af7d2136bbe365fee1d/tornado-6.5.8-cp39-abi3-win_arm64.whl", hash = "sha256:68a7468c7e289f8514d7d664101753903217eff1bb6822c6b5994a0b5f5bcb26", size = 451411, upload-time = "2026-08-07T02:12:41.469Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.66.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/85/3ce0f9f7d3f596e7ea57f4e5ce8c18cb44e4a9daa58ddb46ee0d13d6bff8/tqdm-4.66.2.tar.gz", hash = "sha256:6cd52cdf0fef0e0f543299cfc96fec90d7b8a7e88745f411ec33eb44d5ed3531", size = 169462, upload-time = "2024-02-10T18:19:57.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/14/e75e52d521442e2fcc9f1df3c5e456aead034203d4797867980de558ab34/tqdm-4.66.2-py3-none-any.whl", hash = "sha256:1ee4f8a893eb9bef51c6e35730cebf234d5d0b6bd112b0271e10ed7c24a02bd9", size = 78296, upload-time = "2024-02-10T18:19:53.524Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/2e/a7fbfe268c8a3b32546930c0297c101d65a4a14c304ad5790a9f478f0e4e/traitlets-5.16.1.tar.gz", hash = "sha256:ed900c2b631aa3a112811139fa97b8d2c3bad5e989656bba4b7e52c7852c18c1", size = 166137, upload-time = "2026-08-03T08:32:36.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/66/0d785f0bc5e4315a96c989bb476d0fc07ea4f85132550c7b156ca2035d52/traitlets-5.16.1-py3-none-any.whl", hash = "sha256:f775618166caa0396c8e337099240f2bd3e5e917d203b2e6fbe21a58d3cb1f6b", size = 86211, upload-time = "2026-08-03T08:32:34.48Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/2e/ba418680ab901dae269360bb8642485eae04f1af91ee2ebb8bd6f3607305/transformers-5.16.1.tar.gz", hash = "sha256:17b0eac726ddc55e84ac58946063e0c6d37fd000c456b581f050ea0f4e822869", size = 9650542, upload-time = "2026-08-26T14:48:58.789Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/4d/ee3728674c0bbc637bb4af88ccf0be697f92e4e90b55f5dc110c44d61b61/transformers-5.16.1-py3-none-any.whl", hash = "sha256:2f2d5b98a5ad3718713653734298fa620754ed683702a635ebb587df3ed29c7e", size = 12080592, upload-time = "2026-08-26T14:48:55.083Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/f7/57713ba479fd405eb76de31404b2c744c289e336b2d999511ebf51e496f7/typer-0.27.2.tar.gz", hash = "sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945", size = 204045, upload-time = "2026-08-28T10:26:55.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl", hash = "sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d", size = 123130, upload-time = "2026-08-28T10:26:53.752Z" },
+]
+
+[[package]]
+name = "types-psycopg2"
+version = "2.9.21.20260724"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/29/09ca8f0ad16105193deabcaf8256059e361e9e37ff24551efd9c739e240b/types_psycopg2-2.9.21.20260724.tar.gz", hash = "sha256:db31031c37de823a2b21c787cb84832174fdda2a99a8b1af648206f19cc32f8c", size = 27644, upload-time = "2026-07-24T04:57:36.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/90/1e77eb76030bb5feb249ecb41cd7647c6ae831ec7bd2b61a61beecac4029/types_psycopg2-2.9.21.20260724-py3-none-any.whl", hash = "sha256:4f87890dd06cea99e3bb0536330ffc2a7320e69059dc1ee0e2c884ef2718f2b4", size = 24964, upload-time = "2026-07-24T04:57:35.703Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260906"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/18/4c2c0290953f8b3b9612adfcb07b57f144ade3ad32a76764fca42b77c5f3/types_requests-2.33.0.20260906.tar.gz", hash = "sha256:76ab8a0fb736744a0c3deee7aa57b2927e301f078d9e61f5391b3e92002416b9", size = 25263, upload-time = "2026-09-06T06:35:47.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/4c/51ec821d22a45b4162fa3f3e9e94ea4c0f8c49e82363b10955baa5438391/types_requests-2.33.0.20260906-py3-none-any.whl", hash = "sha256:9f53622652bd921ead7a54d665be1b8d518165c8b51cc9d68d944cd6b6bfa8fb", size = 21461, upload-time = "2026-09-06T06:35:45.856Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "umap-learn"
+version = "0.5.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pynndescent" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/ee/af4171241117f85c74b5ca6448ea1033cc28d599c13651d67289bacd4083/umap_learn-0.5.12.tar.gz", hash = "sha256:6aff02ecac5f2aad9f3c65ee518d7ae93e1a985ae38721fdcffceee4232c33c7", size = 96672, upload-time = "2026-04-08T20:03:54.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/98/f63318ccbe75c810011fe9233884c5d348d94d90005de1b79e5f93bef9c0/umap_learn-0.5.12-py3-none-any.whl", hash = "sha256:f2a85d2a2adcb52b541bed9b27a23ca169b56bb1b23283abeebfb8dfb8a42fe5", size = 91849, upload-time = "2026-04-08T20:03:52.561Z" },
+]
+
+[[package]]
+name = "uri-template"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.7.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/1c/69faa2e6a83484e2a8227bce5cfaa183941c5720f99c48f204931d286b07/virtualenv-21.7.8.tar.gz", hash = "sha256:1dc49c790072a9072cb1803f9bd62aa69cd583077cada32390f75505cdc64c9b", size = 5347580, upload-time = "2026-09-01T13:36:13.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/34/88d507d4a4030fa559788de9c690a214f9a4053aa1d91cfb60e9b36127c2/virtualenv-21.7.8-py3-none-any.whl", hash = "sha256:3040eb3cbf5d32b10ffd57d167e6a162237ad82ba7d8cf1400a1efed593d85ac", size = 5324617, upload-time = "2026-09-01T13:36:11.248Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/57/ed58088fafdf4c55a0ad6bde846502567645424d7ebf325230b9237f4085/wcwidth-0.8.3.tar.gz", hash = "sha256:d128512515fbf4612e0ff21fd6380399210318b7b54a9af59dff8454cf9730eb", size = 1458450, upload-time = "2026-08-28T18:10:06.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl", hash = "sha256:d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4", size = 331669, upload-time = "2026-08-28T18:10:04.909Z" },
+]
+
+[[package]]
+name = "webcolors"
+version = "25.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", hash = "sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf", size = 53491, upload-time = "2025-10-31T07:51:03.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", hash = "sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d", size = 14905, upload-time = "2025-10-31T07:51:01.778Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/a0/8fd707bcb776a7be556bad06a2ea5fb9bd519df78ef8e26f70ccf0f38bff/webencodings-0.6.1.tar.gz", hash = "sha256:565f9ad031c702dae404e27a099e3e09186a3ab1b9520f06d215502b651fd910", size = 15001, upload-time = "2026-08-15T14:22:57.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c6/040cbc72480d789a5f40d63fb484d3106554c4dfa2d2b70ad5022057750f/webencodings-0.6.1-py3-none-any.whl", hash = "sha256:7fab6269c8bf237c657876b52058ccb182e861518d1c695c1a9aaa8c1c105d5b", size = 8745, upload-time = "2026-08-15T14:22:56.31Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/cb/a5abcc2891249f393827c650c6296660ce40374ac22d99ab9aea41f9d2a2/websocket_client-1.9.2.tar.gz", hash = "sha256:0fcb57545848be86992e128218fd96dd87a6769ffdb1a968dff79632b85604d0", size = 84110, upload-time = "2026-08-31T14:08:40.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/d2/cc4dc1271e464942db7ee278baae2daa99ee77cb2af744025c04da585a3e/websocket_client-1.9.2-py3-none-any.whl", hash = "sha256:e1a673830a9c7bfa47b1cd3d5e4178f4c9651d80a4eab02c9c23a1c3ec6250ce", size = 95786, upload-time = "2026-08-31T14:08:39.899Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wheel"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/20/50ed6bdf27dec98b568a8ae25dc599f35baa3d9709f9e83fd1edb56b9a90/wheel-0.48.0.tar.gz", hash = "sha256:94800765601e9171bf5d58d066e640662842bcedcbab982b2c90787a2c987322", size = 66471, upload-time = "2026-08-11T22:02:27.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl", hash = "sha256:3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab", size = 33320, upload-time = "2026-08-11T22:02:26.1Z" },
+]
+
+[[package]]
+name = "widgetsnbextension"
+version = "4.0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/60/bc7a980fc78837d6ef8f5940cca4cadc433364503a4c4d42e2a7a0de3231/widgetsnbextension-4.0.16.tar.gz", hash = "sha256:adeea0ae78f0856ee4945f413299801b82a0a01416303301f39a704282a37b73", size = 1111094, upload-time = "2026-08-18T08:52:55.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/95/40e17e20046b7bc820d29d09ae84ec157ec8dd6e6f6cd722626292c31b2e/widgetsnbextension-4.0.16-py3-none-any.whl", hash = "sha256:a31a8774885b96fe825462f5d6496166f0c7cae111195b6465c801d230eb5a4e", size = 2225148, upload-time = "2026-08-18T08:52:53.736Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ba/8dc25478ed234dacc7d83c671634f347d0bdfb65bf0502f41879cf2f15a9/wrapt-2.4.0.tar.gz", hash = "sha256:7082fc1f94b020ac275870c4af71b09cff22876fe6e9c4c0ad01ea21d217b288", size = 161179, upload-time = "2026-08-30T04:41:51.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/22/581a0b44349d5babe526c958f365b8126e0fbd8fc2810e80446c47358050/wrapt-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ef4e2d6e399ce6eecc80179a6b9ef6544f121288f95fc132bc36c9d9503903af", size = 96374, upload-time = "2026-08-30T04:39:42.335Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/90/095984648cec62a786bb27c0b50f6cfa5856d1e073ba1006fe148d190084/wrapt-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b9b32d5e4f0a179cef5075cc79b79d6d3482c44c434c12969e48c6719e06d95", size = 96178, upload-time = "2026-08-30T04:39:43.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/fd/b20e3cb3cab35131b515edf18e8cd777dff680fc76fc00919481f4e536af/wrapt-2.4.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7dbbdbfdacb85c2d962fa52db791c77943fd777d600d74c95af2d53b32f5a94", size = 227806, upload-time = "2026-08-30T04:39:45.264Z" },
+    { url = "https://files.pythonhosted.org/packages/08/75/c8dfba5e0caf17cd0718a0cbbe76cb85e637a2d65183fb728232419f6fca/wrapt-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39cd68df4dff79f5336f9c745c06259d204bcb42d504040c9c91eac9e2abb39c", size = 229004, upload-time = "2026-08-30T04:39:47.068Z" },
+    { url = "https://files.pythonhosted.org/packages/42/05/d4853fbd33e5860b10d5aec690f563547a92a82e61fb8bb2d4ece1ce3570/wrapt-2.4.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2a9f1a2f75bb95257cc5744e255e10a5a86e923f328b40ad3dbf9d8d03430013", size = 208934, upload-time = "2026-08-30T04:39:48.73Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/66/23d0e8de9b411fd198af5121627587563657370c8d509fbe5ea8adb3df79/wrapt-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8763ad01e3725b7751a4575f38bbcc19c0aa0822fec91c5c5bd21ce3ce7e1d2b", size = 225709, upload-time = "2026-08-30T04:39:50.287Z" },
+    { url = "https://files.pythonhosted.org/packages/01/37/3b357bc90530d510ae59ae7ac48265c482ae899e47637ca4436645688b40/wrapt-2.4.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9125c6dbe8b88c00dd8ef4fc1e55757e8eb4720b6b2b2cc610a45bd32bd28c57", size = 207090, upload-time = "2026-08-30T04:39:51.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/0c/d8a5c6dbcc2d221308223bcea4130c6332454a855cb4dbd5dcb2360b13b2/wrapt-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:28f5de1526831b8f173889a436e289fe181ede8c66c9feb669d1aca8fd602eaf", size = 216269, upload-time = "2026-08-30T04:39:53.641Z" },
+    { url = "https://files.pythonhosted.org/packages/92/93/cc9fc8fef1d3d25edaa1c2dc2337b556dc1d0613ddc1c4a6fe9ee08ad705/wrapt-2.4.0-cp312-cp312-win32.whl", hash = "sha256:a9ca1cdb3f7facb4990c7739ea5afbaceeb6728d066feedde03a4cfe83b29b03", size = 91187, upload-time = "2026-08-30T04:39:55.38Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/a7b10705172bdb669b9687a8ff68bbe5f566437d2a49ad6d976af48b6d10/wrapt-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b464316489fb2fca0669ea0f8f07290054a0f26fc72982d3e4cf95469628ba9", size = 96423, upload-time = "2026-08-30T04:39:56.81Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/e838ac6463a1a1a1817b2f184ee2aa20c54692b80368c5063403c8d2461c/wrapt-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:db1285071ea09a7767fac608e7b5c7b03c09833b06186875a359905fbc659d29", size = 93003, upload-time = "2026-08-30T04:39:58.237Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/fafe0002f572ced999c792cfe8b05d39269c63d8193d15d25bd828bcad7a/wrapt-2.4.0-py3-none-any.whl", hash = "sha256:18aabd9301d06026f5900538051773d6f87f65ae02cdc60de482df978513dc0a", size = 73713, upload-time = "2026-08-30T04:41:49.805Z" },
+]
+
+[[package]]
+name = "xarray"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/96/3f7bdd00e505ec3698903415b30135024703e017b28c6b61f98da3193b0d/xarray-2026.7.0.tar.gz", hash = "sha256:361b495928fdbf5b58d0969bb6775339019da5e93ca74d61ddf4eb5edd6ce604", size = 3145348, upload-time = "2026-07-09T17:38:26.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/5b/28365212062939d213802e5e5fe855cdb231e1c2a93254ba1690066504e3/xarray-2026.7.0-py3-none-any.whl", hash = "sha256:bf9dd130b93806dc78e90c1b7ac24851b31557b888674c53622235691cf21824", size = 1426778, upload-time = "2026-07-09T17:38:24.224Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
+]
+
+[[package]]
+name = "xyzservices"
+version = "2026.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/bd/b75d5c2312caec607ec995200fa1eb8453225fd869947ec743919c279544/xyzservices-2026.9.1.tar.gz", hash = "sha256:8d1a39bf6b192940cc5db5264eeefc1b20dd184f8b83b1303b078743744f5943", size = 1134047, upload-time = "2026-09-04T10:35:41.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/71/9219fe65ef32bddc0b5d14e1d98dfefe9d2c9c1b1d1e93efca1f29fcbd4d/xyzservices-2026.9.1-py3-none-any.whl", hash = "sha256:af4fddac0f1fa5f7951834e2c58e10109e722be548cb1fe4f1a8e8b18cef4c09", size = 98829, upload-time = "2026-09-04T10:35:40.08Z" },
+]
+
+[[package]]
+name = "zict"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/ac/3c494dd7ec5122cff8252c1a209b282c0867af029f805ae9befd73ae37eb/zict-3.0.0.tar.gz", hash = "sha256:e321e263b6a97aafc0790c3cfb3c04656b7066e6738c37fffcca95d803c9fba5", size = 33238, upload-time = "2023-04-17T21:41:16.041Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl", hash = "sha256:5796e36bd0e0cc8cf0fbc1ace6a68912611c1dbd74750a3f3026b9b9d6a327ae", size = 43332, upload-time = "2023-04-17T21:41:13.444Z" },
+]

--- a/docker-compose.recovery.yml
+++ b/docker-compose.recovery.yml
@@ -1,0 +1,20 @@
+# Compose override for the P-022 §C poller recovery suite.
+#
+# Used with docker-compose.test.yml, e.g.
+#   docker compose -f docker-compose.test.yml -f docker-compose.recovery.yml \
+#     --env-file test.env up -d postgres
+#
+# Two deliberate differences from the plain test stack:
+#   * the host port is NOT 5432 — a developer's live local Postgres usually owns
+#     that port, and the recovery suite creates/drops databases, so it must never
+#     be able to reach a real one by accident. Override with
+#     POLIS_RECOVERY_PG_PORT.
+#   * the data directory is tmpfs: every `up` starts from a clean initdb, which
+#     re-runs server/postgres/migrations/*.sql (the REAL migrations baked into
+#     server/Dockerfile-db), and nothing survives teardown.
+services:
+  postgres:
+    ports: !override
+      - "${POLIS_RECOVERY_PG_PORT:-55432}:5432"
+    tmpfs:
+      - /var/lib/postgresql/data


### PR DESCRIPTION
**Stacked on #2702** (base is that branch; retargets to `edge` when it merges).

## Why
The Python poller published a conversation's results as three separate transactions (`math_main`, `math_bidtopid`, `math_ptptstats`), so a crash between them left mixed generations, permanently for a conversation that then went quiet. Recovery scenarios R05 and R09, previously pinned as strict xfails, now pass. Inherited from Clojure's design (`conv_man.clj:158-169`, which is worse: its writes run outside any error handling).

## What
- `database/postgres.py`, `poller/math_writer.py`: tick allocation + all three upserts in ONE `engine.begin()`; fixed lock order (`math_ticks` → bidtopid → ptptstats → main), per-zid rows so two zids cannot deadlock; `write_math_main` is the last statement so a reader never sees `math_main` ahead of its companions; blobs pre-encoded outside the transaction (`encode_math_blob`).
- `poller/service.py`: on load-or-init, unequal `math_tick` across the three rows triggers a full rebuild with a clear log line; a boot-time DB error in that scan is logged and survived (`start()` only; `poll_once` still propagates).
- Tests: R05/R09 xfails removed; R01/R05/R09 negative controls re-pointed for the new write order (assertions preserved); new `test_atomic_publish.py`; `test_start_survives_a_boot_time_scan_failure`.

Not fixed here, tracked: the `max(caching_tick)+1` cursor is still racy under READ COMMITTED (R12 stays xfail; this change shrinks but does not close the window). Follow-ups noted in code: cap the startup REBUILD burst; meter rebuild thrash during a dual-run.

## Verification
`make test-recovery` → 244 passed, 1 skipped, 9 xfailed. `uv run pytest tests/poller -q` → same. `make test-recovery-races` → 20/20 iterations, 40 passed + 3 xfailed each. Implemented by a headless Codex worker; independently reviewed (verdict: merge with edits E1/E2/E3/E6, all applied); rebuilt on the #2702 base with duplicated prerequisites dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s