### PR TITLE
certify: strict inventory and run manifest — the battery can no longer pass vacuously (P-022 B1)

### DIFF
--- a/delphi/polismath/replay/certify.py
+++ b/delphi/polismath/replay/certify.py
@@ -42,6 +42,8 @@ import os
 import re
 import subprocess
 import threading
+import uuid
+from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -141,6 +143,8 @@ class BatteryEntry:
     n_cuts: int | None = None
     schedule_path: Path | None = None
     notes: str = ""
+    optional: bool = False
+    role: str | None = None
 
 
 def derive_schedule_id(
@@ -172,7 +176,18 @@ def parse_battery_entry(e: dict[str, Any], *, battery_dir: Path | None = None) -
     """Parse one battery entry — either ``{"schedule": "<path>"}`` (base id
     read verbatim from the referenced schedule.json) or ``{"preset": ...,
     "n_cuts": ...}``."""
+    if not isinstance(e, dict):
+        raise ValueError("battery entries must be objects")
+    unknown = set(e) - {"dataset", "schedule", "preset", "n_cuts", "notes", "optional", "role"}
+    if unknown:
+        raise ValueError(f"unknown battery fields: {sorted(unknown)}")
     dataset = e["dataset"]
+    st._safe_path_component(dataset, label="dataset")
+    if type(e.get("optional", False)) is not bool:
+        raise ValueError("optional must be boolean")
+    if "schedule" in e and "preset" in e:
+        raise ValueError("declare schedule or preset, not both")
+    extra = {"optional": e.get("optional", False), "role": e.get("role")}
 
     if "schedule" in e:
         schedule_path = Path(e["schedule"])
@@ -189,7 +204,7 @@ def parse_battery_entry(e: dict[str, Any], *, battery_dir: Path | None = None) -
         base_id = schedule_json["schedule_id"]
         schedule_id = derive_schedule_id(base_schedule_id=base_id)
         return BatteryEntry(dataset=dataset, schedule_id=schedule_id,
-                             schedule_path=schedule_path, notes=e.get("notes", ""))
+                             schedule_path=schedule_path, notes=e.get("notes", ""), **extra)
 
     preset = e.get("preset")
     if preset not in _VALID_PRESETS:
@@ -200,14 +215,18 @@ def parse_battery_entry(e: dict[str, Any], *, battery_dir: Path | None = None) -
     n_cuts = e.get("n_cuts")
     if preset in _NCUTS_PRESETS and n_cuts is None:
         raise ValueError(f"preset {preset!r} requires n_cuts in battery entry {e!r}")
+    if n_cuts is not None and (type(n_cuts) is not int or n_cuts <= 0):
+        raise ValueError("n_cuts must be a positive integer")
     schedule_id = derive_schedule_id(preset=preset, n_cuts=n_cuts)
     return BatteryEntry(dataset=dataset, schedule_id=schedule_id,
-                         preset=preset, n_cuts=n_cuts, notes=e.get("notes", ""))
+                         preset=preset, n_cuts=n_cuts, notes=e.get("notes", ""), **extra)
 
 
 def load_battery(path: str | Path = DEFAULT_BATTERY_PATH) -> list[BatteryEntry]:
     path = Path(path)
     data = json.loads(path.read_text())
+    if not isinstance(data, list) or not data:
+        raise ValueError("battery must be a nonempty list")
     return [parse_battery_entry(e, battery_dir=path.parent) for e in data]
 
 
@@ -328,6 +347,8 @@ def canonical_schedule_hash(spec: sched.ScheduleSpec) -> str:
         "source": spec.source,
         "restart_after": getattr(spec, "restart_after", None),
         "clojure": getattr(spec, "clojure", None),
+        "coverage": spec.coverage,
+        "empty_output": spec.empty_output,
     }
     return _canonical_hash(payload)
 
@@ -536,12 +557,25 @@ def _write_temp_schedule(spec: sched.ScheduleSpec, root: Path) -> Path:
 
 
 #: Recording-cache manifest schema version. BUMP this to invalidate every
-#: existing cached recording at once. Bumped to 2 for M3 (P-019): the py
+#: existing cached recording at once. Version 3 adds checkpoint content hashes
+#: and requires cursor metadata on both engines. Version 2 (M3/P-019): the py
 #: manifest now keys on the comments CSV (moderation events Python loads from
 #: it), and the schedule hash now covers restart_after/clojure — recordings made
 #: under the old keys must not be reused, or a comments-only or restart-only edit
 #: would compare a fresh run against a stale one and report its old MATCH.
-_RECORDING_MANIFEST_VERSION = 2
+_RECORDING_MANIFEST_VERSION = 3
+
+
+def _recording_hashes(directory: Path) -> dict[str, str]:
+    return {p.name: sha256_file(p) for p in sorted(directory.glob("step-*")) if p.is_file()}
+
+
+def _clear_recording(directory: Path) -> None:
+    """A producer must not inherit old steps or a success marker on failure."""
+    for p in directory.glob("step-*"):
+        if p.is_file():
+            p.unlink()
+    (directory / "cache_manifest.json").unlink(missing_ok=True)
 
 
 def _manifest_matches(manifest_path: Path, expected: dict[str, Any]) -> bool:
@@ -549,15 +583,28 @@ def _manifest_matches(manifest_path: Path, expected: dict[str, Any]) -> bool:
         return False
     try:
         existing = json.loads(manifest_path.read_text())
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CertifyError("recording-manifest", f"malformed recording manifest: {manifest_path}") from exc
+    if not isinstance(existing, dict):
+        raise CertifyError("recording-manifest", "recording manifest must be an object")
+    # Old versions require a fresh producer run, never acceptance of old steps.
+    if existing.get("manifest_version") in (1, 2):
         return False
+    if type(existing.get("manifest_version")) is not int or existing["manifest_version"] != _RECORDING_MANIFEST_VERSION:
+        raise CertifyError("recording-manifest", "unknown or missing recording manifest version")
+    hashes = existing.pop("checkpoint_sha256", None)
+    if not isinstance(hashes, dict) or set(existing) != set(expected):
+        raise CertifyError("recording-manifest", "malformed recording manifest fields")
+    if hashes != _recording_hashes(manifest_path.parent):
+        raise CertifyError("recording-integrity", "checkpoint files differ from recording manifest")
     return existing == expected
 
 
 def _write_manifest(manifest_path: Path, manifest: dict[str, Any]) -> None:
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     with open(manifest_path, "w") as fh:
-        json.dump(manifest, fh, indent=2, sort_keys=True)
+        json.dump({**manifest, "checkpoint_sha256": _recording_hashes(manifest_path.parent)},
+                  fh, indent=2, sort_keys=True)
 
 
 #: Pure-harness paths (relative to ``polismath/``) excluded from the py
