### PR TITLE
fix(server): topic-agenda job lookup applied Limit before Filter and erased delphi_job_id

### DIFF
--- a/server/__tests__/integration/topic-agenda-job-attribution.test.ts
+++ b/server/__tests__/integration/topic-agenda-job-attribution.test.ts
@@ -87,13 +87,18 @@ describe.each(["post", "put"] as const)(
       });
     }
 
-    async function expectStoredJob(jobId: string | null) {
+    async function expectStoredJob(
+      jobId: string | null,
+      storedSelections: unknown = selections
+    ) {
       const response = await agent
         .get("/api/v3/topicAgenda/selections")
         .query({ conversation_id: conversationId });
       expect(response.status).toBe(200);
       expect(response.body.data.delphi_job_id).toBe(jobId);
-      expect(response.body.data.archetypal_selections).toEqual(selections);
+      expect(response.body.data.archetypal_selections).toEqual(
+        storedSelections
+      );
     }
 
     it("returns and stores the newest completed job", async () => {
@@ -108,6 +113,19 @@ describe.each(["post", "put"] as const)(
     it("returns the older completed job without erasing it when a newer job is pending", async () => {
       const completed = await createJob("COMPLETED", 1);
       expect((await save()).body.data.job_id).toBe(completed);
+      await createJob("PENDING", 2);
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    // The Limit-before-Filter regression proper: no row exists beforehand, so
+    // COALESCE has nothing to restore and cannot mask a null attribution. A
+    // reintroduced `Limit: 1` reads only the newer PENDING job, filters it
+    // away and stores null, which this case must catch.
+    it("attributes the older completed job when a newer job is pending and no selections row exists", async () => {
+      const completed = await createJob("COMPLETED", 1);
       await createJob("PENDING", 2);
       const response = await save();
       expect(response.status).toBe(200);
@@ -184,10 +202,11 @@ describe.each(["post", "put"] as const)(
       await expectStoredJob(completed);
     });
 
-    it("fails without changing selections or attribution if a later query page fails", async () => {
+    it("still saves selections and preserves attribution if a later query page fails", async () => {
       const completed = await createJob("COMPLETED", 1);
       const initial = await save();
       expect(initial.body.data.job_id).toBe(completed);
+      const changed = [{ topic_id: "changed-topic", priority: 2 }];
       for (let i = 2; i < 29; i++) {
         await createJob("PENDING", i);
       }
@@ -218,13 +237,18 @@ describe.each(["post", "put"] as const)(
             zid: Number(zid),
             pid: Number(initial.body.data.participant_id),
           },
-          body: { selections: [{ topic_id: "changed-topic", priority: 2 }] },
+          body: { selections: changed },
         } as RequestWithP,
         response as unknown as Response
       );
-      expect(response.status).toHaveBeenCalledWith(500);
+      // A DynamoDB outage must degrade to "selections saved, attribution kept",
+      // never to a 500 that discards the participant's selections.
+      expect(response.status).not.toHaveBeenCalled();
+      expect(response.json).toHaveBeenCalledTimes(1);
+      expect(response.json.mock.calls[0][0].status).toBe("success");
+      expect(response.json.mock.calls[0][0].data.job_id).toBe(completed);
       expect(queryCount).toBe(2);
-      await expectStoredJob(completed);
+      await expectStoredJob(completed, changed);
     });
   }
 );

--- a/server/__tests__/integration/topic-agenda-job-attribution.test.ts
+++ b/server/__tests__/integration/topic-agenda-job-attribution.test.ts
@@ -1,0 +1,230 @@
+import { randomUUID } from "crypto";
+import { Response } from "express";
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  getJwtAuthenticatedAgent,
+  setupAuthAndConvo,
+} from "../setup/api-test-helpers";
+import {
+  docClient,
+  ensureJobQueueTableExists,
+} from "../setup/dynamodb-test-helpers";
+import pgQuery from "../../src/db/pg-query";
+import { RequestWithP } from "../../src/d";
+import {
+  handle_POST_topicAgenda_selections,
+  handle_PUT_topicAgenda_selections,
+} from "../../src/routes/delphi/topicAgenda";
+
+// These tests use real DynamoDB Local queries and PostgreSQL writes. Fixtures
+// must use the internal zid, not the public conversation invite returned by API helpers.
+describe.each(["post", "put"] as const)(
+  "Topic agenda %s job attribution",
+  (method) => {
+    let agent: any;
+    let conversationId: string;
+    let zid: string;
+    let jobIds: string[];
+    const selections = [{ topic_id: "synthetic-topic", priority: 1 }];
+
+    beforeAll(async () => {
+      await ensureJobQueueTableExists();
+    });
+
+    beforeEach(async () => {
+      jobIds = [];
+      const setup = await setupAuthAndConvo({ createConvo: true });
+      conversationId = setup.conversationId;
+      ({ agent } = await getJwtAuthenticatedAgent(setup.testUser));
+      const rows = (await pgQuery.queryP(
+        "SELECT zid FROM zinvites WHERE zinvite = $1",
+        [conversationId]
+      )) as { zid: number }[];
+      zid = rows[0].zid.toString();
+    });
+
+    afterEach(async () => {
+      jest.restoreAllMocks();
+      for (const jobId of jobIds) {
+        await docClient.send(
+          new DeleteCommand({
+            TableName: "Delphi_JobQueue",
+            Key: { job_id: jobId },
+          })
+        );
+      }
+    });
+
+    async function createJob(status: string, order: number, padding = "") {
+      const jobId = `test-topic-agenda-${randomUUID()}`;
+      jobIds.push(jobId);
+      await docClient.send(
+        new PutCommand({
+          TableName: "Delphi_JobQueue",
+          Item: {
+            job_id: jobId,
+            conversation_id: zid,
+            status,
+            created_at: new Date(
+              Date.UTC(2025, 0, 1, 0, 0, order)
+            ).toISOString(),
+            padding,
+          },
+        })
+      );
+      return jobId;
+    }
+
+    function save(nextSelections = selections) {
+      return agent[method]("/api/v3/topicAgenda/selections").send({
+        conversation_id: conversationId,
+        selections: nextSelections,
+      });
+    }
+
+    async function expectStoredJob(jobId: string | null) {
+      const response = await agent
+        .get("/api/v3/topicAgenda/selections")
+        .query({ conversation_id: conversationId });
+      expect(response.status).toBe(200);
+      expect(response.body.data.delphi_job_id).toBe(jobId);
+      expect(response.body.data.archetypal_selections).toEqual(selections);
+    }
+
+    it("returns and stores the newest completed job", async () => {
+      await createJob("COMPLETED", 1);
+      const newest = await createJob("COMPLETED", 2);
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(newest);
+      await expectStoredJob(newest);
+    });
+
+    it("returns the older completed job without erasing it when a newer job is pending", async () => {
+      const completed = await createJob("COMPLETED", 1);
+      expect((await save()).body.data.job_id).toBe(completed);
+      await createJob("PENDING", 2);
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    it("continues through an empty filtered page to the newest completed job", async () => {
+      await createJob("COMPLETED", 0);
+      const completed = await createJob("COMPLETED", 1);
+      for (let i = 2; i < 29; i++) {
+        await createJob(i % 2 ? "PENDING" : "PROCESSING", i);
+      }
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    it("continues beyond DynamoDB's 1 MB page boundary", async () => {
+      const completed = await createJob("COMPLETED", 1);
+      for (let i = 2; i < 6; i++) {
+        await createJob("PENDING", i, "x".repeat(350_000));
+      }
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    it("returns and stores null for new selections when no job exists", async () => {
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBeNull();
+      await expectStoredJob(null);
+    });
+
+    it("returns null when all jobs are failed", async () => {
+      await createJob("FAILED", 1);
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBeNull();
+      await expectStoredJob(null);
+    });
+
+    it("preserves existing attribution when only a pending job remains", async () => {
+      const completed = await createJob("COMPLETED", 1);
+      expect((await save()).body.data.job_id).toBe(completed);
+      await docClient.send(
+        new DeleteCommand({
+          TableName: "Delphi_JobQueue",
+          Key: { job_id: completed },
+        })
+      );
+      await createJob("PENDING", 2);
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    it("preserves existing attribution when the index returns no jobs", async () => {
+      const completed = await createJob("COMPLETED", 1);
+      expect((await save()).body.data.job_id).toBe(completed);
+      await docClient.send(
+        new DeleteCommand({
+          TableName: "Delphi_JobQueue",
+          Key: { job_id: completed },
+        })
+      );
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    it("fails without changing selections or attribution if a later query page fails", async () => {
+      const completed = await createJob("COMPLETED", 1);
+      const initial = await save();
+      expect(initial.body.data.job_id).toBe(completed);
+      for (let i = 2; i < 29; i++) {
+        await createJob("PENDING", i);
+      }
+      // Only inject the failure; the first page still comes from DynamoDB Local.
+      const originalSend = DynamoDBDocumentClient.prototype.send;
+      let queryCount = 0;
+      jest
+        .spyOn(DynamoDBDocumentClient.prototype, "send")
+        .mockImplementation(function (
+          this: DynamoDBDocumentClient,
+          command: any
+        ): any {
+          if (command instanceof QueryCommand && ++queryCount === 2) {
+            return Promise.reject(new Error("Synthetic DynamoDB page failure"));
+          }
+          return originalSend.call(this, command);
+        });
+      // Invoke the handler in this Jest module context so the failure spy is
+      // applied; API helpers otherwise use the separate global-setup server.
+      const response = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+      const handler =
+        method === "post"
+          ? handle_POST_topicAgenda_selections
+          : handle_PUT_topicAgenda_selections;
+      await handler(
+        {
+          p: {
+            zid: Number(zid),
+            pid: Number(initial.body.data.participant_id),
+          },
+          body: { selections: [{ topic_id: "changed-topic", priority: 2 }] },
+        } as RequestWithP,
+        response as unknown as Response
+      );
+      expect(response.status).toHaveBeenCalledWith(500);
+      expect(queryCount).toBe(2);
+      await expectStoredJob(completed);
+    });
+  }
+);

--- a/server/src/routes/delphi/topicAgenda.ts
+++ b/server/src/routes/delphi/topicAgenda.ts
@@ -1,6 +1,10 @@
 import _ from "underscore";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  QueryCommandInput,
+} from "@aws-sdk/lib-dynamodb";
 import { Response } from "express";
 
 import { RequestWithP } from "../../d";
@@ -35,12 +39,12 @@ const docClient = DynamoDBDocumentClient.from(dynamoClient, {
 });
 
 /**
- * Get the current Delphi job ID for a conversation
+ * Get the newest completed Delphi job ID for a conversation.
  */
 async function getCurrentDelphiJobId(zid: string): Promise<string | null> {
   try {
     // Query the ConversationIndex GSI to find completed jobs for this conversation
-    const queryParams = {
+    const queryParams: QueryCommandInput = {
       TableName: "Delphi_JobQueue",
       IndexName: "ConversationIndex",
       KeyConditionExpression: "conversation_id = :zid",
@@ -53,20 +57,26 @@ async function getCurrentDelphiJobId(zid: string): Promise<string | null> {
         ":status": "COMPLETED",
       },
       ScanIndexForward: false, // Sort by created_at DESC
-      Limit: 1,
+      Limit: 25,
     };
 
-    const result = await docClient.send(new QueryCommand(queryParams));
-
-    if (result.Items && result.Items.length > 0) {
-      const jobId = result.Items[0].job_id;
-      return jobId;
-    }
+    // DynamoDB applies Limit before FilterExpression. An empty page may still
+    // have older completed jobs, so only stop once a match is found or the
+    // conversation's pages are exhausted (including the 1 MB page boundary).
+    do {
+      const result = await docClient.send(new QueryCommand(queryParams));
+      if (result.Items?.length) {
+        return result.Items[0].job_id;
+      }
+      queryParams.ExclusiveStartKey = result.LastEvaluatedKey;
+    } while (queryParams.ExclusiveStartKey);
 
     return null;
   } catch (error: any) {
     logger.error("Error getting current Delphi job ID from DynamoDB", error);
-    return null;
+    // A failed lookup is not evidence of absence. Let the handler fail before
+    // writing selections rather than overwriting their attribution with null.
+    throw error;
   }
 }
 
@@ -95,17 +105,18 @@ export async function handle_POST_topicAgenda_selections(
     // Get current Delphi job ID
     const jobId = await getCurrentDelphiJobId(zid.toString());
 
-    // Use UPSERT (INSERT ... ON CONFLICT UPDATE) to handle both new and existing records
+    // Preserve existing attribution when the GSI has no completed job: its
+    // eventually consistent results cannot prove the referenced job is gone.
     const query = `
       INSERT INTO topic_agenda_selections (zid, pid, archetypal_selections, delphi_job_id, total_selections, created_at, updated_at)
       VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
       ON CONFLICT (zid, pid) 
       DO UPDATE SET 
         archetypal_selections = EXCLUDED.archetypal_selections,
-        delphi_job_id = EXCLUDED.delphi_job_id,
+        delphi_job_id = COALESCE(EXCLUDED.delphi_job_id, topic_agenda_selections.delphi_job_id),
         total_selections = EXCLUDED.total_selections,
         updated_at = CURRENT_TIMESTAMP
-      RETURNING zid, pid, total_selections
+      RETURNING zid, pid, total_selections, delphi_job_id
     `;
 
     const result = await pgQuery.queryP(query, [
@@ -124,7 +135,7 @@ export async function handle_POST_topicAgenda_selections(
         participant_id: pid.toString(),
         selections_count:
           (result as any)[0]?.total_selections || selections.length,
-        job_id: jobId,
+        job_id: (result as any)[0].delphi_job_id,
       },
     };
 
@@ -242,16 +253,17 @@ export async function handle_PUT_topicAgenda_selections(
     // Get current Delphi job ID
     const jobId = await getCurrentDelphiJobId(zid.toString());
 
-    // Update the record
+    // An empty, eventually consistent GSI lookup cannot prove an existing
+    // attribution is absent/terminal. Preserve it unless a completed job replaces it.
     const updateQuery = `
       UPDATE topic_agenda_selections 
       SET 
         archetypal_selections = $3,
-        delphi_job_id = $4,
+        delphi_job_id = COALESCE($4, delphi_job_id),
         total_selections = $5,
         updated_at = CURRENT_TIMESTAMP
       WHERE zid = $1 AND pid = $2
-      RETURNING zid, pid, total_selections
+      RETURNING zid, pid, total_selections, delphi_job_id
     `;
 
     const result = await pgQuery.queryP(updateQuery, [
@@ -299,7 +311,7 @@ export async function handle_PUT_topicAgenda_selections(
           conversation_id: zid.toString(),
           participant_id: pid.toString(),
           selections_count: rows[0]?.total_selections || selections.length,
-          job_id: jobId,
+          job_id: rows[0].delphi_job_id,
         },
       });
     }

--- a/server/src/routes/delphi/topicAgenda.ts
+++ b/server/src/routes/delphi/topicAgenda.ts
@@ -38,6 +38,12 @@ const docClient = DynamoDBDocumentClient.from(dynamoClient, {
   },
 });
 
+// Bound the work one participant save can trigger. Without a cap the query is
+// bounded only by the conversation's partition size; with COALESCE in place,
+// bailing out early is non-destructive (it preserves any existing attribution).
+const MAX_JOB_QUERY_PAGES = 20;
+const JOB_QUERY_PAGE_SIZE = 25;
+
 /**
  * Get the newest completed Delphi job ID for a conversation.
  */
@@ -57,26 +63,31 @@ async function getCurrentDelphiJobId(zid: string): Promise<string | null> {
         ":status": "COMPLETED",
       },
       ScanIndexForward: false, // Sort by created_at DESC
-      Limit: 25,
+      Limit: JOB_QUERY_PAGE_SIZE,
     };
 
     // DynamoDB applies Limit before FilterExpression. An empty page may still
-    // have older completed jobs, so only stop once a match is found or the
-    // conversation's pages are exhausted (including the 1 MB page boundary).
-    do {
+    // have older completed jobs, so only stop once a match is found, the
+    // conversation's pages are exhausted (including the 1 MB page boundary),
+    // or the page cap is reached.
+    for (let page = 0; page < MAX_JOB_QUERY_PAGES; page++) {
       const result = await docClient.send(new QueryCommand(queryParams));
       if (result.Items?.length) {
         return result.Items[0].job_id;
       }
+      if (!result.LastEvaluatedKey) {
+        break;
+      }
       queryParams.ExclusiveStartKey = result.LastEvaluatedKey;
-    } while (queryParams.ExclusiveStartKey);
+    }
 
     return null;
   } catch (error: any) {
     logger.error("Error getting current Delphi job ID from DynamoDB", error);
-    // A failed lookup is not evidence of absence. Let the handler fail before
-    // writing selections rather than overwriting their attribution with null.
-    throw error;
+    // Degrade instead of failing the request: a null here cannot erase an
+    // existing attribution (the writes below COALESCE it), while throwing
+    // would 500 the handler and drop the participant's selections entirely.
+    return null;
   }
 }
 
@@ -135,7 +146,7 @@ export async function handle_POST_topicAgenda_selections(
         participant_id: pid.toString(),
         selections_count:
           (result as any)[0]?.total_selections || selections.length,
-        job_id: (result as any)[0].delphi_job_id,
+        job_id: (result as any)[0]?.delphi_job_id ?? null,
       },
     };
 


### PR DESCRIPTION
## Why
`server/src/routes/delphi/topicAgenda.ts` queried `Delphi_JobQueue` via `ConversationIndex` with `Limit: 1` and a `FilterExpression` on `status`. DynamoDB applies `Limit` before the filter, so the query read one arbitrary item, filtered it away, and reported "no job"; the selection path then erased the conversation's `delphi_job_id`. Effect: while any job was pending, every topic-agenda selection lost its job attribution.

## What
- Paginated key-condition query on `conversation_id`, status filtered after; bounded to 20 pages × 25 items.
- The erase path no longer runs on an empty query result.
- On a DynamoDB error the route degrades (returns `null` attribution, selections still saved) instead of a 500 that lost participant selections.
- 20 tests (`server/__tests__/integration/topic-agenda-job-attribution.test.ts`), including a no-pre-existing-row case that a reintroduced `Limit: 1` fails (mutation-checked: 9/20 fail).

Full suite: 44 suites / 322 passed / 1 skipped; tsc, prettier, eslint clean. Response shape unchanged.

Follow-up (tracked in the job-id design work): erasure is now never performed, so `delphi_job_id` can hold a dangling reference after a reset; no impact today (`nextComment` discards it).

Found by the job-id system map; implemented by a headless Codex worker; independently reviewed (merge with edits, all applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s