### PR TITLE
cost(cdk): Delphi small pool min/desired 2→1

### DIFF
--- a/cdk/autoscaling.ts
+++ b/cdk/autoscaling.ts
@@ -71,8 +71,15 @@ export default (
   const asgDelphiSmall = new autoscaling.AutoScalingGroup(self, 'AsgDelphiSmall', {
     vpc,
     launchTemplate: delphiSmallLaunchTemplate,
-    minCapacity: 2,
-    desiredCapacity: 2,
+    // Halved 2026-09 (2 -> 1). 14 days of CloudWatch on this ASG show a 0.625% mean hourly CPU
+    // (max hourly average 1.082%), and the Delphi_JobQueue has had zero jobs created since
+    // 2026-08-01; lifetime demanded compute is 74 hours in 12.9 months. The second instance is not
+    // redundancy: delphi/scripts/job_poller.py is a single-threaded claimant behind a DynamoDB
+    // lease, so a second poller adds a competing claimant, not throughput. maxCapacity stays at 7
+    // so the CPU target-tracking policy below can still scale out under real load.
+    // Revert by setting both back to 2 and running cdk deploy.
+    minCapacity: 1,
+    desiredCapacity: 1,
     maxCapacity: 7,
     vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
     healthCheck: autoscaling.HealthCheck.ec2({ grace: cdk.Duration.minutes(5) }),


### PR DESCRIPTION
Cost: ~$265/mo. The Delphi small pool (c7i.2xlarge) has run two instances since 2025-10-21 at a 14-day CPU mean of 0.6%, with zero jobs created since 2026-08-01 (measured from CloudWatch and the job-queue table, read-only). This sets `minCapacity`/`desiredCapacity` to 1 and keeps `maxCapacity` 7 so the existing CPU target-tracking policy can still scale out.

Verified with `cdk diff` against the deployed stack: the only change is `DesiredCapacity 2→1, MinSize 2→1` on the Delphi small ASG. No instance refresh or replacement is triggered (no rolling UpdatePolicy; launch-template version unchanged); the ASG simply retires one instance on the next `cdk deploy`. CodeDeploy's `OneAtATime` config has no floor of two, and delphi-large has run at 0 since 2026-07-31 without affecting deploys.

Revert: set both back to 2 and deploy. Note a revert boots launch-template v25, which has not booted since 2025-10-21.

Follow-up: full scale-to-zero design (P-003) is in review; this takes half the saving with none of its cold-boot risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s