### PR TITLE
PROD DEPLOY 09/09/2026 — authz fixes, topic-agenda lookup, engine-scoped math reads

### DIFF
--- a/cdk/launchTemplates.ts
+++ b/cdk/launchTemplates.ts
@@ -52,7 +52,9 @@ export default (
       'sudo systemctl start docker',
       'sudo systemctl enable docker',
       'sudo usermod -a -G docker ec2-user',
-      'sudo curl -L https://github.com/docker/compose/releases/download/v2.40.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose',
+      // $(uname -m) → x86_64 on the web/delphi tiers, aarch64 on the Graviton math worker. A hardcoded
+      // x86_64 binary aborts the boot script on ARM (Exec format error) and the CodeDeploy agent never installs.
+      'sudo curl -L https://github.com/docker/compose/releases/download/v2.40.0/docker-compose-linux-$(uname -m) -o /usr/local/bin/docker-compose',
       'sudo chmod +x /usr/local/bin/docker-compose',
       'docker-compose --version',
       'sudo yum install -y jq',

--- a/client-admin/src/components/conversation-admin/topic-moderation/TopicDetail.js
+++ b/client-admin/src/components/conversation-admin/topic-moderation/TopicDetail.js
@@ -4,6 +4,7 @@
 import React, { useState, useEffect } from 'react'
 import { Box, Flex, Heading, Text, Button, Checkbox, Label } from 'theme-ui'
 import { Link, useParams } from 'react-router-dom'
+import PolisNet from '../../../util/net'
 
 const TopicDetail = () => {
   const [comments, setComments] = useState([])
@@ -69,14 +70,17 @@ const TopicDetail = () => {
     if (selectedComments.size === 0) return
 
     try {
+      const token = await PolisNet.getAccessTokenSilentlySPA()
       const response = await fetch('/api/v3/topicMod/moderate', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token && { Authorization: `Bearer ${token}` })
+        },
         body: JSON.stringify({
-          report_id: conversation_id,
+          conversation_id: conversation_id,
           comment_ids: Array.from(selectedComments),
-          action: action,
-          moderator: 'admin' // TODO: Get from auth state
+          action: action
         })
       })
       const data = await response.json()

--- a/client-admin/src/components/conversation-admin/topic-moderation/TopicTree.js
+++ b/client-admin/src/components/conversation-admin/topic-moderation/TopicTree.js
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react'
 import { Box, Flex, Heading, Text, Button } from 'theme-ui'
 import { Link, useParams } from 'react-router-dom'
 import PropTypes from 'prop-types'
+import PolisNet from '../../../util/net'
 
 const TopicTree = ({ conversation_id }) => {
   const [selectedLayer, setSelectedLayer] = useState('0')
@@ -59,16 +60,17 @@ const TopicTree = ({ conversation_id }) => {
 
   const moderateTopic = async (topicKey, action) => {
     try {
+      const token = await PolisNet.getAccessTokenSilentlySPA()
       const response = await fetch('/api/v3/topicMod/moderate', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          ...(token && { Authorization: `Bearer ${token}` })
         },
         body: JSON.stringify({
           conversation_id: conversation_id,
           topic_key: topicKey,
-          action: action,
-          moderator: 'admin' // TODO: Get from auth state
+          action: action
         })
       })
       const data = await response.json()

--- a/client-report/src/components/commentsReport/CommentsReport.jsx
+++ b/client-report/src/components/commentsReport/CommentsReport.jsx
@@ -202,7 +202,7 @@ const CommentsReport = ({ math, comments, conversation, ptptCount, formatTid, vo
   const pollForLogs = async => {
     net.polisGet("/api/v3/delphi/logs", {
       job_id: visualizationJobs.find(job => job.status === "PROCESSING" && !job.jobId.includes("batch_report_"))?.jobId || jobInProgress?.job_id
-    })
+    }, authToken)
     .then(response => {
       setProcessedLogs(response);
       const isFinished = response?.find(m => m.message.includes("Results stored in DynamoDB for conversation"));

--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -277,12 +277,27 @@ class MathPollerService:
         # the coldest (see _remember).
         self._convs: "OrderedDict[int, Conversation]" = OrderedDict()
         self._retry_counts: Dict[int, int] = {}
-        self._parked: set = set()
         self._pool: Optional[ConversationWorkerPool] = None
         self._threads: List[threading.Thread] = []
         self._stop = threading.Event()
         self._vote_wm: Optional[int] = None
         self._mod_wm: Optional[int] = None
+
+    @property
+    def _parked(self) -> set:
+        """Parked-zid truth is owned SOLELY by the worker pool — one
+        lock-protected set (P-022 R04). This is a READ-ONLY view; the service
+        never keeps a second set that could disagree with the pool's. Park and
+        unpark always go through ``pool.park`` / ``pool.unpark`` (each atomic
+        with the pool's queue/active bookkeeping under the same lock), so an
+        interleaving between "mark parked" and "stop the queue" — the old
+        divergence bug — is no longer expressible.
+
+        Returns an empty set before the pool is constructed so early lookups are
+        safe."""
+        if self._pool is None:
+            return set()
+        return self._pool.parked_zids()
 
     # -- lifecycle ---------------------------------------------------------- #
     def _ensure_runtime(self) -> None:
@@ -387,7 +402,7 @@ class MathPollerService:
         re-persists — reprocessing the interval that was skipped when the global
         watermark advanced past the failure."""
         assert self._pool is not None
-        for zid in sorted(self._parked):
+        for zid in sorted(self._pool.parked_zids()):
             logger.info("Reconciler recovering parked zid=%s (M1)", zid)
             self._unpark(zid)  # clears park + invalidates cache
             self._pool.submit(zid, REBUILD, [])
@@ -405,13 +420,11 @@ class MathPollerService:
         batch on the stale cached conv would leave the failed interval missing
         forever. Dropping the cache entry forces `_run_engine` down the
         load-or-init path, which subsumes both the lost and the new votes."""
-        if zid not in self._parked:
+        if self._pool is None or not self._pool.is_parked(zid):
             return
-        self._parked.discard(zid)
         self._retry_counts.pop(zid, None)
         self._convs.pop(zid, None)  # invalidate → next touch rebuilds full history
-        if self._pool is not None:
-            self._pool.unpark(zid)
+        self._pool.unpark(zid)  # pool owns parked truth (P-022 R04)
         logger.info(
             "Un-parked zid=%s: invalidated cache; next batch rebuilds full "
             "history (M1 recovery)", zid,
@@ -455,7 +468,7 @@ class MathPollerService:
 
     # -- per-zid processing (runs on pool threads) -------------------------- #
     def _handle_zid(self, zid: int, coalesced: CoalescedBatch) -> None:
-        if zid in self._parked:
+        if self._pool is not None and self._pool.is_parked(zid):
             return
         try:
             self._run_engine(zid, coalesced)
@@ -639,13 +652,25 @@ class MathPollerService:
                 attempts,
                 error,
             )
-            self._parked.add(zid)
+            # The pool is the SINGLE owner of parked truth (P-022 R04): park
+            # here in one atomic step instead of setting a separate service-side
+            # marker first and then calling pool.park. The old two-step sequence
+            # let a reconciliation land in the gap — clearing the service marker
+            # and queueing a REBUILD that pool.park then dropped — leaving the
+            # service (unparked) and pool (parked) permanently disagreeing.
             if self._pool is not None:
                 self._pool.park(zid)
 
     def _requeue(self, zid: int, coalesced: CoalescedBatch) -> None:
         if self._pool is None:
             return
+        # Preserve ALL coalesced message kinds on retry (P-022 R03). Dropping the
+        # REBUILD flag here was the old bug: a reconciler rebuild that failed once
+        # was never re-submitted, and because the reconciler had already cleared
+        # the parked marker (`_unpark`) the zid ended up neither parked nor queued
+        # — silently lost until an unrelated restart.
+        if coalesced.rebuild:
+            self._pool.submit(zid, REBUILD, [])
         if coalesced.votes:
             self._pool.submit(zid, VOTES, list(coalesced.votes))
         if coalesced.moderation:

--- a/delphi/polismath/poller/worker_pool.py
+++ b/delphi/polismath/poller/worker_pool.py
@@ -111,6 +111,17 @@ class ConversationWorkerPool:
         with self._lock:
             return zid in self._parked
 
+    def parked_zids(self) -> Set[int]:
+        """Snapshot of currently-parked zids under the pool lock.
+
+        The pool is the SINGLE owner of parked-zid truth (P-022 R04): the
+        service reads its parked set through this method rather than keeping a
+        second set that must agree by convention. Returning a fresh copy under
+        the lock guarantees the snapshot cannot tear against a concurrent
+        park()/unpark()/submit()."""
+        with self._lock:
+            return set(self._parked)
+
     def submit(self, zid: int, message_type: str, batch: List[Any]) -> None:
         """Queue a batch for a zid; ensure exactly one worker drains it."""
         with self._lock:

--- a/delphi/tests/poller/test_error_path.py
+++ b/delphi/tests/poller/test_error_path.py
@@ -12,11 +12,44 @@ from polismath.poller.worker_pool import CoalescedBatch
 from unittest.mock import MagicMock
 
 
+class FakePool:
+    """A synchronous stand-in for ConversationWorkerPool that OWNS parked truth
+    the same way the real pool does (P-022 R04), so ``service._parked`` — now a
+    read-through view of the pool — reflects reality. It records submit/park/
+    unpark calls for assertions without spawning worker threads (these tests
+    drive ``_handle_zid`` / ``_poll_votes_once`` directly)."""
+
+    def __init__(self):
+        self._parked = set()
+        self.submitted = []
+        self.park_calls = []
+        self.unpark_calls = []
+
+    def submit(self, zid, message_type, batch):
+        if zid in self._parked:
+            return
+        self.submitted.append((zid, message_type, batch))
+
+    def park(self, zid):
+        self.park_calls.append(zid)
+        self._parked.add(zid)
+
+    def unpark(self, zid):
+        self.unpark_calls.append(zid)
+        self._parked.discard(zid)
+
+    def is_parked(self, zid):
+        return zid in self._parked
+
+    def parked_zids(self):
+        return set(self._parked)
+
+
 def _service(tmp_path, retry_cap=1):
     pg = MagicMock()
     cfg = PollerConfig(dump_dir=str(tmp_path), retry_cap=retry_cap)
     svc = MathPollerService(pg, cfg)
-    svc._pool = MagicMock()  # capture requeue / park without real threads
+    svc._pool = FakePool()  # capture requeue / park without real threads
     return svc
 
 
@@ -43,9 +76,9 @@ class TestErrorPath:
         assert "kaboom" in payload["error"]
         assert payload["batch"]["votes"] == [{"pid": "1", "tid": "1", "vote": 1}]
         # retry: batch requeued, zid NOT parked yet
-        svc._pool.submit.assert_called()
+        assert svc._pool.submitted, "the batch must be requeued on the first failure"
         assert 5 not in svc._parked
-        svc._pool.park.assert_not_called()
+        assert svc._pool.park_calls == []
 
     def test_second_failure_parks_zid(self, tmp_path, monkeypatch):
         svc = _service(tmp_path)
@@ -59,7 +92,7 @@ class TestErrorPath:
         svc._handle_zid(5, batch)  # attempt 2 -> park (exceeds retry_cap=1)
 
         assert 5 in svc._parked
-        svc._pool.park.assert_called_once_with(5)
+        assert svc._pool.park_calls == [5]
         assert len(_dumps(tmp_path, 5)) == 2  # dumped on each failure
 
     def test_parked_zid_is_skipped(self, tmp_path, monkeypatch):
@@ -112,8 +145,8 @@ class TestErrorPath:
 
         assert 5 not in svc._parked
         assert svc._retry_counts.get(5) is None
-        svc._pool.unpark.assert_called_once_with(5)
-        svc._pool.submit.assert_called_with(5, "votes", [{"zid": 5, "created": 100}])
+        assert svc._pool.unpark_calls == [5]
+        assert svc._pool.submitted[-1] == (5, "votes", [{"zid": 5, "created": 100}])
 
 
 def test_pool_unpark_reenables_dispatch():

--- a/delphi/tests/poller/test_park_rebuild_recovery.py
+++ b/delphi/tests/poller/test_park_rebuild_recovery.py
@@ -1,0 +1,316 @@
+"""P-022 §C R03/R04: park/rebuild recovery under fault and race.
+
+These drive the REAL ``MathPollerService`` and REAL ``ConversationWorkerPool``
+(threads, coalescing, retry, park) and exercise the two control-flow defects the
+P-022 recovery probes reproduced against the integration branch:
+
+* R03 (park then silence) — a reconciler REBUILD that fails transiently must be
+  retried WITH the rebuild flag preserved and eventually publish; a persistent
+  failure must leave a visible parked state with BOUNDED retries (no hot loop,
+  no silent loss).  Exercises the ``_requeue`` rebuild-preservation fix.
+
+* R04 (park/unpark races) — the pool is the SINGLE owner of parked truth, so a
+  reconciliation interleaved with parking can never leave service and pool
+  disagreeing, and overlapping rebuild triggers still run at most one handler
+  per zid with no dropped rebuild.
+
+Determinism comes from ``threading.Event`` latches at named boundaries (the
+``_load_or_init`` entry and the ``pool.park`` boundary) and from ``pool.join``
+(which blocks until the pool is idle) — never from ``sleep`` timing.
+"""
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from polismath.poller.service import MathPollerService, PollerConfig
+from polismath.poller.worker_pool import CoalescedBatch, REBUILD, VOTES, MODERATION
+
+
+class RecordingWriter:
+    """Records the zids whose updates were published (a successful rebuild)."""
+
+    def __init__(self, pg=None):
+        self.writes = []
+
+    def write_conv_updates(self, zid, conv):
+        self.writes.append(zid)
+
+
+class RecordingPool:
+    """A non-threaded pool that records submit/park/unpark and owns parked truth
+    the same way the real pool does — for the ``_requeue`` unit test."""
+
+    def __init__(self):
+        self._parked = set()
+        self.submitted = []
+
+    def submit(self, zid, message_type, batch):
+        if zid in self._parked:
+            return
+        self.submitted.append((zid, message_type, batch))
+
+    def park(self, zid):
+        self._parked.add(zid)
+
+    def unpark(self, zid):
+        self._parked.discard(zid)
+
+    def is_parked(self, zid):
+        return zid in self._parked
+
+    def parked_zids(self):
+        return set(self._parked)
+
+
+@pytest.fixture
+def make_svc():
+    """Build MathPollerServices with a REAL worker pool + recording writer.
+
+    ``_load_or_init`` is monkeypatched per test to control the rebuild outcome,
+    so the rebuild path (reconciler REBUILD -> _run_engine conv=None ->
+    _load_or_init -> write -> remember) is exercised end-to-end without a real
+    Conversation/Postgres."""
+    created = []
+
+    def _make(retry_cap=1, pool_size=1):
+        svc = MathPollerService(
+            MagicMock(),
+            PollerConfig(worker_pool_size=pool_size, retry_cap=retry_cap),
+        )
+        svc._writer = RecordingWriter()
+        svc._ensure_runtime()
+        created.append(svc)
+        return svc
+
+    yield _make
+    for s in created:
+        s._pool.shutdown()
+
+
+def _drain(svc, timeout=5.0):
+    assert svc._pool.join(timeout=timeout), "worker pool did not drain in time"
+
+
+# --------------------------------------------------------------------------- #
+# Retry-preserves-rebuild unit test (the R03 root-cause fix)
+# --------------------------------------------------------------------------- #
+class TestRequeuePreservesRebuild:
+    def test_requeue_preserves_rebuild_and_all_kinds(self):
+        svc = MathPollerService(MagicMock(), PollerConfig(retry_cap=1))
+        svc._pool = RecordingPool()
+        batch = CoalescedBatch(
+            votes=[{"pid": 1}], moderation=[{"tid": 2}], rebuild=True
+        )
+        svc._requeue(7, batch)
+        kinds = [mt for _, mt, _ in svc._pool.submitted]
+        assert REBUILD in kinds, "a retry MUST preserve the rebuild flag (R03)"
+        assert VOTES in kinds and MODERATION in kinds
+
+    def test_requeue_rebuild_only_still_resubmits_rebuild(self):
+        svc = MathPollerService(MagicMock(), PollerConfig(retry_cap=1))
+        svc._pool = RecordingPool()
+        svc._requeue(7, CoalescedBatch(rebuild=True))
+        assert svc._pool.submitted == [(7, REBUILD, [])], (
+            "a rebuild-only batch (the reconciler case) must be re-submitted, "
+            "not dropped"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# R03 — park then silence
+# --------------------------------------------------------------------------- #
+class TestR03ParkThenSilence:
+    def test_transient_rebuild_failure_eventually_publishes(self, make_svc):
+        """Exhaust retries -> parked; no new traffic; reconciler runs and the
+        first rebuild fails once, then succeeds. Require eventual publication and
+        ALL park/retry markers cleared."""
+        svc = make_svc(retry_cap=1)
+        calls = {"n": 0}
+
+        def loader(zid):
+            calls["n"] += 1
+            if calls["n"] <= 3:  # 2 to park, then 1 transient reconcile failure
+                raise RuntimeError("transient rebuild failure")
+            return object()
+
+        svc._load_or_init = loader
+
+        # Exhaust retries -> park (attempt 1 fails -> requeue REBUILD -> attempt 2
+        # fails -> park). This ALREADY depends on the rebuild-preservation fix:
+        # without it the requeue drops the rebuild and the zid never parks.
+        svc._pool.submit(1, REBUILD, [])
+        _drain(svc)
+        assert 1 in svc._parked, "the zid must be parked after exhausting retries"
+        assert svc._writer.writes == []
+
+        # Silence. The reconciler recovers: unpark + REBUILD; fail once, then win.
+        svc._reconcile_once()
+        _drain(svc)
+
+        assert svc._writer.writes == [1], "the rebuild must eventually publish"
+        assert 1 not in svc._parked and not svc._pool.is_parked(1)
+        assert svc._retry_counts.get(1) is None, "retry markers must be cleared"
+
+    def test_persistent_failure_stays_parked_with_bounded_retries(self, make_svc):
+        """Persistent failure -> visible parked/unhealthy state, BOUNDED retries
+        each cycle (no hot loop), and no silent loss (no phantom publication)."""
+        svc = make_svc(retry_cap=1)
+        calls = {"n": 0}
+
+        def loader(zid):
+            calls["n"] += 1
+            raise RuntimeError("persistent failure")
+
+        svc._load_or_init = loader
+
+        svc._pool.submit(1, REBUILD, [])
+        _drain(svc)
+        assert 1 in svc._parked
+        # retry_cap + 1 attempts before parking: strictly bounded, not a hot loop.
+        assert calls["n"] == 2
+
+        # Repeated reconcile cycles keep the zid visibly parked with the SAME
+        # bounded number of attempts each cycle — never a runaway loop, never
+        # silently dropped.
+        for cycle in range(3):
+            svc._reconcile_once()
+            _drain(svc)
+            assert 1 in svc._parked, f"still parked after reconcile cycle {cycle}"
+
+        assert svc._writer.writes == [], "a failing rebuild must never publish"
+        assert calls["n"] == 2 + 3 * 2, "each reconcile retries a bounded 2 times"
+
+
+# --------------------------------------------------------------------------- #
+# R04 — park/unpark races
+# --------------------------------------------------------------------------- #
+class TestR04ParkUnparkRaces:
+    def test_reconcile_while_worker_parks_never_diverges(self, make_svc):
+        """Barrier at the pool.park boundary: freeze the worker mid-park and fire
+        the reconciler (and a new-vote unpark). Because the pool is the sole owner
+        of parked truth, the reconciler cannot observe a half-parked zid, so
+        service and pool never disagree and no rebuild is dropped. Recovery then
+        completes quietly."""
+        svc = make_svc(retry_cap=0, pool_size=2)
+        calls = {"n": 0}
+
+        def loader(zid):
+            calls["n"] += 1
+            if calls["n"] == 1:  # only the first (parking) rebuild fails
+                raise RuntimeError("force park on active worker")
+            return object()
+
+        svc._load_or_init = loader
+
+        at_park = threading.Event()
+        release = threading.Event()
+        real_park = svc._pool.park
+
+        def hooked_park(zid):
+            at_park.set()
+            assert release.wait(timeout=5)
+            real_park(zid)
+
+        svc._pool.park = hooked_park
+
+        # Kick off the failing rebuild; the worker heads into park and freezes.
+        svc._pool.submit(1, REBUILD, [])
+        assert at_park.wait(timeout=5)
+
+        # Worker frozen AT the park boundary. Fire a reconcile + a new-vote poll.
+        # The pool is not yet parked, so both are safely no-ops here — and,
+        # crucially, service and pool agree at every instant.
+        svc._reconcile_once()
+        svc._pg.poll_votes_since.return_value = [
+            {"zid": 1, "pid": 9, "tid": 9, "vote": 1, "created": 100}
+        ]
+        svc._vote_wm = 0
+        svc._poll_votes_once()
+        assert svc._parked == svc._pool.parked_zids(), "views must never diverge"
+
+        # Let the worker finish parking.
+        release.set()
+        _drain(svc)
+        assert svc._pool.is_parked(1) and 1 in svc._parked, "consistent: both parked"
+
+        # A later reconcile recovers cleanly (loader now succeeds).
+        svc._pool.park = real_park  # remove the freeze hook
+        svc._reconcile_once()
+        _drain(svc)
+        assert not svc._pool.is_parked(1) and 1 not in svc._parked
+        assert svc._writer.writes == [1], "the rebuild is recovered, not dropped"
+
+    def test_overlapping_rebuilds_run_one_handler_per_zid(self, make_svc):
+        """Overlap two rebuild triggers for one zid while a handler is in flight
+        (multi-worker pool). Require at most ONE active handler per zid and no
+        dropped rebuild."""
+        svc = make_svc(retry_cap=1, pool_size=4)
+        entered = threading.Event()
+        proceed = threading.Event()
+        lock = threading.Lock()
+        conc = {"cur": 0, "max": 0, "n": 0}
+
+        def loader(zid):
+            with lock:
+                conc["n"] += 1
+                conc["cur"] += 1
+                conc["max"] = max(conc["max"], conc["cur"])
+            entered.set()
+            assert proceed.wait(timeout=5)
+            with lock:
+                conc["cur"] -= 1
+            return object()
+
+        svc._load_or_init = loader
+
+        svc._pool.submit(1, REBUILD, [])  # worker A enters loader and freezes
+        assert entered.wait(timeout=5)
+        svc._pool.submit(1, REBUILD, [])  # overlapping trigger: must NOT run now
+        proceed.set()
+        _drain(svc)
+
+        assert conc["max"] == 1, "at most one active handler per zid"
+        assert conc["n"] >= 1, "the rebuild ran; nothing silently dropped"
+        assert svc._writer.writes and svc._writer.writes[0] == 1
+
+    def test_reconcile_and_new_vote_unpark_converge(self, make_svc):
+        """Trigger the reconciler and a new-vote unpark concurrently on a parked
+        zid. Both funnel through the pool-owned parked state, so the outcome is a
+        single quiet recovery with service and pool in agreement."""
+        svc = make_svc(retry_cap=0, pool_size=2)
+        svc._load_or_init = lambda zid: object()  # rebuild always succeeds now
+
+        # Park zid 1 directly (pool is the owner of parked truth).
+        svc._pool.park(1)
+        assert 1 in svc._parked
+
+        svc._pg.poll_votes_since.return_value = [
+            {"zid": 1, "pid": 1, "tid": 1, "vote": 1, "created": 100}
+        ]
+        svc._vote_wm = 0
+
+        barrier = threading.Barrier(2)
+
+        def reconcile():
+            barrier.wait(timeout=5)
+            svc._reconcile_once()
+
+        def poll():
+            barrier.wait(timeout=5)
+            svc._poll_votes_once()
+
+        t1 = threading.Thread(target=reconcile)
+        t2 = threading.Thread(target=poll)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+        _drain(svc)
+
+        assert not svc._pool.is_parked(1) and 1 not in svc._parked
+        assert svc._parked == svc._pool.parked_zids()
+        assert svc._writer.writes and svc._writer.writes[-1] == 1, (
+            "the zid recovers exactly once, from authoritative history"
+        )

--- a/server/__tests__/integration/data-export-authz.test.ts
+++ b/server/__tests__/integration/data-export-authz.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Authorization tests for the data-export routes.
+ *
+ * GET /api/v3/dataExport/results signs a 7-day S3 URL for a conversation's full
+ * data dump. It used to build the object key by concatenating the caller's
+ * `filename` onto the math-env prefix and never looked at the conversation the
+ * request had resolved, so any caller holding any valid token could exchange
+ * another conversation's export filename for a signed URL to that
+ * conversation's data. It now requires ownership of the resolved conversation,
+ * and derives the key from that conversation's zinvite plus the validated
+ * pieces of the filename.
+ *
+ * GET /api/v3/dataExport is the trigger for that same export. It likewise had
+ * authentication but no owner check, so any token holder could enqueue a
+ * generate_export_data task against any conversation — choosing the
+ * `unixTimestamp` that becomes part of the resulting object's name — and have
+ * the completion email sent to their own address. It now takes the same
+ * ownership gate.
+ */
+import { beforeAll, describe, expect, test } from "@jest/globals";
+import {
+  createConversation,
+  getJwtAuthenticatedAgent,
+  newAgent,
+  setAgentJwt,
+  setupAuthAndConvo,
+  type TestUser,
+} from "../setup/api-test-helpers";
+import { getPooledTestUser } from "../setup/test-user-helpers";
+
+describe("data export authorization", () => {
+  let ownerConversationId: string;
+  let strangerConversationId: string;
+  let ownerAgent: any;
+  let strangerAgent: any;
+  let anonAgent: any;
+
+  // The export worker names dumps polis-export-<conversation_id>-<millis>.zip
+  const exportTimestamp = 1758000000000;
+  let ownerFilename: string;
+
+  beforeAll(async () => {
+    // Owner: pooled user 1, owns the conversation whose export is at stake.
+    const convo = await setupAuthAndConvo({
+      createConvo: true,
+      commentCount: 1,
+    });
+    ownerConversationId = convo.conversationId;
+    ownerFilename = `polis-export-${ownerConversationId}-${exportTimestamp}.zip`;
+
+    const { agent } = await getJwtAuthenticatedAgent(convo.testUser);
+    ownerAgent = agent;
+
+    // Stranger: pooled user 2, authenticated, with a conversation of their own
+    // so they can pass a conversation_id they legitimately own.
+    const pooled = getPooledTestUser(2);
+    const strangerUser: TestUser = {
+      email: pooled.email,
+      hname: pooled.name,
+      password: pooled.password,
+    } as TestUser;
+    const { agent: strangerJwtAgent, token: strangerToken } =
+      await getJwtAuthenticatedAgent(strangerUser);
+    strangerConversationId = await createConversation(strangerJwtAgent, {
+      topic: "Stranger's own conversation",
+      description: "Used to supply a conversation_id the stranger owns",
+    });
+    strangerAgent = await newAgent();
+    setAgentJwt(strangerAgent, strangerToken);
+
+    // Unauthenticated caller: no Authorization header at all.
+    anonAgent = await newAgent();
+  });
+
+  describe("GET /api/v3/dataExport/results", () => {
+    test("unauthenticated caller is rejected with 401", async () => {
+      const response = await anonAgent.get(
+        `/api/v3/dataExport/results?conversation_id=${ownerConversationId}&filename=${ownerFilename}`
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    test("authenticated non-owner is rejected with 403", async () => {
+      const response = await strangerAgent.get(
+        `/api/v3/dataExport/results?conversation_id=${ownerConversationId}&filename=${ownerFilename}`
+      );
+
+      expect(response.status).toBe(403);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_data_export_results_auth"
+      );
+    });
+
+    test("a filename for another conversation does not yield a signed URL", async () => {
+      // The exact pre-fix exploit: the caller passes a conversation_id they do
+      // own, so any ownership check on that parameter alone passes, and asks
+      // for a different conversation's export by name.
+      const response = await strangerAgent.get(
+        `/api/v3/dataExport/results?conversation_id=${strangerConversationId}&filename=${ownerFilename}`
+      );
+
+      expect(response.status).toBe(403);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_data_export_results_conversation"
+      );
+      expect(response.headers.location).toBeUndefined();
+    });
+
+    test("path traversal in the filename is rejected with 400", async () => {
+      const response = await ownerAgent.get(
+        `/api/v3/dataExport/results?conversation_id=${ownerConversationId}&filename=${encodeURIComponent(
+          "../../../etc/passwd"
+        )}`
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_data_export_results_filename_invalid"
+      );
+      expect(response.headers.location).toBeUndefined();
+    });
+
+    test("a traversal suffix on an otherwise valid name is rejected with 400", async () => {
+      const response = await ownerAgent.get(
+        `/api/v3/dataExport/results?conversation_id=${ownerConversationId}&filename=${encodeURIComponent(
+          `${ownerFilename}/../../prod/secrets`
+        )}`
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_data_export_results_filename_invalid"
+      );
+    });
+
+    test("a missing filename is rejected with 400 rather than signing a key", async () => {
+      const response = await ownerAgent.get(
+        `/api/v3/dataExport/results?conversation_id=${ownerConversationId}`
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_data_export_results_filename_missing"
+      );
+    });
+
+    test("the owner gets a signed URL for their own conversation's export", async () => {
+      const response = await ownerAgent
+        .get(
+          `/api/v3/dataExport/results?conversation_id=${ownerConversationId}&filename=${ownerFilename}`
+        )
+        .redirects(0);
+
+      expect(response.status).toBe(302);
+
+      const location = response.headers.location as string;
+      expect(location).toBeDefined();
+      expect(location).toContain("polis-datadump");
+      // The key is the one the export worker would have written for THIS
+      // conversation, and the URL is signed.
+      expect(location).toContain(
+        `polis-export-${ownerConversationId}-${exportTimestamp}.zip`
+      );
+      expect(location).toMatch(/Signature|X-Amz-Signature/);
+    });
+  });
+
+  describe("GET /api/v3/dataExport (export trigger)", () => {
+    const unixTimestamp = 1758000000;
+
+    test("unauthenticated caller is rejected with 401", async () => {
+      const response = await anonAgent.get(
+        `/api/v3/dataExport?conversation_id=${ownerConversationId}&unixTimestamp=${unixTimestamp}&format=csv`
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    test("authenticated non-owner is rejected with 403 and enqueues nothing", async () => {
+      // Pre-fix, this enqueued a generate_export_data task for the owner's
+      // conversation, named by a timestamp of the caller's choosing, and mailed
+      // the download link to the caller.
+      const response = await strangerAgent.get(
+        `/api/v3/dataExport?conversation_id=${ownerConversationId}&unixTimestamp=${unixTimestamp}&format=csv`
+      );
+
+      expect(response.status).toBe(403);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_data_export_auth"
+      );
+    });
+
+    test("the owner can still trigger an export of their own conversation", async () => {
+      const response = await ownerAgent.get(
+        `/api/v3/dataExport?conversation_id=${ownerConversationId}&unixTimestamp=${unixTimestamp}&format=csv`
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({});
+    });
+  });
+});

--- a/server/__tests__/integration/delphi-authz.test.ts
+++ b/server/__tests__/integration/delphi-authz.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Authorization tests for the two Delphi/topic-moderation routes that
+ * previously had no route-level authentication:
+ *
+ *   POST /api/v3/topicMod/moderate  - trusted a caller-supplied `moderator`
+ *                                     string and applied moderation to any
+ *                                     conversation named in the request.
+ *   GET  /api/v3/delphi/logs        - returned pipeline logs for any job_id.
+ *
+ * Both now require a JWT and conversation ownership, derived from the
+ * authenticated user rather than from any request field.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "@jest/globals";
+import {
+  createConversation,
+  getJwtAuthenticatedAgent,
+  newAgent,
+  setAgentJwt,
+  setupAuthAndConvo,
+  type TestUser,
+} from "../setup/api-test-helpers";
+import { getPooledTestUser } from "../setup/test-user-helpers";
+import {
+  ensureJobQueueTableExists,
+  createCompletedDelphiJob,
+  cleanupDelphiJobs,
+} from "../setup/dynamodb-test-helpers";
+
+describe("Delphi route authorization", () => {
+  let conversationId: string;
+  let commentIds: number[];
+  let ownerAgent: any;
+  let strangerAgent: any;
+  let anonAgent: any;
+  let jobId: string;
+
+  // Two batch jobs, one per owner, whose ids share the first eight characters
+  // ("batch_re") — the prefix the route used to filter CloudWatch on.
+  let strangerConversationId: string;
+  let ownerBatchJobId: string;
+  let strangerBatchJobId: string;
+  const ownerMarker = "OWNER-ONLY-SECRET-a3f91c";
+  const strangerMarker = "STRANGER-ONLY-SECRET-7d20be";
+
+  beforeAll(async () => {
+    await ensureJobQueueTableExists();
+
+    // Owner: pooled user 1 creates the conversation and its comments.
+    const convo = await setupAuthAndConvo({
+      createConvo: true,
+      commentCount: 2,
+    });
+    conversationId = convo.conversationId;
+    commentIds = convo.commentIds;
+
+    const { agent } = await getJwtAuthenticatedAgent(convo.testUser);
+    ownerAgent = agent;
+
+    // Stranger: pooled user 2, authenticated but unrelated to the conversation.
+    const pooled = getPooledTestUser(2);
+    const strangerUser: TestUser = {
+      email: pooled.email,
+      hname: pooled.name,
+      password: pooled.password,
+    } as TestUser;
+    const { agent: strangerJwtAgent, token: strangerToken } =
+      await getJwtAuthenticatedAgent(strangerUser);
+    strangerAgent = await newAgent();
+    setAgentJwt(strangerAgent, strangerToken);
+
+    // Unauthenticated caller: no Authorization header at all.
+    anonAgent = await newAgent();
+
+    // A Delphi job belonging to the owner's conversation.
+    jobId = await createCompletedDelphiJob(conversationId);
+
+    // The stranger owns a conversation of their own, so they can hold a job
+    // they are legitimately authorized for.
+    strangerConversationId = await createConversation(strangerJwtAgent, {
+      topic: "Stranger's own conversation",
+      description: "Owns a batch job sharing the prefix of the owner's job",
+    });
+
+    // Batch job ids are `batch_report_<report_id>_<ts>_<suffix>`, so every one
+    // of them starts with the same eight characters. Each row carries a
+    // distinct marker in its own log entries.
+    const stamp = Date.now();
+    ownerBatchJobId = `batch_report_${conversationId}_${stamp}_owner`;
+    strangerBatchJobId = `batch_report_${strangerConversationId}_${stamp}_str`;
+
+    await createCompletedDelphiJob(conversationId, ownerBatchJobId, [
+      `[stdout] ${ownerMarker} processing conversation ${conversationId}`,
+      "[stdout] Results stored in DynamoDB for conversation",
+    ]);
+    await createCompletedDelphiJob(strangerConversationId, strangerBatchJobId, [
+      `[stdout] ${strangerMarker} processing the stranger's conversation`,
+    ]);
+  });
+
+  afterAll(async () => {
+    if (conversationId) {
+      await cleanupDelphiJobs(conversationId);
+    }
+    if (strangerConversationId) {
+      await cleanupDelphiJobs(strangerConversationId);
+    }
+  });
+
+  describe("POST /api/v3/topicMod/moderate", () => {
+    test("unauthenticated caller is rejected with 401", async () => {
+      const response = await anonAgent.post("/api/v3/topicMod/moderate").send({
+        conversation_id: conversationId,
+        comment_ids: commentIds,
+        action: "reject",
+      });
+
+      expect(response.status).toBe(401);
+    });
+
+    test("a supplied `moderator` field does not authenticate the caller", async () => {
+      // This is the exact shape of the pre-fix exploit: no token, but a
+      // moderator identity asserted in the request body.
+      const response = await anonAgent.post("/api/v3/topicMod/moderate").send({
+        conversation_id: conversationId,
+        comment_ids: commentIds,
+        action: "reject",
+        moderator: "admin",
+      });
+
+      expect(response.status).toBe(401);
+    });
+
+    test("authenticated non-owner is rejected with 403", async () => {
+      const response = await strangerAgent
+        .post("/api/v3/topicMod/moderate")
+        .send({
+          conversation_id: conversationId,
+          comment_ids: commentIds,
+          action: "reject",
+        });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_topicMod_moderate_auth"
+      );
+    });
+
+    test("a supplied `moderator` field does not authorize a non-owner", async () => {
+      const response = await strangerAgent
+        .post("/api/v3/topicMod/moderate")
+        .send({
+          conversation_id: conversationId,
+          comment_ids: commentIds,
+          action: "reject",
+          moderator: "admin",
+        });
+
+      expect(response.status).toBe(403);
+    });
+
+    test("non-owner attempt leaves comment moderation state unchanged", async () => {
+      const response = await ownerAgent.get(
+        `/api/v3/comments?conversation_id=${conversationId}&moderation=true`
+      );
+
+      expect(response.status).toBe(200);
+      const rejected = response.body.filter(
+        (c: { tid: number; mod: number }) =>
+          commentIds.includes(c.tid) && c.mod === -1
+      );
+      expect(rejected).toHaveLength(0);
+    });
+
+    test("owner succeeds with 200 without supplying a `moderator` field", async () => {
+      const response = await ownerAgent.post("/api/v3/topicMod/moderate").send({
+        conversation_id: conversationId,
+        comment_ids: commentIds,
+        action: "reject",
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("status", "success");
+      expect(response.body).toHaveProperty("moderated_at");
+    });
+
+    test("owner's moderation actually applied to the comments", async () => {
+      const response = await ownerAgent.get(
+        `/api/v3/comments?conversation_id=${conversationId}&moderation=true`
+      );
+
+      expect(response.status).toBe(200);
+      const touched = response.body.filter((c: { tid: number }) =>
+        commentIds.includes(c.tid)
+      );
+      expect(touched.length).toBeGreaterThan(0);
+      for (const comment of touched) {
+        expect(comment.mod).toBe(-1);
+      }
+    });
+  });
+
+  describe("GET /api/v3/delphi/logs", () => {
+    test("unauthenticated caller is rejected with 401", async () => {
+      const response = await anonAgent.get(
+        `/api/v3/delphi/logs?job_id=${encodeURIComponent(jobId)}`
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    test("authenticated non-owner is rejected with 403", async () => {
+      const response = await strangerAgent.get(
+        `/api/v3/delphi/logs?job_id=${encodeURIComponent(jobId)}`
+      );
+
+      expect(response.status).toBe(403);
+      expect(response.body).toHaveProperty(
+        "message",
+        "polis_err_delphi_logs_auth"
+      );
+    });
+
+    test("owner receives the log events with 200", async () => {
+      const response = await ownerAgent.get(
+        `/api/v3/delphi/logs?job_id=${encodeURIComponent(jobId)}`
+      );
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    test("an unknown job_id is a 404, not a log read", async () => {
+      const response = await ownerAgent.get(
+        "/api/v3/delphi/logs?job_id=no-such-delphi-job-id"
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    test("a missing job_id is a 400", async () => {
+      const response = await ownerAgent.get("/api/v3/delphi/logs");
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/v3/delphi/logs is bound to the authorized job", () => {
+    // The route used to authorize one job and then return every CloudWatch
+    // event matching the first eight characters of its id. All batch job ids
+    // begin `batch_report_`, so that prefix is the constant "batch_re" and one
+    // owner's authorized request returned other owners' log lines. Logs now
+    // come from the authorized job's own Delphi_JobQueue row.
+    test("the two fixture jobs really do share the eight-character prefix", () => {
+      expect(ownerBatchJobId.slice(0, 8)).toBe("batch_re");
+      expect(strangerBatchJobId.slice(0, 8)).toBe("batch_re");
+      expect(ownerBatchJobId).not.toBe(strangerBatchJobId);
+    });
+
+    test("the owner sees only their own job's log lines", async () => {
+      const response = await ownerAgent.get(
+        `/api/v3/delphi/logs?job_id=${encodeURIComponent(ownerBatchJobId)}`
+      );
+
+      expect(response.status).toBe(200);
+      const text = JSON.stringify(response.body);
+      expect(text).toContain(ownerMarker);
+      expect(text).not.toContain(strangerMarker);
+      // Every line names the full job id, never a truncated prefix.
+      for (const event of response.body) {
+        expect(event.message).toContain(ownerBatchJobId);
+      }
+    });
+
+    test("the stranger sees only their own job's log lines", async () => {
+      const response = await strangerAgent.get(
+        `/api/v3/delphi/logs?job_id=${encodeURIComponent(strangerBatchJobId)}`
+      );
+
+      expect(response.status).toBe(200);
+      const text = JSON.stringify(response.body);
+      expect(text).toContain(strangerMarker);
+      expect(text).not.toContain(ownerMarker);
+    });
+
+    test("the completion sentinel the report client watches for survives", async () => {
+      const response = await ownerAgent.get(
+        `/api/v3/delphi/logs?job_id=${encodeURIComponent(ownerBatchJobId)}`
+      );
+
+      expect(response.status).toBe(200);
+      expect(
+        response.body.find((m: { message: string }) =>
+          m.message.includes("Results stored in DynamoDB for conversation")
+        )
+      ).toBeDefined();
+    });
+
+    test("a same-prefix job belonging to another owner is still a 403", async () => {
+      const response = await strangerAgent.get(
+        `/api/v3/delphi/logs?job_id=${encodeURIComponent(ownerBatchJobId)}`
+      );
+
+      expect(response.status).toBe(403);
+      expect(JSON.stringify(response.body)).not.toContain(ownerMarker);
+    });
+  });
+
+  describe("async handlers answer instead of escaping Express 3", () => {
+    // Express 3 invokes route callbacks without awaiting them, so a rejection
+    // inside an async handler — for example from the ownership query — would
+    // never produce a response: the request hangs and the rejection surfaces
+    // as an unhandled rejection. Each of these routes must always answer.
+    test("non-owner requests all get a real response and raise no unhandled rejection", async () => {
+      const rejections: unknown[] = [];
+      const onRejection = (reason: unknown) => rejections.push(reason);
+      process.on("unhandledRejection", onRejection);
+
+      try {
+        const responses = await Promise.all([
+          strangerAgent.get(
+            `/api/v3/delphi/logs?job_id=${encodeURIComponent(jobId)}`
+          ),
+          strangerAgent.post("/api/v3/topicMod/moderate").send({
+            conversation_id: conversationId,
+            comment_ids: commentIds,
+            action: "reject",
+          }),
+          strangerAgent.get(
+            `/api/v3/dataExport?conversation_id=${conversationId}&unixTimestamp=1758000000&format=csv`
+          ),
+          strangerAgent.get(
+            `/api/v3/dataExport/results?conversation_id=${conversationId}&filename=polis-export-${conversationId}-1758000000000.zip`
+          ),
+        ]);
+
+        for (const response of responses) {
+          expect(response.status).toBe(403);
+        }
+
+        // Give any escaped rejection a turn of the loop to be reported.
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(rejections).toHaveLength(0);
+      } finally {
+        process.off("unhandledRejection", onRejection);
+      }
+    });
+  });
+});

--- a/server/__tests__/integration/math-env-isolation.test.ts
+++ b/server/__tests__/integration/math-env-isolation.test.ts
@@ -1,0 +1,196 @@
+import Config from "../../src/config";
+import pg from "../../src/db/pg-query";
+import { getPca, prefetchLatestPcaData } from "../../src/utils/pca";
+import {
+  getBidIndexToPidMapping,
+  getPidsForGid,
+} from "../../src/utils/participants";
+import { pool, closePool } from "../setup/db-test-helpers";
+
+// Real migrated Postgres, both engines publishing for the SAME conversation.
+// The Clojure service in the test stack uses dev, leaving these fixtures alone.
+describe("math_env namespace isolation", () => {
+  const originalEnv = Config.mathEnv;
+  let zid: number;
+  let tickBase = 0;
+  let reads: jest.SpyInstance;
+
+  async function seed(env: string, tick: number, pid: number) {
+    const data = {
+      sentinel: env,
+      math_tick: tick,
+      "group-clusters": [{ id: 0, members: [0], center: [0, 0] }],
+      "base-clusters": {
+        id: [0],
+        x: [0],
+        y: [0],
+        count: [1],
+        members: [[pid]],
+      },
+    };
+    await pool.query(
+      `insert into math_main (zid, math_env, data, last_vote_timestamp, math_tick, caching_tick)
+       values ($1, $2, $3, 0, $4, $4)`,
+      [zid, env, data, tick]
+    );
+    await pool.query(
+      "insert into math_bidtopid (zid, math_env, data, math_tick) values ($1, $2, $3, $4)",
+      [zid, env, { math_tick: tick, bidToPid: [[pid]] }, tick]
+    );
+    await pool.query(
+      "insert into math_ptptstats (zid, math_env, data, math_tick) values ($1, $2, $3, $4)",
+      [zid, env, { sentinel: env }, tick]
+    );
+  }
+
+  async function setTick(env: string, tick: number) {
+    await pool.query(
+      "update math_main set math_tick = $1, caching_tick = $1 where zid = $2 and math_env = $3",
+      [tick, zid, env]
+    );
+  }
+
+  beforeEach(async () => {
+    tickBase += 10000;
+    const result = await pool.query(
+      "insert into conversations default values returning zid"
+    );
+    zid = result.rows[0].zid;
+    await seed("prod", tickBase + 10, 11);
+    await seed("python", tickBase + 1000, 22);
+    reads = jest.spyOn(pg, "queryP_readOnly"); // Calls through to real Postgres.
+  });
+
+  afterEach(async () => {
+    reads?.mockRestore();
+    Config.mathEnv = originalEnv;
+    for (const table of [
+      "math_main",
+      "math_bidtopid",
+      "math_ptptstats",
+      "conversations",
+    ]) {
+      await pool.query(`delete from ${table} where zid = $1`, [zid]);
+    }
+  });
+  afterAll(closePool);
+
+  test.each(["prod", "python"])(
+    "%s point reads, participant joins, and cached latest/tick reads",
+    async (env) => {
+      Config.mathEnv = env;
+      const tick = tickBase + (env === "prod" ? 10 : 1000);
+      const pid = env === "prod" ? 11 : 22;
+      // A point read must not pick the other engine's newer row.
+      expect(await getPca(zid, tick)).toBeUndefined();
+      const result = await getPca(zid, -1);
+      expect(result?.asPOJO.sentinel).toBe(env);
+      expect(result?.asPOJO.math_tick).toBe(tick);
+      reads.mockClear();
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe(env);
+      expect((await getPca(zid, tick - 1))?.asPOJO.sentinel).toBe(env);
+      expect(await getPca(zid, tick)).toBeUndefined();
+      expect(reads).not.toHaveBeenCalled();
+      expect((await getBidIndexToPidMapping(zid, -1)).bidToPid).toEqual([
+        [pid],
+      ]);
+      expect(await getBidIndexToPidMapping(zid, tick)).toEqual(
+        new Error("polis_err_get_pca_results_not_new")
+      );
+      expect(await getPidsForGid(zid, 0, -1)).toEqual([pid]);
+      Config.mathEnv = env === "prod" ? "python" : "prod";
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe(Config.mathEnv);
+      expect(await getPidsForGid(zid, 0, -1)).toEqual([
+        env === "prod" ? 22 : 11,
+      ]);
+      Config.mathEnv = env;
+      expect((await getPca(zid, -1))?.asPOJO.sentinel).toBe(env);
+    }
+  );
+
+  test("empty fallback cache stays in its namespace", async () => {
+    await pool.query(
+      "delete from math_main where zid = $1 and math_env = 'prod'",
+      [zid]
+    );
+    Config.mathEnv = "prod";
+    expect((await getPca(zid))?.asPOJO.math_tick).toBe(0);
+    Config.mathEnv = "python";
+    expect((await getPca(zid))?.asPOJO.sentinel).toBe("python");
+    Config.mathEnv = "prod";
+    expect((await getPca(zid))?.asPOJO.math_tick).toBe(0);
+  });
+
+  test.each(["prod", "python"])(
+    "%s prefetch cursor and cache stay scoped across batches and env switches",
+    async (env) => {
+      const otherEnv = env === "prod" ? "python" : "prod";
+      const currentTick = tickBase + 10;
+      const foreignTick = tickBase + 1000;
+      await setTick(env, currentTick);
+      await setTick(otherEnv, foreignTick);
+      Config.mathEnv = env;
+      await prefetchLatestPcaData();
+      reads.mockClear();
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe(env);
+      expect(reads).not.toHaveBeenCalled(); // Really served the prefetched cache.
+      await setTick(env, currentTick + 1);
+      await prefetchLatestPcaData();
+      expect(reads.mock.calls[0][1]).toEqual([currentTick, env]);
+      expect((await getPca(zid))?.asPOJO.math_tick).toBe(currentTick + 1);
+      Config.mathEnv = otherEnv;
+      await prefetchLatestPcaData();
+      reads.mockClear();
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe(otherEnv);
+      expect(reads).not.toHaveBeenCalled();
+      await prefetchLatestPcaData();
+      expect(reads.mock.calls[0][1]).toEqual([foreignTick, otherEnv]);
+      Config.mathEnv = env;
+      reads.mockClear();
+      await prefetchLatestPcaData();
+      expect(reads.mock.calls[0][1]).toEqual([currentTick + 1, env]);
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe(env);
+    }
+  );
+
+  test.each(["point", "prefetch"])(
+    "%s results keep their original env when config changes in flight",
+    async (path) => {
+      const query = pg.queryP_readOnly.bind(pg);
+      let release!: () => void;
+      let arrived!: () => void;
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const queried = new Promise<void>((resolve) => {
+        arrived = resolve;
+      });
+      reads.mockImplementationOnce(
+        async (...args: Parameters<typeof pg.queryP_readOnly>) => {
+          const rows = await query(...args); // Real DB result, held before delivery.
+          arrived();
+          await held;
+          return rows;
+        }
+      );
+      Config.mathEnv = "prod";
+      const pending = path === "point" ? getPca(zid) : prefetchLatestPcaData();
+      try {
+        await queried;
+        Config.mathEnv = "python";
+      } finally {
+        release();
+      }
+      await pending;
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe("python");
+      Config.mathEnv = "prod";
+      reads.mockClear();
+      expect((await getPca(zid))?.asPOJO.sentinel).toBe("prod");
+      expect(reads).not.toHaveBeenCalled();
+      if (path === "prefetch") {
+        await prefetchLatestPcaData();
+        expect(reads.mock.calls[0][1]).toEqual([tickBase + 10, "prod"]);
+      }
+    }
+  );
+});

--- a/server/__tests__/integration/topic-agenda-job-attribution.test.ts
+++ b/server/__tests__/integration/topic-agenda-job-attribution.test.ts
@@ -1,0 +1,254 @@
+import { randomUUID } from "crypto";
+import { Response } from "express";
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  getJwtAuthenticatedAgent,
+  setupAuthAndConvo,
+} from "../setup/api-test-helpers";
+import {
+  docClient,
+  ensureJobQueueTableExists,
+} from "../setup/dynamodb-test-helpers";
+import pgQuery from "../../src/db/pg-query";
+import { RequestWithP } from "../../src/d";
+import {
+  handle_POST_topicAgenda_selections,
+  handle_PUT_topicAgenda_selections,
+} from "../../src/routes/delphi/topicAgenda";
+
+// These tests use real DynamoDB Local queries and PostgreSQL writes. Fixtures
+// must use the internal zid, not the public conversation invite returned by API helpers.
+describe.each(["post", "put"] as const)(
+  "Topic agenda %s job attribution",
+  (method) => {
+    let agent: any;
+    let conversationId: string;
+    let zid: string;
+    let jobIds: string[];
+    const selections = [{ topic_id: "synthetic-topic", priority: 1 }];
+
+    beforeAll(async () => {
+      await ensureJobQueueTableExists();
+    });
+
+    beforeEach(async () => {
+      jobIds = [];
+      const setup = await setupAuthAndConvo({ createConvo: true });
+      conversationId = setup.conversationId;
+      ({ agent } = await getJwtAuthenticatedAgent(setup.testUser));
+      const rows = (await pgQuery.queryP(
+        "SELECT zid FROM zinvites WHERE zinvite = $1",
+        [conversationId]
+      )) as { zid: number }[];
+      zid = rows[0].zid.toString();
+    });
+
+    afterEach(async () => {
+      jest.restoreAllMocks();
+      for (const jobId of jobIds) {
+        await docClient.send(
+          new DeleteCommand({
+            TableName: "Delphi_JobQueue",
+            Key: { job_id: jobId },
+          })
+        );
+      }
+    });
+
+    async function createJob(status: string, order: number, padding = "") {
+      const jobId = `test-topic-agenda-${randomUUID()}`;
+      jobIds.push(jobId);
+      await docClient.send(
+        new PutCommand({
+          TableName: "Delphi_JobQueue",
+          Item: {
+            job_id: jobId,
+            conversation_id: zid,
+            status,
+            created_at: new Date(
+              Date.UTC(2025, 0, 1, 0, 0, order)
+            ).toISOString(),
+            padding,
+          },
+        })
+      );
+      return jobId;
+    }
+
+    function save(nextSelections = selections) {
+      return agent[method]("/api/v3/topicAgenda/selections").send({
+        conversation_id: conversationId,
+        selections: nextSelections,
+      });
+    }
+
+    async function expectStoredJob(
+      jobId: string | null,
+      storedSelections: unknown = selections
+    ) {
+      const response = await agent
+        .get("/api/v3/topicAgenda/selections")
+        .query({ conversation_id: conversationId });
+      expect(response.status).toBe(200);
+      expect(response.body.data.delphi_job_id).toBe(jobId);
+      expect(response.body.data.archetypal_selections).toEqual(
+        storedSelections
+      );
+    }
+
+    it("returns and stores the newest completed job", async () => {
+      await createJob("COMPLETED", 1);
+      const newest = await createJob("COMPLETED", 2);
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(newest);
+      await expectStoredJob(newest);
+    });
+
+    it("returns the older completed job without erasing it when a newer job is pending", async () => {
+      const completed = await createJob("COMPLETED", 1);
+      expect((await save()).body.data.job_id).toBe(completed);
+      await createJob("PENDING", 2);
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    // The Limit-before-Filter regression proper: no row exists beforehand, so
+    // COALESCE has nothing to restore and cannot mask a null attribution. A
+    // reintroduced `Limit: 1` reads only the newer PENDING job, filters it
+    // away and stores null, which this case must catch.
+    it("attributes the older completed job when a newer job is pending and no selections row exists", async () => {
+      const completed = await createJob("COMPLETED", 1);
+      await createJob("PENDING", 2);
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    it("continues through an empty filtered page to the newest completed job", async () => {
+      await createJob("COMPLETED", 0);
+      const completed = await createJob("COMPLETED", 1);
+      for (let i = 2; i < 29; i++) {
+        await createJob(i % 2 ? "PENDING" : "PROCESSING", i);
+      }
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    it("continues beyond DynamoDB's 1 MB page boundary", async () => {
+      const completed = await createJob("COMPLETED", 1);
+      for (let i = 2; i < 6; i++) {
+        await createJob("PENDING", i, "x".repeat(350_000));
+      }
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    it("returns and stores null for new selections when no job exists", async () => {
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBeNull();
+      await expectStoredJob(null);
+    });
+
+    it("returns null when all jobs are failed", async () => {
+      await createJob("FAILED", 1);
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBeNull();
+      await expectStoredJob(null);
+    });
+
+    it("preserves existing attribution when only a pending job remains", async () => {
+      const completed = await createJob("COMPLETED", 1);
+      expect((await save()).body.data.job_id).toBe(completed);
+      await docClient.send(
+        new DeleteCommand({
+          TableName: "Delphi_JobQueue",
+          Key: { job_id: completed },
+        })
+      );
+      await createJob("PENDING", 2);
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    it("preserves existing attribution when the index returns no jobs", async () => {
+      const completed = await createJob("COMPLETED", 1);
+      expect((await save()).body.data.job_id).toBe(completed);
+      await docClient.send(
+        new DeleteCommand({
+          TableName: "Delphi_JobQueue",
+          Key: { job_id: completed },
+        })
+      );
+      const response = await save();
+      expect(response.status).toBe(200);
+      expect(response.body.data.job_id).toBe(completed);
+      await expectStoredJob(completed);
+    });
+
+    it("still saves selections and preserves attribution if a later query page fails", async () => {
+      const completed = await createJob("COMPLETED", 1);
+      const initial = await save();
+      expect(initial.body.data.job_id).toBe(completed);
+      const changed = [{ topic_id: "changed-topic", priority: 2 }];
+      for (let i = 2; i < 29; i++) {
+        await createJob("PENDING", i);
+      }
+      // Only inject the failure; the first page still comes from DynamoDB Local.
+      const originalSend = DynamoDBDocumentClient.prototype.send;
+      let queryCount = 0;
+      jest
+        .spyOn(DynamoDBDocumentClient.prototype, "send")
+        .mockImplementation(function (
+          this: DynamoDBDocumentClient,
+          command: any
+        ): any {
+          if (command instanceof QueryCommand && ++queryCount === 2) {
+            return Promise.reject(new Error("Synthetic DynamoDB page failure"));
+          }
+          return originalSend.call(this, command);
+        });
+      // Invoke the handler in this Jest module context so the failure spy is
+      // applied; API helpers otherwise use the separate global-setup server.
+      const response = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+      const handler =
+        method === "post"
+          ? handle_POST_topicAgenda_selections
+          : handle_PUT_topicAgenda_selections;
+      await handler(
+        {
+          p: {
+            zid: Number(zid),
+            pid: Number(initial.body.data.participant_id),
+          },
+          body: { selections: changed },
+        } as RequestWithP,
+        response as unknown as Response
+      );
+      // A DynamoDB outage must degrade to "selections saved, attribution kept",
+      // never to a 500 that discards the participant's selections.
+      expect(response.status).not.toHaveBeenCalled();
+      expect(response.json).toHaveBeenCalledTimes(1);
+      expect(response.json.mock.calls[0][0].status).toBe("success");
+      expect(response.json.mock.calls[0][0].data.job_id).toBe(completed);
+      expect(queryCount).toBe(2);
+      await expectStoredJob(completed, changed);
+    });
+  }
+);

--- a/server/__tests__/setup/dynamodb-test-helpers.ts
+++ b/server/__tests__/setup/dynamodb-test-helpers.ts
@@ -113,15 +113,19 @@ export async function ensureJobQueueTableExists(): Promise<void> {
  * Creates a completed Delphi job for a conversation
  * @param conversationId The conversation ID (zid)
  * @param jobId Optional job ID (defaults to generated ID)
+ * @param logMessages Optional log lines to store on the job row, in the shape
+ *   `delphi/scripts/job_poller.py:update_job_logs` writes them
+ *   (`logs` = a JSON string `{"entries":[{timestamp, level, message}]}`).
  * @returns The created job ID
  */
 export async function createCompletedDelphiJob(
   conversationId: string,
-  jobId?: string
+  jobId?: string,
+  logMessages?: string[]
 ): Promise<string> {
   const actualJobId = jobId || `test-job-${conversationId}-${Date.now()}`;
 
-  const item = {
+  const item: Record<string, any> = {
     job_id: actualJobId,
     conversation_id: conversationId.toString(),
     status: "COMPLETED",
@@ -145,6 +149,16 @@ export async function createCompletedDelphiJob(
       created_by: "integration-test",
     },
   };
+
+  if (logMessages) {
+    item.logs = JSON.stringify({
+      entries: logMessages.map((message) => ({
+        timestamp: new Date().toISOString(),
+        level: "INFO",
+        message,
+      })),
+    });
+  }
 
   await docClient.send(
     new PutCommand({

--- a/server/app.ts
+++ b/server/app.ts
@@ -883,7 +883,12 @@ helpersInitialized.then(
 
     app.get("/api/v3/delphi", moveToBody, handle_GET_delphi);
 
-    app.get("/api/v3/delphi/logs", moveToBody, handle_GET_delphi_job_logs);
+    app.get(
+      "/api/v3/delphi/logs",
+      moveToBody,
+      hybridAuth(assignToP),
+      handle_GET_delphi_job_logs
+    );
 
     // Add POST endpoint for creating Delphi jobs
     app.post(
@@ -975,6 +980,7 @@ helpersInitialized.then(
     app.post(
       "/api/v3/topicMod/moderate",
       moveToBody,
+      hybridAuth(assignToP),
       need(
         "conversation_id",
         getConversationIdFetchZid,

--- a/server/src/routes/dataExport.ts
+++ b/server/src/routes/dataExport.ts
@@ -1,5 +1,6 @@
 import { getUserInfoForUid2 } from "../user";
-import { doAddDataExportTask } from "../utils/common";
+import { doAddDataExportTask, isModerator } from "../utils/common";
+import { getZinvite } from "../utils/zinvite";
 import Config from "../config";
 import { failJson } from "../utils/fail";
 import AWS from "aws-sdk";
@@ -8,42 +9,150 @@ import { UserInfo } from "../d";
 AWS.config.update({ region: Config.awsRegion });
 const s3Client = new AWS.S3({ apiVersion: "2006-03-01" });
 
-function handle_GET_dataExport(
+async function handle_GET_dataExport(
   req: { p: { uid?: number; zid: number; unixTimestamp: number; format: any } },
   res: { json: (arg0: {}) => void }
 ) {
-  getUserInfoForUid2(req.p.uid)
-    .then((user: UserInfo) => {
-      return doAddDataExportTask(
+  const { uid, zid } = req.p;
+
+  // Express 3 invokes route callbacks without awaiting them, so anything that
+  // throws or rejects below — including the synchronous calls — would escape
+  // the router and leave the request hanging as an unhandled rejection rather
+  // than answering. Every path out of this handler writes a response.
+  try {
+    // Enqueuing an export is work performed against someone else's conversation:
+    // it dumps that conversation's votes and comments to S3 under a filename the
+    // requester chose (`unixTimestamp` becomes part of the object name) and mails
+    // the download link to the *caller's* address. So it takes the same ownership
+    // gate as GET /api/v3/dataExport/results, which serves the result.
+    let isMod: boolean;
+    try {
+      isMod = await isModerator(zid, uid);
+    } catch (err) {
+      return failJson(res, 500, "polis_err_data_export_auth_check", err);
+    }
+    if (!isMod) {
+      return failJson(res, 403, "polis_err_data_export_auth");
+    }
+
+    let user: UserInfo;
+    try {
+      user = await getUserInfoForUid2(uid);
+    } catch (err) {
+      return failJson(res, 500, "polis_err_data_export123b", err);
+    }
+
+    try {
+      await doAddDataExportTask(
         Config.mathEnv,
         user.email!,
-        req.p.zid,
+        zid,
         req.p.unixTimestamp * 1000,
         req.p.format,
         Math.abs((Math.random() * 999999999999) >> 0)
-      )
-        .then(() => {
-          res.json({});
-        })
-        .catch((err: any) => {
-          failJson(res, 500, "polis_err_data_export123", err);
-        });
-    })
-    .catch((err: any) => {
-      failJson(res, 500, "polis_err_data_export123b", err);
-    });
+      );
+    } catch (err) {
+      return failJson(res, 500, "polis_err_data_export123", err);
+    }
+
+    res.json({});
+  } catch (err) {
+    return failJson(res, 500, "polis_err_data_export_misc", err);
+  }
 }
 
-function handle_GET_dataExport_results(
-  req: { p: { filename: string } },
+/**
+ * The export worker (math/src/polismath/darwin/core.clj, `generate-filename`)
+ * names every dump `polis-export-<conversation_id>-<epoch millis>.<zip|xlsx>`
+ * and uploads it to `polis-datadump` under `<math env>/<that name>`.
+ *
+ * So the parts of a legitimate name are: the conversation the export belongs
+ * to, a timestamp, and one of two extensions. Nothing else is ever a valid
+ * export object, which is what makes it safe to rebuild the key from the
+ * parsed pieces instead of concatenating whatever the caller sent.
+ */
+const EXPORT_FILENAME = /^polis-export-([A-Za-z0-9]+)-(\d{1,20})\.(zip|xlsx)$/;
+
+async function handle_GET_dataExport_results(
+  req: {
+    p: {
+      uid?: number;
+      zid: number;
+      conversation_id: string;
+      filename?: string;
+    };
+  },
   res: { redirect: (arg0: any) => void }
 ) {
-  const url = s3Client.getSignedUrl("getObject", {
-    Bucket: "polis-datadump",
-    Key: Config.mathEnv + "/" + req.p.filename,
-    Expires: 60 * 60 * 24 * 7,
-  });
-  res.redirect(url);
+  const { uid, zid, filename } = req.p;
+
+  // Same Express 3 error boundary as handle_GET_dataExport above: a rejection
+  // or a throw from the signer must become a response, not a hung request.
+  try {
+    // A signed URL hands out the conversation's full vote/comment dump, so it
+    // requires ownership of the conversation the request resolved, exactly as
+    // the report export routes do. `filename` is caller input and grants
+    // nothing on its own.
+    let isMod: boolean;
+    try {
+      isMod = await isModerator(zid, uid);
+    } catch (err) {
+      return failJson(
+        res,
+        500,
+        "polis_err_data_export_results_auth_check",
+        err
+      );
+    }
+    if (!isMod) {
+      return failJson(res, 403, "polis_err_data_export_results_auth");
+    }
+
+    if (!filename || typeof filename !== "string") {
+      return failJson(
+        res,
+        400,
+        "polis_err_data_export_results_filename_missing"
+      );
+    }
+
+    // Reject path separators, traversal and anything else that is not a bare
+    // export name before it can reach the key.
+    const parsed = EXPORT_FILENAME.exec(filename);
+    if (!parsed) {
+      return failJson(
+        res,
+        400,
+        "polis_err_data_export_results_filename_invalid"
+      );
+    }
+    const [, namedConversationId, timestamp, extension] = parsed;
+
+    // Bind the object to the conversation the caller was authorized for: the
+    // conversation_id in the name has to be this conversation's, resolved from
+    // the zid server-side rather than taken from the request.
+    let zinvite: string | undefined;
+    try {
+      zinvite = (await getZinvite(zid)) as string | undefined;
+    } catch (err) {
+      return failJson(res, 500, "polis_err_data_export_results_zinvite", err);
+    }
+    if (!zinvite || zinvite !== namedConversationId) {
+      return failJson(res, 403, "polis_err_data_export_results_conversation");
+    }
+
+    // Built from validated parts only; `filename` itself never reaches the key.
+    const key = `${Config.mathEnv}/polis-export-${zinvite}-${timestamp}.${extension}`;
+
+    const url = s3Client.getSignedUrl("getObject", {
+      Bucket: "polis-datadump",
+      Key: key,
+      Expires: 60 * 60 * 24 * 7,
+    });
+    res.redirect(url);
+  } catch (err) {
+    return failJson(res, 500, "polis_err_data_export_results_misc", err);
+  }
 }
 
 export { handle_GET_dataExport, handle_GET_dataExport_results };

--- a/server/src/routes/delphi.ts
+++ b/server/src/routes/delphi.ts
@@ -1,13 +1,14 @@
 import { Request, Response } from "express";
 import logger from "../utils/logger";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import {
-  CloudWatchLogsClient,
-  FilterLogEventsCommand,
-  FilteredLogEvent,
-} from "@aws-sdk/client-cloudwatch-logs";
+  DynamoDBDocumentClient,
+  GetCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { getZidFromReport } from "../utils/parameter";
+import { getZidFromConversationId } from "../conversation";
+import { isModerator } from "../utils/common";
 import Config from "../config";
 
 const dynamoDBConfig: any = {
@@ -33,10 +34,6 @@ const docClient = DynamoDBDocumentClient.from(client, {
     convertEmptyValues: true,
     removeUndefinedValues: true,
   },
-});
-
-const logsClient = new CloudWatchLogsClient({
-  region: Config.AWS_REGION || "us-east-1",
 });
 
 /**
@@ -219,64 +216,177 @@ export async function handle_GET_delphi(req: Request, res: Response) {
   }
 }
 
-const getLogs = async (
-  logGroupName: string,
-  startTime: number,
-  endTime: number,
-  filterPattern: string,
+/**
+ * One line of a Delphi job's log, in the shape this route has always returned
+ * (a CloudWatch `FilteredLogEvent` subset: epoch-millisecond `timestamp` plus
+ * `message`). The client keys log lines by `timestamp` and renders `message`.
+ */
+interface DelphiJobLogEvent {
+  timestamp?: number;
+  message?: string;
+}
+
+/**
+ * Reads the log lines belonging to exactly one Delphi job, from that job's own
+ * Delphi_JobQueue row.
+ *
+ * This route used to scrape CloudWatch with the filter pattern
+ * `"[DELPHI JOB <first 8 chars of job_id>"`, which is what
+ * `delphi/scripts/job_poller.py:update_job_logs` mirrors to the console. That
+ * prefix does not identify a job: every CREATE_NARRATIVE_BATCH job id begins
+ * `batch_report_...`, so all of them share the prefix `batch_re` (checker jobs
+ * likewise share `batch_ch`), and even random UUID prefixes can collide. Any
+ * caller who owned one such job passed the ownership check and then received
+ * every other owner's matching events from the shared log group. Authorization
+ * has to bind the data that is returned, not just the row that is looked up,
+ * so the prefix scrape is gone and is not replaced by a narrower one: there is
+ * no way to recover full job identity from prefix-only historical messages, so
+ * ambiguous events are never returned.
+ *
+ * The same `update_job_logs` writes each entry, in full and structured, to the
+ * job's own row (`logs` = `{"entries":[{timestamp, level, message}]}`, most
+ * recent 50), including every mirrored `[stdout]` line. Reading that row is
+ * exact by construction — a Dynamo `GetCommand` on the primary key — and it
+ * preserves the completion sentinel the report client watches for
+ * ("Results stored in DynamoDB for conversation", printed by
+ * `delphi/run_delphi.py` and mirrored into the entries).
+ */
+function readJobLogEvents(
+  item: Record<string, any>,
   job_id: string
-): Promise<FilteredLogEvent[]> => {
-  if (Config.awsLogGroupName === "docker") {
-    return [
-      {
-        message: `[DELPHI JOB ${job_id.slice(
-          -8
-        )}] INFO: view logs in console! - ${Date.now()}`,
-      },
-    ];
-  } else {
-    let allEvents: FilteredLogEvent[] = [];
-    let nextToken: string | undefined = undefined;
-
-    try {
-      do {
-        const command = new FilterLogEventsCommand({
-          logGroupName: logGroupName,
-          startTime: startTime,
-          endTime: endTime,
-          filterPattern: filterPattern,
-          nextToken: nextToken,
-        });
-
-        const response = await logsClient.send(command);
-
-        if (response.events) {
-          allEvents.push(...response.events);
-        }
-
-        nextToken = response.nextToken;
-      } while (nextToken);
-
-      return allEvents;
-    } catch (err) {
-      logger.error("Error fetching logs:", err);
-      throw err;
-    }
+): DelphiJobLogEvent[] {
+  const raw = item?.logs;
+  if (raw === undefined || raw === null) {
+    return [];
   }
-};
+
+  let parsed: any;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      logger.warn(`Unparseable logs on delphi job ${job_id}`, err);
+      return [];
+    }
+  } else {
+    parsed = raw;
+  }
+
+  const entries = parsed?.entries;
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  return entries.map((entry: any) => {
+    // Stored as an ISO-8601 string; the response has always carried epoch
+    // millis, so keep that and drop unparseable values rather than emitting
+    // NaN.
+    const parsedTime = Date.parse(entry?.timestamp);
+    const level = entry?.level ? `${entry.level}` : "INFO";
+    return {
+      timestamp: Number.isNaN(parsedTime) ? undefined : parsedTime,
+      // The full job id, never a truncated prefix, so a line is always
+      // attributable to the job it was authorized against.
+      message: `[DELPHI JOB ${job_id}] ${level}: ${entry?.message ?? ""}`,
+    };
+  });
+}
+
+/**
+ * Fetches one Delphi_JobQueue row by its primary key.
+ *
+ * @returns the row, or null when no such job exists.
+ */
+async function getDelphiJob(
+  job_id: string
+): Promise<Record<string, any> | null> {
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: "Delphi_JobQueue",
+      Key: { job_id },
+    })
+  );
+
+  return result.Item ?? null;
+}
+
+/**
+ * Resolves the conversation a Delphi job belongs to, as a numeric zid.
+ *
+ * Delphi_JobQueue rows store `conversation_id` as a string that is either the
+ * numeric zid (the topicAgenda/ConversationIndex convention) or the public
+ * conversation_id (zinvite) that the job was submitted with, so both are
+ * accepted here.
+ *
+ * @returns the zid, or null when it cannot be resolved.
+ */
+async function getZidForDelphiJob(
+  item: Record<string, any>,
+  job_id: string
+): Promise<number | null> {
+  const raw = item?.conversation_id;
+  if (raw === undefined || raw === null || raw === "") {
+    return null;
+  }
+
+  const asString = String(raw);
+  if (/^\d+$/.test(asString)) {
+    return Number(asString);
+  }
+
+  try {
+    const zid = await getZidFromConversationId(asString);
+    return zid === undefined || zid === null ? null : Number(zid);
+  } catch (err) {
+    logger.warn(
+      `Could not resolve conversation_id ${asString} for delphi job ${job_id}`,
+      err
+    );
+    return null;
+  }
+}
 
 export async function handle_GET_delphi_job_logs(req: Request, res: Response) {
   const job_id = req.query.job_id as string;
-  const threeHoursAgo = Date.now() - 3 * 3600 * 1000;
+  const uid = req.p?.uid as number | undefined;
+
+  // Express 3 invokes route callbacks without awaiting them, so a rejection
+  // anywhere below would escape the router and leave the request hanging as an
+  // unhandled rejection. The whole handler — lookup, authorization and log
+  // read — therefore shares one error boundary that always writes a response.
   try {
-    const logs = await getLogs(
-      Config.awsLogGroupName,
-      threeHoursAgo,
-      Date.now(),
-      `"[DELPHI JOB ${job_id.slice(0, 8)}"`,
-      job_id
-    );
-    return res.json(logs);
+    if (!job_id || typeof job_id !== "string") {
+      return res
+        .status(400)
+        .json({ status: "error", message: "job_id is required" });
+    }
+
+    // Logs may contain conversation content, so reading them requires
+    // ownership of the conversation the job was run for.
+    const item = await getDelphiJob(job_id);
+    if (item === null) {
+      return res
+        .status(404)
+        .json({ status: "error", message: "Job not found" });
+    }
+
+    const zid = await getZidForDelphiJob(item, job_id);
+    if (zid === null) {
+      return res
+        .status(404)
+        .json({ status: "error", message: "Job not found" });
+    }
+
+    const isMod = await isModerator(zid, uid);
+    if (!isMod) {
+      return res
+        .status(403)
+        .json({ status: "error", message: "polis_err_delphi_logs_auth" });
+    }
+
+    // Read from the authorized row itself, so every line returned belongs to
+    // the job that was authorized.
+    return res.json(readJobLogEvents(item, job_id));
   } catch (error) {
     logger.error(`Failed to retrieve logs for id ${job_id}`, error);
     return res

--- a/server/src/routes/delphi/topicAgenda.ts
+++ b/server/src/routes/delphi/topicAgenda.ts
@@ -1,6 +1,10 @@
 import _ from "underscore";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  QueryCommandInput,
+} from "@aws-sdk/lib-dynamodb";
 import { Response } from "express";
 
 import { RequestWithP } from "../../d";
@@ -34,13 +38,19 @@ const docClient = DynamoDBDocumentClient.from(dynamoClient, {
   },
 });
 
+// Bound the work one participant save can trigger. Without a cap the query is
+// bounded only by the conversation's partition size; with COALESCE in place,
+// bailing out early is non-destructive (it preserves any existing attribution).
+const MAX_JOB_QUERY_PAGES = 20;
+const JOB_QUERY_PAGE_SIZE = 25;
+
 /**
- * Get the current Delphi job ID for a conversation
+ * Get the newest completed Delphi job ID for a conversation.
  */
 async function getCurrentDelphiJobId(zid: string): Promise<string | null> {
   try {
     // Query the ConversationIndex GSI to find completed jobs for this conversation
-    const queryParams = {
+    const queryParams: QueryCommandInput = {
       TableName: "Delphi_JobQueue",
       IndexName: "ConversationIndex",
       KeyConditionExpression: "conversation_id = :zid",
@@ -53,19 +63,30 @@ async function getCurrentDelphiJobId(zid: string): Promise<string | null> {
         ":status": "COMPLETED",
       },
       ScanIndexForward: false, // Sort by created_at DESC
-      Limit: 1,
+      Limit: JOB_QUERY_PAGE_SIZE,
     };
 
-    const result = await docClient.send(new QueryCommand(queryParams));
-
-    if (result.Items && result.Items.length > 0) {
-      const jobId = result.Items[0].job_id;
-      return jobId;
+    // DynamoDB applies Limit before FilterExpression. An empty page may still
+    // have older completed jobs, so only stop once a match is found, the
+    // conversation's pages are exhausted (including the 1 MB page boundary),
+    // or the page cap is reached.
+    for (let page = 0; page < MAX_JOB_QUERY_PAGES; page++) {
+      const result = await docClient.send(new QueryCommand(queryParams));
+      if (result.Items?.length) {
+        return result.Items[0].job_id;
+      }
+      if (!result.LastEvaluatedKey) {
+        break;
+      }
+      queryParams.ExclusiveStartKey = result.LastEvaluatedKey;
     }
 
     return null;
   } catch (error: any) {
     logger.error("Error getting current Delphi job ID from DynamoDB", error);
+    // Degrade instead of failing the request: a null here cannot erase an
+    // existing attribution (the writes below COALESCE it), while throwing
+    // would 500 the handler and drop the participant's selections entirely.
     return null;
   }
 }
@@ -95,17 +116,18 @@ export async function handle_POST_topicAgenda_selections(
     // Get current Delphi job ID
     const jobId = await getCurrentDelphiJobId(zid.toString());
 
-    // Use UPSERT (INSERT ... ON CONFLICT UPDATE) to handle both new and existing records
+    // Preserve existing attribution when the GSI has no completed job: its
+    // eventually consistent results cannot prove the referenced job is gone.
     const query = `
       INSERT INTO topic_agenda_selections (zid, pid, archetypal_selections, delphi_job_id, total_selections, created_at, updated_at)
       VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
       ON CONFLICT (zid, pid) 
       DO UPDATE SET 
         archetypal_selections = EXCLUDED.archetypal_selections,
-        delphi_job_id = EXCLUDED.delphi_job_id,
+        delphi_job_id = COALESCE(EXCLUDED.delphi_job_id, topic_agenda_selections.delphi_job_id),
         total_selections = EXCLUDED.total_selections,
         updated_at = CURRENT_TIMESTAMP
-      RETURNING zid, pid, total_selections
+      RETURNING zid, pid, total_selections, delphi_job_id
     `;
 
     const result = await pgQuery.queryP(query, [
@@ -124,7 +146,7 @@ export async function handle_POST_topicAgenda_selections(
         participant_id: pid.toString(),
         selections_count:
           (result as any)[0]?.total_selections || selections.length,
-        job_id: jobId,
+        job_id: (result as any)[0]?.delphi_job_id ?? null,
       },
     };
 
@@ -242,16 +264,17 @@ export async function handle_PUT_topicAgenda_selections(
     // Get current Delphi job ID
     const jobId = await getCurrentDelphiJobId(zid.toString());
 
-    // Update the record
+    // An empty, eventually consistent GSI lookup cannot prove an existing
+    // attribution is absent/terminal. Preserve it unless a completed job replaces it.
     const updateQuery = `
       UPDATE topic_agenda_selections 
       SET 
         archetypal_selections = $3,
-        delphi_job_id = $4,
+        delphi_job_id = COALESCE($4, delphi_job_id),
         total_selections = $5,
         updated_at = CURRENT_TIMESTAMP
       WHERE zid = $1 AND pid = $2
-      RETURNING zid, pid, total_selections
+      RETURNING zid, pid, total_selections, delphi_job_id
     `;
 
     const result = await pgQuery.queryP(updateQuery, [
@@ -299,7 +322,7 @@ export async function handle_PUT_topicAgenda_selections(
           conversation_id: zid.toString(),
           participant_id: pid.toString(),
           selections_count: rows[0]?.total_selections || selections.length,
-          job_id: jobId,
+          job_id: rows[0].delphi_job_id,
         },
       });
     }

--- a/server/src/routes/delphi/topicMod.ts
+++ b/server/src/routes/delphi/topicMod.ts
@@ -10,6 +10,8 @@ import {
 import Config from "../../config";
 import p from "../../db/pg-query";
 import { getClusterAssignmentsSimple } from "../../utils/commentClusters";
+import { isModerator } from "../../utils/common";
+import { failJson } from "../../utils/fail";
 
 // DynamoDB configuration (reuse from topics.ts)
 const dynamoDBConfig: DynamoDBClientConfig = {
@@ -258,12 +260,14 @@ export async function handle_POST_topicMod_moderate(
   res: Response
 ) {
   try {
-    const { topic_key, comment_ids, action, moderator } = req.body;
+    // Note: any `moderator` field in the request body is deliberately ignored.
+    // The acting moderator is derived from the authenticated user only.
+    const { topic_key, comment_ids, action } = req.body;
 
-    if (!action || !moderator) {
+    if (!action) {
       return res.json({
         status: "error",
-        message: "action and moderator are required",
+        message: "action is required",
       });
     }
 
@@ -275,6 +279,15 @@ export async function handle_POST_topicMod_moderate(
     }
 
     const zid = req.p.zid as number;
+    const uid = req.p.uid as number | undefined;
+
+    // Only a conversation owner/site moderator may moderate this conversation.
+    const isMod = await isModerator(zid, uid);
+    if (!isMod) {
+      return failJson(res, 403, "polis_err_topicMod_moderate_auth");
+    }
+
+    const moderator = String(uid);
     const moderate_conversation_id = zid.toString();
     const now = new Date().toISOString();
 

--- a/server/src/routes/math.ts
+++ b/server/src/routes/math.ts
@@ -26,8 +26,8 @@ function handle_GET_math_pca(
 
 // Cache the knowledge of whether there are any pca results for a given zid.
 // Needed to determine whether to return a 404 or a 304.
-// zid -> boolean
-const pcaResultsExistForZid: Record<number, boolean> = {};
+// [math_env, zid] -> boolean
+const pcaResultsExistForZid: Record<string, boolean> = {};
 
 function handle_GET_math_pca2(
   req: {
@@ -54,6 +54,7 @@ function handle_GET_math_pca2(
   }
 ) {
   const zid = req.p.zid;
+  const cacheKey = JSON.stringify([Config.mathEnv, zid]);
   let math_tick = req.p.math_tick;
   const keys = req.p.keys;
 
@@ -84,7 +85,7 @@ function handle_GET_math_pca2(
   }
 
   function finishWith304or404() {
-    if (pcaResultsExistForZid[zid]) {
+    if (pcaResultsExistForZid[cacheKey]) {
       res.status(304).end();
     } else {
       // Technically, this should probably be a 404, but
@@ -122,12 +123,12 @@ function handle_GET_math_pca2(
         res.send(data.asBufferOfGzippedJson);
       } else {
         // check whether we should return a 304 or a 404
-        if (pcaResultsExistForZid[zid] === undefined) {
+        if (pcaResultsExistForZid[cacheKey] === undefined) {
           // This server doesn't know yet if there are any PCA results in the DB
           // So try querying from -1
           return getPca(zid, -1).then(function (data: any) {
             const exists = !!data;
-            pcaResultsExistForZid[zid] = exists;
+            pcaResultsExistForZid[cacheKey] = exists;
             finishWith304or404();
           });
         } else {

--- a/server/src/utils/pca.ts
+++ b/server/src/utils/pca.ts
@@ -73,77 +73,76 @@ export type PcaCacheItem = {
 };
 
 const pcaCacheSize = Config.cacheMathResults ? 300 : 1;
-const pcaCache = new LruCache<number, PcaCacheItem>({
+const pcaCache = new LruCache<string, PcaCacheItem>({
   max: pcaCacheSize,
 });
 
-// this scheme might not last forever. For now, there are only a couple of MB worth of conversation pca data.
-let lastPrefetchedMathTick = -1;
+// Each namespace has an independent publication cursor and cache entries.
+const lastPrefetchedMathTicks = new Map<string, number>();
+
+function pcaCacheKey(mathEnv: string, zid: number): string {
+  return JSON.stringify([mathEnv, zid]);
+}
+
+// One batch, shared by the background loop and integration tests. Capture the
+// namespace before any async work so a config change cannot relabel its results.
+export async function prefetchLatestPcaData(): Promise<void> {
+  const mathEnv = Config.mathEnv;
+  let lastPrefetchedMathTick = lastPrefetchedMathTicks.get(mathEnv) ?? -1;
+  const rows = await pg.queryP_readOnly<
+    Array<{ data: any; math_tick: any; caching_tick: any; zid: number }>
+  >(
+    "select * from math_main where caching_tick > ($1) and math_env = ($2) order by caching_tick limit 10;",
+    [lastPrefetchedMathTick, mathEnv]
+  );
+
+  await Promise.all(
+    (
+      rows as Array<{
+        data: any;
+        math_tick: any;
+        caching_tick: any;
+        zid: number;
+      }>
+    ).map((row) => {
+      const item = row.data;
+      if (row.math_tick) {
+        item.math_tick = Number(row.math_tick);
+      }
+      if (row.caching_tick) {
+        item.caching_tick = Number(row.caching_tick);
+      }
+      logger.info("mathpoll updating", {
+        caching_tick: item.caching_tick,
+        zid: row.zid,
+      });
+      lastPrefetchedMathTick = Math.max(
+        lastPrefetchedMathTick,
+        Number(row.caching_tick)
+      );
+      processMathObject(item);
+      return updatePcaCache(mathEnv, row.zid, item);
+    })
+  );
+  lastPrefetchedMathTicks.set(
+    mathEnv,
+    Math.max(lastPrefetchedMathTicks.get(mathEnv) ?? -1, lastPrefetchedMathTick)
+  );
+}
 
 // Background polling function to proactively cache PCA data
 export function fetchAndCacheLatestPcaData() {
-  let lastPrefetchPollStartTime = Date.now();
-
-  function waitTime() {
-    const timePassed = Date.now() - lastPrefetchPollStartTime;
-    return Math.max(0, 2500 - timePassed);
-  }
-
-  function pollForLatestPcaData() {
-    lastPrefetchPollStartTime = Date.now();
-
-    pg.queryP_readOnly<
-      Array<{ data: any; math_tick: any; caching_tick: any; zid: number }>
-    >(
-      "select * from math_main where caching_tick > ($1) order by caching_tick limit 10;",
-      [lastPrefetchedMathTick]
-    )
-      .then((rows) => {
-        const rowsArray = rows as Array<{
-          data: any;
-          math_tick: any;
-          caching_tick: any;
-          zid: number;
-        }>;
-
-        if (!rowsArray || !rowsArray.length) {
-          // call again
-          setTimeout(pollForLatestPcaData, waitTime());
-          return;
-        }
-
-        const results = rowsArray.map((row) => {
-          const item = row.data;
-
-          if (row.math_tick) {
-            item.math_tick = Number(row.math_tick);
-          }
-          if (row.caching_tick) {
-            item.caching_tick = Number(row.caching_tick);
-          }
-
-          logger.info("mathpoll updating", {
-            caching_tick: item.caching_tick,
-            zid: row.zid,
-          });
-
-          if (item.caching_tick > lastPrefetchedMathTick) {
-            lastPrefetchedMathTick = item.caching_tick;
-          }
-
-          processMathObject(item);
-
-          return updatePcaCache(row.zid, item);
-        });
-
-        Promise.all(results).then(() => {
-          setTimeout(pollForLatestPcaData, waitTime());
-        });
-      })
-      .catch((err) => {
-        logger.error("mathpoll error", err);
-        setTimeout(pollForLatestPcaData, waitTime());
-      });
+  async function pollForLatestPcaData() {
+    const pollStart = Date.now();
+    try {
+      await prefetchLatestPcaData();
+    } catch (err) {
+      logger.error("mathpoll error", err);
+    }
+    setTimeout(
+      pollForLatestPcaData,
+      Math.max(0, 2500 - (Date.now() - pollStart))
+    );
   }
 
   // Start the polling process
@@ -321,7 +320,8 @@ export function getPca(
   zid?: number,
   math_tick?: number
 ): Promise<PcaCacheItem | undefined> {
-  let cached = pcaCache.get(zid);
+  const mathEnv = Config.mathEnv;
+  let cached = pcaCache.get(pcaCacheKey(mathEnv, zid));
   if (cached && cached.expiration < Date.now()) {
     cached = undefined;
   }
@@ -358,7 +358,7 @@ export function getPca(
   return pg
     .queryP_readOnly<Array<{ data: any; math_tick: any }>>(
       "select * from math_main where zid = ($1) and math_env = ($2);",
-      [zid, Config.mathEnv]
+      [zid, mathEnv]
     )
     .then((rows) => {
       const queryEnd = Date.now();
@@ -374,7 +374,7 @@ export function getPca(
           {
             zid,
             math_tick,
-            math_env: Config.mathEnv,
+            math_env: mathEnv,
           }
         );
 
@@ -387,7 +387,7 @@ export function getPca(
           );
           return ensureCompletePcaStructure(zid).then((completeData) => {
             const dataWithZid = { ...completeData, zid: zid };
-            return updatePcaCache(zid, dataWithZid);
+            return updatePcaCache(mathEnv, zid, dataWithZid);
           });
         }
 
@@ -416,12 +416,13 @@ export function getPca(
       // Ensure all required fields exist by merging with empty structure if needed
       return ensureCompletePcaStructure(zid, item).then((completeData) => {
         const dataWithZid = { ...completeData, zid: zid };
-        return updatePcaCache(zid, dataWithZid);
+        return updatePcaCache(mathEnv, zid, dataWithZid);
       });
     });
 }
 
 function updatePcaCache(
+  mathEnv: string,
   zid: number,
   item: { zid: number }
 ): Promise<PcaCacheItem> {
@@ -448,7 +449,7 @@ function updatePcaCache(
           repness: (item as any).repness || {},
         } as unknown as PcaCacheItem;
         // save in LRU cache, but don't update the lastPrefetchedMathTick
-        pcaCache.set(zid, o);
+        pcaCache.set(pcaCacheKey(mathEnv, zid), o);
         resolve(o);
       }
     );


### PR DESCRIPTION
# PROD DEPLOY 09/09/2026 — edge → stable

Previous stable tip: PROD DEPLOY 09/08/2026 (#2685). Five commits.

## What this carries
- **#2706 — four authorization fixes** (server): `POST /api/v3/topicMod/moderate` (was: no auth, trusted a caller-supplied moderator; anyone with a public conversation id could moderate comments), `GET /api/v3/delphi/logs` (was: unauthenticated; now reads the authorized job's own queue-row logs, CloudWatch prefix scraping removed), `GET /api/v3/dataExport/results` (was: signed a 7-day S3 URL from a caller-supplied filename; any token + another conversation's predictable filename → its full export), `GET /api/v3/dataExport` (trigger: owner check). Client-admin and client-report callers updated to send bearer tokens. 330 server tests.
- **#2707 — topic-agenda job lookup**: DynamoDB `Limit` before `Filter` read one arbitrary row, reported "no job", and erased `delphi_job_id` on every selection while a job was pending. 322 tests.
- **#2703 — math result reads scoped by `math_env`** (prefetch, caches, routes). Required before any shadow run of the Python engine. 302 tests.
- **#2700 — poller park/rebuild ownership** (Python poller; not started in prod, no runtime effect).
- **#2699 — ARM docker-compose boot fix** (CDK launch templates; already applied to the live stack on 09/08 from the branch; this makes `stable` match).

**No CDK deploy needed** for this promotion (#2699 is already live). Deploy = `deploy-alpha-aws.yml` on `stable` (image build + CodeDeploy), which needs the two `production` environment approvals.

## Rollback
Revert PR against `stable` (`git revert -m 1 <merge-sha>`), redeploy. See the "revert the revert" note in #2685 before the next deploy after a rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s