@@ -639,6 +686,7 @@ def ensure_py_recording(
         return py_dir, True
 
     tmp_schedule = _write_temp_schedule(spec, root)
+    _clear_recording(py_dir)
     result = run_py_driver(tmp_schedule, out_root=root)
     if result.returncode != 0:
         raise CertifyError(
@@ -681,6 +729,7 @@ def ensure_clj_recording(
         return clj_dir, True
 
     tmp_schedule = _write_temp_schedule(spec, root)
+    _clear_recording(clj_dir)
     rec_dir.mkdir(parents=True, exist_ok=True)
     result = run_clj_driver(tmp_schedule, votes_csv, out_dir=rec_dir, comments_csv=comments_csv)
     if result.returncode != 0:
@@ -712,7 +761,17 @@ def compare_recording_pair(
     """
     clj_blobs = load_clj_blobs(Path(clj_dir))
     py_blobs = st.load_step_blobs(Path(py_dir))
-    aligned = min(len(clj_blobs), len(py_blobs))
+    if not clj_blobs or not py_blobs:
+        raise CertifyError("empty-recording", "both engines must produce nonempty recordings")
+    if len(clj_blobs) != len(py_blobs):
+        raise CertifyError("step-count-mismatch",
+                           f"clj={len(clj_blobs)} steps, py={len(py_blobs)} steps")
+    # Even the standalone comparer/focuser must reject gaps and renamed copies.
+    for directory, suffix in ((Path(clj_dir), ".blob.json"), (Path(py_dir), ".json")):
+        names = sorted(p.name for p in directory.glob(f"step-*{suffix}"))
+        if names != sorted(f"step-{i:03d}{suffix}" for i in range(len(clj_blobs))):
+            raise CertifyError("checkpoint-identity", "checkpoint filenames must be contiguous")
+    aligned = len(clj_blobs)
     cmp = comparer if comparer is not None else _acceptance_projecting_comparer()
     cfg_hash = _comparer_cfg_hash(cmp)
     cache_root = Path(cache_root)
@@ -721,6 +780,8 @@ def compare_recording_pair(
     for i in range(aligned):
         clj_proj = project_acceptance(clj_blobs[i])
         py_proj = project_acceptance(py_blobs[i])
+        if not clj_proj or not py_proj:
+            raise CertifyError("checkpoint-schema", "empty acceptance blob")
         clj_hash = _canonical_hash(clj_proj)
         py_hash = _canonical_hash(py_proj)
 
@@ -810,32 +871,128 @@ def _summarize_divergences(cmp_result: dict[str, Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Per-entry certification.
 # ---------------------------------------------------------------------------
+@dataclass
+class ExpectedEntry:
+    entry: BatteryEntry
+    spec: sched.ScheduleSpec
+    votes_csv: Path
+    votes_sha: str
+    comments_csv: Path | None
+    comments_sha: str | None
+    stream_end: int
+    checkpoints: list[dict[str, int]]
+
+    def inventory(self) -> list[dict[str, Any]]:
+        return [{
+            "dataset": self.entry.dataset, "schedule_id": self.entry.schedule_id,
+            "role": self.entry.role or f"{self.entry.dataset}:{self.entry.schedule_id}",
+            "engine": engine, "coverage": self.spec.coverage,
+            "stream_end": self.stream_end, "checkpoints": self.checkpoints,
+        } for engine in ("clj", "py")]
+
+
+def prepare_entry(entry: BatteryEntry) -> ExpectedEntry:
+    """Resolve inputs and checkpoint identities before any producer can run."""
+    st.recording_dir(entry.dataset, entry.schedule_id)
+    if not dataset_available(entry.dataset):
+        raise CertifyError("dataset-unavailable", "dataset-unavailable")
+    votes_csv = votes_csv_path(entry.dataset)
+    if votes_csv is None:
+        raise CertifyError("dataset-unavailable", "no votes CSV found")
+    votes_sha = sha256_file(votes_csv)
+    ds = real_data.load_export_votes(entry.dataset)
+    spec = build_effective_spec(entry, ds)
+    if spec.dataset != entry.dataset:
+        raise CertifyError("inventory", "schedule dataset does not match battery")
+    steps = sched.slice_schedule(ds, spec)
+    if not steps:
+        raise CertifyError("inventory", "nonzero expected checkpoints required")
+    if spec.coverage not in ("full-stream", "prefix-diagnostic"):
+        raise CertifyError("inventory", "unknown schedule coverage")
+    if spec.coverage == "full-stream" and steps[-1].cut_slot != ds.n:
+        raise CertifyError("inventory", "final cut must reach stream end")
+    if spec.coverage == "full-stream" and len(sched._resolve_mod_events(ds, spec)) != sum(
+        len(s.mod_events) for s in steps
+    ):
+        raise CertifyError("inventory", "final cut leaves moderation events unconsumed")
+    if spec.restart_after is not None and (
+        type(spec.restart_after) is not int or not 0 <= spec.restart_after < len(steps) - 1
+    ):
+        raise CertifyError("inventory", "restart_after requires a subsequent checkpoint")
+    if steps[0].cut_slot == 0:
+        if not isinstance(spec.empty_output, dict) or not spec.empty_output:
+            raise CertifyError("inventory", "zero checkpoint requires a nonempty empty_output contract")
+        if not set(spec.empty_output) <= ACCEPTANCE_KEYS:
+            raise CertifyError("inventory", "empty_output must name acceptance fields")
+    comments = comments_csv_path(entry.dataset) if spec.moderation != "none" else None
+    if spec.moderation == "interleave-by-timestamp" and comments is None:
+        raise CertifyError("dataset-unavailable", "moderation schedule requires comments CSV")
+    checkpoints = [{"index": s.index, "prev_slot": s.prev_slot, "cut_slot": s.cut_slot,
+                    "batch_size": len(s.vote_events), "cut_time_ms": s.cut_time_ms}
+                   for s in steps]
+    # Pass resolved absolute cursors to BOTH engines. Neither driver gets to
+    # independently round fractions or silently change the expected inventory.
+    resolved = spec.to_dict()
+    resolved["cuts"] = {"mode": "vote-count", "at": [s.cut_slot for s in steps]}
+    if steps[0].cut_slot == 0:
+        resolved["cuts"]["empty_checkpoint"] = True
+    return ExpectedEntry(entry, sched.ScheduleSpec.from_dict(resolved), votes_csv, votes_sha,
+                         comments, sha256_file(comments) if comments else None, ds.n, checkpoints)
+
+
+def validate_recording_inventory(directory: Path, engine: str, expected: ExpectedEntry) -> None:
+    """Exact file and cursor equality, independently for each engine."""
+    suffixes = (".blob.json", ".meta.json") if engine == "clj" else (".json",)
+    names = {f"step-{c['index']:03d}{suffix}" for c in expected.checkpoints for suffix in suffixes}
+    actual = {p.name for p in directory.glob("step-*.json")}
+    if actual != names:
+        raise CertifyError("checkpoint-inventory",
+                           f"{engine}: missing={sorted(names - actual)}, unexpected={sorted(actual - names)}")
+    for checkpoint in expected.checkpoints:
+        stem = f"step-{checkpoint['index']:03d}"
+        meta_path = directory / (stem + (".meta.json" if engine == "clj" else ".json"))
+        meta = json.loads(meta_path.read_text())
+        if not isinstance(meta, dict) or any(
+            type(meta.get(k)) is not int or meta[k] != v for k, v in checkpoint.items()
+        ):
+            raise CertifyError("checkpoint-identity", f"{engine}: metadata differs at {stem}")
+        blob = (json.loads((directory / (stem + ".blob.json")).read_text())
+                if engine == "clj" else meta.get("blob"))
+        if not isinstance(blob, dict) or not project_acceptance(blob):
+            raise CertifyError("checkpoint-schema", f"{engine}: missing acceptance blob at {stem}")
+        if checkpoint["cut_slot"] == 0:
+            projected = project_acceptance(blob)
+            if any(k not in projected or projected[k] != v for k, v in expected.spec.empty_output.items()):
+                raise CertifyError("empty-output", f"{engine}: {stem} violates declared empty_output")
+
+
+def _entry_error(entry: BatteryEntry, exc: Exception) -> dict[str, Any]:
+    stage = exc.stage if isinstance(exc, CertifyError) else "setup"
+    optional_missing = entry.optional and stage == "dataset-unavailable"
+    return {"dataset": entry.dataset, "schedule_id": entry.schedule_id,
+            "verdict": "SKIPPED" if optional_missing else "ERROR",
+            "optional": entry.optional, "stage": stage, "reason": str(exc)}
+
+
 def _certify_entry_heavy(
     entry: BatteryEntry, *, root: Path, refresh_clj: bool = False, refresh_py: bool = False,
+    expected: ExpectedEntry | None = None,
 ) -> dict[str, Any]:
     """The parallel-safe part of certifying one entry: ensure both recordings
     and run the hash-first compare — NO ledger access, so a whole battery can
     fan these out across workers. Terminal verdicts (SKIPPED/ERROR/MATCH) come
     back complete; a divergence carries its summary under ``"_summary"`` for
     the strictly-serial ledger fold (:func:`_fold_entry_into_ledger`)."""
-    if not dataset_available(entry.dataset):
-        return {"dataset": entry.dataset, "schedule_id": entry.schedule_id,
-                "verdict": "SKIPPED", "reason": "dataset-unavailable"}
-
     try:
-        votes_csv = votes_csv_path(entry.dataset)
-        if votes_csv is None:
-            raise CertifyError("setup", f"no *-votes.csv found for dataset {entry.dataset!r}")
-        votes_sha = sha256_file(votes_csv)
-        ds = real_data.load_export_votes(entry.dataset)
-        spec = build_effective_spec(entry, ds)
+        expected = expected or prepare_entry(entry)
+        votes_csv, votes_sha, spec = expected.votes_csv, expected.votes_sha, expected.spec
 
         # --comments only when the schedule actually requests moderation
         # (interleaving or an explicit list) AND the dataset has a comments
         # CSV to weave from — existing moderation="none" entries never pass
         # it, so their recordings/caches are untouched (MOD_RESTART_PORT_
         # SPEC.md "Python ports" item 5).
-        comments_csv = comments_csv_path(entry.dataset) if spec.moderation != "none" else None
+        comments_csv = expected.comments_csv
 
         clj_dir, _ = ensure_clj_recording(entry, spec, votes_sha, votes_csv, root=root,
                                            refresh=refresh_clj, comments_csv=comments_csv)
@@ -843,20 +1000,15 @@ def _certify_entry_heavy(
         # must be part of the py cache key, mirroring the clj side above.
         py_dir, _ = ensure_py_recording(entry, spec, votes_sha, root=root,
                                         refresh=refresh_py, comments_csv=comments_csv)
-    except CertifyError as exc:
-        return {"dataset": entry.dataset, "schedule_id": entry.schedule_id,
-                "verdict": "ERROR", "stage": exc.stage, "reason": str(exc)}
+        if sha256_file(votes_csv) != votes_sha or (
+            comments_csv is not None and sha256_file(comments_csv) != expected.comments_sha
+        ):
+            raise CertifyError("input-changed", "inputs changed after inventory construction")
+        validate_recording_inventory(clj_dir, "clj", expected)
+        validate_recording_inventory(py_dir, "py", expected)
+        cmp_result = compare_recording_pair(clj_dir, py_dir, cache_root=root)
     except Exception as exc:  # noqa: BLE001 - one bad entry must not crash the battery
-        return {"dataset": entry.dataset, "schedule_id": entry.schedule_id,
-                "verdict": "ERROR", "stage": "setup", "reason": str(exc)}
-
-    cmp_result = compare_recording_pair(clj_dir, py_dir, cache_root=root)
-
-    if cmp_result["step_count_mismatch"]:
-        return {"dataset": entry.dataset, "schedule_id": entry.schedule_id,
-                "verdict": "ERROR", "stage": "step-count-mismatch",
-                "reason": f"clj={cmp_result['n_steps_clj']} steps, "
-                          f"py={cmp_result['n_steps_py']} steps"}
+        return _entry_error(entry, exc)
 
     div_steps = [s for s in cmp_result["per_step"] if not s["match"]]
     if not div_steps:
@@ -937,19 +1089,66 @@ def run_battery(
     root = root or st.replays_root()
     ledger_path = ledger_path or default_ledger_path()
     ledger = load_ledger(ledger_path)
-
-    if only:
-        entries = _filter_only(entries, only)
+    selected = _filter_only(entries, only) if only is not None else entries
+    prepared: dict[tuple[str, str], ExpectedEntry] = {}
+    errors: dict[tuple[str, str], dict[str, Any]] = {}
+    inventory = []
+    configuration_errors = []
+    if not entries:
+        configuration_errors.append("battery has zero entries")
+    if not selected:
+        configuration_errors.append("selection has zero entries")
+    seen = set()
+    # Resolve the WHOLE battery before dispatching even the first worker.
+    for entry in entries:
+        key = (entry.dataset, entry.schedule_id)
+        if key in seen:
+            configuration_errors.append(f"duplicate battery entry: {key}")
+            continue
+        seen.add(key)
+        try:
+            expected = prepare_entry(entry)
+            prepared[key] = expected
+            inventory.extend(expected.inventory())
+        except Exception as exc:
+            errors[key] = _entry_error(entry, exc)
+    full_datasets = {p.entry.dataset for p in prepared.values() if p.spec.coverage == "full-stream"}
+    for p in prepared.values():
+        if p.spec.coverage == "prefix-diagnostic" and p.entry.dataset not in full_datasets:
+            errors[(p.entry.dataset, p.entry.schedule_id)] = _entry_error(
+                p.entry, CertifyError("inventory", "prefix diagnostic requires a full-stream companion"))
+    run_id = str(uuid.uuid4())
+    started = datetime.now(timezone.utc).isoformat()
+    manifest = {
+        "schema": "polis-certification-run/1", "run_id": run_id, "started_at": started,
+        "entry_statuses": ["PASS", "FAIL", "INCONCLUSIVE", "APPROVED_DIFFERENCE"],
+        "finished_at": None, "verdict": "INCONCLUSIVE", "partial": only is not None,
+        "configuration": {"only": only, "refresh_clj": refresh_clj,
+                          "refresh_py": refresh_py, "workers": workers},
+        "configuration_errors": configuration_errors, "inventory": inventory,
+        "entries": [{"dataset": e.dataset, "schedule_id": e.schedule_id,
+                     "role": e.role or f"{e.dataset}:{e.schedule_id}", "optional": e.optional,
+                     "status": "INCONCLUSIVE", "reason": "not completed"} for e in entries],
+        "resolved_schedules": [{"dataset": p.entry.dataset, "schedule_id": p.entry.schedule_id,
+                                "schedule": p.spec.to_dict(), "votes_sha256": p.votes_sha,
+                                "comments_sha256": p.comments_sha} for p in prepared.values()],
+    }
+    _write_json(root / "run_manifest.json", manifest)
 
     def _heavy(entry: BatteryEntry) -> dict[str, Any]:
+        key = (entry.dataset, entry.schedule_id)
+        if key in errors:
+            return errors[key]
+        if configuration_errors:
+            return _entry_error(entry, CertifyError("inventory", "; ".join(configuration_errors)))
         return _certify_entry_heavy(entry, root=root, refresh_clj=refresh_clj,
-                                    refresh_py=refresh_py)
+                                    refresh_py=refresh_py, expected=prepared[key])
 
-    if workers > 1 and len(entries) > 1:
-        with ThreadPoolExecutor(max_workers=min(workers, len(entries))) as pool:
-            heavies = list(pool.map(_heavy, entries))
+    if workers > 1 and len(selected) > 1:
+        with ThreadPoolExecutor(max_workers=min(workers, len(selected))) as pool:
+            heavies = list(pool.map(_heavy, selected))
     else:
-        heavies = [_heavy(e) for e in entries]
+        heavies = [_heavy(e) for e in selected]
 
     results = []
     for heavy in heavies:
@@ -957,23 +1156,50 @@ def run_battery(
         results.append(result)
 
     save_ledger(ledger, ledger_path)
-    report = {"battery": results, "root": str(root)}
+    by_key = {(r["dataset"], r["schedule_id"]): r for r in results}
+    for item in manifest["entries"]:
+        result = by_key.get((item["dataset"], item["schedule_id"]))
+        if result is None:
+            item["reason"] = "not selected: PARTIAL RUN, NOT A GATE"
+        else:
+            item["status"] = {"MATCH": "PASS", "ERROR": "FAIL", "DIVERGENCE": "FAIL",
+                              "SKIPPED": "INCONCLUSIVE"}[result["verdict"]]
+            item["reason"] = result.get("reason", result["verdict"])
+            item["result"] = result
+    verdict = "PASS"
+    if configuration_errors or any(e["status"] == "FAIL" for e in manifest["entries"]):
+        verdict = "FAIL"
+    elif only is not None or any(e["status"] != "PASS" for e in manifest["entries"]):
+        verdict = "INCONCLUSIVE"
+    manifest.update(verdict=verdict, finished_at=datetime.now(timezone.utc).isoformat())
+    _write_json(root / "run_manifest.json", manifest)
+    report = {"battery": results, "root": str(root), "verdict": verdict,
+              "partial": only is not None, "inventory": inventory,
+              "configuration_errors": configuration_errors,
+              "run_manifest": str(root / "run_manifest.json")}
     _write_json(root / "certify_report.json", report)
     return report
 
 
-def battery_exit_code(results: list[dict[str, Any]], *, strict: bool) -> int:
-    bad = any(r["verdict"] in ("DIVERGENCE", "ERROR") for r in results)
-    if strict:
-        bad = bad or any(r["verdict"] == "SKIPPED" for r in results)
-    return 1 if bad else 0
+def battery_exit_code(results: list[dict[str, Any]] | dict[str, Any], *, strict: bool) -> int:
+    if isinstance(results, dict):
+        if strict:
+            return int(results.get("verdict") != "PASS" or results.get("partial", False))
+        return int(results.get("verdict") == "FAIL" or
+                   battery_exit_code(results["battery"], strict=False))
+    return int(not results or any(
+        r["verdict"] != "MATCH" and not (
+            not strict and r["verdict"] == "SKIPPED" and r.get("optional") is True
+        ) for r in results))
 
 
 def _write_json(path: Path, data: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as fh:
+    tmp = path.with_suffix(f".tmp-{os.getpid()}-{threading.get_ident()}")
+    with open(tmp, "w") as fh:
         json.dump(data, fh, indent=2, sort_keys=True, default=str)
         fh.write("\n")
+    os.replace(tmp, path)
 
 
 # ---------------------------------------------------------------------------
@@ -1012,6 +1238,10 @@ def render_run_lines(report: dict[str, Any], *, max_lines: int = 40) -> list[str
     '+N more' line if the battery is too large to fit), and a footer."""
     header = [ACCEPTANCE_NOTICE, f"certify: {len(report['battery'])} entries  root={report['root']}"]
     footer = [_format_footer(report["battery"])]
+    if report.get("partial"):
+        header.append("PARTIAL RUN, NOT A GATE (--only)")
+    if "verdict" in report:
+        footer.append(f"gate verdict: {report['verdict']}  manifest={report.get('run_manifest')}")
     budget = max_lines - len(header) - len(footer)
     entries = report["battery"]
     if len(entries) <= budget:
@@ -1046,7 +1276,11 @@ def run_focus(
                 "reason": f"expected clj/ and py/ both present under {rec_dir}"}
 
     ledger = load_ledger(ledger_path)
-    cmp_result = compare_recording_pair(clj_dir, py_dir, cache_root=root)
+    try:
+        cmp_result = compare_recording_pair(clj_dir, py_dir, cache_root=root)
+    except (CertifyError, ValueError, TypeError, OSError) as exc:
+        return {"dataset": dataset, "schedule_id": schedule_id, "verdict": "ERROR",
+                "stage": getattr(exc, "stage", "recording-schema"), "reason": str(exc)}
     div_steps = [s for s in cmp_result["per_step"] if not s["match"]]
 
     _write_json(rec_dir / "focus-report.json", {

--- a/delphi/polismath/replay/certify.py
+++ b/delphi/polismath/replay/certify.py
@@ -181,6 +181,71 @@ def _is_integral(value: Any) -> bool:
     return type(value) is int
 
 
+#: The versioned alias policy (P-022 B1 review round 3). ``_kebab`` maps a raw
+#: snake key onto its kebab spelling, so two DISTINCT raw keys can normalize to
+#: the same canonical name. Collapsing them into one dict silently drops one of
+#: the two values — and the dropped one never reaches the type/finiteness
+#: checks below, which is how ``{"n_cmts": "invalid-count", "n-cmts": 1}`` and
+#: ``{"hidden_value": NaN, "hidden-value": 0}`` certified PASS. Alias collisions
+#: are therefore rejected, with ONE declared exception: ``Conversation.to_dict``
+#: deliberately emits ``group-clusters`` AND its legacy ``group_clusters`` twin
+#: from the same value (conversation.py, "Legacy field for backward
+#: compatibility"), so that pair is admitted only while the two spellings carry
+#: DEEPLY EQUAL values. Anything else — an undeclared pair, a declared pair
+#: whose values disagree, a three-way collision — fails naming every raw
+#: spelling involved. When the legacy twin is finally dropped, delete the entry
+#: and this policy becomes "no collisions at all".
+_ALIAS_POLICY_VERSION = "v1"
+_ALIASED_CHECKPOINT_KEYS: frozenset[str] = frozenset({"group-clusters"})
+
+
+def _deep_equal(a: Any, b: Any) -> bool:
+    """Structural equality with JSON-ish type strictness: ``True``/``1`` differ,
+    ``1``/``1.0`` differ, and NaN never equals itself (so a duplicated NaN alias
+    is a value disagreement, not a permitted twin)."""
+    if isinstance(a, dict) and isinstance(b, dict):
+        return len(a) == len(b) and all(
+            k in b and _deep_equal(v, b[k]) for k, v in a.items())
+    if isinstance(a, list) and isinstance(b, list):
+        return len(a) == len(b) and all(_deep_equal(x, y) for x, y in zip(a, b))
+    if type(a) is not type(b):
+        return False
+    return bool(a == b)
+
+
+def _raw_alias_groups(blob: dict) -> dict[Any, list[Any]]:
+    """Canonical key -> the raw keys that normalize onto it, in blob order."""
+    groups: dict[Any, list[Any]] = {}
+    for k in blob:
+        groups.setdefault(_kebab(k), []).append(k)
+    return groups
+
+
+def _check_alias_collisions(blob: dict, label: str) -> None:
+    """Reject aliased raw keys BEFORE the canonical dict is built (see
+    :data:`_ALIASED_CHECKPOINT_KEYS`). Snake-only and kebab-only blobs, which
+    have no collision at all, are unaffected."""
+    for canonical, raw_keys in _raw_alias_groups(blob).items():
+        if len(raw_keys) == 1:
+            continue
+        spellings = ", ".join(repr(k) for k in raw_keys)
+        quantifier = "both" if len(raw_keys) == 2 else "all"
+        if canonical not in _ALIASED_CHECKPOINT_KEYS:
+            raise CertifyError(
+                "checkpoint-schema",
+                f"{label}: raw keys {spellings} {quantifier} normalize to {canonical!r}; "
+                f"alias collisions are rejected (alias policy "
+                f"{_ALIAS_POLICY_VERSION}) — one value would be dropped before "
+                f"validation")
+        first = blob[raw_keys[0]]
+        if len(raw_keys) > 2 or not all(_deep_equal(first, blob[k]) for k in raw_keys[1:]):
+            raise CertifyError(
+                "checkpoint-schema",
+                f"{label}: raw keys {spellings} normalize to the declared alias "
+                f"{canonical!r} but do not carry deeply equal values (alias "
+                f"policy {_ALIAS_POLICY_VERSION})")
+
+
 def _find_nonfinite(value: Any, path: str) -> str | None:
     """Depth-first search for a NaN/Infinity float anywhere under ``value``,
     returning its dotted path (or ``None``). json.dumps' ``allow_nan`` default
@@ -212,8 +277,8 @@ def validate_checkpoint_blob(
     ``label`` identifies the checkpoint in the message (e.g. ``"clj: step-002"``).
     ``require_keys=False`` skips only the required-key presence check — used for
     the zero/empty checkpoint and for the standalone comparer, which has no cut
-    metadata to tell an empty checkpoint from a truncated one. Type and
-    finiteness checks always run.
+    metadata to tell an empty checkpoint from a truncated one. Type,
+    alias-collision and finiteness checks always run.
 
     Not a full schema (see the module comment): presence, integrality,
     finiteness, container and ID types only.
@@ -223,6 +288,26 @@ def validate_checkpoint_blob(
             "checkpoint-schema",
             f"{label}: checkpoint blob must be a JSON object, got {type(blob).__name__}")
 
+    # UNTOUCHED-RAW checks first, before any normalization (P-022 B1 review,
+    # round 3). Building the canonical dict is lossy: aliased raw keys collapse
+    # onto one entry and the loser's value escapes every check below, so both
+    # the alias policy and the finiteness scan run against `blob` itself.
+    _check_alias_collisions(blob, label)
+
+    # json.dumps' allow_nan default lets NaN/Infinity round-trip through a
+    # recording file and hash EQUAL on both engines, so nothing downstream would
+    # ever notice them. Scanning the raw blob (not the canonical dict, not the
+    # acceptance projection) means a non-finite under an unprojected or aliased
+    # key still fails: the producer computed garbage either way.
+    nonfinite = _find_nonfinite(blob, "")
+    if nonfinite is not None:
+        raise CertifyError(
+            "checkpoint-schema",
+            f"{label}: non-finite number (NaN/Infinity) at field '{nonfinite.lstrip('.')}'")
+
+    # Collision-free by the check above: every canonical key has exactly one
+    # raw value (or a declared, deeply-equal alias twin of it), so each accepted
+    # field is type-checked through its unique canonical identity.
     canon = {_kebab(k): v for k, v in blob.items()}
 
     if require_keys:
@@ -288,15 +373,6 @@ def validate_checkpoint_blob(
                 "checkpoint-schema",
                 f"{label}: field {key!r} must be an integer or string id, got "
                 f"{type(value).__name__} {value!r}")
-
-    # Finiteness LAST and over the whole raw blob, not just the acceptance
-    # projection: a NaN hiding under an unprojected key still means the
-    # producer computed garbage, and NaN==NaN never trips the comparer.
-    nonfinite = _find_nonfinite(canon, "")
-    if nonfinite is not None:
-        raise CertifyError(
-            "checkpoint-schema",
-            f"{label}: non-finite number (NaN/Infinity) at field '{nonfinite.lstrip('.')}'")
 
 
 def _acceptance_projecting_comparer(**kwargs: Any) -> StepComparer:

--- a/delphi/polismath/replay/certify.py
+++ b/delphi/polismath/replay/certify.py
@@ -734,14 +734,47 @@ def run_clj_driver(
         raise CertifyError("clj-driver-launch", str(exc)) from exc
 
 
+# Reject anything that would make the (dataset, schedule_id) -> path mapping
+# ambiguous or let it escape the scratch directory. "/" is the one delimiter
+# that cannot appear in either component, which is exactly what makes the
+# nested layout in _write_temp_schedule injective — so it must be rejected,
+# along with the platform separator, traversal and empty/dot names.
+def _validate_path_component(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise CertifyError("schedule-path",
+                           f"{field} must be a nonempty string, got {value!r}")
+    if value in (".", "..") or "/" in value or os.sep in value or "\0" in value:
+        raise CertifyError("schedule-path",
+                           f"{field} must not contain a path separator or traversal: {value!r}")
+    return value
+
+
 def _write_temp_schedule(spec: sched.ScheduleSpec, root: Path) -> Path:
     """Write ``spec`` (with its final, collision-free schedule_id already
     baked in) to a scratch file used purely as the driver CLI's ``--schedule``
-    input — overwritten deterministically per (dataset, schedule_id)."""
-    tmp_dir = root / ".certify_cache" / "tmp_schedules"
+    input.
+
+    The path is UNAMBIGUOUS in (dataset, schedule_id). The previous
+    ``f"{dataset}__{schedule_id}.json"`` flattening was not: the valid pairs
+    ``("synthetic__a", "b-clojure-legacy")`` and ``("synthetic", "a__b-clojure-legacy")``
+    produced the same filename, so whichever entry wrote second silently handed
+    the OTHER entry's schedule to a producer (P-022 B1 review, P2). Distinct
+    recording directories do not isolate this shared input file.
+
+    Both components are validated to contain no path separator, so ``/`` — the
+    one delimiter that cannot occur inside either — makes the nested layout
+    ``<dataset>/<schedule_id>.json`` injective. The write is atomic (tmp +
+    ``os.replace``) so a concurrent battery worker reaching the same key can
+    never observe a torn file as its ``--schedule`` input.
+    """
+    dataset = _validate_path_component(spec.dataset, "schedule dataset")
+    schedule_id = _validate_path_component(spec.schedule_id, "schedule_id")
+    tmp_dir = root / ".certify_cache" / "tmp_schedules" / dataset
     tmp_dir.mkdir(parents=True, exist_ok=True)
-    p = tmp_dir / f"{spec.dataset}__{spec.schedule_id}.json"
-    spec.write_json(p)
+    p = tmp_dir / f"{schedule_id}.json"
+    staging = p.with_name(f"{schedule_id}.tmp-{os.getpid()}-{threading.get_ident()}")
+    spec.write_json(staging)
+    os.replace(staging, p)
     return p
 
 

--- a/delphi/polismath/replay/certify.py
+++ b/delphi/polismath/replay/certify.py
@@ -649,6 +649,35 @@ def _clj_source_hashes() -> tuple[str, str]:
     )
 
 
+def run_provenance(root: Path, battery_path: str | Path | None = None) -> dict[str, Any]:
+    """Everything this runner can attest about WHAT produced a verdict: the
+    Clojure driver and math source it replayed against, the Python engine tree,
+    and the comparer configuration + code. A run manifest without these records
+    only that *a* verdict was reached, not by which engine, driver or comparer —
+    which is most of the manifest's purpose.
+
+    These are deliberately the SAME hashes the recording cache keys on
+    (:func:`ensure_clj_recording`, :func:`ensure_py_recording`,
+    :func:`_comparer_cfg_hash`), so a manifest and the recordings it judged
+    cannot silently disagree about their provenance.
+
+    Deliberately NOT attested here — P-022 defers them to a later slice:
+    interpreter/JVM/BLAS versions, architecture, container image digests and
+    dependency-lock fingerprints."""
+    replay_clj_sha256, math_src_sha256 = _clj_source_hashes()
+    return {
+        "engine_tree_sha256": _engine_tree_hash_cached(),
+        "replay_clj_sha256": replay_clj_sha256,
+        "math_src_sha256": math_src_sha256,
+        "comparer_cfg_sha256": _comparer_cfg_hash(_acceptance_projecting_comparer()),
+        "recording_manifest_version": _RECORDING_MANIFEST_VERSION,
+        "battery_path": str(battery_path) if battery_path is not None else None,
+        "root": str(root),
+        "deferred": ["runtime_versions", "architecture", "image_digest",
+                     "jvm", "blas", "dependency_lock_sha256"],
+    }
+
+
 def ensure_py_recording(
     entry: BatteryEntry, spec: sched.ScheduleSpec, votes_sha: str, *, root: Path,
     refresh: bool = False, comments_csv: Path | None = None,
@@ -962,8 +991,23 @@ def validate_recording_inventory(directory: Path, engine: str, expected: Expecte
             raise CertifyError("checkpoint-schema", f"{engine}: missing acceptance blob at {stem}")
         if checkpoint["cut_slot"] == 0:
             projected = project_acceptance(blob)
-            if any(k not in projected or projected[k] != v for k, v in expected.spec.empty_output.items()):
-                raise CertifyError("empty-output", f"{engine}: {stem} violates declared empty_output")
+            missing = sorted(k for k in expected.spec.empty_output if k not in projected)
+            wrong = sorted(k for k, v in expected.spec.empty_output.items()
+                           if k in projected and projected[k] != v)
+            if missing or wrong:
+                # Name the offending keys: the two engines' empty prep-main blobs
+                # genuinely disagree (Clojure omits n/n-cmts/tids/in-conv where
+                # Python emits their empty values), and that is an OUTPUT-CONTRACT
+                # question for P-022, not a harness defect. A bare "violates
+                # declared empty_output" reads like a regression; this does not.
+                raise CertifyError(
+                    "empty-output",
+                    f"{engine}: {stem} does not satisfy the schedule's declared "
+                    f"empty_output contract — absent keys {missing}, wrong values "
+                    f"{ {k: projected[k] for k in wrong} } (expected "
+                    f"{ {k: expected.spec.empty_output[k] for k in wrong} }). The "
+                    f"engines' empty-compute representations are not yet reconciled; "
+                    f"see the schedule's notes.")
 
 
 def _entry_error(entry: BatteryEntry, exc: Exception) -> dict[str, Any]:
@@ -994,12 +1038,16 @@ def _certify_entry_heavy(
         # SPEC.md "Python ports" item 5).
         comments_csv = expected.comments_csv
 
-        clj_dir, _ = ensure_clj_recording(entry, spec, votes_sha, votes_csv, root=root,
-                                           refresh=refresh_clj, comments_csv=comments_csv)
+        clj_dir, clj_cached = ensure_clj_recording(entry, spec, votes_sha, votes_csv, root=root,
+                                                   refresh=refresh_clj, comments_csv=comments_csv)
         # M3 (P-019): the comments CSV is an input to the PYTHON replay too, so it
         # must be part of the py cache key, mirroring the clj side above.
-        py_dir, _ = ensure_py_recording(entry, spec, votes_sha, root=root,
-                                        refresh=refresh_py, comments_csv=comments_csv)
+        py_dir, py_cached = ensure_py_recording(entry, spec, votes_sha, root=root,
+                                                refresh=refresh_py, comments_csv=comments_csv)
+        # Recorded in the run manifest: a verdict reached entirely from cache is
+        # a different provenance claim than one that re-ran both engines.
+        cache = {"clj": "hit" if clj_cached else "miss",
+                 "py": "hit" if py_cached else "miss"}
         if sha256_file(votes_csv) != votes_sha or (
             comments_csv is not None and sha256_file(comments_csv) != expected.comments_sha
         ):
@@ -1013,11 +1061,11 @@ def _certify_entry_heavy(
     div_steps = [s for s in cmp_result["per_step"] if not s["match"]]
     if not div_steps:
         return {"dataset": entry.dataset, "schedule_id": entry.schedule_id,
-                "verdict": "MATCH", "n_steps": cmp_result["aligned_steps"]}
+                "verdict": "MATCH", "n_steps": cmp_result["aligned_steps"], "cache": cache}
 
     summary = _summarize_divergences(cmp_result)
     return {"dataset": entry.dataset, "schedule_id": entry.schedule_id,
-            "verdict": "DIVERGENCE",
+            "verdict": "DIVERGENCE", "cache": cache,
             "first_div_step": summary["first_div_step"],
             "n_div_steps": summary["n_div_steps"], "_summary": summary}
 
@@ -1072,10 +1120,40 @@ def _filter_only(entries: list[BatteryEntry], only: str) -> list[BatteryEntry]:
     return [e for e in entries if e.dataset == only]
 
 
+#: Name of the pointer file naming the most recent run manifest in a root. The
+#: manifests themselves are per-run (:func:`run_manifest_path`) — a later debug
+#: run must never be able to destroy a release run's manifest.
+RUN_MANIFEST_LATEST = "run_manifest_latest.json"
+
+
+def run_manifest_path(root: Path, run_id: str) -> Path:
+    """``<root>/run_manifest-<run_id>.json``. Manifests are per-run and never
+    overwritten: a run against an already-used root (a debug re-run, a retry,
+    anything sharing the recording store) would otherwise silently clobber the
+    manifest that attested a release."""
+    return Path(root) / f"run_manifest-{run_id}.json"
+
+
+def _write_run_manifest(root: Path, manifest: dict[str, Any]) -> Path:
+    """Write the manifest under its own run id and repoint ``latest``. The
+    pointer is a convenience for humans and tooling; the per-run file is the
+    record of truth."""
+    path = run_manifest_path(root, manifest["run_id"])
+    _write_json(path, manifest)
+    _write_json(Path(root) / RUN_MANIFEST_LATEST, {
+        "schema": "polis-certification-run-pointer/1",
+        "run_id": manifest["run_id"],
+        "verdict": manifest["verdict"],
+        "finished_at": manifest["finished_at"],
+        "run_manifest": str(path),
+    })
+    return path
+
+
 def run_battery(
     entries: list[BatteryEntry], *, root: Path | None = None, refresh_clj: bool = False,
     refresh_py: bool = False, ledger_path: str | Path | None = None, only: str | None = None,
-    workers: int = 1,
+    workers: int = 1, battery_path: str | Path | None = None,
 ) -> dict[str, Any]:
     """Certify every (filtered) entry, persist the ledger once, and write the
     machine report to ``<root>/certify_report.json``. Does NOT print — see
@@ -1124,7 +1202,10 @@ def run_battery(
         "entry_statuses": ["PASS", "FAIL", "INCONCLUSIVE", "APPROVED_DIFFERENCE"],
         "finished_at": None, "verdict": "INCONCLUSIVE", "partial": only is not None,
         "configuration": {"only": only, "refresh_clj": refresh_clj,
-                          "refresh_py": refresh_py, "workers": workers},
+                          "refresh_py": refresh_py, "workers": workers,
+                          "battery_path": str(battery_path) if battery_path is not None else None,
+                          "root": str(root)},
+        "provenance": run_provenance(root, battery_path),
         "configuration_errors": configuration_errors, "inventory": inventory,
         "entries": [{"dataset": e.dataset, "schedule_id": e.schedule_id,
                      "role": e.role or f"{e.dataset}:{e.schedule_id}", "optional": e.optional,
@@ -1133,7 +1214,7 @@ def run_battery(
                                 "schedule": p.spec.to_dict(), "votes_sha256": p.votes_sha,
                                 "comments_sha256": p.comments_sha} for p in prepared.values()],
     }
-    _write_json(root / "run_manifest.json", manifest)
+    manifest_path = _write_run_manifest(root, manifest)
 
     def _heavy(entry: BatteryEntry) -> dict[str, Any]:
         key = (entry.dataset, entry.schedule_id)
@@ -1165,6 +1246,7 @@ def run_battery(
             item["status"] = {"MATCH": "PASS", "ERROR": "FAIL", "DIVERGENCE": "FAIL",
                               "SKIPPED": "INCONCLUSIVE"}[result["verdict"]]
             item["reason"] = result.get("reason", result["verdict"])
+            item["cache"] = result.get("cache")
             item["result"] = result
     verdict = "PASS"
     if configuration_errors or any(e["status"] == "FAIL" for e in manifest["entries"]):
@@ -1172,11 +1254,11 @@ def run_battery(
     elif only is not None or any(e["status"] != "PASS" for e in manifest["entries"]):
         verdict = "INCONCLUSIVE"
     manifest.update(verdict=verdict, finished_at=datetime.now(timezone.utc).isoformat())
-    _write_json(root / "run_manifest.json", manifest)
+    manifest_path = _write_run_manifest(root, manifest)
     report = {"battery": results, "root": str(root), "verdict": verdict,
               "partial": only is not None, "inventory": inventory,
               "configuration_errors": configuration_errors,
-              "run_manifest": str(root / "run_manifest.json")}
+              "run_id": run_id, "run_manifest": str(manifest_path)}
     _write_json(root / "certify_report.json", report)
     return report
 

--- a/delphi/polismath/replay/certify.py
+++ b/delphi/polismath/replay/certify.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import functools
 import hashlib
 import json
+import math
 import os
 import re
 import subprocess
@@ -108,6 +109,194 @@ def project_acceptance(blob: dict[str, Any]) -> dict[str, Any]:
     return canonicalize_blob(
         {k: v for k, v in proj.items() if k not in ACCEPTANCE_EXCLUDED_KEYS}
     )
+
+
+# ---------------------------------------------------------------------------
+# Raw checkpoint validation (P-022 B1 review, P1).
+# ---------------------------------------------------------------------------
+# A NONEMPTY acceptance projection is not a valid checkpoint. `json.dumps`
+# round-trips NaN/Infinity by default (allow_nan=True), and
+# :func:`compare_recording_pair` short-circuits equal per-engine hashes to
+# MATCH *before* anything inspects the values — so two producers emitting the
+# SAME malformed blob (``{"n": NaN}``, ``{"n": "invalid-count"}``) certified
+# PASS with strict exit 0. Correct cursor metadata and valid file hashes do not
+# make the payload valid.
+#
+# Every checkpoint of BOTH engines is now validated RAW — before projection,
+# before hashing, before any cached step verdict, and on recording-cache hits
+# too — so a malformed value fails its entry regardless of what the other
+# engine emitted, and the reason names the offending field.
+#
+# Deliberately NOT a full schema: the versioned per-field B/G blob schema is a
+# later slice. Key names come from crosslang's ``PREP_MAIN_KEYS`` whitelist
+# (the single source of truth for prep-main spelling); this layer pins only
+# presence, integrality, finiteness and container/ID types.
+
+#: Required on every checkpoint whose cut slot is nonzero. The ZERO checkpoint
+#: is deliberately excluded: the engines' empty-compute representations are not
+#: reconciled (Clojure omits n/n-cmts/tids/in-conv where Python emits their
+#: empty values) and that checkpoint is governed by the schedule's declared
+#: ``empty_output`` contract instead — see validate_recording_inventory.
+_REQUIRED_CHECKPOINT_KEYS: tuple[str, ...] = ("n", "n-cmts", "tids", "in-conv")
+
+#: Integer-valued (never float, never bool, never a numeric string) and >= 0.
+_COUNT_CHECKPOINT_KEYS: tuple[str, ...] = ("n", "n-cmts")
+
+#: Epoch-millisecond stamps: integral or null.
+_TIMESTAMP_CHECKPOINT_KEYS: tuple[str, ...] = ("lastVoteTimestamp", "lastModTimestamp")
+
+#: Lists of integral ids. ``tids``/``in-conv`` are always emitted as lists;
+#: the set-semantic trio is nullable on both engines (see the committed
+#: real_data cold-start blobs, where mod-in/mod-out/meta-tids are null).
+_ID_LIST_CHECKPOINT_KEYS: tuple[str, ...] = ("tids", "in-conv", "mod-in", "mod-out", "meta-tids")
+_NULLABLE_CHECKPOINT_KEYS: frozenset[str] = frozenset(
+    {"mod-in", "mod-out", "meta-tids", "lastVoteTimestamp", "lastModTimestamp"}
+)
+
+#: Object-valued containers (JSON objects on both engines).
+_MAPPING_CHECKPOINT_KEYS: tuple[str, ...] = (
+    "pca", "base-clusters", "repness", "consensus", "group-votes", "votes-base",
+    "user-vote-counts", "comment-priorities", "group-aware-consensus",
+)
+
+#: Array-valued containers.
+_SEQUENCE_CHECKPOINT_KEYS: tuple[str, ...] = ("group-clusters",)
+
+#: ``zid`` is an identifier, not a number to compute with: int or str, never a
+#: float/container. (The battery's synthetic fixtures use string zids.)
+_ID_SCALAR_CHECKPOINT_KEYS: tuple[str, ...] = ("zid",)
+
+# Every name above must be a real prep-main key: no ad-hoc field invented here
+# can drift away from the canonicalization whitelist.
+assert set(
+    _REQUIRED_CHECKPOINT_KEYS + _COUNT_CHECKPOINT_KEYS + _TIMESTAMP_CHECKPOINT_KEYS
+    + _ID_LIST_CHECKPOINT_KEYS + _MAPPING_CHECKPOINT_KEYS + _SEQUENCE_CHECKPOINT_KEYS
+    + _ID_SCALAR_CHECKPOINT_KEYS
+) <= PREP_MAIN_KEYS, "checkpoint contract names a key prep-main does not emit"
+
+
+def _is_integral(value: Any) -> bool:
+    """True for a JSON integer. ``bool`` is a Python int but not a count, and a
+    float (even 3.0) is not how either engine spells an integral field."""
+    return type(value) is int
+
+
+def _find_nonfinite(value: Any, path: str) -> str | None:
+    """Depth-first search for a NaN/Infinity float anywhere under ``value``,
+    returning its dotted path (or ``None``). json.dumps' ``allow_nan`` default
+    lets these round-trip through a recording file and hash equal on both
+    engines, so nothing downstream would ever notice them."""
+    if isinstance(value, float):
+        return path if not math.isfinite(value) else None
+    if isinstance(value, dict):
+        for k, v in value.items():
+            found = _find_nonfinite(v, f"{path}.{k}")
+            if found is not None:
+                return found
+        return None
+    if isinstance(value, (list, tuple)):
+        for i, v in enumerate(value):
+            found = _find_nonfinite(v, f"{path}[{i}]")
+            if found is not None:
+                return found
+        return None
+    return None
+
+
+def validate_checkpoint_blob(
+    blob: Any, label: str, *, require_keys: bool = True,
+) -> None:
+    """Raw validation of ONE checkpoint blob. Raises :class:`CertifyError`
+    (stage ``checkpoint-schema``) naming the offending field.
+
+    ``label`` identifies the checkpoint in the message (e.g. ``"clj: step-002"``).
+    ``require_keys=False`` skips only the required-key presence check — used for
+    the zero/empty checkpoint and for the standalone comparer, which has no cut
+    metadata to tell an empty checkpoint from a truncated one. Type and
+    finiteness checks always run.
+
+    Not a full schema (see the module comment): presence, integrality,
+    finiteness, container and ID types only.
+    """
+    if not isinstance(blob, dict):
+        raise CertifyError(
+            "checkpoint-schema",
+            f"{label}: checkpoint blob must be a JSON object, got {type(blob).__name__}")
+
+    canon = {_kebab(k): v for k, v in blob.items()}
+
+    if require_keys:
+        missing = [k for k in _REQUIRED_CHECKPOINT_KEYS if k not in canon]
+        if missing:
+            raise CertifyError(
+                "checkpoint-schema",
+                f"{label}: checkpoint blob is missing required field(s) {missing}")
+
+    def present(keys: tuple[str, ...]):
+        for k in keys:
+            if k in canon:
+                yield k, canon[k]
+
+    for key, value in present(_COUNT_CHECKPOINT_KEYS):
+        if not _is_integral(value) or value < 0:
+            raise CertifyError(
+                "checkpoint-schema",
+                f"{label}: field {key!r} must be a non-negative integer, got "
+                f"{type(value).__name__} {value!r}")
+
+    for key, value in present(_TIMESTAMP_CHECKPOINT_KEYS):
+        if value is None:
+            continue
+        if not _is_integral(value):
+            raise CertifyError(
+                "checkpoint-schema",
+                f"{label}: field {key!r} must be an integer or null, got "
+                f"{type(value).__name__} {value!r}")
+
+    for key, value in present(_ID_LIST_CHECKPOINT_KEYS):
+        if value is None and key in _NULLABLE_CHECKPOINT_KEYS:
+            continue
+        if not isinstance(value, list):
+            raise CertifyError(
+                "checkpoint-schema",
+                f"{label}: field {key!r} must be an array of integer ids, got "
+                f"{type(value).__name__}")
+        for i, element in enumerate(value):
+            if not _is_integral(element):
+                raise CertifyError(
+                    "checkpoint-schema",
+                    f"{label}: field {key!r}[{i}] must be an integer id, got "
+                    f"{type(element).__name__} {element!r}")
+
+    for key, value in present(_MAPPING_CHECKPOINT_KEYS):
+        if not isinstance(value, dict):
+            raise CertifyError(
+                "checkpoint-schema",
+                f"{label}: field {key!r} must be a JSON object, got "
+                f"{type(value).__name__}")
+
+    for key, value in present(_SEQUENCE_CHECKPOINT_KEYS):
+        if not isinstance(value, list):
+            raise CertifyError(
+                "checkpoint-schema",
+                f"{label}: field {key!r} must be a JSON array, got "
+                f"{type(value).__name__}")
+
+    for key, value in present(_ID_SCALAR_CHECKPOINT_KEYS):
+        if not (_is_integral(value) or isinstance(value, str)):
+            raise CertifyError(
+                "checkpoint-schema",
+                f"{label}: field {key!r} must be an integer or string id, got "
+                f"{type(value).__name__} {value!r}")
+
+    # Finiteness LAST and over the whole raw blob, not just the acceptance
+    # projection: a NaN hiding under an unprojected key still means the
+    # producer computed garbage, and NaN==NaN never trips the comparer.
+    nonfinite = _find_nonfinite(canon, "")
+    if nonfinite is not None:
+        raise CertifyError(
+            "checkpoint-schema",
+            f"{label}: non-finite number (NaN/Infinity) at field '{nonfinite.lstrip('.')}'")
 
 
 def _acceptance_projecting_comparer(**kwargs: Any) -> StepComparer:
@@ -807,6 +996,15 @@ def compare_recording_pair(
 
     per_step: list[dict[str, Any]] = []
     for i in range(aligned):
+        # RAW validation first, per engine, BEFORE projection/hash/cached
+        # verdict: equal hashes short-circuit to MATCH below, so two producers
+        # emitting the same malformed value would otherwise certify clean
+        # (P-022 B1 review, P1). require_keys=False — the standalone comparer
+        # has no cursor metadata and so cannot tell a legitimate empty
+        # checkpoint from a truncated one; the certify path enforces presence
+        # in validate_recording_inventory, where cut slots are known.
+        validate_checkpoint_blob(clj_blobs[i], f"clj: step-{i:03d}", require_keys=False)
+        validate_checkpoint_blob(py_blobs[i], f"py: step-{i:03d}", require_keys=False)
         clj_proj = project_acceptance(clj_blobs[i])
         py_proj = project_acceptance(py_blobs[i])
         if not clj_proj or not py_proj:
@@ -989,6 +1187,13 @@ def validate_recording_inventory(directory: Path, engine: str, expected: Expecte
                 if engine == "clj" else meta.get("blob"))
         if not isinstance(blob, dict) or not project_acceptance(blob):
             raise CertifyError("checkpoint-schema", f"{engine}: missing acceptance blob at {stem}")
+        # Raw field validation, independently per engine and on cache hits too:
+        # a nonempty projection says nothing about the VALUES in it (P-022 B1
+        # review, P1). The zero checkpoint is exempted from required-key
+        # presence only — the empty_output contract below governs it — but its
+        # types and finiteness are still checked.
+        validate_checkpoint_blob(blob, f"{engine}: {stem}",
+                                 require_keys=checkpoint["cut_slot"] != 0)
         if checkpoint["cut_slot"] == 0:
             projected = project_acceptance(blob)
             missing = sorted(k for k in expected.spec.empty_output if k not in projected)

--- a/delphi/polismath/replay/schedule.py
+++ b/delphi/polismath/replay/schedule.py
@@ -67,12 +67,21 @@ class ScheduleSpec:
     # `_restart_conversation`). None (default) means no restart — every
     # existing schedule is unaffected.
     restart_after: int | None = None
+    coverage: str = "full-stream"
+    # Exact required fields in the empty checkpoint's acceptance projection.
+    empty_output: dict[str, Any] | None = None
     # Verbatim mapping this spec was loaded from (None → reconstruct on demand).
     _raw: dict[str, Any] | None = field(default=None, repr=False, compare=False)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "ScheduleSpec":
         """Build from a §4 mapping, retaining it verbatim for round-tripping."""
+        if not isinstance(d, dict):
+            raise ValueError("schedule must be an object")
+        unknown = set(d) - {"dataset", "schedule_id", "cuts", "source", "moderation",
+                            "clojure", "notes", "restart_after", "coverage", "empty_output"}
+        if unknown:
+            raise ValueError(f"unknown schedule fields: {sorted(unknown)}")
         return cls(
             dataset=d["dataset"],
             schedule_id=d["schedule_id"],
@@ -82,6 +91,8 @@ class ScheduleSpec:
             clojure=d.get("clojure", {"warm_start": "chain"}),
             notes=d.get("notes", ""),
             restart_after=d.get("restart_after"),
+            coverage=d.get("coverage", "full-stream"),
+            empty_output=d.get("empty_output"),
             _raw=dict(d),
         )
 
@@ -103,6 +114,8 @@ class ScheduleSpec:
             "clojure": self.clojure,
             "notes": self.notes,
             "restart_after": self.restart_after,
+            "coverage": self.coverage,
+            "empty_output": self.empty_output,
         }
 
     def write_json(self, path: str | Path) -> None:
@@ -138,17 +151,26 @@ class ReplayStep:
 def resolve_cut_slots(dataset: ReplayDataset, cuts: dict[str, Any]) -> Schedule:
     """Resolve a §4 ``cuts`` spec into a validated :data:`Schedule`.
 
-    Returns a strictly-increasing tuple of 1-based slots in ``1..n``. Slots
-    that resolve to 0 (e.g. a timestamp before the first vote) are dropped as
-    degenerate — recomputing an empty conversation is a no-op. Duplicate slots
-    are collapsed; out-of-range slots raise via ``validate_schedule``.
+    A zero slot requires ``empty_checkpoint: true``. Duplicate resolved slots
+    are errors unless ``deduplicate: true`` explicitly requests collapsing
+    them. Order is preserved: decreasing slots are always errors.
     """
+    if not isinstance(cuts, dict):
+        raise ValueError("cuts must be an object")
+    unknown = set(cuts) - {"mode", "at", "empty_checkpoint", "deduplicate"}
+    if unknown:
+        raise ValueError(f"unknown cut fields: {sorted(unknown)}")
     mode = cuts.get("mode")
     if mode not in _VALID_MODES:
         raise ValueError(
             f"unknown cut mode {mode!r}; expected one of {sorted(_VALID_MODES)}"
         )
     at = cuts.get("at", [])
+    if not isinstance(at, list):
+        raise ValueError("cuts.at must be a list")
+    for flag in ("empty_checkpoint", "deduplicate"):
+        if flag in cuts and type(cuts[flag]) is not bool:
+            raise ValueError(f"cuts.{flag} must be boolean")
     n = dataset.n
 
     raw_slots: list[int] = []
@@ -156,6 +178,8 @@ def resolve_cut_slots(dataset: ReplayDataset, cuts: dict[str, Any]) -> Schedule:
         if a == _END:
             raw_slots.append(n)
         elif mode in ("vote-count", "explicit-event-index"):
+            if type(a) is not int:
+                raise ValueError(f"vote cut must be an integer, got {a!r}")
             raw_slots.append(int(a))
         elif mode == "fraction":
             f = float(a)
@@ -166,11 +190,15 @@ def resolve_cut_slots(dataset: ReplayDataset, cuts: dict[str, Any]) -> Schedule:
             # slot = number of votes with t_ms <= T (votes are time-sorted).
             raw_slots.append(_count_votes_up_to(dataset.votes, int(a)))
 
-    # Drop degenerate 0-slots, dedupe, sort.
-    slots = tuple(sorted({s for s in raw_slots if s > 0}))
+    if any(a > b for a, b in zip(raw_slots, raw_slots[1:])):
+        raise ValueError("schedule not strictly increasing: cut order must be preserved")
+    if len(set(raw_slots)) != len(raw_slots) and not cuts.get("deduplicate", False):
+        raise ValueError("duplicate resolved cut slots; opt in with deduplicate: true")
+    slots = tuple(dict.fromkeys(raw_slots))
+    if 0 in slots and not cuts.get("empty_checkpoint", False):
+        raise ValueError("zero cut requires explicit empty_checkpoint: true")
     schedule: Schedule = slots
-    # validate_schedule enforces 1<=s<=n and strict monotonicity.
-    dataset.validate_schedule(schedule)
+    dataset.validate_schedule(schedule, allow_zero=cuts.get("empty_checkpoint", False))
     return schedule
 
 
@@ -209,8 +237,8 @@ def slice_schedule(dataset: ReplayDataset, spec: ScheduleSpec) -> list[ReplaySte
     prev = 0
     for i, cut in enumerate(slots):
         batch = tuple(dataset.votes[prev:cut])  # 1-based (prev, cut] → 0-based slice
-        cut_time_ms = dataset.votes[cut - 1].t_ms
-        prev_time = dataset.votes[prev - 1].t_ms if prev > 0 else None
+        cut_time_ms = dataset.votes[cut - 1].t_ms if cut else 0
+        prev_time = steps[-1].cut_time_ms if steps else None
         step_mods = tuple(
             m
             for m in mod_events
@@ -284,27 +312,27 @@ def preset_every_vote(dataset_name: str, n: int, *, schedule_id: str = "every-vo
 def preset_uniform(dataset_name: str, n: int, n_cuts: int, *,
                    schedule_id: str | None = None) -> ScheduleSpec:
     """``n_cuts`` evenly-spaced recomputes; the last lands on ``n``."""
-    slots = _dedupe_slots([round(n * i / n_cuts) for i in range(1, n_cuts + 1)], n)
+    slots = _preset_slots([round(n * i / n_cuts) for i in range(1, n_cuts + 1)], n)
     return _spec(dataset_name, schedule_id or f"uniform-{n_cuts}",
-                 {"mode": "vote-count", "at": slots},
+                 {"mode": "vote-count", "at": slots, "deduplicate": True},
                  notes=f"{n_cuts} evenly-spaced recomputes")
 
 
 def preset_front_loaded(dataset_name: str, n: int, *, n_cuts: int = 6,
                         schedule_id: str = "front-loaded") -> ScheduleSpec:
     """Recomputes concentrated EARLY (quadratic spacing, denser at the start)."""
-    slots = _dedupe_slots([round(n * (i / n_cuts) ** 2) for i in range(1, n_cuts + 1)], n)
-    return _spec(dataset_name, schedule_id, {"mode": "vote-count", "at": slots},
+    slots = _preset_slots([round(n * (i / n_cuts) ** 2) for i in range(1, n_cuts + 1)], n)
+    return _spec(dataset_name, schedule_id, {"mode": "vote-count", "at": slots, "deduplicate": True},
                  notes="front-loads recomputes into the early conversation")
 
 
 def preset_back_loaded(dataset_name: str, n: int, *, n_cuts: int = 6,
                        schedule_id: str = "back-loaded") -> ScheduleSpec:
     """Recomputes concentrated LATE (mirror of front-loaded)."""
-    slots = _dedupe_slots(
+    slots = _preset_slots(
         [round(n * (1 - (1 - i / n_cuts) ** 2)) for i in range(1, n_cuts + 1)], n
     )
-    return _spec(dataset_name, schedule_id, {"mode": "vote-count", "at": slots},
+    return _spec(dataset_name, schedule_id, {"mode": "vote-count", "at": slots, "deduplicate": True},
                  notes="back-loads recomputes into the late conversation")
 
 
@@ -326,12 +354,15 @@ def preset_per_day(dataset_name: str, dataset: ReplayDataset, *,
         prev_day = d
     if dataset.n:
         slots.append(dataset.n)  # close the final day
-    slots = _dedupe_slots(slots, dataset.n)
+    slots = _preset_slots(slots, dataset.n)
     return _spec(dataset_name, schedule_id,
                  {"mode": "explicit-event-index", "at": slots},
                  notes="one recompute per UTC day (from real timestamps)")
 
 
-def _dedupe_slots(slots: list[int], n: int) -> list[int]:
-    """Clamp to ``1..n``, drop 0/dupes, keep sorted — as a plain JSON list."""
-    return sorted({max(1, min(int(s), n)) for s in slots if s > 0})
+def _preset_slots(slots: list[int], n: int) -> list[int]:
+    """Space preset cuts over available votes; resolution owns explicit dedup.
+
+    Preserve zero on empty datasets so missing empty-checkpoint opt-in fails.
+    """
+    return [min(n, max(1, int(s))) for s in slots]

--- a/delphi/polismath/replay/types.py
+++ b/delphi/polismath/replay/types.py
@@ -149,11 +149,12 @@ class ReplayDataset:
             strict_moderation=strict_moderation,
         )
 
-    def validate_schedule(self, schedule: Schedule) -> None:
-        prev = 0
+    def validate_schedule(self, schedule: Schedule, *, allow_zero: bool = False) -> None:
+        minimum = 0 if allow_zero else 1
+        prev = minimum - 1
         for s in schedule:
-            if not 1 <= s <= self.n:
-                raise ValueError(f"cut slot {s} outside 1..{self.n}")
+            if not minimum <= s <= self.n:
+                raise ValueError(f"cut slot {s} outside {minimum}..{self.n}")
             if s <= prev:
                 raise ValueError(f"schedule not strictly increasing at slot {s}")
             prev = s

--- a/delphi/scripts/certify.py
+++ b/delphi/scripts/certify.py
@@ -30,6 +30,7 @@ Usage (from delphi/)::
 from __future__ import annotations
 
 import sys
+import uuid
 from pathlib import Path
 
 import click
@@ -61,13 +62,22 @@ def run(battery_path, only, refresh_clj, refresh_py, strict, root, workers):
     try:
         entries = cert.load_battery(battery_path)
         report = cert.run_battery(entries, root=root, refresh_clj=refresh_clj,
-                                 refresh_py=refresh_py, only=only, workers=workers)
+                                 refresh_py=refresh_py, only=only, workers=workers,
+                                 battery_path=battery_path)
     except (ValueError, KeyError, TypeError, OSError) as exc:
         output_root = root or cert.st.replays_root()
-        manifest_path = output_root / "run_manifest.json"
+        # Per-run filename here too: a battery that fails to even load must not
+        # overwrite the manifest of the last run that actually reached a verdict.
+        run_id = str(uuid.uuid4())
+        manifest_path = cert.run_manifest_path(output_root, run_id)
         cert._write_json(manifest_path, {
-            "schema": "polis-certification-run/1", "verdict": "FAIL", "partial": only is not None,
+            "schema": "polis-certification-run/1", "run_id": run_id, "verdict": "FAIL",
+            "partial": only is not None, "finished_at": None,
             "inventory": [], "entries": [], "configuration_errors": [str(exc)],
+        })
+        cert._write_json(output_root / cert.RUN_MANIFEST_LATEST, {
+            "schema": "polis-certification-run-pointer/1", "run_id": run_id,
+            "verdict": "FAIL", "finished_at": None, "run_manifest": str(manifest_path),
         })
         click.echo(f"certify: FAIL [configuration] {exc}; manifest={manifest_path}")
         sys.exit(1)

--- a/delphi/scripts/certify.py
+++ b/delphi/scripts/certify.py
@@ -19,7 +19,7 @@ Usage (from delphi/)::
     # Force re-running a driver (bypass the content-hash cache):
     uv run python scripts/certify.py run --refresh-clj --refresh-py
 
-    # SKIPPED (dataset-unavailable) entries also fail the run:
+    # A strict run succeeds only on a complete PASS manifest:
     uv run python scripts/certify.py run --strict
 
     # Inspect the earliest divergent step of an EXISTING recording pair
@@ -50,7 +50,7 @@ def cli() -> None:
 @click.option("--refresh-clj", is_flag=True, help="Force re-run the Clojure driver.")
 @click.option("--refresh-py", is_flag=True, help="Force re-run the Python driver.")
 @click.option("--strict", is_flag=True,
-              help="SKIPPED (dataset-unavailable) entries also fail the run.")
+              help="Exit nonzero unless the complete run manifest verdict is PASS.")
 @click.option("--root", type=click.Path(path_type=Path), default=None,
               help="Recording store root (default: real_data/.local/replays).")
 @click.option("--workers", type=int, default=6, show_default=True,
@@ -58,12 +58,25 @@ def cli() -> None:
                    "fold stays serial, so results match --workers 1 exactly.")
 def run(battery_path, only, refresh_clj, refresh_py, strict, root, workers):
     """Certify every entry in the battery (or a filtered subset)."""
-    entries = cert.load_battery(battery_path)
-    report = cert.run_battery(entries, root=root, refresh_clj=refresh_clj,
-                               refresh_py=refresh_py, only=only, workers=workers)
+    try:
+        entries = cert.load_battery(battery_path)
+        report = cert.run_battery(entries, root=root, refresh_clj=refresh_clj,
+                                 refresh_py=refresh_py, only=only, workers=workers)
+    except (ValueError, KeyError, TypeError, OSError) as exc:
+        output_root = root or cert.st.replays_root()
+        manifest_path = output_root / "run_manifest.json"
+        cert._write_json(manifest_path, {
+            "schema": "polis-certification-run/1", "verdict": "FAIL", "partial": only is not None,
+            "inventory": [], "entries": [], "configuration_errors": [str(exc)],
+        })
+        click.echo(f"certify: FAIL [configuration] {exc}; manifest={manifest_path}")
+        sys.exit(1)
+    # Carry the CLI selection into the summary even if a caller substitutes a runner.
+    if only is not None:
+        report["partial"] = True
     for line in cert.render_run_lines(report):
         click.echo(line)
-    sys.exit(cert.battery_exit_code(report["battery"], strict=strict))
+    sys.exit(cert.battery_exit_code(report, strict=strict))
 
 
 @cli.command()

--- a/delphi/scripts/certify_battery.json
+++ b/delphi/scripts/certify_battery.json
@@ -83,8 +83,8 @@
   },
   {
     "dataset": "pc-zerovote-01",
-    "preset": "single-cut",
-    "notes": "prodclone: zero-vote conversation \u2014 empty-conversation edge"
+    "notes": "prodclone: zero-vote conversation \u2014 empty-conversation edge",
+    "schedule": "schedules/pc-zerovote-01-empty.json"
   },
   {
     "dataset": "pc-modheavy-01",

--- a/delphi/scripts/schedules/pc-zerovote-01-empty.json
+++ b/delphi/scripts/schedules/pc-zerovote-01-empty.json
@@ -14,5 +14,5 @@
     "tids": [],
     "in-conv": []
   },
-  "notes": "Explicit empty compute; both engines must satisfy the declared empty state."
+  "notes": "Explicit empty compute; both engines must satisfy the declared empty state. KNOWN BLOCKER (P-022, tracked separately): the engines' empty prep-main blobs disagree today — Clojure omits n/n-cmts/tids/in-conv from an empty compute where Python emits their empty values — so this entry FAILS at stage empty-output until that output contract is reconciled. That failure is a real, previously hidden divergence, not a harness regression."
 }

--- a/delphi/scripts/schedules/pc-zerovote-01-empty.json
+++ b/delphi/scripts/schedules/pc-zerovote-01-empty.json
@@ -1,0 +1,18 @@
+{
+  "dataset": "pc-zerovote-01",
+  "schedule_id": "single-cut",
+  "cuts": {
+    "mode": "vote-count",
+    "at": [
+      0
+    ],
+    "empty_checkpoint": true
+  },
+  "empty_output": {
+    "n": 0,
+    "n-cmts": 0,
+    "tids": [],
+    "in-conv": []
+  },
+  "notes": "Explicit empty compute; both engines must satisfy the declared empty state."
+}

--- a/delphi/scripts/schedules/vw-every-vote-56.json
+++ b/delphi/scripts/schedules/vw-every-vote-56.json
@@ -63,5 +63,6 @@
     ]
   },
   "moderation": "none",
-  "notes": "every-vote PREFIX (56 single-vote steps): maximal-density warm-start edge case, truncated BEFORE the first Q11 knife-edge (step 57's near-coincident pair, whose merge/no-merge decision is bit-chaotic and irreducible cross-language \u2014 CLOJURE_QUIRKS.md Q11, journal 2026-07-22)"
+  "notes": "every-vote PREFIX (56 single-vote steps): maximal-density warm-start edge case, truncated BEFORE the first Q11 knife-edge (step 57's near-coincident pair, whose merge/no-merge decision is bit-chaotic and irreducible cross-language \u2014 CLOJURE_QUIRKS.md Q11, journal 2026-07-22)",
+  "coverage": "prefix-diagnostic"
 }

--- a/delphi/tests/replay_harness/strict_schedule_test.clj
+++ b/delphi/tests/replay_harness/strict_schedule_test.clj
@@ -1,0 +1,38 @@
+;; From math/: clojure -M ../delphi/tests/replay_harness/strict_schedule_test.clj
+(load-file "dev/replay.clj")
+(require '[clojure.test :refer :all])
+
+(def votes [{:t-ms 10 :pid 1 :tid 1 :sign 1}
+            {:t-ms 20 :pid 2 :tid 1 :sign -1}])
+
+(deftest explicit-zero-checkpoint
+  (let [slots (replay/resolve-cut-slots [] {"mode" "vote-count" "at" [0] "empty_checkpoint" true})
+        steps (replay/slice-schedule [] slots)]
+    (is (= [0] slots))
+    (is (= [{:index 0 :prev-slot 0 :cut-slot 0 :votes [] :mods [] :cut-time-ms 0}] steps))))
+
+(deftest undeclared-zero-rejected
+  (is (thrown-with-msg? Exception #"empty_checkpoint"
+        (replay/resolve-cut-slots [] {"mode" "vote-count" "at" ["end"]}))))
+
+(deftest duplicate-rejected
+  (is (thrown-with-msg? Exception #"duplicate"
+        (replay/resolve-cut-slots votes {"mode" "vote-count" "at" [1 1 2]}))))
+
+(deftest duplicate-opt-in
+  (is (= [1 2] (replay/resolve-cut-slots votes
+                {"mode" "vote-count" "at" [1 1 2] "deduplicate" true}))))
+
+(deftest out-of-order-rejected-even-with-opt-in
+  (is (thrown-with-msg? Exception #"increasing"
+        (replay/resolve-cut-slots votes
+          {"mode" "vote-count" "at" [1 2 1] "deduplicate" true}))))
+
+(deftest zero-before-positive-preserves-batches
+  (let [steps (replay/slice-schedule votes [0 1 2])]
+    (is (= [[] [(first votes)] [(second votes)]] (mapv :votes steps)))
+    (is (= [0 10 20] (mapv :cut-time-ms steps)))))
+
+(let [{:keys [fail error]} (run-tests)]
+  (shutdown-agents)
+  (System/exit (if (zero? (+ fail error)) 0 1)))

--- a/delphi/tests/replay_harness/test_certify.py
+++ b/delphi/tests/replay_harness/test_certify.py
@@ -603,7 +603,7 @@ def test_certify_entry_passes_comments_when_moderation_requested(tmp_path, monke
     schedule_path = tmp_path / "sched.json"
     schedule_path.write_text(json.dumps({
         "dataset": "vw", "schedule_id": "mod-comments-test",
-        "cuts": {"mode": "vote-count", "at": [10]},
+        "cuts": {"mode": "vote-count", "at": ["end"]},
         "moderation": "interleave-by-timestamp",
         "clojure": {"warm_start": "chain"}, "notes": "",
     }))
@@ -635,10 +635,10 @@ def test_certify_entry_omits_comments_when_moderation_none(tmp_path, monkeypatch
     assert "--comments" not in clj_cmds[0]
 
 
-def test_certify_entry_skipped_for_missing_dataset(tmp_path):
+def test_certify_entry_fails_for_missing_required_dataset(tmp_path):
     entry = _make_entry(dataset="no-such-dataset-xyz")
     result, ledger = cert.certify_entry(entry, root=tmp_path, ledger={})
-    assert result["verdict"] == "SKIPPED"
+    assert result["verdict"] == "ERROR"
     assert result["reason"] == "dataset-unavailable"
     assert ledger == {}
 
@@ -744,7 +744,7 @@ def test_render_focus_lines_caps_exact_divergences_shown():
 # Battery-level exit code.
 # ---------------------------------------------------------------------------
 def test_battery_exit_code():
-    results = [{"verdict": "MATCH"}, {"verdict": "SKIPPED"}]
+    results = [{"verdict": "MATCH"}, {"verdict": "SKIPPED", "optional": True}]
     assert cert.battery_exit_code(results, strict=False) == 0
     assert cert.battery_exit_code(results, strict=True) == 1
 
@@ -811,6 +811,11 @@ def _seed_cached_pair(root: Path, ds: str, sid: str, *, divergent: bool) -> None
     _write_clj_step(rec / "clj", 0, blob)
     py_blob = dict(blob, n=blob["n"] + 5) if divergent else blob
     _write_py_step(rec / "py", 0, py_blob)
+    # Cached fixtures must carry the actual scheduled endpoint on both engines.
+    expected = cert.prepare_entry(_make_entry(dataset=ds, schedule_id=sid))
+    checkpoint = expected.checkpoints[0]
+    (rec / "clj" / "step-000.meta.json").write_text(json.dumps(checkpoint))
+    (rec / "py" / "step-000.json").write_text(json.dumps({**checkpoint, "blob": py_blob}))
 
 
 def test_run_battery_parallel_matches_serial_report_and_ledger(tmp_path, monkeypatch):

--- a/delphi/tests/replay_harness/test_certify_cli.py
+++ b/delphi/tests/replay_harness/test_certify_cli.py
@@ -83,22 +83,44 @@ def test_run_skipped_ok_by_default_but_fails_with_strict(monkeypatch):
     assert res_strict.exit_code == 1, res_strict.output
 
 
+def _passing_report():
+    """A complete, non-partial PASS — the shape a real gate run produces when
+    every entry matches. Flag-passthrough tests run against THIS so they still
+    exercise the success exit path; a report with a zero-entry battery can only
+    ever exit 1, which would make the assertions vacuous."""
+    return {"battery": [{"dataset": "vw", "schedule_id": "uniform8-clojure-legacy",
+                         "verdict": "MATCH", "n_steps": 3}],
+            "root": "/tmp/x", "verdict": "PASS", "partial": False,
+            "run_manifest": "/tmp/x/run_manifest-abc.json"}
+
+
 def test_run_passes_cli_flags_through_to_library(monkeypatch):
     mod = _module()
     captured: dict = {}
 
     def fake_run_battery(entries, **kw):
         captured.update(kw)
-        return {"battery": [], "root": "/tmp/x"}
+        return _passing_report()
 
-    monkeypatch.setattr(mod.cert, "load_battery", lambda path: [])
+    monkeypatch.setattr(mod.cert, "load_battery", lambda path: ["entry"])
     monkeypatch.setattr(mod.cert, "run_battery", fake_run_battery)
 
+    # Complete run of a green battery: strict gate satisfied, exit 0.
+    res = CliRunner().invoke(mod.cli, ["run", "--strict", "--refresh-clj", "--refresh-py"])
+    assert res.exit_code == 0, res.output
+    assert captured["only"] is None
+    assert captured["refresh_clj"] is True
+    assert captured["refresh_py"] is True
+
+    # Same green battery, but --only makes it a partial — which can never pass a
+    # strict gate however green the selected entries are.
+    captured.clear()
     res = CliRunner().invoke(
         mod.cli,
-        ["run", "--only", "vw:uniform8-clojure-legacy", "--refresh-clj", "--refresh-py"],
+        ["run", "--strict", "--only", "vw:uniform8-clojure-legacy",
+         "--refresh-clj", "--refresh-py"],
     )
-    assert res.exit_code == 1, res.output  # zero entries cannot pass
+    assert res.exit_code == 1, res.output
     assert "PARTIAL RUN, NOT A GATE" in res.output
     assert captured["only"] == "vw:uniform8-clojure-legacy"
     assert captured["refresh_clj"] is True
@@ -111,19 +133,32 @@ def test_run_passes_workers_through_and_defaults_to_six(monkeypatch):
 
     def fake_run_battery(entries, **kw):
         captured.update(kw)
-        return {"battery": [], "root": "/tmp/x"}
+        return _passing_report()
 
-    monkeypatch.setattr(mod.cert, "load_battery", lambda path: [])
+    monkeypatch.setattr(mod.cert, "load_battery", lambda path: ["entry"])
     monkeypatch.setattr(mod.cert, "run_battery", fake_run_battery)
 
-    res = CliRunner().invoke(mod.cli, ["run", "--workers", "3"])
-    assert res.exit_code == 1, res.output  # zero entries cannot pass
+    res = CliRunner().invoke(mod.cli, ["run", "--strict", "--workers", "3"])
+    assert res.exit_code == 0, res.output
     assert captured["workers"] == 3
 
     captured.clear()
-    res = CliRunner().invoke(mod.cli, ["run"])
-    assert res.exit_code == 1, res.output
+    res = CliRunner().invoke(mod.cli, ["run", "--strict"])
+    assert res.exit_code == 0, res.output
     assert captured["workers"] == 6
+
+
+def test_run_with_zero_entries_cannot_pass(monkeypatch):
+    """The success path above must not be reachable by an empty battery: a run
+    that certified nothing is not a PASS."""
+    mod = _module()
+    monkeypatch.setattr(mod.cert, "load_battery", lambda path: [])
+    monkeypatch.setattr(mod.cert, "run_battery",
+                        lambda entries, **kw: {"battery": [], "root": "/tmp/x"})
+
+    for argv in (["run"], ["run", "--strict"]):
+        res = CliRunner().invoke(mod.cli, argv)
+        assert res.exit_code == 1, res.output
 
 
 def test_run_stdout_budget_with_large_mocked_battery(monkeypatch):

--- a/delphi/tests/replay_harness/test_certify_cli.py
+++ b/delphi/tests/replay_harness/test_certify_cli.py
@@ -71,7 +71,7 @@ def test_run_skipped_ok_by_default_but_fails_with_strict(monkeypatch):
     mod = _module()
     report = {"battery": [
         {"dataset": "vw", "schedule_id": "x",
-         "verdict": "SKIPPED", "reason": "dataset-unavailable"},
+         "verdict": "SKIPPED", "reason": "dataset-unavailable", "optional": True},
     ], "root": "/tmp/x"}
     monkeypatch.setattr(mod.cert, "load_battery", lambda path: ["entry"])
     monkeypatch.setattr(mod.cert, "run_battery", lambda entries, **kw: report)
@@ -98,7 +98,8 @@ def test_run_passes_cli_flags_through_to_library(monkeypatch):
         mod.cli,
         ["run", "--only", "vw:uniform8-clojure-legacy", "--refresh-clj", "--refresh-py"],
     )
-    assert res.exit_code == 0, res.output
+    assert res.exit_code == 1, res.output  # zero entries cannot pass
+    assert "PARTIAL RUN, NOT A GATE" in res.output
     assert captured["only"] == "vw:uniform8-clojure-legacy"
     assert captured["refresh_clj"] is True
     assert captured["refresh_py"] is True
@@ -116,12 +117,12 @@ def test_run_passes_workers_through_and_defaults_to_six(monkeypatch):
     monkeypatch.setattr(mod.cert, "run_battery", fake_run_battery)
 
     res = CliRunner().invoke(mod.cli, ["run", "--workers", "3"])
-    assert res.exit_code == 0, res.output
+    assert res.exit_code == 1, res.output  # zero entries cannot pass
     assert captured["workers"] == 3
 
     captured.clear()
     res = CliRunner().invoke(mod.cli, ["run"])
-    assert res.exit_code == 0, res.output
+    assert res.exit_code == 1, res.output
     assert captured["workers"] == 6
 
 

--- a/delphi/tests/replay_harness/test_certify_strict_gate.py
+++ b/delphi/tests/replay_harness/test_certify_strict_gate.py
@@ -1,0 +1,326 @@
+"""Negative controls: a passing synthetic battery must fail when coverage breaks.
+
+Producers are local fakes, but schedule resolution, store validation, cache
+manifests, numeric comparison, run manifest and CLI exit paths are real.
+"""
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from polismath.replay import certify as cert, schedule as sched
+from polismath.replay.driver import run_replay
+from polismath.replay.types import ReplayDataset
+
+EMPTY = {"n": 0, "n-cmts": 0, "tids": [], "in-conv": []}
+
+
+@pytest.fixture
+def battery(tmp_path, monkeypatch):
+    ds = ReplayDataset.build([(10, 1, 1, 1), (20, 2, 1, -1)])
+    votes = tmp_path / "synthetic-votes.csv"
+    votes.write_text("timestamp,participant,comment,vote\n10,1,1,1\n20,2,1,-1\n")
+    monkeypatch.setattr(cert, "dataset_available", lambda name: name == "synthetic")
+    monkeypatch.setattr(cert, "votes_csv_path", lambda name: votes)
+    monkeypatch.setattr(cert.real_data, "load_export_votes", lambda name: ds)
+    monkeypatch.setattr(cert, "_clj_source_hashes", lambda: ("clj-source", "math-source"))
+    monkeypatch.setattr(cert, "_engine_tree_hash_cached", lambda: "python-source")
+    entry = cert.parse_battery_entry({"dataset": "synthetic", "preset": "every-vote"})
+    state = {"mutation": None, "calls": 0}
+    root = tmp_path / "recordings"
+
+    def produce(spec_path, engine):
+        state["calls"] += 1
+        manifest = json.loads((root / "run_manifest.json").read_text())
+        assert manifest["verdict"] == "INCONCLUSIVE"
+        assert len(manifest["inventory"]) >= 2  # written BEFORE first producer
+        spec = sched.ScheduleSpec.from_json_file(spec_path)
+        steps = sched.slice_schedule(ds, spec)
+        out = root / spec.dataset / spec.schedule_id / engine
+        out.mkdir(parents=True, exist_ok=True)
+        if state["mutation"] == "timeout":
+            raise subprocess.TimeoutExpired("synthetic-producer", 1)
+        if state["mutation"] == "producer-failure":
+            return subprocess.CompletedProcess([], 1, "", "synthetic failure")
+        for step in steps:
+            meta = {"index": step.index, "prev_slot": step.prev_slot,
+                    "cut_slot": step.cut_slot, "batch_size": len(step.vote_events),
+                    "cut_time_ms": step.cut_time_ms}
+            blob = EMPTY if step.cut_slot == 0 else {
+                "n": step.cut_slot, "n-cmts": 1, "tids": [1], "in-conv": [1]}
+            stem = f"step-{step.index:03d}"
+            if engine == "clj":
+                (out / (stem + ".blob.json")).write_text(json.dumps(blob))
+                (out / (stem + ".meta.json")).write_text(json.dumps(meta))
+            else:
+                (out / (stem + ".json")).write_text(json.dumps({**meta, "blob": blob}))
+        mutation = state["mutation"]
+        if mutation == "empty-both" or (mutation == "empty-py" and engine == "py"):
+            for path in out.glob("step-*.json"):
+                path.unlink()
+        if engine == "py":
+            first = out / "step-000.json"
+            if mutation == "remove":
+                (out / "step-001.json").unlink()
+            elif mutation == "duplicate":
+                (out / "step-002.json").write_text(first.read_text())
+            elif mutation == "identity":
+                payload = json.loads(first.read_text()); payload["cut_slot"] = 999
+                first.write_text(json.dumps(payload))
+            elif mutation == "duplicate-index":
+                payload = json.loads((out / "step-001.json").read_text()); payload["index"] = 0
+                (out / "step-001.json").write_text(json.dumps(payload))
+            elif mutation == "malformed-step":
+                first.write_text("{")
+            elif mutation == "empty-blob":
+                payload = json.loads(first.read_text()); payload["blob"] = {}
+                first.write_text(json.dumps(payload))
+            elif mutation == "wrong-empty":
+                payload = json.loads(first.read_text()); payload["blob"]["n"] = 1
+                first.write_text(json.dumps(payload))
+        return subprocess.CompletedProcess([], 0, "", "")
+
+    monkeypatch.setattr(cert, "run_clj_driver", lambda spec, votes, **kw: produce(spec, "clj"))
+    monkeypatch.setattr(cert, "run_py_driver", lambda spec, **kw: produce(spec, "py"))
+
+    def run(entries=None, **kwargs):
+        return cert.run_battery(entries if entries is not None else [entry], root=root,
+                                ledger_path=tmp_path / "ledger.json", **kwargs)
+    return entry, state, root, ds, run
+
+
+def assert_pass(report):
+    assert report["verdict"] == "PASS", report
+    assert cert.battery_exit_code(report, strict=True) == 0
+
+
+@pytest.mark.parametrize("mutation,stage", [
+    ("remove", "checkpoint-inventory"), ("duplicate", "checkpoint-inventory"),
+    ("empty-both", "checkpoint-inventory"), ("empty-py", "checkpoint-inventory"),
+    ("identity", "checkpoint-identity"), ("duplicate-index", "checkpoint-identity"),
+    ("malformed-step", "setup"), ("empty-blob", "checkpoint-schema"),
+    ("timeout", "setup"), ("producer-failure", "clj-driver"),
+])
+def test_damaged_producer_turns_pass_to_fail(battery, mutation, stage):
+    entry, state, root, ds, run = battery
+    assert_pass(run())
+    state["mutation"] = mutation
+    report = run(refresh_clj=True, refresh_py=True)
+    assert report["verdict"] == "FAIL"
+    assert report["battery"][0]["stage"] == stage
+    assert cert.battery_exit_code(report, strict=True) == 1
+    manifest = json.loads((root / "run_manifest.json").read_text())
+    assert manifest["entries"][0]["status"] == "FAIL"
+    assert manifest["finished_at"] is not None
+
+
+def test_inventory_exact_and_cached_pass(battery):
+    entry, state, root, ds, run = battery
+    report = run(); assert_pass(report)
+    inventory = report["inventory"]
+    assert [i["engine"] for i in inventory] == ["clj", "py"]
+    assert all([c["cut_slot"] for c in i["checkpoints"]] == [1, 2] for i in inventory)
+    assert_pass(run())
+    assert state["calls"] == 2
+
+
+@pytest.mark.parametrize("mutation,stage", [("hash", "recording-integrity"),
+                                            ("json", "recording-manifest"),
+                                            ("unknown-field", "recording-manifest")])
+def test_corrupt_cached_recording_rejected(battery, mutation, stage):
+    entry, state, root, ds, run = battery
+    assert_pass(run())
+    py = root / entry.dataset / entry.schedule_id / "py"
+    if mutation == "hash":
+        (py / "step-000.json").write_text("{}")
+    elif mutation == "json":
+        (py / "cache_manifest.json").write_text("{")
+    else:
+        p = py / "cache_manifest.json"; d = json.loads(p.read_text()); d["typo"] = True
+        p.write_text(json.dumps(d))
+    report = run()
+    assert report["verdict"] == "FAIL"
+    assert report["battery"][0]["stage"] == stage
+
+
+def test_missing_dataset_required_fails_optional_is_inconclusive(battery, monkeypatch):
+    entry, state, root, ds, run = battery
+    assert_pass(run())
+    monkeypatch.setattr(cert, "dataset_available", lambda name: False)
+    report = run()
+    assert report["verdict"] == "FAIL"
+    assert report["battery"][0]["stage"] == "dataset-unavailable"
+    optional = cert.parse_battery_entry({"dataset": "synthetic", "preset": "every-vote", "optional": True})
+    report = run([optional])
+    assert report["verdict"] == "INCONCLUSIVE"
+    assert report["battery"][0]["verdict"] == "SKIPPED"
+    assert cert.battery_exit_code(report, strict=True) == 1
+
+
+def test_empty_and_duplicate_batteries_rejected_before_producers(battery):
+    entry, state, root, ds, run = battery
+    for entries in ([], [entry, entry]):
+        report = run(entries)
+        assert report["verdict"] == "FAIL"
+        assert report["configuration_errors"]
+    assert state["calls"] == 0
+
+
+def test_only_is_partial_even_if_filter_selects_entire_battery(battery):
+    entry, state, root, ds, run = battery
+    assert_pass(run())
+    report = run(only="synthetic")
+    assert report["partial"] is True
+    assert report["verdict"] == "INCONCLUSIVE"
+    assert cert.battery_exit_code(report, strict=True) == 1
+    assert "PARTIAL RUN, NOT A GATE" in "\n".join(cert.render_run_lines(report))
+    assert run(only="absent")["verdict"] == "FAIL"
+
+
+def make_schedule(tmp_path, at, **extra):
+    path = tmp_path / "schedule.json"
+    path.write_text(json.dumps({"dataset": "synthetic", "schedule_id": "custom",
+                               "cuts": {"mode": "vote-count", "at": at}, **extra}))
+    return cert.parse_battery_entry({"dataset": "synthetic", "schedule": str(path)})
+
+
+def test_zero_vote_requires_explicit_checkpoint_and_empty_contract(battery, tmp_path):
+    entry, state, root, ds, run = battery
+    ds.votes.clear()
+    explicit = make_schedule(tmp_path, [0], cuts={"mode": "vote-count", "at": [0],
+                                                "empty_checkpoint": True}, empty_output=EMPTY)
+    report = run([explicit]); assert_pass(report)
+    assert report["inventory"][0]["checkpoints"] == [{
+        "index": 0, "prev_slot": 0, "cut_slot": 0, "batch_size": 0, "cut_time_ms": 0}]
+    for at in ([], ["end"]):
+        missing = make_schedule(tmp_path, at)
+        report = run([missing])
+        assert report["verdict"] == "FAIL"
+        assert "nonzero expected" in report["battery"][0]["reason"] or "empty_checkpoint" in report["battery"][0]["reason"]
+    no_contract = make_schedule(tmp_path, [0], cuts={"mode": "vote-count", "at": [0], "empty_checkpoint": True})
+    assert "empty_output" in run([no_contract])["battery"][0]["reason"]
+
+
+def test_zero_checkpoint_checks_declared_output(battery, tmp_path):
+    entry, state, root, ds, run = battery
+    ds.votes.clear()
+    entry = make_schedule(tmp_path, [0], cuts={"mode": "vote-count", "at": [0], "empty_checkpoint": True}, empty_output=EMPTY)
+    assert_pass(run([entry]))
+    state["mutation"] = "wrong-empty"
+    report = run([entry], refresh_py=True)
+    assert report["battery"][0]["stage"] == "empty-output"
+
+
+def test_real_python_driver_records_zero_compute():
+    spec = sched.ScheduleSpec("synthetic", "empty", {"mode": "vote-count", "at": [0], "empty_checkpoint": True}, empty_output=EMPTY)
+    records = run_replay(ReplayDataset.build([]), spec)
+    assert len(records) == 1
+    assert records[0].cut_slot == 0 and records[0].batch_size == 0
+    projected = cert.project_acceptance(records[0].blob)
+    assert {k: projected[k] for k in EMPTY} == EMPTY
+
+
+@pytest.mark.parametrize("cuts,reason", [
+    ({"mode": "vote-count", "at": [1, 1, 2]}, "duplicate"),
+    ({"mode": "vote-count", "at": [2, 1]}, "strictly increasing"),
+    ({"mode": "vote-count", "at": [0, 2]}, "empty_checkpoint"),
+])
+def test_schedule_never_silently_discards_cuts(cuts, reason):
+    ds = ReplayDataset.build([(10, 1, 1, 1), (20, 2, 1, -1)])
+    with pytest.raises(ValueError, match=reason):
+        sched.resolve_cut_slots(ds, cuts)
+
+
+def test_prefix_requires_full_stream_companion(battery, tmp_path):
+    entry, state, root, ds, run = battery
+    short = make_schedule(tmp_path, [1])
+    assert "stream end" in run([short])["battery"][0]["reason"]
+    prefix = make_schedule(tmp_path, [1], coverage="prefix-diagnostic")
+    assert "companion" in run([prefix])["battery"][0]["reason"]
+    assert_pass(run([prefix, entry]))
+
+
+def cli_module():
+    path = Path(cert.__file__).parents[2] / "scripts" / "certify.py"
+    spec = importlib.util.spec_from_file_location("strict_certify_cli", path)
+    module = importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+    return module
+
+
+def test_cli_strict_partial_fails_with_manifest(battery, monkeypatch):
+    entry, state, root, ds, run = battery
+    module = cli_module()
+    monkeypatch.setattr(module.cert, "load_battery", lambda path: [entry])
+    monkeypatch.setattr(module.cert, "default_ledger_path", lambda: root / "ledger.json")
+    result = CliRunner().invoke(module.cli, ["run", "--strict", "--root", str(root), "--only", "synthetic"])
+    assert result.exit_code == 1, result.output
+    assert "PARTIAL RUN, NOT A GATE" in result.output
+    manifest = json.loads((root / "run_manifest.json").read_text())
+    assert manifest["partial"] and manifest["verdict"] == "INCONCLUSIVE"
+
+
+@pytest.mark.parametrize("config", [[], {}, [{"dataset": "synthetic", "preset": "single-cut", "typo": True}], "{"])
+def test_cli_malformed_battery_writes_failure_manifest(tmp_path, config):
+    path = tmp_path / "battery.json"
+    path.write_text(config if isinstance(config, str) else json.dumps(config))
+    root = tmp_path / "out"
+    result = CliRunner().invoke(cli_module().cli, ["run", "--strict", "--battery", str(path), "--root", str(root)])
+    assert result.exit_code == 1
+    assert json.loads((root / "run_manifest.json").read_text())["verdict"] == "FAIL"
+
+
+@pytest.mark.parametrize("counts", [(0, 0), (1, 0), (1, 2)])
+def test_standalone_compare_and_focus_reject_empty_or_unequal(tmp_path, counts):
+    rec = tmp_path / "synthetic" / "single"
+    for engine, count in zip(("clj", "py"), counts):
+        directory = rec / engine; directory.mkdir(parents=True)
+        for index in range(count):
+            suffix = ".blob.json" if engine == "clj" else ".json"
+            payload = EMPTY if engine == "clj" else {"index": index, "blob": EMPTY}
+            (directory / f"step-{index:03d}{suffix}").write_text(json.dumps(payload))
+    with pytest.raises(cert.CertifyError, match="nonempty|steps"):
+        cert.compare_recording_pair(rec / "clj", rec / "py", cache_root=tmp_path)
+    assert cert.run_focus("synthetic", "single", root=tmp_path, ledger_path=tmp_path / "ledger.json")["verdict"] == "ERROR"
+
+
+def test_missing_manifest_version_is_malformed(battery):
+    entry, state, root, ds, run = battery
+    assert_pass(run())
+    path = root / entry.dataset / entry.schedule_id / "py" / "cache_manifest.json"
+    path.write_text('{}')
+    report = run()
+    assert report["verdict"] == "FAIL"
+    assert report["battery"][0]["stage"] == "recording-manifest"
+
+
+def test_empty_acceptance_blobs_do_not_match(tmp_path):
+    clj, py = tmp_path / "clj", tmp_path / "py"
+    clj.mkdir(); py.mkdir()
+    (clj / "step-000.blob.json").write_text('{}')
+    (py / "step-000.json").write_text('{"index":0,"blob":{}}')
+    with pytest.raises(cert.CertifyError, match="empty acceptance blob"):
+        cert.compare_recording_pair(clj, py, cache_root=tmp_path)
+
+
+def test_only_keeps_full_inventory_and_marks_unselected_entries(battery):
+    entry, state, root, ds, run = battery
+    companion = cert.parse_battery_entry({"dataset": "synthetic", "preset": "single-cut"})
+    report = run([entry, companion], only=f"synthetic:{entry.schedule_id}")
+    assert len(report["inventory"]) == 4
+    manifest = json.loads((root / "run_manifest.json").read_text())
+    assert [e["status"] for e in manifest["entries"]] == ["PASS", "INCONCLUSIVE"]
+    assert manifest["verdict"] == "INCONCLUSIVE"
+    assert state["calls"] == 2
+
+
+def test_unknown_schedule_and_cut_fields_fail_before_producers(battery, tmp_path):
+    entry, state, root, ds, run = battery
+    for extra in ({"typo": True}, {"cuts": {"mode": "vote-count", "at": [2], "typo": True}}):
+        entry = make_schedule(tmp_path, [2], **extra)
+        report = run([entry])
+        assert report["verdict"] == "FAIL"
+        assert "unknown" in report["battery"][0]["reason"]
+    assert state["calls"] == 0

--- a/delphi/tests/replay_harness/test_certify_strict_gate.py
+++ b/delphi/tests/replay_harness/test_certify_strict_gate.py
@@ -39,7 +39,27 @@ PAIRED_MALFORMED = {
     "list-pca": (lambda b: {**b, "pca": [1, 2]}, "pca"),
     "nested-nan": (lambda b: {**b, "pca": {"center": [0.0, float("nan")]}}, "pca.center[1]"),
     "nested-inf": (lambda b: {**b, "base-clusters": {"x": [float("inf")]}}, "base-clusters.x[0]"),
+    # P-022 B1 review, round 3 — alias collisions. `_kebab` collapsed two raw
+    # spellings into one canonical entry BEFORE any validation ran, so the
+    # dropped value was never type- or finiteness-checked and the pair still
+    # certified PASS. Both insertion orders, so a later valid alias cannot hide
+    # an invalid original (and vice versa), plus a three-way collision.
+    "alias-count-snake-first": (
+        lambda b: {"n_cmts": "invalid-count", **b}, "'n_cmts'"),
+    "alias-count-kebab-first": (
+        lambda b: {**b, "n_cmts": "invalid-count"}, "'n_cmts'"),
+    "alias-nan-extension-snake-first": (
+        lambda b: {"hidden_value": float("nan"), **b, "hidden-value": 0}, "'hidden_value'"),
+    "alias-nan-extension-kebab-first": (
+        lambda b: {"hidden-value": 0, **b, "hidden_value": float("nan")}, "'hidden_value'"),
+    "alias-three-way": (
+        lambda b: {**b, "a_b_c": 1, "a-b_c": 2, "a-b-c": 3}, "'a-b-c'"),
 }
+
+#: Raw key sets whose two spellings collapse onto one canonical key. Used by the
+#: direct-validation controls below (the end-to-end paired controls live in
+#: :data:`PAIRED_MALFORMED`).
+VALID_BASE = {"n": 1, "n-cmts": 1, "tids": [1], "in-conv": [1]}
 
 
 def latest_manifest(root):
@@ -544,7 +564,12 @@ def test_paired_malformed_blobs_would_have_hash_matched(battery):
         cert._canonical_hash(cert.project_acceptance(py))
 
 
-@pytest.mark.parametrize("mutation", ["nan-count", "string-count", "inf-count", "string-tid"])
+@pytest.mark.parametrize("mutation", [
+    "nan-count", "string-count", "inf-count", "string-tid",
+    "alias-count-snake-first", "alias-count-kebab-first",
+    "alias-nan-extension-snake-first", "alias-nan-extension-kebab-first",
+    "alias-three-way",
+])
 def test_compare_recording_pair_rejects_identical_malformed_blobs(tmp_path, mutation):
     """The standalone comparer entry point must reject them too — it is the
     function that owns the hash short-circuit."""
@@ -646,6 +671,145 @@ def test_checkpoint_contract_keys_come_from_the_crosslang_whitelist():
         | set(cert._ID_SCALAR_CHECKPOINT_KEYS)
     assert named <= PREP_MAIN_KEYS
     assert set(cert._REQUIRED_CHECKPOINT_KEYS) <= cert.ACCEPTANCE_KEYS
+
+
+# ---------------------------------------------------------------------------
+# P-022 B1 review, round 3 — alias collisions must be rejected on the UNTOUCHED
+# raw blob.
+#
+# `canon = {_kebab(k): v for k, v in blob.items()}` ran BEFORE every check, so
+# two raw keys that normalize to the same canonical name silently collapsed and
+# the loser's value reached nothing: `{"n_cmts": "invalid-count", "n-cmts": 1}`
+# and `{"hidden_value": NaN, "hidden-value": 0}` both certified PASS. Raw
+# validation now runs on `blob` itself and aliased keys fail naming EVERY raw
+# spelling involved.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("blob,needles", [
+    # Both insertion orders of the two reproducers, an invalid FIRST spelling
+    # and an invalid SECOND spelling, plus a three-way collision.
+    ({"n_cmts": "invalid-count", **VALID_BASE}, ("n_cmts", "n-cmts")),
+    ({**VALID_BASE, "n_cmts": "invalid-count"}, ("n_cmts", "n-cmts")),
+    ({"hidden_value": float("nan"), **VALID_BASE, "hidden-value": 0},
+     ("hidden_value", "hidden-value")),
+    ({"hidden-value": 0, **VALID_BASE, "hidden_value": float("nan")},
+     ("hidden_value", "hidden-value")),
+    ({**VALID_BASE, "a_b_c": 1, "a-b_c": 2, "a-b-c": 3},
+     ("a_b_c", "a-b_c", "a-b-c")),
+    # Equal values do not make the collapse safe: the ambiguity is the defect.
+    ({**VALID_BASE, "hidden_value": 0, "hidden-value": 0},
+     ("hidden_value", "hidden-value")),
+    # ...and a canonical key of the CONTRACT is no different.
+    ({**VALID_BASE, "in_conv": [1]}, ("in_conv", "in-conv")),
+])
+def test_validate_checkpoint_blob_rejects_alias_collisions(blob, needles):
+    with pytest.raises(cert.CertifyError) as excinfo:
+        cert.validate_checkpoint_blob(blob, "clj: step-000")
+    assert excinfo.value.stage == "checkpoint-schema"
+    message = str(excinfo.value)
+    for needle in needles:
+        assert repr(needle) in message, message
+    assert "clj: step-000" in message
+
+
+def test_alias_collision_rejected_by_the_standalone_comparer_too():
+    """``require_keys=False`` (the standalone comparer / zero checkpoint) skips
+    only the presence check — the alias policy still runs."""
+    with pytest.raises(cert.CertifyError, match="n_cmts"):
+        cert.validate_checkpoint_blob(
+            {"n_cmts": "invalid-count", "n-cmts": 1}, "py: step-000",
+            require_keys=False)
+
+
+def test_alias_collision_is_caught_before_the_lossy_canonical_dict():
+    """Non-vacuity: every PRE-fix admission criterion still holds for the
+    reproducers. The canonical dict really does drop the invalid value, the
+    acceptance projection really is nonempty, and the two engines' projections
+    really do hash EQUAL — so only the raw alias check rejects them."""
+    hidden = {**VALID_BASE, "hidden_value": float("nan"), "hidden-value": 0}
+    count = {"n_cmts": "invalid-count", **VALID_BASE}
+    for blob in (hidden, count):
+        canon = {cert._kebab(k): v for k, v in blob.items()}
+        # The lossy collapse: the canonical dict is CLEAN, which is exactly why
+        # validating it instead of the raw blob certified PASS.
+        cert.validate_checkpoint_blob(canon, "clj: step-000")
+        assert cert._find_nonfinite(canon, "") is None
+        # ...and the invalid value is gone from the acceptance projection too,
+        # so both engines emitting this blob hash EQUAL to a valid recording's.
+        projection = cert.project_acceptance(blob)
+        assert projection == cert.project_acceptance(VALID_BASE)
+        assert cert._canonical_hash(projection) == \
+            cert._canonical_hash(cert.project_acceptance(VALID_BASE))
+        # Only the raw alias check rejects them.
+        with pytest.raises(cert.CertifyError, match="alias"):
+            cert.validate_checkpoint_blob(blob, "clj: step-000")
+
+
+def test_declared_legacy_alias_twin_is_accepted_only_when_values_agree():
+    """``Conversation.to_dict`` emits ``group-clusters`` AND its legacy
+    ``group_clusters`` twin from the same value, so the real Python driver's
+    every checkpoint carries that pair — the policy admits it while the two
+    spellings agree, and rejects it the moment they do not."""
+    assert cert._ALIASED_CHECKPOINT_KEYS == frozenset({"group-clusters"})
+    groups = [{"id": 0, "members": [1, 2]}]
+    cert.validate_checkpoint_blob(
+        {**VALID_BASE, "group-clusters": groups, "group_clusters": list(groups)},
+        "py: step-000")
+    with pytest.raises(cert.CertifyError, match="deeply equal"):
+        cert.validate_checkpoint_blob(
+            {**VALID_BASE, "group-clusters": groups, "group_clusters": []},
+            "py: step-000")
+    # A NaN never equals itself, so a duplicated non-finite twin is a value
+    # disagreement — it can never ride in on the exemption.
+    with pytest.raises(cert.CertifyError, match="deeply equal"):
+        cert.validate_checkpoint_blob(
+            {**VALID_BASE, "group-clusters": float("nan"),
+             "group_clusters": float("nan")},
+            "py: step-000")
+    # The exemption covers that ONE canonical key: no other collision inherits
+    # it, however equal the values.
+    with pytest.raises(cert.CertifyError, match="alias collisions are rejected"):
+        cert.validate_checkpoint_blob(
+            {**VALID_BASE, "base-clusters": {}, "base_clusters": {}}, "py: step-000")
+
+
+def test_single_spelling_blobs_are_untouched_by_the_alias_policy():
+    """Ordinary snake-only and kebab-only compatibility must survive."""
+    for blob in (
+        {"n": 0, "n_cmts": 0, "tids": [], "in_conv": [], "group_clusters": []},
+        {"n": 0, "n-cmts": 0, "tids": [], "in-conv": [], "group-clusters": []},
+    ):
+        cert.validate_checkpoint_blob(blob, "py: step-000")
+
+
+def test_committed_real_blobs_have_no_alias_collisions():
+    """The contract is grounded in the shapes the engines actually emit: no
+    committed blob relies on a collapse the policy now forbids."""
+    real_dir = Path(cert.__file__).resolve().parents[2] / "real_data"
+    blobs = sorted(real_dir.glob("*/*math_blob*.json"))
+    assert blobs
+    for path in blobs:
+        groups = cert._raw_alias_groups(json.loads(path.read_text()))
+        collisions = {c: ks for c, ks in groups.items() if len(ks) > 1}
+        assert not {c for c in collisions} - set(cert._ALIASED_CHECKPOINT_KEYS), \
+            f"{path.name}: undeclared alias collisions {collisions}"
+
+
+def test_cached_recordings_are_revalidated_for_alias_collisions(battery):
+    """Cache-hit control: an alias collision in an already-recorded checkpoint
+    fails on the cached path too, with no producer rerun."""
+    entry, state, root, ds, run = battery
+    assert_pass(run())
+    rec = root / entry.dataset / entry.schedule_id
+    for path in (rec / "clj" / "step-000.blob.json", rec / "py" / "step-000.json"):
+        payload = json.loads(path.read_text())
+        target = payload if path.name.endswith(".blob.json") else payload["blob"]
+        target["n_cmts"] = "invalid-count"
+        path.write_text(json.dumps(payload))
+    # No refresh: the cached recordings are re-validated, so this can never be
+    # served as a MATCH.
+    report = run()
+    assert report["verdict"] == "FAIL", report
+    assert report["battery"][0]["stage"] in ("recording-integrity", "checkpoint-schema")
 
 
 # ---------------------------------------------------------------------------

--- a/delphi/tests/replay_harness/test_certify_strict_gate.py
+++ b/delphi/tests/replay_harness/test_certify_strict_gate.py
@@ -646,3 +646,49 @@ def test_checkpoint_contract_keys_come_from_the_crosslang_whitelist():
         | set(cert._ID_SCALAR_CHECKPOINT_KEYS)
     assert named <= PREP_MAIN_KEYS
     assert set(cert._REQUIRED_CHECKPOINT_KEYS) <= cert.ACCEPTANCE_KEYS
+
+
+# ---------------------------------------------------------------------------
+# P-022 B1 review, P2 — the temporary schedule path must be collision-free.
+# ---------------------------------------------------------------------------
+def _spec(dataset, schedule_id):
+    return sched.ScheduleSpec(dataset=dataset, schedule_id=schedule_id,
+                              cuts={"mode": "vote-count", "at": [1]})
+
+
+def test_temp_schedule_path_does_not_collide_for_valid_component_pairs(tmp_path):
+    """``f"{dataset}__{schedule_id}.json"`` mapped these two VALID pairs onto one
+    path, so the second entry's write silently handed its schedule to the
+    first entry's producer."""
+    a = _spec("synthetic__a", "b-clojure-legacy")
+    b = _spec("synthetic", "a__b-clojure-legacy")
+    pa = cert._write_temp_schedule(a, tmp_path)
+    pb = cert._write_temp_schedule(b, tmp_path)
+    assert pa != pb
+    assert json.loads(pa.read_text())["dataset"] == "synthetic__a"
+    assert json.loads(pb.read_text())["dataset"] == "synthetic"
+    assert json.loads(pa.read_text())["schedule_id"] == "b-clojure-legacy"
+    assert json.loads(pb.read_text())["schedule_id"] == "a__b-clojure-legacy"
+
+
+def test_temp_schedule_path_is_stable_for_the_same_pair(tmp_path):
+    a = _spec("synthetic", "every-vote-clojure-legacy")
+    assert cert._write_temp_schedule(a, tmp_path) == cert._write_temp_schedule(a, tmp_path)
+
+
+def test_temp_schedule_write_leaves_no_staging_files(tmp_path):
+    cert._write_temp_schedule(_spec("synthetic", "s"), tmp_path)
+    tmp_dir = tmp_path / ".certify_cache" / "tmp_schedules"
+    assert [p.name for p in sorted(tmp_dir.rglob("*")) if p.is_file()] == ["s.json"]
+
+
+@pytest.mark.parametrize("dataset,schedule_id", [
+    ("../escape", "s"), ("d", "../escape"), ("", "s"), ("d", ""),
+    ("d/e", "s"), ("d", "e/f"), ("..", "s"), (".", "s"),
+])
+def test_temp_schedule_rejects_ambiguous_or_traversing_components(
+    tmp_path, dataset, schedule_id
+):
+    with pytest.raises(cert.CertifyError) as excinfo:
+        cert._write_temp_schedule(_spec(dataset, schedule_id), tmp_path)
+    assert excinfo.value.stage == "schedule-path"

--- a/delphi/tests/replay_harness/test_certify_strict_gate.py
+++ b/delphi/tests/replay_harness/test_certify_strict_gate.py
@@ -3,6 +3,7 @@
 Producers are local fakes, but schedule resolution, store validation, cache
 manifests, numeric comparison, run manifest and CLI exit paths are real.
 """
+import hashlib
 import importlib.util
 import json
 import subprocess
@@ -16,6 +17,14 @@ from polismath.replay.driver import run_replay
 from polismath.replay.types import ReplayDataset
 
 EMPTY = {"n": 0, "n-cmts": 0, "tids": [], "in-conv": []}
+
+
+def latest_manifest(root):
+    """Read the run manifest the ``latest`` pointer names. Manifests are keyed
+    by run id so a later run cannot overwrite an earlier one, so there is no
+    fixed path to read — everything goes through the pointer."""
+    pointer = json.loads((Path(root) / cert.RUN_MANIFEST_LATEST).read_text())
+    return json.loads(Path(pointer["run_manifest"]).read_text())
 
 
 @pytest.fixture
@@ -34,7 +43,7 @@ def battery(tmp_path, monkeypatch):
 
     def produce(spec_path, engine):
         state["calls"] += 1
-        manifest = json.loads((root / "run_manifest.json").read_text())
+        manifest = latest_manifest(root)
         assert manifest["verdict"] == "INCONCLUSIVE"
         assert len(manifest["inventory"]) >= 2  # written BEFORE first producer
         spec = sched.ScheduleSpec.from_json_file(spec_path)
@@ -81,6 +90,11 @@ def battery(tmp_path, monkeypatch):
             elif mutation == "wrong-empty":
                 payload = json.loads(first.read_text()); payload["blob"]["n"] = 1
                 first.write_text(json.dumps(payload))
+            elif mutation == "absent-empty":
+                # The real Clojure/Python empty-blob divergence in miniature: the
+                # contract's key is not wrong, it is simply not emitted at all.
+                payload = json.loads(first.read_text()); payload["blob"].pop("n")
+                first.write_text(json.dumps(payload))
         return subprocess.CompletedProcess([], 0, "", "")
 
     monkeypatch.setattr(cert, "run_clj_driver", lambda spec, votes, **kw: produce(spec, "clj"))
@@ -112,7 +126,7 @@ def test_damaged_producer_turns_pass_to_fail(battery, mutation, stage):
     assert report["verdict"] == "FAIL"
     assert report["battery"][0]["stage"] == stage
     assert cert.battery_exit_code(report, strict=True) == 1
-    manifest = json.loads((root / "run_manifest.json").read_text())
+    manifest = latest_manifest(root)
     assert manifest["entries"][0]["status"] == "FAIL"
     assert manifest["finished_at"] is not None
 
@@ -212,6 +226,16 @@ def test_zero_checkpoint_checks_declared_output(battery, tmp_path):
     state["mutation"] = "wrong-empty"
     report = run([entry], refresh_py=True)
     assert report["battery"][0]["stage"] == "empty-output"
+    # The message must name what actually differs. pc-zerovote-01 fails here on
+    # a genuine, unreconciled engine output contract, and a bare "violates
+    # empty_output" would read as a harness regression instead.
+    reason = report["battery"][0]["reason"]
+    assert "empty_output contract" in reason and "wrong values {'n': 1}" in reason
+
+    state["mutation"] = "absent-empty"
+    report = run([entry], refresh_py=True)
+    assert report["battery"][0]["stage"] == "empty-output"
+    assert "absent keys ['n']" in report["battery"][0]["reason"]
 
 
 def test_real_python_driver_records_zero_compute():
@@ -258,7 +282,7 @@ def test_cli_strict_partial_fails_with_manifest(battery, monkeypatch):
     result = CliRunner().invoke(module.cli, ["run", "--strict", "--root", str(root), "--only", "synthetic"])
     assert result.exit_code == 1, result.output
     assert "PARTIAL RUN, NOT A GATE" in result.output
-    manifest = json.loads((root / "run_manifest.json").read_text())
+    manifest = latest_manifest(root)
     assert manifest["partial"] and manifest["verdict"] == "INCONCLUSIVE"
 
 
@@ -269,7 +293,7 @@ def test_cli_malformed_battery_writes_failure_manifest(tmp_path, config):
     root = tmp_path / "out"
     result = CliRunner().invoke(cli_module().cli, ["run", "--strict", "--battery", str(path), "--root", str(root)])
     assert result.exit_code == 1
-    assert json.loads((root / "run_manifest.json").read_text())["verdict"] == "FAIL"
+    assert latest_manifest(root)["verdict"] == "FAIL"
 
 
 @pytest.mark.parametrize("counts", [(0, 0), (1, 0), (1, 2)])
@@ -310,7 +334,7 @@ def test_only_keeps_full_inventory_and_marks_unselected_entries(battery):
     companion = cert.parse_battery_entry({"dataset": "synthetic", "preset": "single-cut"})
     report = run([entry, companion], only=f"synthetic:{entry.schedule_id}")
     assert len(report["inventory"]) == 4
-    manifest = json.loads((root / "run_manifest.json").read_text())
+    manifest = latest_manifest(root)
     assert [e["status"] for e in manifest["entries"]] == ["PASS", "INCONCLUSIVE"]
     assert manifest["verdict"] == "INCONCLUSIVE"
     assert state["calls"] == 2
@@ -324,3 +348,116 @@ def test_unknown_schedule_and_cut_fields_fail_before_producers(battery, tmp_path
         assert report["verdict"] == "FAIL"
         assert "unknown" in report["battery"][0]["reason"]
     assert state["calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# P-022 §B negative controls for the remaining INPUT classes: a change to only
+# the comments, only the restart seam, or only a vote's polarity must reach the
+# gate. Each is carried by a recording-cache key (comments CSV sha256, schedule
+# hash via restart_after, votes CSV sha256) — the mechanism exists, but nothing
+# asserted it, so a loosened key would silently re-certify the previous run's
+# recordings and report its stale MATCH.
+# ---------------------------------------------------------------------------
+def _stamp(*parts):
+    """A small integer fingerprint of the inputs, carried in an acceptance field
+    so a stale recording is visibly stale rather than merely old."""
+    return 1 + int(hashlib.sha256(repr(parts).encode()).hexdigest()[:8], 16) % 9973
+
+
+@pytest.fixture
+def input_change(tmp_path, monkeypatch):
+    """A green battery whose fake producers stamp every input into the recorded
+    blob. Returns ``(run, state, root, blob_stamps)``."""
+    votes = tmp_path / "synthetic-votes.csv"
+    comments = tmp_path / "synthetic-comments.csv"
+    schedule = tmp_path / "input-change.json"
+    root = tmp_path / "recordings"
+    state = {"calls": 0, "polarity": -1, "restart_after": 0}
+    comments.write_text("tid,mod\n1,1\n")
+
+    def write_inputs():
+        votes.write_text("timestamp,participant,comment,vote\n"
+                         f"10,1,1,1\n20,2,1,{state['polarity']}\n30,3,1,1\n40,4,1,1\n")
+        schedule.write_text(json.dumps({
+            "dataset": "synthetic", "schedule_id": "input-change",
+            "cuts": {"mode": "vote-count", "at": [2, 3, 4]},
+            "moderation": [{"t_ms": 15, "tid": 1, "mod": 1}],
+            "restart_after": state["restart_after"], "coverage": "full-stream",
+        }))
+
+    def dataset(_name=None):
+        return ReplayDataset.build([(10, 1, 1, 1), (20, 2, 1, state["polarity"]),
+                                    (30, 3, 1, 1), (40, 4, 1, 1)])
+
+    write_inputs()
+    monkeypatch.setattr(cert, "dataset_available", lambda name: name == "synthetic")
+    monkeypatch.setattr(cert, "votes_csv_path", lambda name: votes)
+    monkeypatch.setattr(cert, "comments_csv_path", lambda name: comments)
+    monkeypatch.setattr(cert.real_data, "load_export_votes", dataset)
+    monkeypatch.setattr(cert, "_clj_source_hashes", lambda: ("clj-source", "math-source"))
+    monkeypatch.setattr(cert, "_engine_tree_hash_cached", lambda: "python-source")
+
+    def produce(spec_path, engine):
+        state["calls"] += 1
+        spec = sched.ScheduleSpec.from_json_file(spec_path)
+        steps = sched.slice_schedule(dataset(), spec)
+        out = root / spec.dataset / spec.schedule_id / engine
+        out.mkdir(parents=True, exist_ok=True)
+        stamp = _stamp(comments.read_text(), spec.restart_after, state["polarity"])
+        for step in steps:
+            meta = {"index": step.index, "prev_slot": step.prev_slot,
+                    "cut_slot": step.cut_slot, "batch_size": len(step.vote_events),
+                    "cut_time_ms": step.cut_time_ms}
+            blob = {"n": step.cut_slot, "n-cmts": stamp, "tids": [1], "in-conv": [1]}
+            stem = f"step-{step.index:03d}"
+            if engine == "clj":
+                (out / (stem + ".blob.json")).write_text(json.dumps(blob))
+                (out / (stem + ".meta.json")).write_text(json.dumps(meta))
+            else:
+                (out / (stem + ".json")).write_text(json.dumps({**meta, "blob": blob}))
+        return subprocess.CompletedProcess([], 0, "", "")
+
+    monkeypatch.setattr(cert, "run_clj_driver", lambda spec, v, **kw: produce(spec, "clj"))
+    monkeypatch.setattr(cert, "run_py_driver", lambda spec, **kw: produce(spec, "py"))
+
+    def run():
+        entry = cert.parse_battery_entry({"dataset": "synthetic", "schedule": str(schedule)})
+        return cert.run_battery([entry], root=root, ledger_path=tmp_path / "ledger.json")
+
+    def stamps():
+        recorded = sorted((root / "synthetic").rglob("step-*.blob.json"))
+        assert recorded, "no clj checkpoints recorded"
+        return {json.loads(p.read_text())["n-cmts"] for p in recorded}
+
+    return run, state, root, comments, write_inputs, stamps
+
+
+@pytest.mark.parametrize("changed", ["comments", "restart", "polarity"])
+def test_single_input_change_cannot_be_served_from_cache(input_change, changed):
+    run, state, root, comments, write_inputs, stamps = input_change
+    assert_pass(run())
+    before = stamps()
+    assert len(before) == 1
+
+    # A re-run with IDENTICAL inputs is served from cache — this is the control
+    # that makes the assertions below meaningful rather than trivially true.
+    assert_pass(run())
+    assert state["calls"] == 2
+    assert stamps() == before
+
+    if changed == "comments":
+        comments.write_text("tid,mod\n1,-1\n")   # moderation source only
+    elif changed == "restart":
+        state["restart_after"] = 1               # schedule seam only
+    else:
+        state["polarity"] = 1                    # one vote's polarity only
+    write_inputs()
+
+    report = run()
+    assert_pass(report)
+    # Both engines re-recorded, and the recordings describe the NEW inputs: a
+    # cache key blind to this change would leave calls at 2 and stamps stale.
+    assert state["calls"] == 4, f"{changed}-only change did not invalidate the cache"
+    assert stamps() != before, f"{changed}-only change left a stale recording in place"
+    entry = latest_manifest(root)["entries"][0]
+    assert entry["cache"] == {"clj": "miss", "py": "miss"}

--- a/delphi/tests/replay_harness/test_certify_strict_gate.py
+++ b/delphi/tests/replay_harness/test_certify_strict_gate.py
@@ -13,10 +13,33 @@ import pytest
 from click.testing import CliRunner
 
 from polismath.replay import certify as cert, schedule as sched
+from polismath.replay.crosslang import PREP_MAIN_KEYS
 from polismath.replay.driver import run_replay
 from polismath.replay.types import ReplayDataset
 
 EMPTY = {"n": 0, "n-cmts": 0, "tids": [], "in-conv": []}
+
+#: Blob mutations applied IDENTICALLY to both engines' checkpoints (P-022 B1
+#: review, P1). Each produces byte-identical malformed recordings, so the
+#: acceptance projection stays nonempty and the two per-engine hashes are
+#: EQUAL — the hash-first shortcut used to short-circuit them to MATCH and
+#: certify PASS with strict exit 0. Every one of these must now FAIL at
+#: ``checkpoint-schema`` with the offending field named. Values are
+#: ``(mutate, field_named_in_reason)``.
+PAIRED_MALFORMED = {
+    "nan-count": (lambda b: {**b, "n": float("nan")}, "n"),
+    "inf-count": (lambda b: {**b, "n": float("-inf")}, "n"),
+    "string-count": (lambda b: {**b, "n": "invalid-count"}, "n"),
+    "float-count": (lambda b: {**b, "n": 1.5}, "n"),
+    "negative-count": (lambda b: {**b, "n": -1}, "n"),
+    "missing-count": (lambda b: {k: v for k, v in b.items() if k != "n"}, "n"),
+    "string-tid": (lambda b: {**b, "tids": ["1"]}, "tids"),
+    "scalar-tids": (lambda b: {**b, "tids": 1}, "tids"),
+    "container-zid": (lambda b: {**b, "zid": {"nope": 1}}, "zid"),
+    "list-pca": (lambda b: {**b, "pca": [1, 2]}, "pca"),
+    "nested-nan": (lambda b: {**b, "pca": {"center": [0.0, float("nan")]}}, "pca.center[1]"),
+    "nested-inf": (lambda b: {**b, "base-clusters": {"x": [float("inf")]}}, "base-clusters.x[0]"),
+}
 
 
 def latest_manifest(root):
@@ -60,6 +83,11 @@ def battery(tmp_path, monkeypatch):
                     "cut_time_ms": step.cut_time_ms}
             blob = EMPTY if step.cut_slot == 0 else {
                 "n": step.cut_slot, "n-cmts": 1, "tids": [1], "in-conv": [1]}
+            # Paired malformation: BOTH engines emit the same broken value, so
+            # the recordings are byte-identical and hash equal.
+            paired = PAIRED_MALFORMED.get(state["mutation"])
+            if paired is not None:
+                blob = paired[0](blob)
             stem = f"step-{step.index:03d}"
             if engine == "clj":
                 (out / (stem + ".blob.json")).write_text(json.dumps(blob))
@@ -89,6 +117,13 @@ def battery(tmp_path, monkeypatch):
                 first.write_text(json.dumps(payload))
             elif mutation == "wrong-empty":
                 payload = json.loads(first.read_text()); payload["blob"]["n"] = 1
+                first.write_text(json.dumps(payload))
+            elif mutation == "py-only-nan":
+                # Asymmetric control: only py is malformed, so the hashes
+                # DIFFER — validation must still name py, not fall through to
+                # the comparer and report a mere divergence.
+                payload = json.loads(first.read_text())
+                payload["blob"]["n"] = float("nan")
                 first.write_text(json.dumps(payload))
             elif mutation == "absent-empty":
                 # The real Clojure/Python empty-blob divergence in miniature: the
@@ -461,3 +496,153 @@ def test_single_input_change_cannot_be_served_from_cache(input_change, changed):
     assert stamps() != before, f"{changed}-only change left a stale recording in place"
     entry = latest_manifest(root)["entries"][0]
     assert entry["cache"] == {"clj": "miss", "py": "miss"}
+
+
+# ---------------------------------------------------------------------------
+# P-022 B1 review, P1 — a nonempty projection is not a valid checkpoint.
+#
+# Before this, `validate_recording_inventory` only asked for a nonempty
+# acceptance projection and `compare_recording_pair` short-circuited equal
+# per-engine hashes to MATCH before anything read the values. Two producers
+# emitting the SAME malformed blob (`{"n": NaN}`, `{"n": "invalid-count"}`)
+# therefore produced a complete run manifest with verdict PASS and strict exit
+# 0. These controls are red until raw validation runs on every checkpoint of
+# both engines, ahead of projection, hashing and any cached verdict.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("mutation", sorted(PAIRED_MALFORMED))
+def test_identical_malformed_blobs_on_both_engines_fail(battery, mutation):
+    entry, state, root, ds, run = battery
+    assert_pass(run())
+    state["mutation"] = mutation
+    report = run(refresh_clj=True, refresh_py=True)
+    assert report["verdict"] == "FAIL", report
+    result = report["battery"][0]
+    assert result["stage"] == "checkpoint-schema", result
+    # The reason must NAME the offending field, not just say "schema".
+    assert PAIRED_MALFORMED[mutation][1] in result["reason"], result["reason"]
+    assert cert.battery_exit_code(report, strict=True) == 1
+    assert latest_manifest(root)["entries"][0]["status"] == "FAIL"
+
+
+def test_paired_malformed_blobs_would_have_hash_matched(battery):
+    """Control that makes the parametrized failures above non-vacuous: the two
+    engines' malformed recordings really are identical, their acceptance
+    projections really are nonempty, and their acceptance hashes really are
+    equal — i.e. every pre-fix admission criterion is still satisfied and only
+    the new raw validation rejects them."""
+    entry, state, root, ds, run = battery
+    assert_pass(run())
+    state["mutation"] = "nan-count"
+    assert run(refresh_clj=True, refresh_py=True)["verdict"] == "FAIL"
+
+    rec = root / entry.dataset / entry.schedule_id
+    clj = json.loads((rec / "clj" / "step-000.blob.json").read_text())
+    py = json.loads((rec / "py" / "step-000.json").read_text())["blob"]
+    assert clj == py or (repr(clj) == repr(py))  # NaN != NaN, compare by repr
+    assert cert.project_acceptance(clj) and cert.project_acceptance(py)
+    assert cert._canonical_hash(cert.project_acceptance(clj)) == \
+        cert._canonical_hash(cert.project_acceptance(py))
+
+
+@pytest.mark.parametrize("mutation", ["nan-count", "string-count", "inf-count", "string-tid"])
+def test_compare_recording_pair_rejects_identical_malformed_blobs(tmp_path, mutation):
+    """The standalone comparer entry point must reject them too — it is the
+    function that owns the hash short-circuit."""
+    blob = PAIRED_MALFORMED[mutation][0](
+        {"n": 2, "n-cmts": 1, "tids": [1], "in-conv": [1]})
+    clj, py = tmp_path / "clj", tmp_path / "py"
+    clj.mkdir(); py.mkdir()
+    (clj / "step-000.blob.json").write_text(json.dumps(blob))
+    (py / "step-000.json").write_text(json.dumps({"index": 0, "blob": blob}))
+    with pytest.raises(cert.CertifyError) as excinfo:
+        cert.compare_recording_pair(clj, py, cache_root=tmp_path)
+    assert excinfo.value.stage == "checkpoint-schema"
+    assert PAIRED_MALFORMED[mutation][1] in str(excinfo.value)
+
+
+def test_malformed_blob_fails_even_when_the_other_engine_is_valid(battery):
+    """Symmetry: validation is per engine, so a malformed blob fails whatever
+    the other engine emitted — a valid partner cannot rescue it."""
+    entry, state, root, ds, run = battery
+    assert_pass(run())
+    state["mutation"] = "py-only-nan"
+    report = run(refresh_clj=True, refresh_py=True)
+    assert report["verdict"] == "FAIL"
+    assert report["battery"][0]["stage"] == "checkpoint-schema"
+    assert "py:" in report["battery"][0]["reason"]
+
+
+def test_cached_recordings_are_revalidated(battery):
+    """Validation must run on recording-cache HITS too: a cached malformed
+    recording is exactly the stale-MATCH failure mode the gate exists to stop."""
+    entry, state, root, ds, run = battery
+    assert_pass(run())
+    rec = root / entry.dataset / entry.schedule_id
+    for path in (rec / "clj" / "step-000.blob.json", rec / "py" / "step-000.json"):
+        payload = json.loads(path.read_text())
+        target = payload if path.name.endswith(".blob.json") else payload["blob"]
+        target["n"] = float("nan")
+        path.write_text(json.dumps(payload))
+    # No refresh: both manifests are re-validated against the (now tampered)
+    # files, so this fails at the integrity check or the schema check — never
+    # a served MATCH.
+    report = run()
+    assert report["verdict"] == "FAIL", report
+    assert report["battery"][0]["stage"] in ("recording-integrity", "checkpoint-schema")
+
+
+# ---------------------------------------------------------------------------
+# validate_checkpoint_blob directly.
+# ---------------------------------------------------------------------------
+def test_validate_checkpoint_blob_accepts_the_committed_real_blobs():
+    """Ground the contract in reality: every committed math blob (the shape the
+    engines actually emit) must validate clean, or the gate is over-strict."""
+    real_dir = Path(cert.__file__).resolve().parents[2] / "real_data"
+    blobs = sorted(real_dir.glob("*/*math_blob*.json"))
+    assert blobs, "no committed real math blobs to validate against"
+    for path in blobs:
+        cert.validate_checkpoint_blob(json.loads(path.read_text()), path.name)
+
+
+@pytest.mark.parametrize("blob,needle", [
+    ({"n": 1, "n-cmts": 1, "tids": [1]}, "in-conv"),
+    ({"n": 1, "n-cmts": True, "tids": [], "in-conv": []}, "n-cmts"),
+    ({"n": 1, "n-cmts": 1, "tids": [], "in-conv": [], "lastVoteTimestamp": "x"},
+     "lastVoteTimestamp"),
+    ({"n": 1, "n-cmts": 1, "tids": [], "in-conv": [], "group-clusters": {}},
+     "group-clusters"),
+    ({"n": 1, "n-cmts": 1, "tids": [], "in-conv": [], "repness": []}, "repness"),
+    ("not-an-object", "JSON object"),
+])
+def test_validate_checkpoint_blob_rejects_and_names_the_field(blob, needle):
+    with pytest.raises(cert.CertifyError) as excinfo:
+        cert.validate_checkpoint_blob(blob, "clj: step-000")
+    assert excinfo.value.stage == "checkpoint-schema"
+    assert needle in str(excinfo.value)
+    assert "clj: step-000" in str(excinfo.value)
+
+
+def test_validate_checkpoint_blob_accepts_nullable_and_snake_spellings():
+    cert.validate_checkpoint_blob(
+        {"n": 0, "n_cmts": 0, "tids": [], "in_conv": [], "mod-in": None,
+         "mod-out": None, "meta-tids": None, "lastModTimestamp": None,
+         "zid": "synthetic"},
+        "py: step-000")
+
+
+def test_validate_checkpoint_blob_require_keys_false_still_checks_values():
+    cert.validate_checkpoint_blob({"n": 0}, "clj: step-000", require_keys=False)
+    with pytest.raises(cert.CertifyError, match="'n'"):
+        cert.validate_checkpoint_blob(
+            {"n": float("nan")}, "clj: step-000", require_keys=False)
+
+
+def test_checkpoint_contract_keys_come_from_the_crosslang_whitelist():
+    """The contract must not invent field names: every key it constrains is one
+    crosslang's canonicalization whitelist actually emits."""
+    named = set(cert._REQUIRED_CHECKPOINT_KEYS) | set(cert._COUNT_CHECKPOINT_KEYS) \
+        | set(cert._TIMESTAMP_CHECKPOINT_KEYS) | set(cert._ID_LIST_CHECKPOINT_KEYS) \
+        | set(cert._MAPPING_CHECKPOINT_KEYS) | set(cert._SEQUENCE_CHECKPOINT_KEYS) \
+        | set(cert._ID_SCALAR_CHECKPOINT_KEYS)
+    assert named <= PREP_MAIN_KEYS
+    assert set(cert._REQUIRED_CHECKPOINT_KEYS) <= cert.ACCEPTANCE_KEYS

--- a/delphi/tests/replay_harness/test_schedule.py
+++ b/delphi/tests/replay_harness/test_schedule.py
@@ -109,8 +109,9 @@ def test_resolve_timestamp_mode(ds8):
     assert slots == (2, 5, 8)
 
 
-def test_resolve_dedupes_and_sorts(ds8):
-    slots = sched.resolve_cut_slots(ds8, {"mode": "vote-count", "at": [5, 2, 5, "end"]})
+def test_resolve_dedupes_only_with_opt_in(ds8):
+    slots = sched.resolve_cut_slots(ds8, {"mode": "vote-count", "at": [2, 5, 5, "end"],
+                                        "deduplicate": True})
     assert slots == (2, 5, 8)
 
 
@@ -119,10 +120,9 @@ def test_cut_slot_out_of_range_raises(ds8):
         sched.resolve_cut_slots(ds8, {"mode": "vote-count", "at": [999]})
 
 
-def test_timestamp_before_first_vote_dropped(ds8):
-    # t=50 is before the first vote (t=100) → slot 0 → dropped (degenerate).
-    slots = sched.resolve_cut_slots(ds8, {"mode": "timestamp", "at": [50, "end"]})
-    assert slots == (8,)
+def test_timestamp_before_first_vote_requires_explicit_checkpoint(ds8):
+    with pytest.raises(ValueError, match="empty_checkpoint"):
+        sched.resolve_cut_slots(ds8, {"mode": "timestamp", "at": [50, "end"]})
 
 
 def test_unknown_mode_raises(ds8):

--- a/math/dev/replay.clj
+++ b/math/dev/replay.clj
@@ -123,23 +123,30 @@
   (count (take-while #(<= (long (:t-ms %)) (long t-ms)) votes)))
 
 (defn validate-slots
-  "Mirror ReplayDataset.validate_schedule: 1<=s<=n, strictly increasing."
-  [slots n]
-  (loop [prev 0 [s & more] slots]
+  "Validate increasing vote cursors, with an explicit zero-checkpoint opt-in."
+  ([slots n] (validate-slots slots n false))
+  ([slots n allow-zero]
+  (loop [prev (if allow-zero -1 0) [s & more] slots]
     (when s
-      (when-not (<= 1 s n)
+      (when-not (<= (if allow-zero 0 1) s n)
         (throw (ex-info (str "cut slot " s " outside 1.." n) {:slot s :n n})))
       (when-not (> s prev)
         (throw (ex-info (str "schedule not strictly increasing at slot " s) {:slot s})))
-      (recur s more))))
+      (recur s more)))))
 
 (defn resolve-cut-slots
-  "Resolve a §4 `cuts` map into strictly-increasing 1-based slots in 1..n.
-  0-slots dropped as degenerate, duplicates collapsed (== schedule.py)."
+  "Mirror schedule.py: preserve order; zero and deduplication require opt-in."
   [votes cuts]
   (let [mode (get cuts "mode")
         at   (get cuts "at" [])
         n    (count votes)]
+    (when-not (and (map? cuts) (vector? at))
+      (throw (ex-info "cuts must be an object and cuts.at a list" {})))
+    (when (seq (remove #{"mode" "at" "empty_checkpoint" "deduplicate"} (keys cuts)))
+      (throw (ex-info "unknown cut fields" {:cuts cuts})))
+    (doseq [flag ["empty_checkpoint" "deduplicate"]]
+      (when (and (contains? cuts flag) (not (instance? Boolean (get cuts flag))))
+        (throw (ex-info (str "cuts." flag " must be boolean") {}))))
     (when-not (valid-modes mode)
       (throw (ex-info (str "unknown cut mode " (pr-str mode)
                            "; expected one of " (sort valid-modes)) {:mode mode})))
@@ -148,7 +155,9 @@
                   (= a "end")
                   n
                   (#{"vote-count" "explicit-event-index"} mode)
-                  (long a)
+                  (do (when-not (integer? a)
+                        (throw (ex-info "vote cut must be an integer" {:cut a})))
+                      (long a))
                   (= mode "fraction")
                   (let [f (double a)]
                     (when-not (and (< 0.0 f) (<= f 1.0))
@@ -156,8 +165,15 @@
                     (py-round (* f n)))
                   (= mode "timestamp")
                   (count-votes-up-to votes (long a))))
-          slots (->> raw (filter pos?) (into (sorted-set)) vec)]
-      (validate-slots slots n)
+          slots (vec (distinct raw))]
+      (when (some (fn [[a b]] (> a b)) (partition 2 1 raw))
+        (throw (ex-info "schedule not strictly increasing: preserve cut order" {:cuts cuts})))
+      (when (and (not= (count raw) (count slots))
+                 (not (true? (get cuts "deduplicate"))))
+        (throw (ex-info "duplicate resolved cut slots" {:cuts cuts})))
+      (when (and (some zero? slots) (not (true? (get cuts "empty_checkpoint"))))
+        (throw (ex-info "zero cut requires explicit empty_checkpoint: true" {:cuts cuts})))
+      (validate-slots slots n (true? (get cuts "empty_checkpoint")))
       slots)))
 
 ;; ---------------------------------------------------------------------------
@@ -174,8 +190,8 @@
    (loop [prev 0 [cut & more] slots i 0 acc []]
      (if (nil? cut)
        acc
-       (let [cut-time  (:t-ms (nth votes (dec cut)))
-             prev-time (when (pos? prev) (:t-ms (nth votes (dec prev))))
+       (let [cut-time  (if (zero? cut) 0 (:t-ms (nth votes (dec cut))))
+             prev-time (:cut-time-ms (peek acc))
              mods (filterv #(and (<= (long (:modified %)) (long cut-time))
                                  (or (nil? prev-time)
                                      (> (long (:modified %)) (long prev-time))))
@@ -308,7 +324,13 @@
   postgres.clj pg-json does (the DB blob's own serialization)."
   [dir step conv]
   (spit (io/file dir (format "step-%03d.blob.json" (:index step)))
-        (json/generate-string (cm/prep-main conv))))
+        (json/generate-string (cm/prep-main conv)))
+  ;; Identity sidecar: the raw prep-main blob deliberately remains unchanged.
+  (spit (io/file dir (format "step-%03d.meta.json" (:index step)))
+        (json/generate-string
+          {:index (:index step) :prev_slot (:prev-slot step)
+           :cut_slot (:cut-slot step) :batch_size (count (:votes step))
+           :cut_time_ms (:cut-time-ms step)})))
 
 (defn write-edn!
   "Write full-fidelity conv state in the `conv-update-dump` shape


### PR DESCRIPTION
## Why
The certification battery could report MATCH between two **empty** recordings: `resolve_cut_slots` silently dropped zero-vote checkpoints, and `compare_recording_pair` aligned recordings by the shorter length. The zero-vote entry in the 20-entry battery was passing on nothing. A release gate must be incapable of that.

## What
- **Expected inventory before the run**: every (dataset, schedule, engine, checkpoint) is enumerated from the battery + schedules; after the run, exact equality per entry. Empty recordings, length mismatches, missing datasets (unless explicitly `optional`), timeouts, stale files, malformed manifests all FAIL. `--only` is marked PARTIAL and can never reach PASS. `--strict` exits 0 only on a complete, non-partial PASS.
- **Run manifest** (`run_manifest-<run_id>.json` + `latest` pointer): inventory, per-entry PASS/FAIL/INCONCLUSIVE/APPROVED_DIFFERENCE, top-level verdict, and provenance (engine/driver/comparer hashes, battery path, cache hits/misses, deferred entries).
- **Explicit zero-vote checkpoint**: schedules can declare a checkpoint at zero votes that must produce the specified empty output (`schedules/pc-zerovote-01-empty.json`); slot dedupe is an error unless opted in.
- Clojure replay driver (`math/dev/replay.clj`): emits the explicit empty checkpoint via a sidecar; the recorded blob is still `(cm/prep-main conv)` verbatim. Reviewer proved the one refactor equivalent on 300 randomized schedules (0 mismatches); Python's identical refactor 400/0.
- Negative controls (`tests/replay_harness/test_certify_strict_gate.py`): remove a step, duplicate a step, empty both stores, missing dataset, `--only`, zero-vote with/without the explicit checkpoint, comments-only, restart-only, polarity-only, absent-empty. Mutation-checked: restoring `min(len(...))` or disabling the file-set check turns 7 controls red.

## Consequence you should expect
**The default battery is now legitimately red on one entry.** Clojure's empty-conversation blob omits `n`, `n-cmts`, `tids`, `in-conv`; Python's includes them. That divergence was invisible before. It stays failing until the empty-output contract is specified (which side is the legacy quirk, which is corrected), tracked in the program notes.

## Verification
`uv run pytest tests/replay_harness -q` → 505 passed, 6 skipped (baseline 465/6). Clojure: `clojure -M ../delphi/tests/replay_harness/strict_schedule_test.clj` → 6 tests, 8 assertions, 0 failures. Tolerances, comparer, poller untouched. Implemented by a headless Codex worker; independently reviewed (merge with edits; all four applied).

Note for a fresh checkout: `uv pip install -e ".[dev]"` before `uv run pytest` (dev extras carry pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s