### PR TITLE
ci: certification battery + recovery matrix on a disposable EC2 box (P-022-E v1)

### DIFF
--- a/.github/workflows/certification-ec2.yml
+++ b/.github/workflows/certification-ec2.yml
@@ -58,7 +58,14 @@ concurrency:
 jobs:
   synthetic:
     name: Synthetic recovery matrix and public-fixture battery
-    if: github.event_name != 'schedule' || github.ref == 'refs/heads/edge'
+    # The environment subject does NOT by itself exclude pull-request jobs: a
+    # job that references an environment gets the environment subject even on a
+    # PR, and GitHub silently creates a referenced-but-missing environment with
+    # NO protection rules. So the ref is checked here as well, on every event.
+    # This is defence in depth, not the control: the `certification-synthetic`
+    # environment must be configured with edge as its only deployment branch
+    # and a required reviewer (docs/ci-ec2.md).
+    if: github.ref == 'refs/heads/edge' || github.ref == 'refs/heads/stable'
     runs-on: ubuntu-24.04
     # Must stay below the role's 6 h max session duration, with room for the
     # teardown. Round 1 allowed 420 minutes against a 360-minute session, so a
@@ -102,11 +109,17 @@ jobs:
             echo "CERTIFY_LAUNCH_TEMPLATE_ID is unset; deploy the CDK construct first (docs/ci-ec2.md)" >&2
             exit 1
           fi
+          # Recorded BEFORE the call, so a lost acknowledgement is still known
+          # to have been a launch attempt. The teardown treats "attempted but
+          # never resolved" as unresolved ownership, not as absence.
+          echo "LAUNCH_ATTEMPTED=1" >> "$GITHUB_ENV"
           # Deterministic client token: a retried step after a lost response
           # returns the SAME instance instead of launching a second one.
           TOKEN="polis-certify-${RUN_TAG}"
           TAGS="ResourceType=instance,Tags=[{Key=polis:ci,Value=disposable},{Key=polis:ci-ref,Value=$TARGET_REF},{Key=polis:ci-run,Value=$RUN_TAG}]"
-          VOLTAGS="ResourceType=volume,Tags=[{Key=polis:ci,Value=disposable}]"
+          # The run tag goes on the volume as well as the instance: an orphan
+          # volume with no owner is as hard to reconcile as an orphan instance.
+          VOLTAGS="ResourceType=volume,Tags=[{Key=polis:ci,Value=disposable},{Key=polis:ci-run,Value=$RUN_TAG}]"
           # Version=1 is pinned here; note that this is a caller choice, not an
           # IAM restriction -- the role could select another version of the same
           # template if one ever existed. Only the CDK deploy creates versions.
@@ -238,15 +251,27 @@ jobs:
           tar -xzf artifacts.tar.gz -C artifacts
           ls -la artifacts
 
-      - name: Validate the summary schema
+      - name: Validate the summary against the declared scope
         if: ${{ always() && env.INSTANCE_ID != '' }}
+        env:
+          RUN_BATTERY: ${{ inputs.run_battery == false && 'false' || 'true' }}
         run: |
           set -euo pipefail
           if [ ! -f artifacts/summary.json ]; then
             echo "::error::no summary.json returned"
             exit 1
           fi
-          python3 ci/p022_check_summary.py artifacts/summary.json
+          # The validator is given the run's DECLARED scope, so a battery that
+          # silently shrank from six cases to one, or an absent battery result
+          # claiming to be an intentional skip, is rejected. It is a coherence
+          # and inventory check, not proof of execution -- the worker produces
+          # every field it inspects.
+          python3 ci/p022_check_summary.py artifacts/summary.json \
+            --run-battery "${RUN_BATTERY}" \
+            --expected-battery-cases 6 \
+            --expected-datasets biodiversity,vw \
+            --expected-main-reports 1 \
+            --expected-race-reports 20
 
       - name: Upload artifacts
         if: ${{ always() }}
@@ -261,6 +286,36 @@ jobs:
       # Re-assume first: a long run's launch-session credentials may be minutes
       # from expiry by now, and the one step that must not fail for lack of
       # credentials is this one.
+      # Round 2 re-assumed the BASE role here, which reaches every instance
+      # sharing the CI tag — the narrowing was real for the main path and absent
+      # for the one step that terminates things (review R2-F5). Now the teardown
+      # session carries a policy too: pinned to this instance when its ID is
+      # known, and only widened to the tag-bounded pattern for the lost-ID
+      # sweep, which cannot name an ARN by definition.
+      - name: Build the teardown session policy
+        id: teardown_scope
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INSTANCE_ID:-}" ]; then
+            # The account field is a wildcard because sts:GetCallerIdentity
+            # needs credentials that may already have expired by this point;
+            # the role's own policy pins the account and region regardless.
+            TARGET="arn:aws:ec2:${AWS_REGION}:*:instance/${INSTANCE_ID}"
+          else
+            TARGET="arn:aws:ec2:${AWS_REGION}:*:instance/*"
+          fi
+          jq -nc --arg arn "$TARGET" '{
+            Version: "2012-10-17",
+            Statement: [
+              {Sid: "ObserveInstances", Effect: "Allow",
+               Action: ["ec2:DescribeInstances", "ec2:DescribeInstanceStatus"], Resource: "*"},
+              {Sid: "TerminateTeardownTarget", Effect: "Allow",
+               Action: "ec2:TerminateInstances", Resource: $arn}
+            ]}' > teardown-policy.json
+          echo "policy=$(cat teardown-policy.json)" >> "$GITHUB_OUTPUT"
+          echo "teardown scoped to $TARGET"
+
       - name: Refresh credentials for teardown
         if: ${{ always() }}
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
@@ -269,10 +324,12 @@ jobs:
           aws-region: ${{ vars.CERTIFY_REGION || 'us-east-1' }}
           role-session-name: certify-teardown-${{ github.run_id }}-${{ github.run_attempt }}
           role-duration-seconds: 3600
+          inline-session-policy: ${{ steps.teardown_scope.outputs.policy }}
 
       - name: Terminate the worker and confirm
         if: ${{ always() }}
         run: |
           python3 ci/p022_teardown.py \
             --run-tag "$RUN_TAG" \
+            --launch-attempted "${LAUNCH_ATTEMPTED:-0}" \
             --instance-id "${INSTANCE_ID:-}"

--- a/.github/workflows/certification-ec2.yml
+++ b/.github/workflows/certification-ec2.yml
@@ -1,0 +1,236 @@
+name: Certification (EC2)
+
+# P-022 §E v1 "minimal". Runs the recovery matrix and the Delphi certification
+# battery on ONE disposable EC2 worker, then destroys it.
+#
+# Nothing here works until the CDK construct behind `-c enableCiEc2=true` has
+# been deployed once and CERTIFY_OIDC_ROLE_ARN / CERTIFY_LAUNCH_TEMPLATE_ID are
+# set. See docs/ci-ec2.md.
+#
+# The worker is NOT a self-hosted runner: it is never registered with GitHub,
+# it has no inbound network path, and it is only reachable through SSM from
+# this job's short-lived OIDC credentials.
+
+on:
+  workflow_dispatch:
+    inputs:
+      instance_type:
+        description: EC2 instance type for the worker (must be arm64/Graviton)
+        required: false
+        default: r8g.4xlarge
+        type: string
+      ref:
+        description: "Git ref to test on the worker (default: this workflow's ref)"
+        required: false
+        default: ''
+        type: string
+      run_battery:
+        description: Run the certification battery as well as the recovery matrix
+        required: false
+        default: true
+        type: boolean
+  schedule:
+    # Nightly. `schedule` always runs the DEFAULT branch's copy of this file,
+    # so the job below refuses to proceed unless that resolved to edge.
+    - cron: '41 5 * * *'
+
+permissions: {}
+
+# One certification campaign at a time, and never cancel a running one: a
+# cancelled job cannot terminate its instance, and GitHub concurrency does not
+# fence an orphaned EC2 box.
+concurrency:
+  group: certification-ec2
+  cancel-in-progress: false
+
+jobs:
+  certify:
+    name: Certification battery and recovery matrix
+    if: github.event_name != 'schedule' || github.ref == 'refs/heads/edge'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 420
+    environment: certification-private
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_REGION: ${{ vars.CERTIFY_REGION || 'us-east-1' }}
+      POLIS_CI_TAG_KEY: 'polis:ci'
+      POLIS_CI_TAG_VALUE: disposable
+      TARGET_REF: ${{ inputs.ref || github.ref_name }}
+      INSTANCE_TYPE: ${{ inputs.instance_type || 'r8g.4xlarge' }}
+
+    steps:
+      - name: Check out the trusted control code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ vars.CERTIFY_OIDC_ROLE_ARN }}
+          aws-region: ${{ vars.CERTIFY_REGION || 'us-east-1' }}
+          role-session-name: certify-${{ github.run_id }}-${{ github.run_attempt }}
+          # The campaign budget is six hours and this action does not refresh;
+          # a one-hour session would expire mid-poll and orphan the worker.
+          role-duration-seconds: 21600
+
+      - name: Launch the disposable worker
+        id: launch
+        env:
+          LAUNCH_TEMPLATE_ID: ${{ vars.CERTIFY_LAUNCH_TEMPLATE_ID }}
+        run: |
+          set -euo pipefail
+          test -n "$LAUNCH_TEMPLATE_ID" || {
+            echo "CERTIFY_LAUNCH_TEMPLATE_ID is unset; deploy the CDK construct first (docs/ci-ec2.md)" >&2
+            exit 1
+          }
+          # Deterministic client token: a retried step after a lost response
+          # returns the SAME instance instead of launching a second one.
+          TOKEN="polis-certify-${{ github.run_id }}-${{ github.run_attempt }}"
+          # Version=1 is pinned; the OIDC role cannot create another version.
+          TAGS="ResourceType=instance,Tags=[{Key=$POLIS_CI_TAG_KEY,Value=$POLIS_CI_TAG_VALUE},{Key=polis:ci-ref,Value=$TARGET_REF},{Key=polis:ci-run,Value=${{ github.run_id }}-${{ github.run_attempt }}}]"
+          VOLTAGS="ResourceType=volume,Tags=[{Key=$POLIS_CI_TAG_KEY,Value=$POLIS_CI_TAG_VALUE}]"
+          INSTANCE_ID=$(aws ec2 run-instances \
+            --launch-template "LaunchTemplateId=${LAUNCH_TEMPLATE_ID},Version=1" \
+            --instance-type "$INSTANCE_TYPE" \
+            --min-count 1 --max-count 1 \
+            --client-token "$TOKEN" \
+            --tag-specifications "$TAGS" "$VOLTAGS" \
+            --query 'Instances[0].InstanceId' --output text)
+          echo "INSTANCE_ID=$INSTANCE_ID" >> "$GITHUB_ENV"
+          echo "instance_id=$INSTANCE_ID" >> "$GITHUB_OUTPUT"
+          echo "Launched $INSTANCE_ID ($INSTANCE_TYPE) for ref $TARGET_REF"
+
+      - name: Wait for SSM registration and bootstrap
+        run: |
+          set -euo pipefail
+          online=None
+          for _ in $(seq 1 60); do
+            online=$(aws ssm describe-instance-information \
+              --filters "Key=InstanceIds,Values=$INSTANCE_ID" \
+              --query 'InstanceInformationList[0].PingStatus' --output text 2>/dev/null || echo None)
+            if [ "$online" = "Online" ]; then break; fi
+            sleep 20
+          done
+          [ "${online:-None}" = "Online" ] || { echo "worker never registered with SSM" >&2; exit 1; }
+          # user-data writes the ready marker last, after docker/compose and the
+          # clone at the requested ref; the failed marker short-circuits.
+          POLIS_SSM_TIMEOUT=1800 bash ci/p022_ssm.sh bootstrap-wait '
+            for i in $(seq 1 120); do
+              [ -f /var/lib/polis-ci-failed ] && { echo "bootstrap failed"; tail -n 60 /var/log/polis-ci-userdata.log; exit 1; }
+              [ -f /var/lib/polis-ci-ready ] && { echo "ready sha=$(cat /var/lib/polis-ci-sha)"; exit 0; }
+              sleep 15
+            done
+            echo "bootstrap timed out"; tail -n 60 /var/log/polis-ci-userdata.log; exit 1'
+
+      - name: Recovery matrix (make test-recovery, make test-recovery-races)
+        run: |
+          set -euo pipefail
+          POLIS_SSM_TIMEOUT=7200 bash ci/p022_ssm.sh recovery \
+            'sudo env POLIS_CI_REPO_ROOT=/opt/polis bash /opt/polis/ci/p022_ec2_run.sh recovery'
+
+      - name: Certification battery
+        if: ${{ inputs.run_battery != false }}
+        env:
+          FIXTURE_S3: ${{ secrets.CERTIFY_FIXTURE_S3_URI }}
+          EVIDENCE_S3: ${{ vars.CERTIFY_EVIDENCE_S3_URI }}
+        run: |
+          set -euo pipefail
+          # The bundle is private prod-derived data and is NOT in the repo. The
+          # WORKER fetches it with its own instance role; this runner never gets
+          # read access. Unset => the worker skips those cases and still runs
+          # the public fixtures.
+          if [ -z "$FIXTURE_S3" ]; then
+            echo "::notice::CERTIFY_FIXTURE_S3_URI is unset; private battery cases will be skipped"
+          fi
+          # These two are spliced into the remote command string. Reject
+          # anything that is not a plain s3:// URI rather than trusting the
+          # value's quoting to hold.
+          for u in "$FIXTURE_S3" "$EVIDENCE_S3"; do
+            case "$u" in
+              ''|s3://[A-Za-z0-9]*) : ;;
+              *) echo "::error::not a plain s3:// URI: $u"; exit 1 ;;
+            esac
+            case "$u" in
+              *[!A-Za-z0-9:/._-]*) echo "::error::unsafe character in S3 URI"; exit 1 ;;
+            esac
+          done
+          POLIS_SSM_TIMEOUT=21600 bash ci/p022_ssm.sh battery \
+            "sudo env POLIS_CI_REPO_ROOT=/opt/polis POLIS_CI_FIXTURE_S3='${FIXTURE_S3}' POLIS_CI_EVIDENCE_S3='${EVIDENCE_S3}' POLIS_CI_RUN='${{ github.run_id }}-${{ github.run_attempt }}' bash /opt/polis/ci/p022_ec2_run.sh battery"
+
+      - name: Collect logs and JUnit
+        if: ${{ always() && env.INSTANCE_ID != '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          # SSM caps command output at 24000 characters, so the artifact tarball
+          # comes back base64 in bounded chunks. Only public-safe files are in
+          # it (see ci/p022_ec2_run.sh); raw battery output goes to the private
+          # evidence bucket, never here.
+          POLIS_SSM_TIMEOUT=900 bash ci/p022_ssm.sh bundle \
+            'sudo bash /opt/polis/ci/p022_ec2_run.sh bundle' | tee bundle.txt || true
+          CHUNKS=$(grep -oE 'CHUNKS=[0-9]+' bundle.txt | tail -n1 | cut -d= -f2 || echo 0)
+          echo "expecting ${CHUNKS:-0} chunk(s)"
+          : > artifacts.b64
+          for i in $(seq 1 "${CHUNKS:-0}"); do
+            POLIS_SSM_RAW=1 POLIS_SSM_TIMEOUT=300 bash ci/p022_ssm.sh "chunk-$i" \
+              "sudo bash /opt/polis/ci/p022_ec2_run.sh chunk $i" >> artifacts.b64 || break
+          done
+          if [ -s artifacts.b64 ]; then
+            base64 -d artifacts.b64 > artifacts.tar.gz
+            tar -xzf artifacts.tar.gz -C artifacts || true
+          fi
+          ls -la artifacts || true
+
+      - name: Upload artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: certification-ec2-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/
+          if-no-files-found: warn
+          retention-days: 7
+
+      # ---------------------------------------------------------------- teardown
+      # This is the only thing in the job that is allowed to be optimistic about
+      # nothing else having worked.
+      - name: Terminate the worker and confirm
+        if: ${{ always() }}
+        run: |
+          set -uo pipefail
+          if [ -z "${INSTANCE_ID:-}" ]; then
+            # The launch step may have created an instance whose ID we lost.
+            # Sweep this run's tag before giving up.
+            ORPHANS=$(aws ec2 describe-instances \
+              --filters "Name=tag:polis:ci-run,Values=${{ github.run_id }}-${{ github.run_attempt }}" \
+                        "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+              --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null || echo '')
+            if [ -z "$ORPHANS" ]; then
+              echo "no instance was launched; nothing to terminate"
+              exit 0
+            fi
+            INSTANCE_ID="$ORPHANS"
+          fi
+          echo "terminating: $INSTANCE_ID"
+          # shellcheck disable=SC2086
+          aws ec2 terminate-instances --instance-ids $INSTANCE_ID || true
+          # Confirm. An unconfirmed termination is a cost leak and a FAILURE of
+          # this job even when every test passed.
+          for _ in $(seq 1 30); do
+            # shellcheck disable=SC2086
+            STATES=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID \
+              --query 'Reservations[].Instances[].State.Name' --output text 2>/dev/null || echo '')
+            echo "state(s): ${STATES:-<none>}"
+            case "$STATES" in
+              *pending*|*running*|*stopping*|*stopped*) ;;
+              '') ;;
+              *) echo "termination confirmed"; exit 0 ;;
+            esac
+            # shellcheck disable=SC2086
+            aws ec2 terminate-instances --instance-ids $INSTANCE_ID >/dev/null 2>&1 || true
+            sleep 10
+          done
+          echo "::error::could not confirm termination of $INSTANCE_ID -- kill it by hand (docs/ci-ec2.md)"
+          exit 1

--- a/.github/workflows/certification-ec2.yml
+++ b/.github/workflows/certification-ec2.yml
@@ -88,16 +88,25 @@ jobs:
         with:
           persist-credentials: false
 
-      # Session 1: broad enough to launch. The role itself is pinned to one
-      # launch template, one instance profile and an IAM-enforced instance-type
-      # allowlist, so "broad" here still cannot select arbitrary spend.
-      - name: Assume the launch role
+      # Session 1 launches, and does ONLY that. The base role holds a
+      # tag-scoped SendCommand that reaches any concurrent campaign's box, and
+      # an identity policy cannot name an instance that does not exist yet — so
+      # instead no live session ever carries that grant: this session subtracts
+      # SSM entirely, and session 2 pins it to one instance ARN.
+      - name: Assume the launch role (launch-only session)
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ vars.CERTIFY_OIDC_ROLE_ARN }}
           aws-region: ${{ vars.CERTIFY_REGION || 'us-east-1' }}
           role-session-name: certify-launch-${{ github.run_id }}-${{ github.run_attempt }}
           role-duration-seconds: 3600
+          inline-session-policy: >-
+            {"Version":"2012-10-17","Statement":[
+              {"Sid":"LaunchOnly","Effect":"Allow",
+               "Action":["ec2:RunInstances","ec2:CreateTags","iam:PassRole",
+                         "ec2:DescribeInstances","ec2:DescribeInstanceStatus",
+                         "sts:GetCallerIdentity"],
+               "Resource":"*"}]}
 
       - name: Launch the disposable worker
         id: launch

--- a/.github/workflows/certification-ec2.yml
+++ b/.github/workflows/certification-ec2.yml
@@ -121,11 +121,24 @@ jobs:
           # The admitted battery inventory, taken from the commit under test —
           # not from this checkout, which may differ.
           git fetch --depth 1 origin "$TARGET_SHA"
-          git show "$TARGET_SHA:delphi/scripts/certify_battery.json" > /tmp/p022-battery.json
-          git show "$TARGET_SHA:delphi/scripts/certify_datasets.json" > /tmp/p022-datasets.json
-          DIGEST=$(python3 ci/p022_battery_digest.py /tmp/p022-battery.json /tmp/p022-datasets.json)
+          # The whole scripts tree, not just the two JSON files: the digest now
+          # hashes the CONTENTS of every referenced schedule, so a same-name
+          # mutation that deletes a restart seam moves it (review R4-F3).
+          rm -rf /tmp/p022-scripts && mkdir -p /tmp/p022-scripts
+          git archive "$TARGET_SHA" delphi/scripts | tar -x -C /tmp/p022-scripts
+          INV=$(python3 ci/p022_battery_digest.py \
+                  /tmp/p022-scripts/delphi/scripts/certify_battery.json \
+                  /tmp/p022-scripts/delphi/scripts/certify_datasets.json \
+                  /tmp/p022-scripts/delphi/scripts)
+          DIGEST=$(printf %s "$INV" | python3 -c 'import json,sys; print(json.load(sys.stdin)["digest"])')
+          RESTARTS=$(printf %s "$INV" | python3 -c 'import json,sys; print(json.load(sys.stdin)["restart_cases"])')
+          if [ "$RESTARTS" -lt 1 ]; then
+            echo "::error::the admitted public battery declares no restart seam"
+            exit 1
+          fi
           echo "BATTERY_DIGEST=$DIGEST" >> "$GITHUB_ENV"
-          echo "scope run_battery=$RUN_BATTERY commit=$TARGET_SHA inventory=$DIGEST"
+          echo "BATTERY_RESTARTS=$RESTARTS" >> "$GITHUB_ENV"
+          echo "scope run_battery=$RUN_BATTERY commit=$TARGET_SHA inventory=$DIGEST restarts=$RESTARTS"
 
       # Session 1 launches, and does ONLY that. The base role holds a
       # tag-scoped SendCommand that reaches any concurrent campaign's box, and
@@ -320,7 +333,10 @@ jobs:
             --expected-datasets biodiversity,vw \
             --expected-main-reports 1 \
             --expected-race-reports 20 \
-            --junit-dir artifacts/junit
+            --junit-dir artifacts/junit \
+            --min-restart-cases "${BATTERY_RESTARTS}" \
+            --min-main-executed 100 \
+            --min-race-executed 10
 
       - name: Upload artifacts
         if: ${{ always() }}

--- a/.github/workflows/certification-ec2.yml
+++ b/.github/workflows/certification-ec2.yml
@@ -81,12 +81,51 @@ jobs:
       RUN_TAG: ${{ github.run_id }}-${{ github.run_attempt }}
       TARGET_REF: ${{ inputs.ref || github.ref_name }}
       INSTANCE_TYPE: ${{ inputs.instance_type || 'r8g.4xlarge' }}
+      # Resolved ONCE, here, and used by both execution and validation. A
+      # schedule event has no dispatch inputs, and an absent input compares
+      # equal to false under GitHub's conversions — so round 3's
+      # `inputs.run_battery != false` skipped the nightly battery AND told the
+      # validator the omission was deliberate (review R3-F3). Only an explicit
+      # manual false selects recovery-only.
+      RUN_BATTERY: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_battery == false) && 'false' || 'true' }}
 
     steps:
       - name: Check out the control code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      # An undeclared scope is not a default; it is a bug in this file.
+      - name: Resolve the run scope and the immutable target commit
+        id: scope_and_sha
+        run: |
+          set -euo pipefail
+          case "$RUN_BATTERY" in
+            true|false) ;;
+            *) echo "::error::RUN_BATTERY resolved to '$RUN_BATTERY'"; exit 1 ;;
+          esac
+          # A branch name is mutable, and the worker used to fall back to `edge`
+          # when its tag read failed. Resolve once, here, and hand the immutable
+          # commit to the launch tag AND to validation (review R3-F4).
+          if printf %s "$TARGET_REF" | grep -Eq '^[0-9a-f]{40}$'; then
+            TARGET_SHA="$TARGET_REF"
+          else
+            TARGET_SHA=$(git ls-remote origin "refs/heads/${TARGET_REF}" | cut -f1)
+          fi
+          if ! printf %s "$TARGET_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::could not resolve '$TARGET_REF' to a commit"
+            exit 1
+          fi
+          echo "TARGET_SHA=$TARGET_SHA" >> "$GITHUB_ENV"
+          # The admitted battery inventory, taken from the commit under test —
+          # not from this checkout, which may differ.
+          git fetch --depth 1 origin "$TARGET_SHA"
+          git show "$TARGET_SHA:delphi/scripts/certify_battery.json" > /tmp/p022-battery.json
+          git show "$TARGET_SHA:delphi/scripts/certify_datasets.json" > /tmp/p022-datasets.json
+          DIGEST=$(python3 ci/p022_battery_digest.py /tmp/p022-battery.json /tmp/p022-datasets.json)
+          echo "BATTERY_DIGEST=$DIGEST" >> "$GITHUB_ENV"
+          echo "scope run_battery=$RUN_BATTERY commit=$TARGET_SHA inventory=$DIGEST"
 
       # Session 1 launches, and does ONLY that. The base role holds a
       # tag-scoped SendCommand that reaches any concurrent campaign's box, and
@@ -125,7 +164,7 @@ jobs:
           # Deterministic client token: a retried step after a lost response
           # returns the SAME instance instead of launching a second one.
           TOKEN="polis-certify-${RUN_TAG}"
-          TAGS="ResourceType=instance,Tags=[{Key=polis:ci,Value=disposable},{Key=polis:ci-ref,Value=$TARGET_REF},{Key=polis:ci-run,Value=$RUN_TAG}]"
+          TAGS="ResourceType=instance,Tags=[{Key=polis:ci,Value=disposable},{Key=polis:ci-ref,Value=$TARGET_SHA},{Key=polis:ci-run,Value=$RUN_TAG}]"
           # The run tag goes on the volume as well as the instance: an orphan
           # volume with no owner is as hard to reconcile as an orphan instance.
           VOLTAGS="ResourceType=volume,Tags=[{Key=polis:ci,Value=disposable},{Key=polis:ci-run,Value=$RUN_TAG}]"
@@ -140,7 +179,7 @@ jobs:
             --tag-specifications "$TAGS" "$VOLTAGS" \
             --query 'Instances[0].InstanceId' --output text)
           echo "INSTANCE_ID=$INSTANCE_ID" >> "$GITHUB_ENV"
-          echo "Launched $INSTANCE_ID ($INSTANCE_TYPE) for ref $TARGET_REF"
+          echo "Launched $INSTANCE_ID ($INSTANCE_TYPE) at commit $TARGET_SHA"
 
       - name: Build the instance-scoped session policy
         id: scope
@@ -212,7 +251,7 @@ jobs:
             'sudo env POLIS_CI_REPO_ROOT=/opt/polis bash /opt/polis/ci/p022_ec2_run.sh recovery'
 
       - name: Public-fixture battery
-        if: ${{ inputs.run_battery != false }}
+        if: ${{ env.RUN_BATTERY == 'true' }}
         run: |
           set -euo pipefail
           # No fixture URI, no secret, no S3: the public fixtures are checked
@@ -262,8 +301,6 @@ jobs:
 
       - name: Validate the summary against the declared scope
         if: ${{ always() && env.INSTANCE_ID != '' }}
-        env:
-          RUN_BATTERY: ${{ inputs.run_battery == false && 'false' || 'true' }}
         run: |
           set -euo pipefail
           if [ ! -f artifacts/summary.json ]; then
@@ -277,10 +314,13 @@ jobs:
           # every field it inspects.
           python3 ci/p022_check_summary.py artifacts/summary.json \
             --run-battery "${RUN_BATTERY}" \
+            --expected-sha "${TARGET_SHA}" \
+            --expected-battery-digest "${BATTERY_DIGEST}" \
             --expected-battery-cases 6 \
             --expected-datasets biodiversity,vw \
             --expected-main-reports 1 \
-            --expected-race-reports 20
+            --expected-race-reports 20 \
+            --junit-dir artifacts/junit
 
       - name: Upload artifacts
         if: ${{ always() }}
@@ -314,19 +354,37 @@ jobs:
           else
             TARGET="arn:aws:ec2:${AWS_REGION}:*:instance/*"
           fi
-          jq -nc --arg arn "$TARGET" '{
+          # The lost-ID path cannot name an ARN, so it carries this run's tag as
+          # a condition instead. Round 3 left that path wildcard and
+          # unconditional, so it could terminate another campaign's box.
+          jq -nc --arg arn "$TARGET" --arg run "$RUN_TAG" '{
             Version: "2012-10-17",
             Statement: [
               {Sid: "ObserveInstances", Effect: "Allow",
                Action: ["ec2:DescribeInstances", "ec2:DescribeInstanceStatus"], Resource: "*"},
-              {Sid: "TerminateTeardownTarget", Effect: "Allow",
-               Action: "ec2:TerminateInstances", Resource: $arn}
+              ({Sid: "TerminateTeardownTarget", Effect: "Allow",
+                Action: "ec2:TerminateInstances", Resource: $arn}
+               + (if ($arn | endswith("/*"))
+                  then {Condition: {StringEquals: {"ec2:ResourceTag/polis:ci-run": $run}}}
+                  else {} end))
             ]}' > teardown-policy.json
+          # A policy that did not get built must never become an OMITTED policy:
+          # the pinned action turns an empty input into no session policy at
+          # all, which hands back the full base-role reach (review R3-F5).
+          if [ ! -s teardown-policy.json ]; then
+            echo "::error::teardown session policy could not be built"
+            exit 1
+          fi
+          python3 -c 'import json,sys; json.load(open(sys.argv[1]))' teardown-policy.json
           echo "policy=$(cat teardown-policy.json)" >> "$GITHUB_OUTPUT"
           echo "teardown scoped to $TARGET"
 
+      # Gated on a policy that actually exists. Without it there is no teardown
+      # session at all, the step below is skipped, and the independent expiry
+      # sweeper is what reaps the instance — which is the correct failure mode,
+      # and is reported as a failure by the guard that follows.
       - name: Refresh credentials for teardown
-        if: ${{ always() }}
+        if: ${{ always() && steps.teardown_scope.outputs.policy != '' }}
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ vars.CERTIFY_OIDC_ROLE_ARN }}
@@ -336,9 +394,16 @@ jobs:
           inline-session-policy: ${{ steps.teardown_scope.outputs.policy }}
 
       - name: Terminate the worker and confirm
-        if: ${{ always() }}
+        if: ${{ always() && steps.teardown_scope.outputs.policy != '' }}
         run: |
           python3 ci/p022_teardown.py \
             --run-tag "$RUN_TAG" \
             --launch-attempted "${LAUNCH_ATTEMPTED:-0}" \
             --instance-id "${INSTANCE_ID:-}"
+
+      - name: Fail if teardown could not be scoped
+        if: ${{ always() && steps.teardown_scope.outputs.policy == '' }}
+        run: |
+          echo "::error::no teardown session policy was produced; this run did not"
+          echo "::error::terminate its worker. The expiry sweeper will reap it."
+          exit 1

--- a/.github/workflows/certification-ec2.yml
+++ b/.github/workflows/certification-ec2.yml
@@ -1,31 +1,42 @@
-name: Certification (EC2)
+name: Synthetic recovery and public-fixture battery (EC2)
 
-# P-022 §E v1 "minimal". Runs the recovery matrix and the Delphi certification
-# battery on ONE disposable EC2 worker, then destroys it.
+# P-022 §E. Runs the recovery matrix and the replay battery restricted to the
+# repository's PUBLIC fixtures on one disposable EC2 worker, then destroys it.
+#
+# THIS IS NOT PRIVATE CERTIFICATION and its verdict (`SYNTHETIC-PASS`) must
+# never be read as one. Astra's #2715 review found that round 1 staged the
+# private prod-derived bundle on a box GitHub could open a root shell on, and
+# returned its raw log to public Actions artifacts. Round 2 removes the private
+# data path outright: there is no fixture bucket, no evidence bucket, and the
+# instance role cannot read either. Private certification needs the isolated
+# worker in cost-reduction/04-plans/P-022-E-ci-spec.md and does not exist yet.
 #
 # Nothing here works until the CDK construct behind `-c enableCiEc2=true` has
 # been deployed once and CERTIFY_OIDC_ROLE_ARN / CERTIFY_LAUNCH_TEMPLATE_ID are
 # set. See docs/ci-ec2.md.
 #
 # The worker is NOT a self-hosted runner: it is never registered with GitHub,
-# it has no inbound network path, and it is only reachable through SSM from
-# this job's short-lived OIDC credentials.
+# has no inbound network path, and is reachable only through SSM from this
+# job's short-lived, instance-scoped credentials.
 
 on:
   workflow_dispatch:
     inputs:
       instance_type:
-        description: EC2 instance type for the worker (must be arm64/Graviton)
+        description: Worker instance type (must be in the IAM-pinned allowlist)
         required: false
         default: r8g.4xlarge
-        type: string
+        type: choice
+        options:
+          - r8g.4xlarge
+          - r8g.2xlarge
       ref:
         description: "Git ref to test on the worker (default: this workflow's ref)"
         required: false
         default: ''
         type: string
       run_battery:
-        description: Run the certification battery as well as the recovery matrix
+        description: Run the public-fixture battery as well as the recovery matrix
         required: false
         default: true
         type: boolean
@@ -36,45 +47,50 @@ on:
 
 permissions: {}
 
-# One certification campaign at a time, and never cancel a running one: a
-# cancelled job cannot terminate its instance, and GitHub concurrency does not
-# fence an orphaned EC2 box.
+# One campaign at a time, and never cancel a running one: a cancelled job is
+# exactly the case where the teardown step does not get to run. The independent
+# expiry sweeper in cdk/ciEc2.ts is what covers that hole; concurrency is not a
+# fence against an orphaned instance.
 concurrency:
   group: certification-ec2
   cancel-in-progress: false
 
 jobs:
-  certify:
-    name: Certification battery and recovery matrix
+  synthetic:
+    name: Synthetic recovery matrix and public-fixture battery
     if: github.event_name != 'schedule' || github.ref == 'refs/heads/edge'
     runs-on: ubuntu-24.04
-    timeout-minutes: 420
-    environment: certification-private
+    # Must stay below the role's 6 h max session duration, with room for the
+    # teardown. Round 1 allowed 420 minutes against a 360-minute session, so a
+    # maximum-length run necessarily lost its credentials before cleanup
+    # (review E7). The job also re-assumes before teardown.
+    timeout-minutes: 300
+    environment: certification-synthetic
     permissions:
       contents: read
       id-token: write
     env:
       AWS_REGION: ${{ vars.CERTIFY_REGION || 'us-east-1' }}
-      POLIS_CI_TAG_KEY: 'polis:ci'
-      POLIS_CI_TAG_VALUE: disposable
+      RUN_TAG: ${{ github.run_id }}-${{ github.run_attempt }}
       TARGET_REF: ${{ inputs.ref || github.ref_name }}
       INSTANCE_TYPE: ${{ inputs.instance_type || 'r8g.4xlarge' }}
 
     steps:
-      - name: Check out the trusted control code
+      - name: Check out the control code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
-      - name: Configure AWS credentials
+      # Session 1: broad enough to launch. The role itself is pinned to one
+      # launch template, one instance profile and an IAM-enforced instance-type
+      # allowlist, so "broad" here still cannot select arbitrary spend.
+      - name: Assume the launch role
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ vars.CERTIFY_OIDC_ROLE_ARN }}
           aws-region: ${{ vars.CERTIFY_REGION || 'us-east-1' }}
-          role-session-name: certify-${{ github.run_id }}-${{ github.run_attempt }}
-          # The campaign budget is six hours and this action does not refresh;
-          # a one-hour session would expire mid-poll and orphan the worker.
-          role-duration-seconds: 21600
+          role-session-name: certify-launch-${{ github.run_id }}-${{ github.run_attempt }}
+          role-duration-seconds: 3600
 
       - name: Launch the disposable worker
         id: launch
@@ -82,16 +98,18 @@ jobs:
           LAUNCH_TEMPLATE_ID: ${{ vars.CERTIFY_LAUNCH_TEMPLATE_ID }}
         run: |
           set -euo pipefail
-          test -n "$LAUNCH_TEMPLATE_ID" || {
+          if [ -z "$LAUNCH_TEMPLATE_ID" ]; then
             echo "CERTIFY_LAUNCH_TEMPLATE_ID is unset; deploy the CDK construct first (docs/ci-ec2.md)" >&2
             exit 1
-          }
+          fi
           # Deterministic client token: a retried step after a lost response
           # returns the SAME instance instead of launching a second one.
-          TOKEN="polis-certify-${{ github.run_id }}-${{ github.run_attempt }}"
-          # Version=1 is pinned; the OIDC role cannot create another version.
-          TAGS="ResourceType=instance,Tags=[{Key=$POLIS_CI_TAG_KEY,Value=$POLIS_CI_TAG_VALUE},{Key=polis:ci-ref,Value=$TARGET_REF},{Key=polis:ci-run,Value=${{ github.run_id }}-${{ github.run_attempt }}}]"
-          VOLTAGS="ResourceType=volume,Tags=[{Key=$POLIS_CI_TAG_KEY,Value=$POLIS_CI_TAG_VALUE}]"
+          TOKEN="polis-certify-${RUN_TAG}"
+          TAGS="ResourceType=instance,Tags=[{Key=polis:ci,Value=disposable},{Key=polis:ci-ref,Value=$TARGET_REF},{Key=polis:ci-run,Value=$RUN_TAG}]"
+          VOLTAGS="ResourceType=volume,Tags=[{Key=polis:ci,Value=disposable}]"
+          # Version=1 is pinned here; note that this is a caller choice, not an
+          # IAM restriction -- the role could select another version of the same
+          # template if one ever existed. Only the CDK deploy creates versions.
           INSTANCE_ID=$(aws ec2 run-instances \
             --launch-template "LaunchTemplateId=${LAUNCH_TEMPLATE_ID},Version=1" \
             --instance-type "$INSTANCE_TYPE" \
@@ -100,8 +118,48 @@ jobs:
             --tag-specifications "$TAGS" "$VOLTAGS" \
             --query 'Instances[0].InstanceId' --output text)
           echo "INSTANCE_ID=$INSTANCE_ID" >> "$GITHUB_ENV"
-          echo "instance_id=$INSTANCE_ID" >> "$GITHUB_OUTPUT"
           echo "Launched $INSTANCE_ID ($INSTANCE_TYPE) for ref $TARGET_REF"
+
+      - name: Build the instance-scoped session policy
+        id: scope
+        run: |
+          set -euo pipefail
+          ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+          INSTANCE_ARN="arn:aws:ec2:${AWS_REGION}:${ACCOUNT}:instance/${INSTANCE_ID}"
+          # Narrows every remaining permission to the single instance this run
+          # launched. The role's own tag conditions cannot do that -- a tag is
+          # shared by every concurrent campaign (review E6). A session policy
+          # intersects with the role policy, so this can only subtract.
+          # ssm:GetCommandInvocation and ssm:DescribeInstanceInformation support
+          # no resource types and no condition keys in the service
+          # authorization reference, so they stay "*" here; that residual is
+          # documented rather than papered over.
+          jq -nc --arg arn "$INSTANCE_ARN" '{
+            Version: "2012-10-17",
+            Statement: [
+              {Sid: "SendToThisInstanceOnly", Effect: "Allow",
+               Action: "ssm:SendCommand", Resource: [$arn, "arn:aws:ssm:*::document/AWS-RunShellScript"]},
+              {Sid: "ReadCommandResults", Effect: "Allow",
+               Action: ["ssm:GetCommandInvocation", "ssm:DescribeInstanceInformation"], Resource: "*"},
+              {Sid: "ObserveInstances", Effect: "Allow",
+               Action: ["ec2:DescribeInstances", "ec2:DescribeInstanceStatus"], Resource: "*"},
+              {Sid: "TerminateThisInstanceOnly", Effect: "Allow",
+               Action: "ec2:TerminateInstances", Resource: $arn}
+            ]}' > session-policy.json
+          # The action takes stringified JSON, not a path; jq -nc emits one line.
+          echo "policy=$(cat session-policy.json)" >> "$GITHUB_OUTPUT"
+          echo "scoped to $INSTANCE_ARN"
+
+      # Session 2: everything after the launch runs with the instance-scoped
+      # policy above and cannot touch another run's box.
+      - name: Re-assume, scoped to this instance
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ vars.CERTIFY_OIDC_ROLE_ARN }}
+          aws-region: ${{ vars.CERTIFY_REGION || 'us-east-1' }}
+          role-session-name: certify-scoped-${{ github.run_id }}-${{ github.run_attempt }}
+          role-duration-seconds: 21600
+          inline-session-policy: ${{ steps.scope.outputs.policy }}
 
       - name: Wait for SSM registration and bootstrap
         run: |
@@ -119,11 +177,11 @@ jobs:
           # clone at the requested ref; the failed marker short-circuits.
           POLIS_SSM_TIMEOUT=1800 bash ci/p022_ssm.sh bootstrap-wait '
             for i in $(seq 1 120); do
-              [ -f /var/lib/polis-ci-failed ] && { echo "bootstrap failed"; tail -n 60 /var/log/polis-ci-userdata.log; exit 1; }
-              [ -f /var/lib/polis-ci-ready ] && { echo "ready sha=$(cat /var/lib/polis-ci-sha)"; exit 0; }
+              if [ -f /var/lib/polis-ci-failed ]; then echo "p022 bootstrap result=failed"; exit 1; fi
+              if [ -f /var/lib/polis-ci-ready ]; then echo "p022 bootstrap result=ready"; exit 0; fi
               sleep 15
             done
-            echo "bootstrap timed out"; tail -n 60 /var/log/polis-ci-userdata.log; exit 1'
+            echo "p022 bootstrap result=timeout"; exit 1'
 
       - name: Recovery matrix (make test-recovery, make test-recovery-races)
         run: |
@@ -131,106 +189,90 @@ jobs:
           POLIS_SSM_TIMEOUT=7200 bash ci/p022_ssm.sh recovery \
             'sudo env POLIS_CI_REPO_ROOT=/opt/polis bash /opt/polis/ci/p022_ec2_run.sh recovery'
 
-      - name: Certification battery
+      - name: Public-fixture battery
         if: ${{ inputs.run_battery != false }}
-        env:
-          FIXTURE_S3: ${{ secrets.CERTIFY_FIXTURE_S3_URI }}
-          EVIDENCE_S3: ${{ vars.CERTIFY_EVIDENCE_S3_URI }}
         run: |
           set -euo pipefail
-          # The bundle is private prod-derived data and is NOT in the repo. The
-          # WORKER fetches it with its own instance role; this runner never gets
-          # read access. Unset => the worker skips those cases and still runs
-          # the public fixtures.
-          if [ -z "$FIXTURE_S3" ]; then
-            echo "::notice::CERTIFY_FIXTURE_S3_URI is unset; private battery cases will be skipped"
-          fi
-          # These two are spliced into the remote command string. Reject
-          # anything that is not a plain s3:// URI rather than trusting the
-          # value's quoting to hold.
-          for u in "$FIXTURE_S3" "$EVIDENCE_S3"; do
-            case "$u" in
-              ''|s3://[A-Za-z0-9]*) : ;;
-              *) echo "::error::not a plain s3:// URI: $u"; exit 1 ;;
-            esac
-            case "$u" in
-              *[!A-Za-z0-9:/._-]*) echo "::error::unsafe character in S3 URI"; exit 1 ;;
-            esac
-          done
+          # No fixture URI, no secret, no S3: the public fixtures are checked
+          # into the repository and the worker has no credential that could
+          # reach anything else. An empty or incomplete public inventory fails
+          # on the box rather than shrinking the run (review E5).
           POLIS_SSM_TIMEOUT=21600 bash ci/p022_ssm.sh battery \
-            "sudo env POLIS_CI_REPO_ROOT=/opt/polis POLIS_CI_FIXTURE_S3='${FIXTURE_S3}' POLIS_CI_EVIDENCE_S3='${EVIDENCE_S3}' POLIS_CI_RUN='${{ github.run_id }}-${{ github.run_attempt }}' bash /opt/polis/ci/p022_ec2_run.sh battery"
+            'sudo env POLIS_CI_REPO_ROOT=/opt/polis bash /opt/polis/ci/p022_ec2_run.sh battery'
 
-      - name: Collect logs and JUnit
+      - name: Collect the fixed-schema summary and JUnit
         if: ${{ always() && env.INSTANCE_ID != '' }}
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          # SSM caps command output at 24000 characters, so the artifact tarball
-          # comes back base64 in bounded chunks. Only public-safe files are in
-          # it (see ci/p022_ec2_run.sh); raw battery output goes to the private
-          # evidence bucket, never here.
-          POLIS_SSM_TIMEOUT=900 bash ci/p022_ssm.sh bundle \
-            'sudo bash /opt/polis/ci/p022_ec2_run.sh bundle' | tee bundle.txt || true
-          CHUNKS=$(grep -oE 'CHUNKS=[0-9]+' bundle.txt | tail -n1 | cut -d= -f2 || echo 0)
-          echo "expecting ${CHUNKS:-0} chunk(s)"
-          : > artifacts.b64
-          for i in $(seq 1 "${CHUNKS:-0}"); do
-            POLIS_SSM_RAW=1 POLIS_SSM_TIMEOUT=300 bash ci/p022_ssm.sh "chunk-$i" \
-              "sudo bash /opt/polis/ci/p022_ec2_run.sh chunk $i" >> artifacts.b64 || break
-          done
-          if [ -s artifacts.b64 ]; then
-            base64 -d artifacts.b64 > artifacts.tar.gz
-            tar -xzf artifacts.tar.gz -C artifacts || true
+          bash ci/p022_ssm.sh summary \
+            'sudo env POLIS_CI_REPO_ROOT=/opt/polis bash /opt/polis/ci/p022_ec2_run.sh summary' || true
+          # The bundle comes back base64 in bounded chunks with a declared
+          # length and sha256. Round 1 truncated an oversized bundle, ignored
+          # tar/extract errors and still succeeded; here a short, corrupt or
+          # unverifiable bundle fails the step.
+          bash ci/p022_ssm.sh bundle \
+            'sudo bash /opt/polis/ci/p022_ec2_run.sh bundle' | tee bundle.txt
+          CHUNKS=$(sed -n 's/^p022 bundle chunks=\([0-9]\+\)$/\1/p' bundle.txt | tail -n1)
+          CHARS=$(sed -n 's/^p022 bundle chars=\([0-9]\+\)$/\1/p' bundle.txt | tail -n1)
+          DIGEST=$(sed -n 's/^p022 bundle sha256=\([0-9a-f]\{64\}\)$/\1/p' bundle.txt | tail -n1)
+          if [ -z "$CHUNKS" ] || [ -z "$CHARS" ] || [ -z "$DIGEST" ]; then
+            echo "::error::worker did not declare a complete bundle"
+            exit 1
           fi
-          ls -la artifacts || true
+          : > artifacts.b64
+          for i in $(seq 1 "$CHUNKS"); do
+            POLIS_SSM_MODE=base64 POLIS_SSM_TIMEOUT=300 bash ci/p022_ssm.sh "chunk-$i" \
+              "sudo bash /opt/polis/ci/p022_ec2_run.sh chunk $i" >> artifacts.b64
+          done
+          GOT=$(wc -c < artifacts.b64)
+          if [ "$GOT" -ne "$CHARS" ]; then
+            echo "::error::bundle length mismatch: expected $CHARS got $GOT"
+            exit 1
+          fi
+          base64 -d artifacts.b64 > artifacts.tar.gz
+          if ! echo "$DIGEST  artifacts.tar.gz" | sha256sum -c -; then
+            echo "::error::bundle digest mismatch"
+            exit 1
+          fi
+          tar -xzf artifacts.tar.gz -C artifacts
+          ls -la artifacts
+
+      - name: Validate the summary schema
+        if: ${{ always() && env.INSTANCE_ID != '' }}
+        run: |
+          set -euo pipefail
+          if [ ! -f artifacts/summary.json ]; then
+            echo "::error::no summary.json returned"
+            exit 1
+          fi
+          python3 ci/p022_check_summary.py artifacts/summary.json
 
       - name: Upload artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: certification-ec2-${{ github.run_id }}-${{ github.run_attempt }}
+          name: synthetic-ec2-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/
           if-no-files-found: warn
           retention-days: 7
 
       # ---------------------------------------------------------------- teardown
-      # This is the only thing in the job that is allowed to be optimistic about
-      # nothing else having worked.
+      # Re-assume first: a long run's launch-session credentials may be minutes
+      # from expiry by now, and the one step that must not fail for lack of
+      # credentials is this one.
+      - name: Refresh credentials for teardown
+        if: ${{ always() }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ vars.CERTIFY_OIDC_ROLE_ARN }}
+          aws-region: ${{ vars.CERTIFY_REGION || 'us-east-1' }}
+          role-session-name: certify-teardown-${{ github.run_id }}-${{ github.run_attempt }}
+          role-duration-seconds: 3600
+
       - name: Terminate the worker and confirm
         if: ${{ always() }}
         run: |
-          set -uo pipefail
-          if [ -z "${INSTANCE_ID:-}" ]; then
-            # The launch step may have created an instance whose ID we lost.
-            # Sweep this run's tag before giving up.
-            ORPHANS=$(aws ec2 describe-instances \
-              --filters "Name=tag:polis:ci-run,Values=${{ github.run_id }}-${{ github.run_attempt }}" \
-                        "Name=instance-state-name,Values=pending,running,stopping,stopped" \
-              --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null || echo '')
-            if [ -z "$ORPHANS" ]; then
-              echo "no instance was launched; nothing to terminate"
-              exit 0
-            fi
-            INSTANCE_ID="$ORPHANS"
-          fi
-          echo "terminating: $INSTANCE_ID"
-          # shellcheck disable=SC2086
-          aws ec2 terminate-instances --instance-ids $INSTANCE_ID || true
-          # Confirm. An unconfirmed termination is a cost leak and a FAILURE of
-          # this job even when every test passed.
-          for _ in $(seq 1 30); do
-            # shellcheck disable=SC2086
-            STATES=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID \
-              --query 'Reservations[].Instances[].State.Name' --output text 2>/dev/null || echo '')
-            echo "state(s): ${STATES:-<none>}"
-            case "$STATES" in
-              *pending*|*running*|*stopping*|*stopped*) ;;
-              '') ;;
-              *) echo "termination confirmed"; exit 0 ;;
-            esac
-            # shellcheck disable=SC2086
-            aws ec2 terminate-instances --instance-ids $INSTANCE_ID >/dev/null 2>&1 || true
-            sleep 10
-          done
-          echo "::error::could not confirm termination of $INSTANCE_ID -- kill it by hand (docs/ci-ec2.md)"
-          exit 1
+          python3 ci/p022_teardown.py \
+            --run-tag "$RUN_TAG" \
+            --instance-id "${INSTANCE_ID:-}"

--- a/cdk/ciEc2.ts
+++ b/cdk/ciEc2.ts
@@ -1,78 +1,105 @@
 /**
- * P-022 §E v1 ("minimal") — disposable EC2 worker for the Delphi certification
- * battery and the recovery matrix.
+ * P-022 §E — disposable EC2 worker for the **synthetic** recovery matrix and
+ * the **public-fixture** replay battery.
  *
- * This construct is DORMANT by default. It is only instantiated when the CDK
- * context flag `enableCiEc2` is true:
+ * ## Scope, after Astra's #2715 review (round 2)
  *
- *     npx cdk synth                          # unchanged stack, nothing here
- *     npx cdk synth -c enableCiEc2=true      # adds the resources below
+ * This is NOT private certification and must never be described as one. Round 1
+ * attached the private fixture-bundle role to a box that GitHub could open a
+ * root shell on, which is not a data boundary at all (review E2). Round 2
+ * removes the private side outright rather than pretending an instance boundary
+ * contains root code:
  *
- * What it provisions (and nothing else):
+ *   - no fixture-bundle read anywhere in this construct,
+ *   - no evidence-bucket write anywhere in this construct,
+ *   - nothing prod-derived is ever staged on the worker,
+ *   - the workflow's verdict is named for what it is (`synthetic`), so it can
+ *     never be mistaken for a certificate.
  *
- *   1. `PolisCertifyGithubOidc` — an IAM role assumable **only** by GitHub
- *      Actions OIDC from this repository on `edge`, `stable` and pull-request
- *      refs. Its permissions are: RunInstances from exactly one launch
- *      template, the launch-time tags that make the instance findable and
- *      killable, PassRole for exactly the worker role, EC2 Describe, tag-scoped
- *      TerminateInstances, and SSM SendCommand/GetCommandInvocation against
- *      tag-scoped instances. No SSH key, no secrets, no S3 fixture read, no
- *      deployment permissions, no template mutation.
+ * Private certification (baked trusted AMI, cloud-init disabled, isolated
+ * account/VPC, endpoint-only egress, autonomous worker publishing a signed
+ * fixed-schema summary that GitHub reads but cannot influence) remains
+ * UNIMPLEMENTED. See cost-reduction/04-plans/P-022-E-ci-spec.md and the round-2
+ * section of P-022-E-implementation-notes.md.
  *
- *   2. `PolisCertifyWorker` — the instance role. SSM core only, plus (optional,
- *      context-gated) read of the private fixture-bundle prefix and write of
- *      the private evidence prefix. The GitHub role can read neither.
+ * ## Gate
  *
- *   3. `CertifyCiLaunchTemplate` — one disposable Graviton box: IMDSv2
- *      required, no public IP, no inbound rules, an encrypted gp3 root volume,
- *      `InstanceInitiatedShutdownBehavior=terminate`, and a user-data script
- *      whose *first* action is `shutdown -h +N` so the instance dies on a hard
- *      deadline even if every later step fails.
+ *     npx cdk synth                       # untouched stack; nothing here exists
+ *     npx cdk synth -c enableCiEc2=true   # adds the resources below
  *
- * Deliberately NOT here (P-022 §E v2, explicitly out of scope): the Lambda
- * admission controller, the JWT capability service, the baked trusted AMI, the
- * signed safe-summary publisher. See cost-reduction/04-plans/P-022-E-ci-spec.md.
+ * ## What it provisions
+ *
+ *   1. `polis-certify-github-oidc` — assumable only by this repository through
+ *      the GitHub **environment** subject (no branch subject, no fork/PR
+ *      subject). It may launch one pinned template at one of a pinned set of
+ *      instance types, tag that launch, Describe, terminate tagged CI boxes,
+ *      and SendCommand `AWS-RunShellScript` at tagged CI boxes. The workflow
+ *      narrows all of that to the single instance it launched with an inline
+ *      session policy at re-assume time.
+ *   2. `polis-certify-worker` — the instance role. An explicit minimal SSM
+ *      agent policy, NOT `AmazonSSMManagedInstanceCore` (which also grants
+ *      `ssm:GetParameter*` on `*` — review E6). No S3, no secrets, no KMS.
+ *   3. `polis-certify-ci` launch template — Graviton, IMDSv2 required, no
+ *      public IP, no inbound rules, encrypted gp3 root, shutdown-terminates,
+ *      and a hard deadline armed as the first user-data action.
+ *   4. An **independent EventBridge expiry sweeper** (review E7, BOARD [12]):
+ *      an hourly Lambda that terminates any `polis:ci=disposable` instance
+ *      older than the deadline, regardless of what GitHub did or failed to do.
  */
 import * as cdk from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 
-/** Tag key/value that every disposable CI instance must carry. Termination,
- *  SSM access and the manual "kill a stuck box" runbook are all scoped to it. */
+/** Tag key/value every disposable CI instance carries. It is the predicate for
+ *  the sweeper, for the operator runbook, and for the terminate/SendCommand
+ *  conditions. Nothing else in the account uses it. */
 export const CI_TAG_KEY = 'polis:ci';
 export const CI_TAG_VALUE = 'disposable';
-/** Launch-time tag the user-data reads (via IMDS instance tags) to learn which
- *  git ref to check out. Treated as untrusted input and validated in bash. */
+/** Launch-time tag the user-data reads (over IMDSv2) to learn which ref to
+ *  check out. Untrusted input; validated in bash before git sees it. */
 export const CI_REF_TAG_KEY = 'polis:ci-ref';
-/** Launch-time tag carrying `<run_id>-<attempt>`; diagnostics only. */
+/** Launch-time tag carrying `<run_id>-<attempt>` — run ownership for the
+ *  teardown's lost-ID sweep, and diagnostics for the sweeper. */
 export const CI_RUN_TAG_KEY = 'polis:ci-run';
 
 export interface CertificationCiEc2Props {
-  /** VPC to place the worker in. A PRIVATE_WITH_EGRESS subnet is used, so the
-   *  box reaches GitHub/PyPI/Maven/SSM through the existing NAT gateway and is
-   *  not reachable from the internet. */
+  /** VPC for the worker. A PRIVATE_WITH_EGRESS subnet is used. */
   readonly vpc: ec2.IVpc;
   /** `owner/repo` allowed to assume the OIDC role. */
   readonly githubRepo: string;
-  /** Instance type. Graviton (arm64) by default — see docs/ci-ec2.md. */
+  /**
+   * GitHub Actions **environment** whose subject is trusted. The workflow job
+   * declares the same name. Round 1 trusted branch and `pull_request` subjects
+   * while the job declared an environment, so the role could not actually be
+   * assumed by its own workflow and could have been assumed by a fork-visible
+   * subject from some other one (review E3).
+   */
+  readonly githubEnvironment: string;
+  /** Default instance type baked into the template. */
   readonly instanceType: ec2.InstanceType;
   /** Must match `instanceType`'s architecture. */
   readonly cpuType: ec2.AmazonLinuxCpuType;
+  /**
+   * Every instance type the OIDC role may launch. Enforced in IAM through
+   * `ec2:InstanceType`, so a dispatch input cannot select arbitrary spend
+   * (review E6 / divergence 4).
+   */
+  readonly allowedInstanceTypes: string[];
   /** Root volume size, GiB. */
   readonly volumeSizeGiB: number;
-  /** Hard deadline, minutes. `shutdown -h +N` + shutdown-behavior=terminate. */
+  /** Hard deadline, minutes: `shutdown -h +N` + shutdown-behavior=terminate. */
   readonly shutdownMinutes: number;
-  /** Optional: bucket holding the private prod-derived fixture bundle. The
-   *  WORKER may read it; the GitHub role may not. Absent → battery skipped. */
-  readonly fixtureBucket?: string;
-  /** Key prefix within `fixtureBucket`. */
-  readonly fixturePrefix: string;
-  /** Optional: bucket for raw private evidence. Worker writes, GitHub cannot
-   *  read (P-022 §E: no private artifact in a public Actions artifact). */
-  readonly evidenceBucket?: string;
-  /** Key prefix within `evidenceBucket`. */
-  readonly evidencePrefix: string;
+  /**
+   * Age, in minutes, past which the independent sweeper kills a CI instance.
+   * Must exceed `shutdownMinutes` so the sweeper is a backstop to the OS timer
+   * rather than a competitor to it.
+   */
+  readonly sweeperMaxAgeMinutes: number;
 }
 
 export class CertificationCiEc2 extends Construct {
@@ -83,46 +110,58 @@ export class CertificationCiEc2 extends Construct {
   constructor(scope: Construct, id: string, props: CertificationCiEc2Props) {
     super(scope, id);
 
+    if (props.sweeperMaxAgeMinutes <= props.shutdownMinutes) {
+      throw new Error(
+        'ciEc2SweeperMaxAgeMinutes must be greater than ciEc2ShutdownMinutes: ' +
+        'the sweeper is the backstop for the OS timer, not a race against it');
+    }
+    if (props.allowedInstanceTypes.length === 0) {
+      throw new Error('ciEc2AllowedInstanceTypes must not be empty');
+    }
+
     const stack = cdk.Stack.of(this);
     const { account, region, partition } = stack;
+    const instanceArnPattern = `arn:${partition}:ec2:${region}:${account}:instance/*`;
 
     // ---------------------------------------------------------------- worker
-    // Instance role. SSM core is what makes SendCommand work at all; it is the
-    // reason there is no SSH key, no public IP and no inbound security-group
-    // rule anywhere in this construct.
+    // Explicitly NOT AmazonSSMManagedInstanceCore. That managed policy grants
+    // ssm:GetParameter and ssm:GetParameters on "*" alongside the agent
+    // actions, so "SSM only, no secrets" would have been false: any plaintext
+    // Parameter Store value in the account would have been readable from the
+    // box (review E6). These are the agent's own actions and nothing else.
     this.workerRole = new iam.Role(this, 'WorkerRole', {
       roleName: 'polis-certify-worker',
-      description: 'P-022 E disposable certification worker (SSM only, no deploy rights)',
+      description: 'P-022 E synthetic CI worker: SSM agent actions only, no data access',
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
-      managedPolicies: [
-        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
-      ],
     });
-
-    if (props.fixtureBucket) {
-      // Read-only, prefix-bound. No ListBucket over the whole bucket: the
-      // prefix condition is what stops a compromised worker enumerating
-      // anything else that happens to live there.
-      this.workerRole.addToPolicy(new iam.PolicyStatement({
-        sid: 'ReadPrivateFixtureBundle',
-        actions: ['s3:GetObject', 's3:GetObjectVersion'],
-        resources: [`arn:${partition}:s3:::${props.fixtureBucket}/${props.fixturePrefix}*`],
-      }));
-      this.workerRole.addToPolicy(new iam.PolicyStatement({
-        sid: 'ListPrivateFixturePrefix',
-        actions: ['s3:ListBucket'],
-        resources: [`arn:${partition}:s3:::${props.fixtureBucket}`],
-        conditions: { StringLike: { 's3:prefix': [`${props.fixturePrefix}*`] } },
-      }));
-    }
-
-    if (props.evidenceBucket) {
-      this.workerRole.addToPolicy(new iam.PolicyStatement({
-        sid: 'WritePrivateEvidence',
-        actions: ['s3:PutObject', 's3:AbortMultipartUpload'],
-        resources: [`arn:${partition}:s3:::${props.evidenceBucket}/${props.evidencePrefix}*`],
-      }));
-    }
+    this.workerRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'SsmAgentRegistration',
+      actions: [
+        'ssm:UpdateInstanceInformation',
+        'ssm:ListAssociations',
+        'ssm:ListInstanceAssociations',
+        'ssm:DescribeAssociation',
+        'ssm:GetDocument',
+        'ssm:DescribeDocument',
+      ],
+      resources: ['*'], // none of these six support resource-level authorization
+    }));
+    this.workerRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'SsmAgentChannels',
+      actions: [
+        'ssmmessages:CreateControlChannel',
+        'ssmmessages:CreateDataChannel',
+        'ssmmessages:OpenControlChannel',
+        'ssmmessages:OpenDataChannel',
+        'ec2messages:AcknowledgeMessage',
+        'ec2messages:DeleteMessage',
+        'ec2messages:FailMessage',
+        'ec2messages:GetEndpoint',
+        'ec2messages:GetMessages',
+        'ec2messages:SendReply',
+      ],
+      resources: ['*'],
+    }));
 
     const instanceProfile = new iam.InstanceProfile(this, 'WorkerInstanceProfile', {
       instanceProfileName: 'polis-certify-worker',
@@ -132,32 +171,25 @@ export class CertificationCiEc2 extends Construct {
     // ------------------------------------------------------------------- net
     const securityGroup = new ec2.SecurityGroup(this, 'WorkerSg', {
       vpc: props.vpc,
-      description: 'P-022 E certification worker: no inbound, egress only',
+      description: 'P-022 E synthetic CI worker: no inbound, egress only',
       allowAllOutbound: true,
     });
 
     // ------------------------------------------------------- launch template
-    const userData = buildUserData(props);
-
     this.launchTemplate = new ec2.LaunchTemplate(this, 'LaunchTemplate', {
       launchTemplateName: 'polis-certify-ci',
-      versionDescription: 'P-022 E v1 disposable certification worker',
+      versionDescription: 'P-022 E synthetic recovery + public-fixture battery worker',
       machineImage: new ec2.AmazonLinuxImage({
         generation: ec2.AmazonLinuxGeneration.AMAZON_LINUX_2023,
         cpuType: props.cpuType,
       }),
       instanceType: props.instanceType,
       instanceProfile,
-      userData,
-      // Cost backstop #1: the OS shuts itself down on a hard deadline (see
-      // buildUserData) and the shutdown terminates rather than stops, so a
-      // wedged job cannot leave a running box or a stopped-but-billed volume.
+      userData: buildUserData(props),
       instanceInitiatedShutdownBehavior: ec2.InstanceInitiatedShutdownBehavior.TERMINATE,
       requireImdsv2: true,
       httpTokens: ec2.LaunchTemplateHttpTokens.REQUIRED,
       httpPutResponseHopLimit: 1,
-      // The user-data needs the ref tag; IMDS tags avoid granting the worker
-      // any ec2:DescribeTags. Hop limit 1 keeps containers off IMDS.
       instanceMetadataTags: true,
       detailedMonitoring: false,
       associatePublicIpAddress: false,
@@ -172,9 +204,6 @@ export class CertificationCiEc2 extends Construct {
       }],
     });
 
-    // Bake the subnet + security group into the template so the caller never
-    // supplies them. IAM also pins both by ARN, but a caller may still pass a
-    // *matching* value; baking them means the ordinary path passes nothing.
     const subnetId = props.vpc.selectSubnets({
       subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
     }).subnetIds[0];
@@ -186,11 +215,7 @@ export class CertificationCiEc2 extends Construct {
       AssociatePublicIpAddress: false,
       DeleteOnTermination: true,
     }]);
-    // NetworkInterfaces and top-level SecurityGroupIds are mutually exclusive.
     cfnLt.addPropertyDeletionOverride('LaunchTemplateData.SecurityGroupIds');
-    // Default tags on instance and volume, so a launch that forgets its own
-    // --tag-specifications is still terminable by tag. (RunInstances-supplied
-    // tag specs REPLACE these per resource type — the workflow re-sends them.)
     cfnLt.addPropertyOverride('LaunchTemplateData.TagSpecifications', [
       { ResourceType: 'instance', Tags: [{ Key: CI_TAG_KEY, Value: CI_TAG_VALUE }] },
       { ResourceType: 'volume', Tags: [{ Key: CI_TAG_KEY, Value: CI_TAG_VALUE }] },
@@ -203,37 +228,32 @@ export class CertificationCiEc2 extends Construct {
     };
 
     // ----------------------------------------------------------- github role
-    // Reuse the account's existing GitHub OIDC provider (the deploy workflows
-    // already authenticate through it); do not create a second one.
+    // The account's GitHub OIDC provider already exists (the deploy workflows
+    // authenticate through it); reference it, do not create a second one.
     const oidcProviderArn = `arn:${partition}:iam::${account}:oidc-provider/token.actions.githubusercontent.com`;
 
     this.githubRole = new iam.Role(this, 'GithubOidcRole', {
       roleName: 'polis-certify-github-oidc',
-      description: 'P-022 E: GitHub Actions launches/observes/terminates the certification worker',
-      // 6 h: the campaign budget is 6 h of compute, and configure-aws-credentials
-      // does not refresh. A 1 h session would expire mid-poll and orphan the box.
+      description: 'P-022 E: launches, drives and destroys the synthetic CI worker',
       maxSessionDuration: cdk.Duration.hours(6),
+      // ENVIRONMENT subject, exactly, and nothing else. No branch subject: an
+      // environment job's token carries the environment form, so a branch
+      // subject would not have matched anyway. No `pull_request`: fork-authored
+      // code must never be able to request this role from any workflow in the
+      // repository, whether or not THIS file has a pull_request trigger.
       assumedBy: new iam.WebIdentityPrincipal(oidcProviderArn, {
         StringEquals: {
           'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
-        },
-        StringLike: {
-          'token.actions.githubusercontent.com:sub': [
-            `repo:${props.githubRepo}:ref:refs/heads/edge`,
-            `repo:${props.githubRepo}:ref:refs/heads/stable`,
-            `repo:${props.githubRepo}:pull_request`,
-          ],
+          'token.actions.githubusercontent.com:sub':
+            `repo:${props.githubRepo}:environment:${props.githubEnvironment}`,
         },
       }),
     });
 
-    // (a) the instance itself: pinned template, pinned instance profile,
-    //     IMDSv2 required, and the disposable tag is mandatory at launch so
-    //     the tag-scoped terminate below can never fail to match.
     this.githubRole.addToPolicy(new iam.PolicyStatement({
       sid: 'LaunchApprovedInstance',
       actions: ['ec2:RunInstances'],
-      resources: [`arn:${partition}:ec2:${region}:${account}:instance/*`],
+      resources: [instanceArnPattern],
       conditions: {
         ArnEquals: {
           'ec2:LaunchTemplate': launchTemplateArn,
@@ -243,13 +263,19 @@ export class CertificationCiEc2 extends Construct {
         StringEquals: {
           'ec2:MetadataHttpTokens': 'required',
           [`aws:RequestTag/${CI_TAG_KEY}`]: CI_TAG_VALUE,
+          // Pinned in IAM, not merely defaulted in the template: a dispatch
+          // input must not be able to select an arbitrary hourly rate.
+          'ec2:InstanceType': props.allowedInstanceTypes,
         },
+        // Every launch must carry the run tag, so the teardown's lost-ID sweep
+        // and the sweeper's forensics always have an owner to name.
+        'ForAllValues:StringEquals': {
+          'aws:TagKeys': [CI_TAG_KEY, CI_REF_TAG_KEY, CI_RUN_TAG_KEY],
+        },
+        StringLike: { [`aws:RequestTag/${CI_RUN_TAG_KEY}`]: '?*' },
       },
     }));
 
-    // (b) the supporting resources the same call creates/consumes. Instance
-    //     configuration condition keys apply to the instance ARN, not to these,
-    //     so they are a separate statement (P-022-E-ci-spec.md).
     this.githubRole.addToPolicy(new iam.PolicyStatement({
       sid: 'ApprovedLaunchResources',
       actions: ['ec2:RunInstances'],
@@ -264,14 +290,11 @@ export class CertificationCiEc2 extends Construct {
       conditions: templateCondition,
     }));
 
-    // Launch-time tagging only. `ec2:CreateAction` pins this to RunInstances,
-    // so the role cannot retag anything that already exists; `aws:TagKeys`
-    // pins the exact three keys.
     this.githubRole.addToPolicy(new iam.PolicyStatement({
       sid: 'TagAtLaunchOnly',
       actions: ['ec2:CreateTags'],
       resources: [
-        `arn:${partition}:ec2:${region}:${account}:instance/*`,
+        instanceArnPattern,
         `arn:${partition}:ec2:${region}:${account}:volume/*`,
         `arn:${partition}:ec2:${region}:${account}:network-interface/*`,
       ],
@@ -280,14 +303,13 @@ export class CertificationCiEc2 extends Construct {
           'ec2:CreateAction': 'RunInstances',
           [`aws:RequestTag/${CI_TAG_KEY}`]: CI_TAG_VALUE,
         },
+        StringLike: { [`aws:RequestTag/${CI_RUN_TAG_KEY}`]: '?*' },
         'ForAllValues:StringEquals': {
           'aws:TagKeys': [CI_TAG_KEY, CI_REF_TAG_KEY, CI_RUN_TAG_KEY],
         },
       },
     }));
 
-    // Attaching an instance profile requires PassRole in addition to
-    // RunInstances. Exactly one role, only to EC2.
     this.githubRole.addToPolicy(new iam.PolicyStatement({
       sid: 'PassOnlyWorkerRole',
       actions: ['iam:PassRole'],
@@ -295,29 +317,31 @@ export class CertificationCiEc2 extends Construct {
       conditions: { StringEquals: { 'iam:PassedToService': 'ec2.amazonaws.com' } },
     }));
 
-    // EC2 Describe* has no resource-level authorization; it is read-only.
+    // EC2 Describe* has no resource-level authorization (confirmed against the
+    // service authorization reference); it is read-only metadata.
     this.githubRole.addToPolicy(new iam.PolicyStatement({
       sid: 'ObserveInstances',
-      actions: [
-        'ec2:DescribeInstances',
-        'ec2:DescribeInstanceStatus',
-        'ec2:DescribeTags',
-        'ec2:DescribeLaunchTemplates',
-        'ec2:DescribeLaunchTemplateVersions',
-      ],
+      actions: ['ec2:DescribeInstances', 'ec2:DescribeInstanceStatus'],
       resources: ['*'],
     }));
 
-    // The `if: always()` teardown, and the manual kill-by-tag runbook.
+    // `ec2:ResourceTag` IS a supported condition key for ec2:TerminateInstances
+    // on the instance resource. The workflow narrows this to the single
+    // instance it launched with an inline session policy; the tag condition is
+    // the floor, for the lost-ID sweep and the operator runbook.
     this.githubRole.addToPolicy(new iam.PolicyStatement({
-      sid: 'TerminateOwnDisposableInstances',
+      sid: 'TerminateDisposableCiInstances',
       actions: ['ec2:TerminateInstances'],
-      resources: [`arn:${partition}:ec2:${region}:${account}:instance/*`],
+      resources: [instanceArnPattern],
       conditions: { StringEquals: { [`ec2:ResourceTag/${CI_TAG_KEY}`]: CI_TAG_VALUE } },
     }));
 
-    // SendCommand is authorized against BOTH the document and the targets, so
-    // it takes two statements: only AWS-RunShellScript, only tagged instances.
+    // SendCommand authorizes against the document AND the target, so two
+    // statements. Round 1 used `ec2:ResourceTag/...` here, which the SSM
+    // service authorization reference does not list for this action — the
+    // instance resource type supports `aws:ResourceTag/${TagKey}` and
+    // `ssm:resourceTag/${TagKey}` only, so the intended target would have been
+    // denied (review E6). Corrected to `ssm:resourceTag/`.
     this.githubRole.addToPolicy(new iam.PolicyStatement({
       sid: 'RunShellScriptDocumentOnly',
       actions: ['ssm:SendCommand'],
@@ -326,20 +350,71 @@ export class CertificationCiEc2 extends Construct {
     this.githubRole.addToPolicy(new iam.PolicyStatement({
       sid: 'SendCommandToDisposableInstancesOnly',
       actions: ['ssm:SendCommand'],
-      resources: [`arn:${partition}:ec2:${region}:${account}:instance/*`],
-      conditions: { StringEquals: { [`ec2:ResourceTag/${CI_TAG_KEY}`]: CI_TAG_VALUE } },
+      resources: [instanceArnPattern],
+      conditions: { StringEquals: { [`ssm:resourceTag/${CI_TAG_KEY}`]: CI_TAG_VALUE } },
     }));
+    // ssm:GetCommandInvocation and ssm:DescribeInstanceInformation support NO
+    // resource types and NO condition keys (service authorization reference),
+    // so they cannot be narrowed here or in a session policy. That residual is
+    // why ListCommands/ListCommandInvocations/CancelCommand were dropped
+    // outright in round 2 rather than kept "for convenience", and why the
+    // account this runs in matters (review E6).
     this.githubRole.addToPolicy(new iam.PolicyStatement({
-      sid: 'ReadOwnCommandResults',
-      actions: [
-        'ssm:GetCommandInvocation',
-        'ssm:ListCommandInvocations',
-        'ssm:ListCommands',
-        'ssm:DescribeInstanceInformation',
-        'ssm:CancelCommand',
-      ],
+      sid: 'ReadCommandResults',
+      actions: ['ssm:GetCommandInvocation', 'ssm:DescribeInstanceInformation'],
       resources: ['*'],
     }));
+
+    // ------------------------------------------------------- expiry sweeper
+    // Independent of GitHub entirely: it runs whether or not a workflow ever
+    // reaches its teardown, whether or not the OS timer armed, and whether or
+    // not the instance's kernel is alive (review E7, BOARD [12]).
+    const sweeperRole = new iam.Role(this, 'SweeperRole', {
+      description: 'P-022 E expiry sweeper: kill overdue disposable CI instances',
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+    sweeperRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'FindOverdueCiInstances',
+      actions: ['ec2:DescribeInstances'],
+      resources: ['*'],
+    }));
+    sweeperRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'TerminateOverdueCiInstances',
+      actions: ['ec2:TerminateInstances'],
+      resources: [instanceArnPattern],
+      conditions: { StringEquals: { [`ec2:ResourceTag/${CI_TAG_KEY}`]: CI_TAG_VALUE } },
+    }));
+
+    // An explicit log group rather than the `logRetention` prop: that prop
+    // drags in a shared LogRetention custom-resource Lambda and its role, which
+    // is three extra account-wide resources for a retention setting.
+    const sweeperLogs = new logs.LogGroup(this, 'ExpirySweeperLogs', {
+      retention: logs.RetentionDays.ONE_MONTH,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+    sweeperLogs.grantWrite(sweeperRole);
+
+    const sweeper = new lambda.Function(this, 'ExpirySweeper', {
+      description: 'Terminates polis:ci=disposable instances older than the hard deadline',
+      runtime: lambda.Runtime.PYTHON_3_12,
+      architecture: lambda.Architecture.ARM_64,
+      handler: 'index.handler',
+      role: sweeperRole,
+      timeout: cdk.Duration.minutes(2),
+      logGroup: sweeperLogs,
+      environment: {
+        MAX_AGE_MINUTES: String(props.sweeperMaxAgeMinutes),
+        CI_TAG_KEY,
+        CI_TAG_VALUE,
+      },
+      code: lambda.Code.fromInline(SWEEPER_SOURCE),
+    });
+
+    new events.Rule(this, 'ExpirySweeperSchedule', {
+      description: 'Hourly expiry sweep for P-022 E disposable CI instances',
+      schedule: events.Schedule.rate(cdk.Duration.hours(1)),
+      targets: [new targets.LambdaFunction(sweeper)],
+    });
 
     // --------------------------------------------------------------- outputs
     new cdk.CfnOutput(this, 'CertifyOidcRoleArn', {
@@ -358,48 +433,102 @@ export class CertificationCiEc2 extends Construct {
 }
 
 /**
- * User data for the disposable worker.
+ * The expiry sweeper. Deliberately tiny, dependency-free and independent of the
+ * Actions run: it is the only teardown guarantee that survives a dead runner, a
+ * forced cancellation, an expired credential or a wedged kernel.
+ */
+const SWEEPER_SOURCE = `
+import datetime, os
+import boto3
+
+MAX_AGE = datetime.timedelta(minutes=int(os.environ["MAX_AGE_MINUTES"]))
+TAG_KEY = os.environ["CI_TAG_KEY"]
+TAG_VALUE = os.environ["CI_TAG_VALUE"]
+ACTIVE = ["pending", "running", "stopping", "stopped"]
+
+
+def handler(event, context):
+    ec2 = boto3.client("ec2")
+    now = datetime.datetime.now(datetime.timezone.utc)
+    overdue, seen = [], 0
+    paginator = ec2.get_paginator("describe_instances")
+    pages = paginator.paginate(Filters=[
+        {"Name": "tag:" + TAG_KEY, "Values": [TAG_VALUE]},
+        {"Name": "instance-state-name", "Values": ACTIVE},
+    ])
+    for page in pages:
+        for reservation in page["Reservations"]:
+            for inst in reservation["Instances"]:
+                seen += 1
+                age = now - inst["LaunchTime"]
+                if age > MAX_AGE:
+                    overdue.append(inst["InstanceId"])
+                    print("OVERDUE %s age=%s state=%s tags=%s" % (
+                        inst["InstanceId"], age, inst["State"]["Name"],
+                        {t["Key"]: t["Value"] for t in inst.get("Tags", [])}))
+    if overdue:
+        # Let a failure here raise: an unswept overdue instance must show up as
+        # a Lambda error metric, not as a silent success.
+        ec2.terminate_instances(InstanceIds=overdue)
+        print("TERMINATED %s" % overdue)
+    return {"seen": seen, "terminated": overdue}
+`;
+
+/**
+ * User data for the synthetic worker.
  *
- * Ordering matters: the shutdown timer is armed BEFORE anything that can fail,
- * so a broken bootstrap still costs at most `shutdownMinutes` of instance time.
+ * Two things in order matter here. First, the hard deadline is armed before
+ * anything that can fail, and — round 2 — a failure to arm it is fatal rather
+ * than swallowed by `|| true`: an instance that cannot promise to kill itself
+ * kills itself now. Second, a redundant in-process timer is started, so the
+ * deadline does not depend on a single `shutdown` implementation.
+ *
  * The git ref arrives as an instance tag read through IMDSv2 and is validated
- * against a strict character class before it is ever handed to git — it is
- * caller-controlled input and is never eval'd or interpolated into a shell
- * command that could break out of its quoting.
+ * against a strict character class before git sees it. Nothing prod-derived is
+ * ever staged here: there is no fixture bucket, and the instance role cannot
+ * read one.
  */
 function buildUserData(props: CertificationCiEc2Props): ec2.UserData {
   const ud = ec2.UserData.forLinux();
+  const deadlineSeconds = props.shutdownMinutes * 60;
   ud.addCommands(
     'set -euo pipefail',
     'exec > >(tee -a /var/log/polis-ci-userdata.log) 2>&1',
     'echo "polis-ci bootstrap starting at $(date -u --iso-8601=seconds)"',
     '',
-    '# --- cost backstop: arm the hard deadline before anything that can fail.',
-    '# The launch template sets InstanceInitiatedShutdownBehavior=terminate, so',
-    '# this halt is a termination, not a stop.',
-    `shutdown -h +${props.shutdownMinutes} "polis-ci hard deadline" || true`,
-    '',
     'fail() { echo "polis-ci bootstrap FAILED: $*" >&2; touch /var/lib/polis-ci-failed; exit 1; }',
     '',
-    '# --- docker + compose (v2 CLI plugin) + the tools the suites shell out to.',
+    '# --- cost backstop, armed before anything that can fail. The launch',
+    '# template sets InstanceInitiatedShutdownBehavior=terminate, so a halt is',
+    '# a termination. An instance that cannot arm its own deadline is a cost',
+    '# leak waiting to happen, so failing to arm it is fatal immediately.',
+    `if ! shutdown -h +${props.shutdownMinutes} "polis-ci hard deadline"; then`,
+    '  echo "could not arm the shutdown timer; terminating now" >&2',
+    '  poweroff -f',
+    '  exit 1',
+    'fi',
+    '# Redundant timer, independent of shutdown(8) and of this script surviving.',
+    `setsid bash -c 'sleep ${deadlineSeconds}; poweroff -f' </dev/null >/dev/null 2>&1 &`,
+    '',
+    '# --- docker + compose + the tools the suites shell out to.',
     'dnf update -y || true',
-    'dnf install -y docker git jq tar gzip make awscli-2 || dnf install -y docker git jq tar gzip',
-    'systemctl enable --now docker',
+    'dnf install -y docker git jq tar gzip make || fail "dnf install"',
+    'systemctl enable --now docker || fail "docker"',
     'usermod -a -G docker ec2-user',
-    '# $(uname -m) resolves to aarch64 on Graviton and x86_64 otherwise; a',
-    '# hardcoded arch here is how a boot script dies with "Exec format error".',
+    '# $(uname -m) is aarch64 on Graviton and x86_64 otherwise; a hardcoded',
+    '# arch here is how a boot script dies with "Exec format error".',
     'COMPOSE_VERSION=v2.40.0',
     'mkdir -p /usr/libexec/docker/cli-plugins',
-    'curl -fsSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" -o /usr/libexec/docker/cli-plugins/docker-compose',
+    'curl -fsSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" -o /usr/libexec/docker/cli-plugins/docker-compose || fail "compose download"',
     'chmod +x /usr/libexec/docker/cli-plugins/docker-compose',
     'ln -sf /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose',
-    'docker compose version',
+    'docker compose version || fail "compose"',
     '',
     '# --- which ref to test: an instance tag, read over IMDSv2.',
     'IMDS_TOKEN="$(curl -fsS -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 600")" || fail "no IMDSv2 token"',
     `POLIS_REF="$(curl -fsS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" "http://169.254.169.254/latest/meta-data/tags/instance/${CI_REF_TAG_KEY}" || true)"`,
     'if [ -z "$POLIS_REF" ]; then POLIS_REF=edge; fi',
-    '# Untrusted input. Allow only ref-shaped characters, and no ".." segment.',
+    '# Untrusted input. Ref-shaped characters only, and no ".." segment.',
     'if ! printf %s "$POLIS_REF" | grep -Eq \'^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$\'; then fail "rejected ref"; fi',
     'case "$POLIS_REF" in *..*) fail "rejected ref" ;; esac',
     '',
@@ -411,7 +540,6 @@ function buildUserData(props: CertificationCiEc2Props): ec2.UserData {
     'chown -R ec2-user:ec2-user /opt/polis',
     '',
     'mkdir -p /var/log/polis-ci',
-    'chown ec2-user:ec2-user /var/log/polis-ci',
     '# The workflow polls for this marker before it sends any SSM command.',
     'touch /var/lib/polis-ci-ready',
     'echo "polis-ci bootstrap ready at $(date -u --iso-8601=seconds) sha=$(cat /var/lib/polis-ci-sha)"',

--- a/cdk/ciEc2.ts
+++ b/cdk/ciEc2.ts
@@ -81,15 +81,24 @@ export interface CertificationCiEc2Props {
    */
   readonly githubEnvironment: string;
   /**
-   * Exact `job_workflow_ref` values the token must carry — the reviewed
-   * workflow file at a reviewed branch. The environment subject binds neither
-   * the workflow nor the event (review R2-F5): a job in ANY workflow that
-   * references this environment gets the same subject. These claims do bind
-   * them, and they fail closed.
+   * Exact `ref` claim values admitted, e.g. `refs/heads/edge`.
+   *
+   * Round 3 bound `job_workflow_ref` and `event_name` instead. Both were wrong
+   * (review R3-F1): `job_workflow_ref` is the claim for a job that CALLS a
+   * reusable workflow, and this job runs directly on a runner, so the token
+   * carries `workflow_ref` and the StringEquals could never match — the trust
+   * policy could not admit the workflow it ships with. `event_name` is emitted
+   * by GitHub but is not in AWS's supported context-key list for this provider,
+   * so it is not a gate STS will evaluate.
+   *
+   * `ref` IS supported, and it is what excludes pull-request jobs: a PR job's
+   * ref is `refs/pull/<n>/merge`, never `refs/heads/edge`. Combined with the
+   * environment-form `sub` and the environment's own branch protection, that is
+   * the admission boundary.
    */
-  readonly githubWorkflowRefs: string[];
-  /** Exact `event_name` values admitted. Excludes `pull_request` at the token. */
-  readonly githubEventNames: string[];
+  readonly githubRefs: string[];
+  /** Exact `repository` claim value; belt and braces with the subject. */
+  readonly githubRepositoryClaim?: string;
   /** Default instance type baked into the template. */
   readonly instanceType: ec2.InstanceType;
   /** Must match `instanceType`'s architecture. */
@@ -130,13 +139,14 @@ export class CertificationCiEc2 extends Construct {
     }
     // An empty list would render as an undefined condition value, which CDK
     // silently drops — the binding would vanish rather than fail. Refuse it.
-    if (!props.githubWorkflowRefs?.length) {
-      throw new Error('ciEc2WorkflowRefs must not be empty: the environment subject '
-        + 'does not bind the workflow, so this claim is the only thing that does');
+    if (!props.githubRefs?.length) {
+      throw new Error('ciEc2Refs must not be empty: the environment subject does not '
+        + 'exclude pull-request jobs, and the ref claim is what does');
     }
-    if (!props.githubEventNames?.length) {
-      throw new Error('ciEc2EventNames must not be empty: the environment subject '
-        + 'does not exclude pull_request, so this claim is the only thing that does');
+    for (const ref of props.githubRefs) {
+      if (!ref.startsWith('refs/heads/')) {
+        throw new Error(`ciEc2Refs entries must be full branch refs, got ${ref}`);
+      }
     }
 
     const stack = cdk.Stack.of(this);
@@ -276,13 +286,13 @@ export class CertificationCiEc2 extends Construct {
           'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
           'token.actions.githubusercontent.com:sub':
             `repo:${props.githubRepo}:environment:${props.githubEnvironment}`,
-          // The subject alone binds neither workflow nor event. These two
-          // claims do. A StringEquals against a list is an OR, so each is an
-          // explicit allowlist. Both must be validated against the repository's
-          // actual token claims before the first real run: a wrong claim name
-          // fails the assume, which is the correct direction to fail.
-          'token.actions.githubusercontent.com:job_workflow_ref': props.githubWorkflowRefs,
-          'token.actions.githubusercontent.com:event_name': props.githubEventNames,
+          // The environment-form subject does not carry the ref, and a job
+          // referencing an environment gets that subject on a pull request too.
+          // `ref` is the supported claim that separates them. StringEquals
+          // against a list is an OR, i.e. an explicit allowlist.
+          'token.actions.githubusercontent.com:ref': props.githubRefs,
+          'token.actions.githubusercontent.com:repository':
+            props.githubRepositoryClaim ?? props.githubRepo,
         },
       }),
     });
@@ -589,7 +599,11 @@ function buildUserData(props: CertificationCiEc2Props): ec2.UserData {
     '# --- which ref to test: an instance tag, read over IMDSv2.',
     'IMDS_TOKEN="$(curl -fsS -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 600")" || fail "no IMDSv2 token"',
     `POLIS_REF="$(curl -fsS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" "http://169.254.169.254/latest/meta-data/tags/instance/${CI_REF_TAG_KEY}" || true)"`,
-    'if [ -z "$POLIS_REF" ]; then POLIS_REF=edge; fi',
+    '# No default. Round 3 fell back to `edge` when the tag read failed, so a',
+    '# box could silently test a different commit from the one the workflow',
+    '# resolved and later validated against (review R3-F4). Missing identity is',
+    '# a bootstrap failure.',
+    'if [ -z "$POLIS_REF" ]; then fail "no polis:ci-ref tag; refusing to guess a ref"; fi',
     '# Untrusted input. Ref-shaped characters only, and no ".." segment.',
     'if ! printf %s "$POLIS_REF" | grep -Eq \'^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$\'; then fail "rejected ref"; fi',
     'case "$POLIS_REF" in *..*) fail "rejected ref" ;; esac',

--- a/cdk/ciEc2.ts
+++ b/cdk/ciEc2.ts
@@ -128,6 +128,16 @@ export class CertificationCiEc2 extends Construct {
     if (props.allowedInstanceTypes.length === 0) {
       throw new Error('ciEc2AllowedInstanceTypes must not be empty');
     }
+    // An empty list would render as an undefined condition value, which CDK
+    // silently drops — the binding would vanish rather than fail. Refuse it.
+    if (!props.githubWorkflowRefs?.length) {
+      throw new Error('ciEc2WorkflowRefs must not be empty: the environment subject '
+        + 'does not bind the workflow, so this claim is the only thing that does');
+    }
+    if (!props.githubEventNames?.length) {
+      throw new Error('ciEc2EventNames must not be empty: the environment subject '
+        + 'does not exclude pull_request, so this claim is the only thing that does');
+    }
 
     const stack = cdk.Stack.of(this);
     const { account, region, partition } = stack;

--- a/cdk/ciEc2.ts
+++ b/cdk/ciEc2.ts
@@ -1,0 +1,420 @@
+/**
+ * P-022 §E v1 ("minimal") — disposable EC2 worker for the Delphi certification
+ * battery and the recovery matrix.
+ *
+ * This construct is DORMANT by default. It is only instantiated when the CDK
+ * context flag `enableCiEc2` is true:
+ *
+ *     npx cdk synth                          # unchanged stack, nothing here
+ *     npx cdk synth -c enableCiEc2=true      # adds the resources below
+ *
+ * What it provisions (and nothing else):
+ *
+ *   1. `PolisCertifyGithubOidc` — an IAM role assumable **only** by GitHub
+ *      Actions OIDC from this repository on `edge`, `stable` and pull-request
+ *      refs. Its permissions are: RunInstances from exactly one launch
+ *      template, the launch-time tags that make the instance findable and
+ *      killable, PassRole for exactly the worker role, EC2 Describe, tag-scoped
+ *      TerminateInstances, and SSM SendCommand/GetCommandInvocation against
+ *      tag-scoped instances. No SSH key, no secrets, no S3 fixture read, no
+ *      deployment permissions, no template mutation.
+ *
+ *   2. `PolisCertifyWorker` — the instance role. SSM core only, plus (optional,
+ *      context-gated) read of the private fixture-bundle prefix and write of
+ *      the private evidence prefix. The GitHub role can read neither.
+ *
+ *   3. `CertifyCiLaunchTemplate` — one disposable Graviton box: IMDSv2
+ *      required, no public IP, no inbound rules, an encrypted gp3 root volume,
+ *      `InstanceInitiatedShutdownBehavior=terminate`, and a user-data script
+ *      whose *first* action is `shutdown -h +N` so the instance dies on a hard
+ *      deadline even if every later step fails.
+ *
+ * Deliberately NOT here (P-022 §E v2, explicitly out of scope): the Lambda
+ * admission controller, the JWT capability service, the baked trusted AMI, the
+ * signed safe-summary publisher. See cost-reduction/04-plans/P-022-E-ci-spec.md.
+ */
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+/** Tag key/value that every disposable CI instance must carry. Termination,
+ *  SSM access and the manual "kill a stuck box" runbook are all scoped to it. */
+export const CI_TAG_KEY = 'polis:ci';
+export const CI_TAG_VALUE = 'disposable';
+/** Launch-time tag the user-data reads (via IMDS instance tags) to learn which
+ *  git ref to check out. Treated as untrusted input and validated in bash. */
+export const CI_REF_TAG_KEY = 'polis:ci-ref';
+/** Launch-time tag carrying `<run_id>-<attempt>`; diagnostics only. */
+export const CI_RUN_TAG_KEY = 'polis:ci-run';
+
+export interface CertificationCiEc2Props {
+  /** VPC to place the worker in. A PRIVATE_WITH_EGRESS subnet is used, so the
+   *  box reaches GitHub/PyPI/Maven/SSM through the existing NAT gateway and is
+   *  not reachable from the internet. */
+  readonly vpc: ec2.IVpc;
+  /** `owner/repo` allowed to assume the OIDC role. */
+  readonly githubRepo: string;
+  /** Instance type. Graviton (arm64) by default — see docs/ci-ec2.md. */
+  readonly instanceType: ec2.InstanceType;
+  /** Must match `instanceType`'s architecture. */
+  readonly cpuType: ec2.AmazonLinuxCpuType;
+  /** Root volume size, GiB. */
+  readonly volumeSizeGiB: number;
+  /** Hard deadline, minutes. `shutdown -h +N` + shutdown-behavior=terminate. */
+  readonly shutdownMinutes: number;
+  /** Optional: bucket holding the private prod-derived fixture bundle. The
+   *  WORKER may read it; the GitHub role may not. Absent → battery skipped. */
+  readonly fixtureBucket?: string;
+  /** Key prefix within `fixtureBucket`. */
+  readonly fixturePrefix: string;
+  /** Optional: bucket for raw private evidence. Worker writes, GitHub cannot
+   *  read (P-022 §E: no private artifact in a public Actions artifact). */
+  readonly evidenceBucket?: string;
+  /** Key prefix within `evidenceBucket`. */
+  readonly evidencePrefix: string;
+}
+
+export class CertificationCiEc2 extends Construct {
+  public readonly githubRole: iam.Role;
+  public readonly workerRole: iam.Role;
+  public readonly launchTemplate: ec2.LaunchTemplate;
+
+  constructor(scope: Construct, id: string, props: CertificationCiEc2Props) {
+    super(scope, id);
+
+    const stack = cdk.Stack.of(this);
+    const { account, region, partition } = stack;
+
+    // ---------------------------------------------------------------- worker
+    // Instance role. SSM core is what makes SendCommand work at all; it is the
+    // reason there is no SSH key, no public IP and no inbound security-group
+    // rule anywhere in this construct.
+    this.workerRole = new iam.Role(this, 'WorkerRole', {
+      roleName: 'polis-certify-worker',
+      description: 'P-022 E disposable certification worker (SSM only, no deploy rights)',
+      assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
+      ],
+    });
+
+    if (props.fixtureBucket) {
+      // Read-only, prefix-bound. No ListBucket over the whole bucket: the
+      // prefix condition is what stops a compromised worker enumerating
+      // anything else that happens to live there.
+      this.workerRole.addToPolicy(new iam.PolicyStatement({
+        sid: 'ReadPrivateFixtureBundle',
+        actions: ['s3:GetObject', 's3:GetObjectVersion'],
+        resources: [`arn:${partition}:s3:::${props.fixtureBucket}/${props.fixturePrefix}*`],
+      }));
+      this.workerRole.addToPolicy(new iam.PolicyStatement({
+        sid: 'ListPrivateFixturePrefix',
+        actions: ['s3:ListBucket'],
+        resources: [`arn:${partition}:s3:::${props.fixtureBucket}`],
+        conditions: { StringLike: { 's3:prefix': [`${props.fixturePrefix}*`] } },
+      }));
+    }
+
+    if (props.evidenceBucket) {
+      this.workerRole.addToPolicy(new iam.PolicyStatement({
+        sid: 'WritePrivateEvidence',
+        actions: ['s3:PutObject', 's3:AbortMultipartUpload'],
+        resources: [`arn:${partition}:s3:::${props.evidenceBucket}/${props.evidencePrefix}*`],
+      }));
+    }
+
+    const instanceProfile = new iam.InstanceProfile(this, 'WorkerInstanceProfile', {
+      instanceProfileName: 'polis-certify-worker',
+      role: this.workerRole,
+    });
+
+    // ------------------------------------------------------------------- net
+    const securityGroup = new ec2.SecurityGroup(this, 'WorkerSg', {
+      vpc: props.vpc,
+      description: 'P-022 E certification worker: no inbound, egress only',
+      allowAllOutbound: true,
+    });
+
+    // ------------------------------------------------------- launch template
+    const userData = buildUserData(props);
+
+    this.launchTemplate = new ec2.LaunchTemplate(this, 'LaunchTemplate', {
+      launchTemplateName: 'polis-certify-ci',
+      versionDescription: 'P-022 E v1 disposable certification worker',
+      machineImage: new ec2.AmazonLinuxImage({
+        generation: ec2.AmazonLinuxGeneration.AMAZON_LINUX_2023,
+        cpuType: props.cpuType,
+      }),
+      instanceType: props.instanceType,
+      instanceProfile,
+      userData,
+      // Cost backstop #1: the OS shuts itself down on a hard deadline (see
+      // buildUserData) and the shutdown terminates rather than stops, so a
+      // wedged job cannot leave a running box or a stopped-but-billed volume.
+      instanceInitiatedShutdownBehavior: ec2.InstanceInitiatedShutdownBehavior.TERMINATE,
+      requireImdsv2: true,
+      httpTokens: ec2.LaunchTemplateHttpTokens.REQUIRED,
+      httpPutResponseHopLimit: 1,
+      // The user-data needs the ref tag; IMDS tags avoid granting the worker
+      // any ec2:DescribeTags. Hop limit 1 keeps containers off IMDS.
+      instanceMetadataTags: true,
+      detailedMonitoring: false,
+      associatePublicIpAddress: false,
+      disableApiTermination: false,
+      blockDevices: [{
+        deviceName: '/dev/xvda',
+        volume: ec2.BlockDeviceVolume.ebs(props.volumeSizeGiB, {
+          volumeType: ec2.EbsDeviceVolumeType.GP3,
+          encrypted: true,
+          deleteOnTermination: true,
+        }),
+      }],
+    });
+
+    // Bake the subnet + security group into the template so the caller never
+    // supplies them. IAM also pins both by ARN, but a caller may still pass a
+    // *matching* value; baking them means the ordinary path passes nothing.
+    const subnetId = props.vpc.selectSubnets({
+      subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+    }).subnetIds[0];
+    const cfnLt = this.launchTemplate.node.defaultChild as ec2.CfnLaunchTemplate;
+    cfnLt.addPropertyOverride('LaunchTemplateData.NetworkInterfaces', [{
+      DeviceIndex: 0,
+      SubnetId: subnetId,
+      Groups: [securityGroup.securityGroupId],
+      AssociatePublicIpAddress: false,
+      DeleteOnTermination: true,
+    }]);
+    // NetworkInterfaces and top-level SecurityGroupIds are mutually exclusive.
+    cfnLt.addPropertyDeletionOverride('LaunchTemplateData.SecurityGroupIds');
+    // Default tags on instance and volume, so a launch that forgets its own
+    // --tag-specifications is still terminable by tag. (RunInstances-supplied
+    // tag specs REPLACE these per resource type — the workflow re-sends them.)
+    cfnLt.addPropertyOverride('LaunchTemplateData.TagSpecifications', [
+      { ResourceType: 'instance', Tags: [{ Key: CI_TAG_KEY, Value: CI_TAG_VALUE }] },
+      { ResourceType: 'volume', Tags: [{ Key: CI_TAG_KEY, Value: CI_TAG_VALUE }] },
+    ]);
+
+    const launchTemplateArn = `arn:${partition}:ec2:${region}:${account}:launch-template/${this.launchTemplate.launchTemplateId}`;
+    const templateCondition = {
+      ArnEquals: { 'ec2:LaunchTemplate': launchTemplateArn },
+      Bool: { 'ec2:IsLaunchTemplateResource': 'true' },
+    };
+
+    // ----------------------------------------------------------- github role
+    // Reuse the account's existing GitHub OIDC provider (the deploy workflows
+    // already authenticate through it); do not create a second one.
+    const oidcProviderArn = `arn:${partition}:iam::${account}:oidc-provider/token.actions.githubusercontent.com`;
+
+    this.githubRole = new iam.Role(this, 'GithubOidcRole', {
+      roleName: 'polis-certify-github-oidc',
+      description: 'P-022 E: GitHub Actions launches/observes/terminates the certification worker',
+      // 6 h: the campaign budget is 6 h of compute, and configure-aws-credentials
+      // does not refresh. A 1 h session would expire mid-poll and orphan the box.
+      maxSessionDuration: cdk.Duration.hours(6),
+      assumedBy: new iam.WebIdentityPrincipal(oidcProviderArn, {
+        StringEquals: {
+          'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+        },
+        StringLike: {
+          'token.actions.githubusercontent.com:sub': [
+            `repo:${props.githubRepo}:ref:refs/heads/edge`,
+            `repo:${props.githubRepo}:ref:refs/heads/stable`,
+            `repo:${props.githubRepo}:pull_request`,
+          ],
+        },
+      }),
+    });
+
+    // (a) the instance itself: pinned template, pinned instance profile,
+    //     IMDSv2 required, and the disposable tag is mandatory at launch so
+    //     the tag-scoped terminate below can never fail to match.
+    this.githubRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'LaunchApprovedInstance',
+      actions: ['ec2:RunInstances'],
+      resources: [`arn:${partition}:ec2:${region}:${account}:instance/*`],
+      conditions: {
+        ArnEquals: {
+          'ec2:LaunchTemplate': launchTemplateArn,
+          'ec2:InstanceProfile': instanceProfile.instanceProfileArn,
+        },
+        Bool: { 'ec2:IsLaunchTemplateResource': 'true' },
+        StringEquals: {
+          'ec2:MetadataHttpTokens': 'required',
+          [`aws:RequestTag/${CI_TAG_KEY}`]: CI_TAG_VALUE,
+        },
+      },
+    }));
+
+    // (b) the supporting resources the same call creates/consumes. Instance
+    //     configuration condition keys apply to the instance ARN, not to these,
+    //     so they are a separate statement (P-022-E-ci-spec.md).
+    this.githubRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'ApprovedLaunchResources',
+      actions: ['ec2:RunInstances'],
+      resources: [
+        `arn:${partition}:ec2:${region}::image/*`,
+        `arn:${partition}:ec2:${region}:${account}:subnet/${subnetId}`,
+        `arn:${partition}:ec2:${region}:${account}:security-group/${securityGroup.securityGroupId}`,
+        `arn:${partition}:ec2:${region}:${account}:network-interface/*`,
+        `arn:${partition}:ec2:${region}:${account}:volume/*`,
+        `arn:${partition}:ec2:${region}:${account}:launch-template/${this.launchTemplate.launchTemplateId}`,
+      ],
+      conditions: templateCondition,
+    }));
+
+    // Launch-time tagging only. `ec2:CreateAction` pins this to RunInstances,
+    // so the role cannot retag anything that already exists; `aws:TagKeys`
+    // pins the exact three keys.
+    this.githubRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'TagAtLaunchOnly',
+      actions: ['ec2:CreateTags'],
+      resources: [
+        `arn:${partition}:ec2:${region}:${account}:instance/*`,
+        `arn:${partition}:ec2:${region}:${account}:volume/*`,
+        `arn:${partition}:ec2:${region}:${account}:network-interface/*`,
+      ],
+      conditions: {
+        StringEquals: {
+          'ec2:CreateAction': 'RunInstances',
+          [`aws:RequestTag/${CI_TAG_KEY}`]: CI_TAG_VALUE,
+        },
+        'ForAllValues:StringEquals': {
+          'aws:TagKeys': [CI_TAG_KEY, CI_REF_TAG_KEY, CI_RUN_TAG_KEY],
+        },
+      },
+    }));
+
+    // Attaching an instance profile requires PassRole in addition to
+    // RunInstances. Exactly one role, only to EC2.
+    this.githubRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'PassOnlyWorkerRole',
+      actions: ['iam:PassRole'],
+      resources: [this.workerRole.roleArn],
+      conditions: { StringEquals: { 'iam:PassedToService': 'ec2.amazonaws.com' } },
+    }));
+
+    // EC2 Describe* has no resource-level authorization; it is read-only.
+    this.githubRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'ObserveInstances',
+      actions: [
+        'ec2:DescribeInstances',
+        'ec2:DescribeInstanceStatus',
+        'ec2:DescribeTags',
+        'ec2:DescribeLaunchTemplates',
+        'ec2:DescribeLaunchTemplateVersions',
+      ],
+      resources: ['*'],
+    }));
+
+    // The `if: always()` teardown, and the manual kill-by-tag runbook.
+    this.githubRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'TerminateOwnDisposableInstances',
+      actions: ['ec2:TerminateInstances'],
+      resources: [`arn:${partition}:ec2:${region}:${account}:instance/*`],
+      conditions: { StringEquals: { [`ec2:ResourceTag/${CI_TAG_KEY}`]: CI_TAG_VALUE } },
+    }));
+
+    // SendCommand is authorized against BOTH the document and the targets, so
+    // it takes two statements: only AWS-RunShellScript, only tagged instances.
+    this.githubRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'RunShellScriptDocumentOnly',
+      actions: ['ssm:SendCommand'],
+      resources: [`arn:${partition}:ssm:${region}::document/AWS-RunShellScript`],
+    }));
+    this.githubRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'SendCommandToDisposableInstancesOnly',
+      actions: ['ssm:SendCommand'],
+      resources: [`arn:${partition}:ec2:${region}:${account}:instance/*`],
+      conditions: { StringEquals: { [`ec2:ResourceTag/${CI_TAG_KEY}`]: CI_TAG_VALUE } },
+    }));
+    this.githubRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'ReadOwnCommandResults',
+      actions: [
+        'ssm:GetCommandInvocation',
+        'ssm:ListCommandInvocations',
+        'ssm:ListCommands',
+        'ssm:DescribeInstanceInformation',
+        'ssm:CancelCommand',
+      ],
+      resources: ['*'],
+    }));
+
+    // --------------------------------------------------------------- outputs
+    new cdk.CfnOutput(this, 'CertifyOidcRoleArn', {
+      value: this.githubRole.roleArn,
+      description: 'Set as the CERTIFY_OIDC_ROLE_ARN repository variable',
+    });
+    new cdk.CfnOutput(this, 'CertifyLaunchTemplateId', {
+      value: this.launchTemplate.launchTemplateId!,
+      description: 'Set as the CERTIFY_LAUNCH_TEMPLATE_ID repository variable',
+    });
+    new cdk.CfnOutput(this, 'CertifyWorkerRoleArn', {
+      value: this.workerRole.roleArn,
+      description: 'Instance role of the disposable worker (not assumable by GitHub)',
+    });
+  }
+}
+
+/**
+ * User data for the disposable worker.
+ *
+ * Ordering matters: the shutdown timer is armed BEFORE anything that can fail,
+ * so a broken bootstrap still costs at most `shutdownMinutes` of instance time.
+ * The git ref arrives as an instance tag read through IMDSv2 and is validated
+ * against a strict character class before it is ever handed to git — it is
+ * caller-controlled input and is never eval'd or interpolated into a shell
+ * command that could break out of its quoting.
+ */
+function buildUserData(props: CertificationCiEc2Props): ec2.UserData {
+  const ud = ec2.UserData.forLinux();
+  ud.addCommands(
+    'set -euo pipefail',
+    'exec > >(tee -a /var/log/polis-ci-userdata.log) 2>&1',
+    'echo "polis-ci bootstrap starting at $(date -u --iso-8601=seconds)"',
+    '',
+    '# --- cost backstop: arm the hard deadline before anything that can fail.',
+    '# The launch template sets InstanceInitiatedShutdownBehavior=terminate, so',
+    '# this halt is a termination, not a stop.',
+    `shutdown -h +${props.shutdownMinutes} "polis-ci hard deadline" || true`,
+    '',
+    'fail() { echo "polis-ci bootstrap FAILED: $*" >&2; touch /var/lib/polis-ci-failed; exit 1; }',
+    '',
+    '# --- docker + compose (v2 CLI plugin) + the tools the suites shell out to.',
+    'dnf update -y || true',
+    'dnf install -y docker git jq tar gzip make awscli-2 || dnf install -y docker git jq tar gzip',
+    'systemctl enable --now docker',
+    'usermod -a -G docker ec2-user',
+    '# $(uname -m) resolves to aarch64 on Graviton and x86_64 otherwise; a',
+    '# hardcoded arch here is how a boot script dies with "Exec format error".',
+    'COMPOSE_VERSION=v2.40.0',
+    'mkdir -p /usr/libexec/docker/cli-plugins',
+    'curl -fsSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" -o /usr/libexec/docker/cli-plugins/docker-compose',
+    'chmod +x /usr/libexec/docker/cli-plugins/docker-compose',
+    'ln -sf /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose',
+    'docker compose version',
+    '',
+    '# --- which ref to test: an instance tag, read over IMDSv2.',
+    'IMDS_TOKEN="$(curl -fsS -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 600")" || fail "no IMDSv2 token"',
+    `POLIS_REF="$(curl -fsS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" "http://169.254.169.254/latest/meta-data/tags/instance/${CI_REF_TAG_KEY}" || true)"`,
+    'if [ -z "$POLIS_REF" ]; then POLIS_REF=edge; fi',
+    '# Untrusted input. Allow only ref-shaped characters, and no ".." segment.',
+    'if ! printf %s "$POLIS_REF" | grep -Eq \'^[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$\'; then fail "rejected ref"; fi',
+    'case "$POLIS_REF" in *..*) fail "rejected ref" ;; esac',
+    '',
+    `git clone --filter=blob:none https://github.com/${props.githubRepo}.git /opt/polis || fail "clone"`,
+    'cd /opt/polis',
+    'git fetch --no-tags origin "$POLIS_REF" || fail "fetch $POLIS_REF"',
+    'git checkout --detach FETCH_HEAD || fail "checkout"',
+    'git rev-parse HEAD > /var/lib/polis-ci-sha',
+    'chown -R ec2-user:ec2-user /opt/polis',
+    '',
+    'mkdir -p /var/log/polis-ci',
+    'chown ec2-user:ec2-user /var/log/polis-ci',
+    '# The workflow polls for this marker before it sends any SSM command.',
+    'touch /var/lib/polis-ci-ready',
+    'echo "polis-ci bootstrap ready at $(date -u --iso-8601=seconds) sha=$(cat /var/lib/polis-ci-sha)"',
+  );
+  return ud;
+}

--- a/cdk/ciEc2.ts
+++ b/cdk/ciEc2.ts
@@ -141,10 +141,20 @@ export class CertificationCiEc2 extends Construct {
         'ssm:ListAssociations',
         'ssm:ListInstanceAssociations',
         'ssm:DescribeAssociation',
-        'ssm:GetDocument',
-        'ssm:DescribeDocument',
       ],
-      resources: ['*'], // none of these six support resource-level authorization
+      // These four have no resource types in the service authorization
+      // reference, so `*` is the only expressible scope.
+      resources: ['*'],
+    }));
+    // GetDocument and DescribeDocument DO take document ARNs, and GetDocument
+    // returns document CONTENT — round 2's comment claiming otherwise was
+    // wrong (review R2-F5). Scoped to the AWS-owned namespace (no account id in
+    // the ARN), which is what the agent needs; any private document this
+    // account owns is now out of reach from the box.
+    this.workerRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'ReadAwsOwnedDocumentsOnly',
+      actions: ['ssm:GetDocument', 'ssm:DescribeDocument'],
+      resources: [`arn:${partition}:ssm:${region}::document/AWS-*`],
     }));
     this.workerRole.addToPolicy(new iam.PolicyStatement({
       sid: 'SsmAgentChannels',
@@ -290,11 +300,34 @@ export class CertificationCiEc2 extends Construct {
       conditions: templateCondition,
     }));
 
+    // Two statements, not one. Round 2 required `aws:RequestTag/polis:ci-run`
+    // for CreateTags on instances, volumes AND network interfaces, but the
+    // launch template tags the root volume with `polis:ci` only — so the volume
+    // tagging half of the very launch this policy authorises would have been
+    // denied (review R2-F1). Run ownership is required where it means
+    // something, on the instance; volumes and ENIs may carry the same allowed
+    // keys without being forced to prove ownership. The workflow sends the run
+    // tag on volumes too, so in practice they carry it — but the authorisation
+    // no longer depends on a tag the template alone cannot supply.
     this.githubRole.addToPolicy(new iam.PolicyStatement({
-      sid: 'TagAtLaunchOnly',
+      sid: 'TagInstanceAtLaunchWithRunOwnership',
+      actions: ['ec2:CreateTags'],
+      resources: [instanceArnPattern],
+      conditions: {
+        StringEquals: {
+          'ec2:CreateAction': 'RunInstances',
+          [`aws:RequestTag/${CI_TAG_KEY}`]: CI_TAG_VALUE,
+        },
+        StringLike: { [`aws:RequestTag/${CI_RUN_TAG_KEY}`]: '?*' },
+        'ForAllValues:StringEquals': {
+          'aws:TagKeys': [CI_TAG_KEY, CI_REF_TAG_KEY, CI_RUN_TAG_KEY],
+        },
+      },
+    }));
+    this.githubRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'TagLaunchVolumesAndInterfaces',
       actions: ['ec2:CreateTags'],
       resources: [
-        instanceArnPattern,
         `arn:${partition}:ec2:${region}:${account}:volume/*`,
         `arn:${partition}:ec2:${region}:${account}:network-interface/*`,
       ],
@@ -303,7 +336,6 @@ export class CertificationCiEc2 extends Construct {
           'ec2:CreateAction': 'RunInstances',
           [`aws:RequestTag/${CI_TAG_KEY}`]: CI_TAG_VALUE,
         },
-        StringLike: { [`aws:RequestTag/${CI_RUN_TAG_KEY}`]: '?*' },
         'ForAllValues:StringEquals': {
           'aws:TagKeys': [CI_TAG_KEY, CI_REF_TAG_KEY, CI_RUN_TAG_KEY],
         },
@@ -355,10 +387,13 @@ export class CertificationCiEc2 extends Construct {
     }));
     // ssm:GetCommandInvocation and ssm:DescribeInstanceInformation support NO
     // resource types and NO condition keys (service authorization reference),
-    // so they cannot be narrowed here or in a session policy. That residual is
-    // why ListCommands/ListCommandInvocations/CancelCommand were dropped
-    // outright in round 2 rather than kept "for convenience", and why the
-    // account this runs in matters (review E6).
+    // so they cannot be narrowed here or in a session policy. State the reach
+    // plainly: GetCommandInvocation returns a command's stdout AND stderr, so
+    // for any command/instance id pair this role can guess or learn, it can
+    // read that command's output anywhere in the account. Dropping the List
+    // APIs removed discoverability, not authorisation. Only running this in an
+    // isolated account closes it, which is why that remains the activation
+    // gate (review E6, R2-F5).
     this.githubRole.addToPolicy(new iam.PolicyStatement({
       sid: 'ReadCommandResults',
       actions: ['ssm:GetCommandInvocation', 'ssm:DescribeInstanceInformation'],
@@ -537,6 +572,27 @@ function buildUserData(props: CertificationCiEc2Props): ec2.UserData {
     'git fetch --no-tags origin "$POLIS_REF" || fail "fetch $POLIS_REF"',
     'git checkout --detach FETCH_HEAD || fail "checkout"',
     'git rev-parse HEAD > /var/lib/polis-ci-sha',
+    'chown -R ec2-user:ec2-user /opt/polis',
+    '',
+    '',
+    '# --- the recovery runtime, BEFORE the ready marker. P-022 section C\'s',
+    '# target runs host `uv run --no-sync pytest`, so a box that has only',
+    '# docker and git cannot run the matrix at all; round 2 installed uv in the',
+    '# battery phase, which never ran with run_battery=false (review R2-F2).',
+    'export HOME=/root',
+    'curl -LsSf https://astral.sh/uv/install.sh -o /tmp/uv-install.sh || fail "uv download"',
+    'sh /tmp/uv-install.sh || fail "uv install"',
+    'install -m 0755 /root/.local/bin/uv /usr/local/bin/uv || fail "uv place"',
+    '(cd /opt/polis/delphi && uv sync) || fail "uv sync"',
+    '# The battery additionally shells out to `clojure -M:replay`.',
+    'dnf install -y java-21-amazon-corretto-headless rlwrap || fail "jvm"',
+    'curl -fsSL -o /tmp/clojure-install.sh https://download.clojure.org/install/linux-install.sh || fail "clj download"',
+    'chmod +x /tmp/clojure-install.sh && /tmp/clojure-install.sh || fail "clj install"',
+    '# Verify rather than assume: a phase must never silently repair a',
+    '# bootstrap that should have failed.',
+    'uv --version || fail "uv missing after install"',
+    'clojure --version || fail "clojure missing after install"',
+    'java -version || fail "java missing after install"',
     'chown -R ec2-user:ec2-user /opt/polis',
     '',
     'mkdir -p /var/log/polis-ci',

--- a/cdk/ciEc2.ts
+++ b/cdk/ciEc2.ts
@@ -80,6 +80,16 @@ export interface CertificationCiEc2Props {
    * subject from some other one (review E3).
    */
   readonly githubEnvironment: string;
+  /**
+   * Exact `job_workflow_ref` values the token must carry — the reviewed
+   * workflow file at a reviewed branch. The environment subject binds neither
+   * the workflow nor the event (review R2-F5): a job in ANY workflow that
+   * references this environment gets the same subject. These claims do bind
+   * them, and they fail closed.
+   */
+  readonly githubWorkflowRefs: string[];
+  /** Exact `event_name` values admitted. Excludes `pull_request` at the token. */
+  readonly githubEventNames: string[];
   /** Default instance type baked into the template. */
   readonly instanceType: ec2.InstanceType;
   /** Must match `instanceType`'s architecture. */
@@ -256,6 +266,13 @@ export class CertificationCiEc2 extends Construct {
           'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
           'token.actions.githubusercontent.com:sub':
             `repo:${props.githubRepo}:environment:${props.githubEnvironment}`,
+          // The subject alone binds neither workflow nor event. These two
+          // claims do. A StringEquals against a list is an OR, so each is an
+          // explicit allowlist. Both must be validated against the repository's
+          // actual token claims before the first real run: a wrong claim name
+          // fails the assume, which is the correct direction to fail.
+          'token.actions.githubusercontent.com:job_workflow_ref': props.githubWorkflowRefs,
+          'token.actions.githubusercontent.com:event_name': props.githubEventNames,
         },
       }),
     });

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -38,6 +38,7 @@ import createCodedeployConfig from '../codedeploy';
 import createALBAndDNS from '../dns';
 import createSecretsAndDependencies from '../secrets';
 import { ImportWorkerService } from './import-worker-service';
+import { CertificationCiEc2 } from '../ciEc2';
 
 interface PolisStackProps extends cdk.StackProps {
   enableSSHAccess?: boolean; // Make optional, default to false
@@ -391,9 +392,36 @@ export class CdkStack extends cdk.Stack {
     // add ECS Fargate service for BYOPD import worker
     new ImportWorkerService(this, 'ImportWorker', {
       vpc: vpc,
-      database: db, 
+      database: db,
       logGroup: logGroup,
     });
+
+    // --- P-022 E: disposable certification CI worker (OFF by default).
+    // Nothing below is synthesized unless `-c enableCiEc2=true` is passed, so a
+    // normal deploy is byte-identical to before. See docs/ci-ec2.md.
+    if (this.node.tryGetContext('enableCiEc2') === true ||
+        this.node.tryGetContext('enableCiEc2') === 'true') {
+      const ciArch = (this.node.tryGetContext('ciEc2Arch') as string | undefined) ?? 'arm64';
+      new CertificationCiEc2(this, 'CertificationCi', {
+        vpc,
+        githubRepo: (this.node.tryGetContext('ciEc2GithubRepo') as string | undefined) ?? 'compdemocracy/polis',
+        // r8g.4xlarge = 16 vCPU / 128 GiB, the class P-022 E asks for so that a
+        // runner OOM cannot be mistaken for a correctness failure.
+        instanceType: new ec2.InstanceType(
+          (this.node.tryGetContext('ciEc2InstanceType') as string | undefined) ?? 'r8g.4xlarge'),
+        cpuType: ciArch === 'arm64'
+          ? ec2.AmazonLinuxCpuType.ARM_64
+          : ec2.AmazonLinuxCpuType.X86_64,
+        volumeSizeGiB: Number(this.node.tryGetContext('ciEc2VolumeGiB') ?? 200),
+        // Generous: the compute budget is 6 h, this is the backstop for a box
+        // whose job died without terminating it.
+        shutdownMinutes: Number(this.node.tryGetContext('ciEc2ShutdownMinutes') ?? 480),
+        fixtureBucket: this.node.tryGetContext('ciEc2FixtureBucket') as string | undefined,
+        fixturePrefix: (this.node.tryGetContext('ciEc2FixturePrefix') as string | undefined) ?? 'p022/bundle/',
+        evidenceBucket: this.node.tryGetContext('ciEc2EvidenceBucket') as string | undefined,
+        evidencePrefix: (this.node.tryGetContext('ciEc2EvidencePrefix') as string | undefined) ?? 'p022/evidence/',
+      });
+    }
 
     // --- Outputs
     new cdk.CfnOutput(this, 'LoadBalancerDNS', { value: lb.loadBalancerDnsName, description: 'Public DNS name of the Application Load Balancer' });

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -412,14 +412,11 @@ export class CdkStack extends cdk.Stack {
         // policy admits this subject and nothing else.
         githubEnvironment: (this.node.tryGetContext('ciEc2GithubEnvironment') as string | undefined)
           ?? 'certification-synthetic',
-        // Binds the token to the reviewed workflow file and to non-PR events,
-        // which the environment subject cannot do on its own.
-        githubWorkflowRefs: ((this.node.tryGetContext('ciEc2WorkflowRefs') as string | undefined)
-          ?? 'compdemocracy/polis/.github/workflows/certification-ec2.yml@refs/heads/edge,'
-           + 'compdemocracy/polis/.github/workflows/certification-ec2.yml@refs/heads/stable')
+        // The environment-form subject carries no ref and is issued to
+        // pull-request jobs too; the `ref` claim is what excludes them.
+        githubRefs: ((this.node.tryGetContext('ciEc2Refs') as string | undefined)
+          ?? 'refs/heads/edge,refs/heads/stable')
           .split(',').map((r) => r.trim()).filter(Boolean),
-        githubEventNames: ((this.node.tryGetContext('ciEc2EventNames') as string | undefined)
-          ?? 'workflow_dispatch,schedule').split(',').map((e) => e.trim()).filter(Boolean),
         // r8g.4xlarge = 16 vCPU / 128 GiB, the class P-022 E asks for so that a
         // runner OOM cannot be mistaken for a correctness failure.
         instanceType: new ec2.InstanceType(

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -412,6 +412,14 @@ export class CdkStack extends cdk.Stack {
         // policy admits this subject and nothing else.
         githubEnvironment: (this.node.tryGetContext('ciEc2GithubEnvironment') as string | undefined)
           ?? 'certification-synthetic',
+        // Binds the token to the reviewed workflow file and to non-PR events,
+        // which the environment subject cannot do on its own.
+        githubWorkflowRefs: ((this.node.tryGetContext('ciEc2WorkflowRefs') as string | undefined)
+          ?? 'compdemocracy/polis/.github/workflows/certification-ec2.yml@refs/heads/edge,'
+           + 'compdemocracy/polis/.github/workflows/certification-ec2.yml@refs/heads/stable')
+          .split(',').map((r) => r.trim()).filter(Boolean),
+        githubEventNames: ((this.node.tryGetContext('ciEc2EventNames') as string | undefined)
+          ?? 'workflow_dispatch,schedule').split(',').map((e) => e.trim()).filter(Boolean),
         // r8g.4xlarge = 16 vCPU / 128 GiB, the class P-022 E asks for so that a
         // runner OOM cannot be mistaken for a correctness failure.
         instanceType: new ec2.InstanceType(

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -402,9 +402,16 @@ export class CdkStack extends cdk.Stack {
     if (this.node.tryGetContext('enableCiEc2') === true ||
         this.node.tryGetContext('enableCiEc2') === 'true') {
       const ciArch = (this.node.tryGetContext('ciEc2Arch') as string | undefined) ?? 'arm64';
+      const ciAllowedTypes = (this.node.tryGetContext('ciEc2AllowedInstanceTypes') as string | undefined)
+        ?? 'r8g.4xlarge,r8g.2xlarge';
+      const ciShutdownMinutes = Number(this.node.tryGetContext('ciEc2ShutdownMinutes') ?? 480);
       new CertificationCiEc2(this, 'CertificationCi', {
         vpc,
         githubRepo: (this.node.tryGetContext('ciEc2GithubRepo') as string | undefined) ?? 'compdemocracy/polis',
+        // Must equal the `environment:` the workflow job declares. The trust
+        // policy admits this subject and nothing else.
+        githubEnvironment: (this.node.tryGetContext('ciEc2GithubEnvironment') as string | undefined)
+          ?? 'certification-synthetic',
         // r8g.4xlarge = 16 vCPU / 128 GiB, the class P-022 E asks for so that a
         // runner OOM cannot be mistaken for a correctness failure.
         instanceType: new ec2.InstanceType(
@@ -412,14 +419,16 @@ export class CdkStack extends cdk.Stack {
         cpuType: ciArch === 'arm64'
           ? ec2.AmazonLinuxCpuType.ARM_64
           : ec2.AmazonLinuxCpuType.X86_64,
+        // Enforced in IAM, so the workflow's instance-type input cannot select
+        // an arbitrary hourly rate.
+        allowedInstanceTypes: ciAllowedTypes.split(',').map((t) => t.trim()).filter(Boolean),
         volumeSizeGiB: Number(this.node.tryGetContext('ciEc2VolumeGiB') ?? 200),
         // Generous: the compute budget is 6 h, this is the backstop for a box
         // whose job died without terminating it.
-        shutdownMinutes: Number(this.node.tryGetContext('ciEc2ShutdownMinutes') ?? 480),
-        fixtureBucket: this.node.tryGetContext('ciEc2FixtureBucket') as string | undefined,
-        fixturePrefix: (this.node.tryGetContext('ciEc2FixturePrefix') as string | undefined) ?? 'p022/bundle/',
-        evidenceBucket: this.node.tryGetContext('ciEc2EvidenceBucket') as string | undefined,
-        evidencePrefix: (this.node.tryGetContext('ciEc2EvidencePrefix') as string | undefined) ?? 'p022/evidence/',
+        shutdownMinutes: ciShutdownMinutes,
+        // The independent sweeper runs behind the OS timer, not against it.
+        sweeperMaxAgeMinutes: Number(
+          this.node.tryGetContext('ciEc2SweeperMaxAgeMinutes') ?? ciShutdownMinutes + 60),
       });
     }
 

--- a/ci/p022_battery_digest.py
+++ b/ci/p022_battery_digest.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""P-022 §E — canonical digest of the admitted PUBLIC battery inventory.
+
+Six selected cases over two dataset names is not an inventory (review R3-F4):
+swapping the `vw` every-vote restart schedule for an ordinary uniform seven-cut
+entry leaves both numbers untouched while deleting the restart seam the battery
+exists to exercise. This digest covers the entries themselves — dataset,
+preset, cut count, schedule file — so any such swap changes it.
+
+The runner computes the expected digest from the resolved target commit and
+passes it to `p022_check_summary.py`; the worker computes it from the tree it
+actually ran and reports it. They must agree.
+
+  usage: p022_battery_digest.py <certify_battery.json> <certify_datasets.json>
+
+The same canonicalisation is duplicated inline in the selector heredoc of
+`ci/p022_ec2_run.sh`, which must stay self-contained; `p2715-r4-verify.py`
+asserts the two implementations agree on the pinned files.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+
+#: Entry fields that define a case. Anything outside this set (notes, comments)
+#: is deliberately excluded so prose edits do not churn the digest.
+FIELDS = ("dataset", "preset", "n_cuts", "schedule")
+
+
+def canonical(battery, datasets):
+    public = {f["slug"] for f in datasets["public_fixtures"]}
+    selected = [e for e in battery if e.get("dataset") in public]
+    # Values are stringified so a missing field sorts and hashes alongside a
+    # present one; `None` and `""` must not be orderable-by-accident.
+    rows = sorted(
+        [[field, "" if entry.get(field) is None else str(entry.get(field))]
+         for field in FIELDS] for entry in selected)
+    return json.dumps(rows, sort_keys=True, separators=(",", ":"))
+
+
+def digest(battery, datasets) -> str:
+    return hashlib.sha256(canonical(battery, datasets).encode("utf-8")).hexdigest()
+
+
+def main(argv) -> int:
+    if len(argv) != 3:
+        print("usage: p022_battery_digest.py <battery.json> <datasets.json>",
+              file=sys.stderr)
+        return 2
+    battery = json.load(open(argv[1]))
+    datasets = json.load(open(argv[2]))
+    print(digest(battery, datasets))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/ci/p022_battery_digest.py
+++ b/ci/p022_battery_digest.py
@@ -1,26 +1,39 @@
 #!/usr/bin/env python3
 """P-022 §E — canonical digest of the admitted PUBLIC battery inventory.
 
-Six selected cases over two dataset names is not an inventory (review R3-F4):
-swapping the `vw` every-vote restart schedule for an ordinary uniform seven-cut
-entry leaves both numbers untouched while deleting the restart seam the battery
-exists to exercise. This digest covers the entries themselves — dataset,
-preset, cut count, schedule file — so any such swap changes it.
+Round 4 hashed dataset/preset/n_cuts/schedule **names**, stringified. Astra's
+review (R4-F3) showed two consequences:
 
-The runner computes the expected digest from the resolved target commit and
-passes it to `p022_check_summary.py`; the worker computes it from the tree it
-actually ran and reports it. They must agree.
+  * deleting `restart_after` from `schedules/vw-uniform8-restart4.json` left the
+    digest untouched — the seam the battery exists to exercise could be removed
+    without moving the number that is supposed to pin the inventory;
+  * `n_cuts=8` and `n_cuts="8"` produced identical digests, because every value
+    was passed through `str()` before hashing.
 
-  usage: p022_battery_digest.py <certify_battery.json> <certify_datasets.json>
+Round 5 therefore hashes:
 
-The same canonicalisation is duplicated inline in the selector heredoc of
-`ci/p022_ec2_run.sh`, which must stay self-contained; `p2715-r4-verify.py`
-asserts the two implementations agree on the pinned files.
+  * each selected entry's fields with their **types preserved** (8 and "8" are
+    different inventories, and a canonical JSON encoding says so);
+  * the **contents** of every referenced schedule file, canonicalised, so a
+    same-name mutation moves the digest;
+  * the public fixture descriptors from `certify_datasets.json`.
+
+It also reports a mechanical restart inventory — how many selected entries
+reference a schedule that actually declares a restart seam — so a candidate
+whose schedules no longer restart cannot quietly shrink the smoke.
+
+  usage: p022_battery_digest.py <certify_battery.json> <certify_datasets.json> <scripts_dir>
+
+`scripts_dir` is the directory the `schedule` paths are relative to (the
+repository's `delphi/scripts`). The same canonicalisation is duplicated inline
+in the selector heredoc of `ci/p022_ec2_run.sh`, which must stay self-contained;
+`p2715-r5-verify.py` asserts the two implementations agree on the pinned files.
 """
 from __future__ import annotations
 
 import hashlib
 import json
+import pathlib
 import sys
 
 #: Entry fields that define a case. Anything outside this set (notes, comments)
@@ -28,29 +41,105 @@ import sys
 FIELDS = ("dataset", "preset", "n_cuts", "schedule")
 
 
-def canonical(battery, datasets):
+def _canonical_json(value) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _schedule_fingerprint(name, read_schedule):
+    """Canonical content digest of a referenced schedule, or a typed marker."""
+    if not name:
+        return None
+    raw = read_schedule(name)
+    if raw is None:
+        return "missing"
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return "unparseable:" + hashlib.sha256(
+            raw if isinstance(raw, bytes) else str(raw).encode()).hexdigest()
+    return hashlib.sha256(_canonical_json(parsed).encode("utf-8")).hexdigest()
+
+
+def _declares_restart(name, read_schedule) -> bool:
+    if not name:
+        return False
+    raw = read_schedule(name)
+    if raw is None:
+        return False
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return False
+    return isinstance(parsed, dict) and parsed.get("restart_after") is not None
+
+
+def inventory(battery, datasets, read_schedule):
+    """Return (canonical string, selected entries, restart-case count).
+
+    `read_schedule(name)` returns the referenced file's bytes/str, or None.
+    It is a required argument: a two-argument digest cannot see the contents it
+    claims to pin, and silently degrading to filenames is how R4-F3 happened.
+    """
     public = {f["slug"] for f in datasets["public_fixtures"]}
     selected = [e for e in battery if e.get("dataset") in public]
-    # Values are stringified so a missing field sorts and hashes alongside a
-    # present one; `None` and `""` must not be orderable-by-accident.
-    rows = sorted(
-        [[field, "" if entry.get(field) is None else str(entry.get(field))]
-         for field in FIELDS] for entry in selected)
-    return json.dumps(rows, sort_keys=True, separators=(",", ":"))
+    rows = []
+    restarts = 0
+    for entry in selected:
+        # Types preserved: the value is embedded as JSON, so 8 and "8" differ.
+        row = {field: entry.get(field) for field in FIELDS}
+        row["schedule_sha256"] = _schedule_fingerprint(entry.get("schedule"),
+                                                       read_schedule)
+        if _declares_restart(entry.get("schedule"), read_schedule):
+            restarts += 1
+        rows.append(_canonical_json(row))
+    body = {
+        "version": "p022-battery-inventory/2",
+        "entries": sorted(rows),
+        "public_fixtures": sorted(_canonical_json(f)
+                                  for f in datasets["public_fixtures"]),
+    }
+    return _canonical_json(body), selected, restarts
 
 
-def digest(battery, datasets) -> str:
-    return hashlib.sha256(canonical(battery, datasets).encode("utf-8")).hexdigest()
+def digest(battery, datasets, read_schedule) -> str:
+    canonical, _, _ = inventory(battery, datasets, read_schedule)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def restart_cases(battery, datasets, read_schedule) -> int:
+    return inventory(battery, datasets, read_schedule)[2]
+
+
+def reader_for(scripts_dir):
+    root = pathlib.Path(scripts_dir)
+
+    def read_schedule(name):
+        # Refuse to escape the scripts directory; a schedule path is data.
+        candidate = (root / name).resolve()
+        if root.resolve() not in candidate.parents and candidate != root.resolve():
+            return None
+        try:
+            return candidate.read_bytes()
+        except OSError:
+            return None
+
+    return read_schedule
 
 
 def main(argv) -> int:
-    if len(argv) != 3:
-        print("usage: p022_battery_digest.py <battery.json> <datasets.json>",
-              file=sys.stderr)
+    if len(argv) != 4:
+        print("usage: p022_battery_digest.py <battery.json> <datasets.json> "
+              "<scripts_dir>", file=sys.stderr)
         return 2
     battery = json.load(open(argv[1]))
     datasets = json.load(open(argv[2]))
-    print(digest(battery, datasets))
+    read_schedule = reader_for(argv[3])
+    canonical, selected, restarts = inventory(battery, datasets, read_schedule)
+    print(json.dumps({
+        "digest": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+        "selected": len(selected),
+        "restart_cases": restarts,
+    }, sort_keys=True))
     return 0
 
 

--- a/ci/p022_check_summary.py
+++ b/ci/p022_check_summary.py
@@ -1,21 +1,45 @@
 #!/usr/bin/env python3
-"""P-022 §E — validate the worker's fixed-schema summary before anyone reads it.
+"""P-022 §E — validate the worker's fixed-schema summary against the run's
+declared scope, on the runner, before anyone reads it.
 
-The summary is produced on the worker by candidate code, so it is untrusted
-input on the way back. This validator is the reason it can be published at all:
-it rejects extra keys, wrong types, out-of-range integers, unknown enum values,
-control characters and anything that is not one of the public fixture slugs.
-A candidate cannot smuggle text out through a field this does not allow, and a
-candidate cannot declare its own PASS: the verdict is recomputed here from the
-component statuses and must agree with the one the worker wrote.
+## What this is NOT (Astra #2715 R2-F4, divergence ruling 8)
 
-  usage: p022_check_summary.py <summary.json>
+This is **not** independent execution evidence and does not make the result
+unforgeable. Every field it inspects is produced by the same recipe that ran the
+tests: a worker that wanted to lie could emit a fully self-consistent record.
+The trust here is explicit and named — `summary.trust` must say
+`reviewed-recipe-self-reported` — and it is the trust appropriate to a synthetic
+smoke over public fixtures. An adversarial certificate needs the independent
+control boundary specified in P-022-E-ci-spec.md, which is not built.
 
-Exit 0 only for a well-formed summary whose recomputed verdict is
-SYNTHETIC-PASS. Anything else is a job failure.
+## What it does do
+
+It refuses evidence that is incoherent, short, or silently absent — the three
+ways round 2 still let a green result through:
+
+  * counts must reconcile: a "pass" with `failed`, `errors` or `xpassed`
+    above zero, or with zero tests executed, is rejected;
+  * the report inventory is pinned: exactly one JUnit report for the matrix and
+    exactly one per race iteration, so nineteen overwritten reports cannot look
+    like a complete run;
+  * the battery inventory length and dataset set are pinned to the run's
+    declared scope, so a battery shortened from six cases to one is rejected;
+  * a missing battery result is only acceptable when the caller declares
+    `--run-battery false`, and then only with a skip reason. An absent result
+    cannot authorise its own downgrade;
+  * the candidate SHA must be a real 40-hex commit and must match the ref the
+    workflow asked for.
+
+  usage: p022_check_summary.py <summary.json> [--run-battery true|false]
+                               [--expected-battery-cases N]
+                               [--expected-datasets a,b]
+                               [--expected-main-reports N]
+                               [--expected-race-reports N]
+                               [--expected-sha SHA]
 """
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
@@ -26,7 +50,23 @@ MAX_INT = 1_000_000
 # these the public fixtures and they are the only data on the box.
 PUBLIC_SLUGS = {"vw", "biodiversity"}
 COUNT_KEYS = {"passed", "failed", "skipped", "xfailed", "xpassed", "errors"}
+# Counts that must be zero for a suite to be called "pass". `xfailed` is
+# expected (P-022 §C retains twelve strict xfails); `xpassed` is not — a strict
+# xfail that starts passing is a regression in the retained-regression set.
+MUST_BE_ZERO = ("failed", "errors", "xpassed")
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SKIP_REASONS = {"not-run-in-this-job"}
+TRUST = "reviewed-recipe-self-reported"
+
+#: The pinned public battery at this revision: six cases over two datasets.
+DEFAULT_EXPECTED = {
+    "run_battery": True,
+    "battery_cases": 6,
+    "datasets": sorted(PUBLIC_SLUGS),
+    "main_reports": 1,
+    "race_reports": 20,
+    "sha": None,
+}
 
 
 class Invalid(Exception):
@@ -52,41 +92,72 @@ def check_counts(obj, name):
     want(set(obj) == COUNT_KEYS, f"{name} keys must be exactly {sorted(COUNT_KEYS)}")
     for key, value in obj.items():
         check_int(value, f"{name}.{key}")
+    return obj
 
 
-def check(summary) -> str:
+def suite_clean(counts) -> bool:
+    """A suite is clean only if it ran something and nothing went wrong."""
+    return counts["passed"] > 0 and all(counts[k] == 0 for k in MUST_BE_ZERO)
+
+
+def check(summary, expected=None) -> str:
+    exp = dict(DEFAULT_EXPECTED, **(expected or {}))
+
     want(isinstance(summary, dict), "summary must be an object")
-    want(set(summary) == {"schema", "kind", "is_certification", "ref_sha",
-                          "recovery", "battery", "verdict"},
+    want(set(summary) == {"schema", "kind", "is_certification", "trust",
+                          "ref_sha", "recovery", "battery", "verdict"},
          f"unexpected top-level keys: {sorted(summary)}")
-    want(summary["schema"] == "p022-synthetic/1",
+    want(summary["schema"] == "p022-synthetic/2",
          f"unknown schema: {summary['schema']!r}")
     want(summary["kind"] == "synthetic-recovery-and-public-fixture-battery",
          f"unknown kind: {summary['kind']!r}")
-    # A synthetic run must never claim to be a certificate.
     want(summary["is_certification"] is False,
          "is_certification must be false for this workflow")
+    # The trust model is stated in the artifact, not merely in the docs.
+    want(summary["trust"] == TRUST, f"trust must be {TRUST!r}")
 
     sha = summary["ref_sha"]
-    want(isinstance(sha, str) and (sha == "" or SHA_RE.match(sha)),
-         "ref_sha must be empty or a 40-hex commit sha")
+    want(isinstance(sha, str) and SHA_RE.match(sha or ""),
+         "ref_sha must be a 40-hex commit sha; an empty identity is not a result")
+    if exp["sha"]:
+        want(sha == exp["sha"],
+             f"ref_sha {sha} is not the ref the workflow asked for ({exp['sha']})")
 
+    # ------------------------------------------------------------- recovery
     rec = summary["recovery"]
     want(isinstance(rec, dict), "recovery must be an object")
-    want(set(rec) == {"main_rc", "races_rc", "junit", "counts",
-                      "races_counts", "status"},
+    want(set(rec) == {"main_rc", "races_rc", "main_reports", "race_reports",
+                      "expected_main_reports", "expected_race_reports",
+                      "counts", "races_counts", "status"},
          f"unexpected recovery keys: {sorted(rec)}")
     main_rc = check_int(rec["main_rc"], "recovery.main_rc", allow_none=True)
     races_rc = check_int(rec["races_rc"], "recovery.races_rc", allow_none=True)
-    want(isinstance(rec["junit"], bool), "recovery.junit must be a boolean")
-    check_counts(rec["counts"], "recovery.counts")
-    check_counts(rec["races_counts"], "recovery.races_counts")
+    main_reports = check_int(rec["main_reports"], "recovery.main_reports")
+    race_reports = check_int(rec["race_reports"], "recovery.race_reports")
+    exp_main = check_int(rec["expected_main_reports"], "recovery.expected_main_reports")
+    exp_races = check_int(rec["expected_race_reports"], "recovery.expected_race_reports")
+    main_counts = check_counts(rec["counts"], "recovery.counts")
+    race_counts = check_counts(rec["races_counts"], "recovery.races_counts")
     want(rec["status"] in {"pass", "fail"}, f"bad recovery.status: {rec['status']!r}")
 
+    # The worker's own expectation must equal the runner's, so a worker cannot
+    # lower the bar it is then measured against.
+    want(exp_main == exp["main_reports"],
+         f"worker expected {exp_main} matrix report(s), run scope says {exp['main_reports']}")
+    want(exp_races == exp["race_reports"],
+         f"worker expected {exp_races} race report(s), run scope says {exp['race_reports']}")
+    reports_ok = (main_reports == exp_main > 0 and race_reports == exp_races > 0)
+
+    counts_ok = suite_clean(main_counts) and suite_clean(race_counts)
+    recovery_ok = main_rc == 0 and races_rc == 0 and reports_ok and counts_ok
+    want((rec["status"] == "pass") == recovery_ok,
+         "recovery.status disagrees with its return codes, report inventory or counts")
+
+    # -------------------------------------------------------------- battery
     bat = summary["battery"]
     want(isinstance(bat, dict), "battery must be an object")
     want(set(bat) == {"rc", "selected", "missing", "datasets",
-                      "private_cases", "status"},
+                      "private_cases", "skip_reason", "status"},
          f"unexpected battery keys: {sorted(bat)}")
     bat_rc = check_int(bat["rc"], "battery.rc", allow_none=True)
     selected = check_int(bat["selected"], "battery.selected")
@@ -94,37 +165,72 @@ def check(summary) -> str:
     want(isinstance(bat["datasets"], list), "battery.datasets must be a list")
     want(all(d in PUBLIC_SLUGS for d in bat["datasets"]),
          f"battery.datasets contains a non-public slug: {bat['datasets']}")
-    # A private case can never have run here; the worker has no credential for
-    # one. Any other value means the summary is describing a different job.
     want(bat["private_cases"] == "not-run",
          f"battery.private_cases must be 'not-run', got {bat['private_cases']!r}")
+    want(isinstance(bat["skip_reason"], str), "battery.skip_reason must be a string")
     want(bat["status"] in {"pass", "fail", "skipped"},
          f"bad battery.status: {bat['status']!r}")
 
-    # Recompute rather than trust. A worker that writes SYNTHETIC-PASS beside a
-    # failing component is itself the failure.
-    recovery_ok = main_rc == 0 and races_rc == 0 and rec["junit"] is True
-    want((rec["status"] == "pass") == recovery_ok,
-         "recovery.status disagrees with its own return codes")
-    if bat_rc is None:
+    if not exp["run_battery"]:
+        # A declared recovery-only run. The absence must be declared by the
+        # caller AND explained by the worker; an absent result is not its own
+        # authorisation.
+        want(bat_rc is None, "run_battery=false but the worker reported a battery result")
+        want(bat["status"] == "skipped", "run_battery=false requires battery.status 'skipped'")
+        want(bat["skip_reason"] in SKIP_REASONS,
+             f"unknown battery.skip_reason: {bat['skip_reason']!r}")
         battery_ok = True
-        want(bat["status"] == "skipped", "battery.rc absent but status is not 'skipped'")
     else:
-        battery_ok = bat_rc == 0 and selected > 0 and missing == 0
+        want(bat_rc is not None,
+             "the battery was requested but no result was reported; "
+             "an absent result cannot downgrade the run to recovery-only")
+        want(bat["skip_reason"] == "",
+             "battery.skip_reason must be empty when the battery ran")
+        # Inventory pinned both ways: a battery shortened from six cases to one
+        # passes every guard that can be written on the worker.
+        want(selected == exp["battery_cases"],
+             f"battery ran {selected} case(s), pinned inventory is {exp['battery_cases']}")
+        want(sorted(bat["datasets"]) == sorted(exp["datasets"]),
+             f"battery datasets {sorted(bat['datasets'])} != pinned {sorted(exp['datasets'])}")
+        want(missing == 0, f"{missing} pinned fixture(s) missing")
+        battery_ok = bat_rc == 0
         want((bat["status"] == "pass") == battery_ok,
-             "battery.status disagrees with its own return code and inventory")
+             "battery.status disagrees with its return code")
 
-    expected = "SYNTHETIC-PASS" if (recovery_ok and battery_ok) else "SYNTHETIC-FAIL"
-    want(summary["verdict"] == expected,
-         f"verdict {summary['verdict']!r} disagrees with recomputed {expected!r}")
-    return expected
+    expected_verdict = ("SYNTHETIC-PASS" if (recovery_ok and battery_ok)
+                        else "SYNTHETIC-FAIL")
+    want(summary["verdict"] == expected_verdict,
+         f"verdict {summary['verdict']!r} disagrees with recomputed {expected_verdict!r}")
+    return expected_verdict
+
+
+def parse_args(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("summary")
+    ap.add_argument("--run-battery", default="true")
+    ap.add_argument("--expected-battery-cases", type=int,
+                    default=DEFAULT_EXPECTED["battery_cases"])
+    ap.add_argument("--expected-datasets",
+                    default=",".join(DEFAULT_EXPECTED["datasets"]))
+    ap.add_argument("--expected-main-reports", type=int,
+                    default=DEFAULT_EXPECTED["main_reports"])
+    ap.add_argument("--expected-race-reports", type=int,
+                    default=DEFAULT_EXPECTED["race_reports"])
+    ap.add_argument("--expected-sha", default="")
+    args = ap.parse_args(argv)
+    return args, {
+        "run_battery": args.run_battery.strip().lower() not in {"false", "0", "no"},
+        "battery_cases": args.expected_battery_cases,
+        "datasets": [d for d in args.expected_datasets.split(",") if d],
+        "main_reports": args.expected_main_reports,
+        "race_reports": args.expected_race_reports,
+        "sha": args.expected_sha or None,
+    }
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) != 2:
-        print("usage: p022_check_summary.py <summary.json>", file=sys.stderr)
-        return 2
-    raw = open(argv[1], "rb").read()
+    args, expected = parse_args(argv[1:])
+    raw = open(args.summary, "rb").read()
     if len(raw) > MAX_BYTES:
         print(f"::error::summary.json is {len(raw)} bytes, cap is {MAX_BYTES}")
         return 1
@@ -133,11 +239,12 @@ def main(argv: list[str]) -> int:
         print("::error::summary.json contains control characters")
         return 1
     try:
-        verdict = check(json.loads(text))
+        verdict = check(json.loads(text), expected)
     except (Invalid, json.JSONDecodeError) as exc:
         print(f"::error::summary.json rejected: {exc}")
         return 1
-    print(f"summary.json valid; verdict={verdict}")
+    print(f"summary.json valid against the declared scope; verdict={verdict}")
+    print(f"trust model: {TRUST} (not independent execution evidence)")
     if verdict != "SYNTHETIC-PASS":
         print("::error::synthetic run did not pass")
         return 1

--- a/ci/p022_check_summary.py
+++ b/ci/p022_check_summary.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""P-022 §E — validate the worker's fixed-schema summary before anyone reads it.
+
+The summary is produced on the worker by candidate code, so it is untrusted
+input on the way back. This validator is the reason it can be published at all:
+it rejects extra keys, wrong types, out-of-range integers, unknown enum values,
+control characters and anything that is not one of the public fixture slugs.
+A candidate cannot smuggle text out through a field this does not allow, and a
+candidate cannot declare its own PASS: the verdict is recomputed here from the
+component statuses and must agree with the one the worker wrote.
+
+  usage: p022_check_summary.py <summary.json>
+
+Exit 0 only for a well-formed summary whose recomputed verdict is
+SYNTHETIC-PASS. Anything else is a job failure.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+MAX_BYTES = 64 * 1024
+MAX_INT = 1_000_000
+# The only fixture slugs this job may ever report; certify_datasets.json calls
+# these the public fixtures and they are the only data on the box.
+PUBLIC_SLUGS = {"vw", "biodiversity"}
+COUNT_KEYS = {"passed", "failed", "skipped", "xfailed", "xpassed", "errors"}
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class Invalid(Exception):
+    pass
+
+
+def want(cond: bool, message: str) -> None:
+    if not cond:
+        raise Invalid(message)
+
+
+def check_int(value, name, *, allow_none=False):
+    if value is None and allow_none:
+        return None
+    want(isinstance(value, int) and not isinstance(value, bool),
+         f"{name} must be an integer, got {type(value).__name__}")
+    want(0 <= value <= MAX_INT, f"{name} out of range: {value}")
+    return value
+
+
+def check_counts(obj, name):
+    want(isinstance(obj, dict), f"{name} must be an object")
+    want(set(obj) == COUNT_KEYS, f"{name} keys must be exactly {sorted(COUNT_KEYS)}")
+    for key, value in obj.items():
+        check_int(value, f"{name}.{key}")
+
+
+def check(summary) -> str:
+    want(isinstance(summary, dict), "summary must be an object")
+    want(set(summary) == {"schema", "kind", "is_certification", "ref_sha",
+                          "recovery", "battery", "verdict"},
+         f"unexpected top-level keys: {sorted(summary)}")
+    want(summary["schema"] == "p022-synthetic/1",
+         f"unknown schema: {summary['schema']!r}")
+    want(summary["kind"] == "synthetic-recovery-and-public-fixture-battery",
+         f"unknown kind: {summary['kind']!r}")
+    # A synthetic run must never claim to be a certificate.
+    want(summary["is_certification"] is False,
+         "is_certification must be false for this workflow")
+
+    sha = summary["ref_sha"]
+    want(isinstance(sha, str) and (sha == "" or SHA_RE.match(sha)),
+         "ref_sha must be empty or a 40-hex commit sha")
+
+    rec = summary["recovery"]
+    want(isinstance(rec, dict), "recovery must be an object")
+    want(set(rec) == {"main_rc", "races_rc", "junit", "counts",
+                      "races_counts", "status"},
+         f"unexpected recovery keys: {sorted(rec)}")
+    main_rc = check_int(rec["main_rc"], "recovery.main_rc", allow_none=True)
+    races_rc = check_int(rec["races_rc"], "recovery.races_rc", allow_none=True)
+    want(isinstance(rec["junit"], bool), "recovery.junit must be a boolean")
+    check_counts(rec["counts"], "recovery.counts")
+    check_counts(rec["races_counts"], "recovery.races_counts")
+    want(rec["status"] in {"pass", "fail"}, f"bad recovery.status: {rec['status']!r}")
+
+    bat = summary["battery"]
+    want(isinstance(bat, dict), "battery must be an object")
+    want(set(bat) == {"rc", "selected", "missing", "datasets",
+                      "private_cases", "status"},
+         f"unexpected battery keys: {sorted(bat)}")
+    bat_rc = check_int(bat["rc"], "battery.rc", allow_none=True)
+    selected = check_int(bat["selected"], "battery.selected")
+    missing = check_int(bat["missing"], "battery.missing")
+    want(isinstance(bat["datasets"], list), "battery.datasets must be a list")
+    want(all(d in PUBLIC_SLUGS for d in bat["datasets"]),
+         f"battery.datasets contains a non-public slug: {bat['datasets']}")
+    # A private case can never have run here; the worker has no credential for
+    # one. Any other value means the summary is describing a different job.
+    want(bat["private_cases"] == "not-run",
+         f"battery.private_cases must be 'not-run', got {bat['private_cases']!r}")
+    want(bat["status"] in {"pass", "fail", "skipped"},
+         f"bad battery.status: {bat['status']!r}")
+
+    # Recompute rather than trust. A worker that writes SYNTHETIC-PASS beside a
+    # failing component is itself the failure.
+    recovery_ok = main_rc == 0 and races_rc == 0 and rec["junit"] is True
+    want((rec["status"] == "pass") == recovery_ok,
+         "recovery.status disagrees with its own return codes")
+    if bat_rc is None:
+        battery_ok = True
+        want(bat["status"] == "skipped", "battery.rc absent but status is not 'skipped'")
+    else:
+        battery_ok = bat_rc == 0 and selected > 0 and missing == 0
+        want((bat["status"] == "pass") == battery_ok,
+             "battery.status disagrees with its own return code and inventory")
+
+    expected = "SYNTHETIC-PASS" if (recovery_ok and battery_ok) else "SYNTHETIC-FAIL"
+    want(summary["verdict"] == expected,
+         f"verdict {summary['verdict']!r} disagrees with recomputed {expected!r}")
+    return expected
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: p022_check_summary.py <summary.json>", file=sys.stderr)
+        return 2
+    raw = open(argv[1], "rb").read()
+    if len(raw) > MAX_BYTES:
+        print(f"::error::summary.json is {len(raw)} bytes, cap is {MAX_BYTES}")
+        return 1
+    text = raw.decode("utf-8", errors="strict")
+    if any(ord(ch) < 0x20 and ch not in "\n\r\t" for ch in text):
+        print("::error::summary.json contains control characters")
+        return 1
+    try:
+        verdict = check(json.loads(text))
+    except (Invalid, json.JSONDecodeError) as exc:
+        print(f"::error::summary.json rejected: {exc}")
+        return 1
+    print(f"summary.json valid; verdict={verdict}")
+    if verdict != "SYNTHETIC-PASS":
+        print("::error::synthetic run did not pass")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/ci/p022_check_summary.py
+++ b/ci/p022_check_summary.py
@@ -46,6 +46,12 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 
+#: THE definition of the summary schema version. The worker reads this exact
+#: line out of this file rather than carrying its own copy: round 5 shipped a
+#: writer emitting /3 against a checker requiring /4, so every otherwise valid
+#: run would have been rejected (review R5-F1). One constant, two readers.
+SCHEMA = "p022-synthetic/4"
+
 MAX_BYTES = 64 * 1024
 MAX_INT = 1_000_000
 # The only fixture slugs this job may ever report; certify_datasets.json calls
@@ -166,8 +172,8 @@ def check(summary, expected=None) -> str:
     want(set(summary) == {"schema", "kind", "is_certification", "trust",
                           "ref_sha", "recovery", "battery", "verdict"},
          f"unexpected top-level keys: {sorted(summary)}")
-    want(summary["schema"] == "p022-synthetic/4",
-         f"unknown schema: {summary['schema']!r}")
+    want(summary["schema"] == SCHEMA,
+         f"unknown schema: {summary['schema']!r} (expected {SCHEMA!r})")
     want(summary["kind"] == "synthetic-recovery-and-public-fixture-battery",
          f"unknown kind: {summary['kind']!r}")
     want(summary["is_certification"] is False,

--- a/ci/p022_check_summary.py
+++ b/ci/p022_check_summary.py
@@ -52,7 +52,11 @@ MAX_INT = 1_000_000
 # these the public fixtures and they are the only data on the box.
 PUBLIC_SLUGS = {"vw", "biodiversity"}
 #: Aggregates over the phase's actual JUnit reports, not a log scrape.
-COUNT_KEYS = {"reports", "tests", "failures", "errors", "skipped"}
+#: `executed` is tests minus skips; `min_executed` is the smallest executed
+#: count of any single report, which is what makes each invocation carry its
+#: weight rather than hiding behind a phase total (review R4-F1).
+COUNT_KEYS = {"reports", "tests", "failures", "errors", "skipped",
+              "executed", "min_executed"}
 MUST_BE_ZERO = ("failures", "errors")
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 SKIP_REASONS = {"not-run-in-this-job"}
@@ -68,6 +72,13 @@ DEFAULT_EXPECTED = {
     "sha": None,
     "battery_digest": None,
     "junit_dir": None,
+    # Minimum executed (non-skipped) tests. Pinned by the trusted control
+    # recipe, NOT inferred from the reports being judged. Conservative floors
+    # well under P-022 §C's recorded 235/1/12 matrix and its per-iteration race
+    # counts; re-pin them when §C merges.
+    "min_main_executed": 100,
+    "min_race_executed": 10,
+    "min_restart_cases": 1,
 }
 
 
@@ -97,9 +108,16 @@ def check_counts(obj, name):
     return obj
 
 
-def suite_clean(counts) -> bool:
-    """A suite is clean only if it ran something and nothing went wrong."""
-    return counts["tests"] > 0 and all(counts[k] == 0 for k in MUST_BE_ZERO)
+def suite_clean(counts, floor: int) -> bool:
+    """Clean means every report executed real tests and nothing went wrong.
+
+    `tests` includes skips, so round 4's `tests > 0` accepted an all-skipped
+    report, and a phase total accepted nineteen empty race invocations beside
+    one real test.
+    """
+    return (counts["executed"] >= floor
+            and counts["min_executed"] > 0
+            and all(counts[k] == 0 for k in MUST_BE_ZERO))
 
 
 def read_reports(directory: pathlib.Path):
@@ -114,19 +132,30 @@ def read_reports(directory: pathlib.Path):
     if not directory.is_dir():
         return out, ["directory is missing"]
     problems = []
+    per_report = []
     for report in sorted(directory.glob("*.xml")):
         out["reports"] += 1
         try:
             root = ET.parse(report).getroot()
         except ET.ParseError as exc:
             problems.append(f"{report.name}: {exc}")
+            per_report.append(0)
             continue
         suites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
         if not suites:
             problems.append(f"{report.name}: no testsuite element")
+        this_tests = this_skipped = 0
         for suite in suites:
             for key in ("tests", "failures", "errors", "skipped"):
                 out[key] += int(suite.get(key, 0) or 0)
+            this_tests += int(suite.get("tests", 0) or 0)
+            this_skipped += int(suite.get("skipped", 0) or 0)
+        executed = this_tests - this_skipped
+        per_report.append(executed)
+        if executed <= 0:
+            problems.append(f"{report.name}: no executed (non-skipped) tests")
+    out["executed"] = out["tests"] - out["skipped"]
+    out["min_executed"] = min(per_report) if per_report else 0
     return out, problems
 
 
@@ -137,7 +166,7 @@ def check(summary, expected=None) -> str:
     want(set(summary) == {"schema", "kind", "is_certification", "trust",
                           "ref_sha", "recovery", "battery", "verdict"},
          f"unexpected top-level keys: {sorted(summary)}")
-    want(summary["schema"] == "p022-synthetic/3",
+    want(summary["schema"] == "p022-synthetic/4",
          f"unknown schema: {summary['schema']!r}")
     want(summary["kind"] == "synthetic-recovery-and-public-fixture-battery",
          f"unknown kind: {summary['kind']!r}")
@@ -160,7 +189,7 @@ def check(summary, expected=None) -> str:
     want(isinstance(rec, dict), "recovery must be an object")
     want(set(rec) == {"main_rc", "races_rc", "main_reports", "race_reports",
                       "expected_main_reports", "expected_race_reports",
-                      "counts", "races_counts", "status"},
+                      "counts", "races_counts", "xpassed", "status"},
          f"unexpected recovery keys: {sorted(rec)}")
     main_rc = check_int(rec["main_rc"], "recovery.main_rc", allow_none=True)
     races_rc = check_int(rec["races_rc"], "recovery.races_rc", allow_none=True)
@@ -170,6 +199,12 @@ def check(summary, expected=None) -> str:
     exp_races = check_int(rec["expected_race_reports"], "recovery.expected_race_reports")
     main_counts = check_counts(rec["counts"], "recovery.counts")
     race_counts = check_counts(rec["races_counts"], "recovery.races_counts")
+    xpassed = check_int(rec["xpassed"], "recovery.xpassed")
+    # A non-strict xfail that passes renders in JUnit as an ordinary pass, so
+    # the XML totals cannot see it; the worker's pytest plugin reports the
+    # count and the phase fails on it (review R4-F2).
+    want(xpassed == 0, f"{xpassed} XPASS result(s): a strict-xfail regression "
+                       "must fail the phase, not be counted as a pass")
     want(rec["status"] in {"pass", "fail"}, f"bad recovery.status: {rec['status']!r}")
 
     # The worker's own expectation must equal the runner's, so a worker cannot
@@ -194,7 +229,10 @@ def check(summary, expected=None) -> str:
                  f"{phase}: summary counts {claimed} do not match the returned "
                  f"reports {actual}")
 
-    counts_ok = suite_clean(main_counts) and suite_clean(race_counts)
+    counts_ok = (suite_clean(main_counts, exp["min_main_executed"])
+                 and suite_clean(race_counts, exp["min_race_executed"] * exp_races)
+                 and main_counts["min_executed"] >= exp["min_main_executed"]
+                 and race_counts["min_executed"] >= exp["min_race_executed"])
     recovery_ok = main_rc == 0 and races_rc == 0 and reports_ok and counts_ok
     want((rec["status"] == "pass") == recovery_ok,
          "recovery.status disagrees with its return codes, report inventory or counts")
@@ -203,7 +241,7 @@ def check(summary, expected=None) -> str:
     bat = summary["battery"]
     want(isinstance(bat, dict), "battery must be an object")
     want(set(bat) == {"rc", "selected", "missing", "datasets", "inventory_digest",
-                      "private_cases", "skip_reason", "status"},
+                      "restart_cases", "private_cases", "skip_reason", "status"},
          f"unexpected battery keys: {sorted(bat)}")
     bat_rc = check_int(bat["rc"], "battery.rc", allow_none=True)
     selected = check_int(bat["selected"], "battery.selected")
@@ -213,6 +251,7 @@ def check(summary, expected=None) -> str:
          f"battery.datasets contains a non-public slug: {bat['datasets']}")
     want(bat["private_cases"] == "not-run",
          f"battery.private_cases must be 'not-run', got {bat['private_cases']!r}")
+    restart_cases = check_int(bat["restart_cases"], "battery.restart_cases")
     want(isinstance(bat["skip_reason"], str), "battery.skip_reason must be a string")
     want(bat["status"] in {"pass", "fail", "skipped"},
          f"bad battery.status: {bat['status']!r}")
@@ -246,6 +285,11 @@ def check(summary, expected=None) -> str:
              "no expected battery inventory digest was supplied")
         want(bat["inventory_digest"] == exp["battery_digest"],
              "battery inventory digest does not match the admitted inventory")
+        # A mechanical coverage floor: a candidate whose schedules no longer
+        # restart cannot quietly shrink the smoke to a no-restart battery.
+        want(restart_cases >= exp["min_restart_cases"],
+             f"{restart_cases} restart-seam case(s), at least "
+             f"{exp['min_restart_cases']} required")
         battery_ok = bat_rc == 0
         want((bat["status"] == "pass") == battery_ok,
              "battery.status disagrees with its return code")
@@ -273,6 +317,13 @@ def parse_args(argv):
     ap.add_argument("--expected-battery-digest", default="")
     ap.add_argument("--junit-dir", default="",
                     help="directory holding the returned recovery/ and races/ reports")
+    ap.add_argument("--min-main-executed", type=int,
+                    default=DEFAULT_EXPECTED["min_main_executed"])
+    ap.add_argument("--min-race-executed", type=int,
+                    default=DEFAULT_EXPECTED["min_race_executed"],
+                    help="minimum executed tests in EACH race invocation")
+    ap.add_argument("--min-restart-cases", type=int,
+                    default=DEFAULT_EXPECTED["min_restart_cases"])
     args = ap.parse_args(argv)
     return args, {
         "run_battery": args.run_battery.strip().lower() not in {"false", "0", "no"},
@@ -283,6 +334,9 @@ def parse_args(argv):
         "sha": args.expected_sha or None,
         "battery_digest": args.expected_battery_digest or None,
         "junit_dir": args.junit_dir or None,
+        "min_main_executed": args.min_main_executed,
+        "min_race_executed": args.min_race_executed,
+        "min_restart_cases": args.min_restart_cases,
     }
 
 

--- a/ci/p022_check_summary.py
+++ b/ci/p022_check_summary.py
@@ -41,19 +41,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import pathlib
 import re
 import sys
+import xml.etree.ElementTree as ET
 
 MAX_BYTES = 64 * 1024
 MAX_INT = 1_000_000
 # The only fixture slugs this job may ever report; certify_datasets.json calls
 # these the public fixtures and they are the only data on the box.
 PUBLIC_SLUGS = {"vw", "biodiversity"}
-COUNT_KEYS = {"passed", "failed", "skipped", "xfailed", "xpassed", "errors"}
-# Counts that must be zero for a suite to be called "pass". `xfailed` is
-# expected (P-022 §C retains twelve strict xfails); `xpassed` is not — a strict
-# xfail that starts passing is a regression in the retained-regression set.
-MUST_BE_ZERO = ("failed", "errors", "xpassed")
+#: Aggregates over the phase's actual JUnit reports, not a log scrape.
+COUNT_KEYS = {"reports", "tests", "failures", "errors", "skipped"}
+MUST_BE_ZERO = ("failures", "errors")
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 SKIP_REASONS = {"not-run-in-this-job"}
 TRUST = "reviewed-recipe-self-reported"
@@ -66,6 +66,8 @@ DEFAULT_EXPECTED = {
     "main_reports": 1,
     "race_reports": 20,
     "sha": None,
+    "battery_digest": None,
+    "junit_dir": None,
 }
 
 
@@ -97,7 +99,35 @@ def check_counts(obj, name):
 
 def suite_clean(counts) -> bool:
     """A suite is clean only if it ran something and nothing went wrong."""
-    return counts["passed"] > 0 and all(counts[k] == 0 for k in MUST_BE_ZERO)
+    return counts["tests"] > 0 and all(counts[k] == 0 for k in MUST_BE_ZERO)
+
+
+def read_reports(directory: pathlib.Path):
+    """Independently aggregate the JUnit files the worker actually returned.
+
+    Round 3 believed the worker's claimed report count without opening a single
+    file, so a summary claiming twenty-one reports passed with zero XML present
+    (review R3-F4). These numbers are computed here, from the artifact, and must
+    equal the ones the summary asserts.
+    """
+    out = {k: 0 for k in COUNT_KEYS}
+    if not directory.is_dir():
+        return out, ["directory is missing"]
+    problems = []
+    for report in sorted(directory.glob("*.xml")):
+        out["reports"] += 1
+        try:
+            root = ET.parse(report).getroot()
+        except ET.ParseError as exc:
+            problems.append(f"{report.name}: {exc}")
+            continue
+        suites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
+        if not suites:
+            problems.append(f"{report.name}: no testsuite element")
+        for suite in suites:
+            for key in ("tests", "failures", "errors", "skipped"):
+                out[key] += int(suite.get(key, 0) or 0)
+    return out, problems
 
 
 def check(summary, expected=None) -> str:
@@ -107,7 +137,7 @@ def check(summary, expected=None) -> str:
     want(set(summary) == {"schema", "kind", "is_certification", "trust",
                           "ref_sha", "recovery", "battery", "verdict"},
          f"unexpected top-level keys: {sorted(summary)}")
-    want(summary["schema"] == "p022-synthetic/2",
+    want(summary["schema"] == "p022-synthetic/3",
          f"unknown schema: {summary['schema']!r}")
     want(summary["kind"] == "synthetic-recovery-and-public-fixture-battery",
          f"unknown kind: {summary['kind']!r}")
@@ -119,9 +149,11 @@ def check(summary, expected=None) -> str:
     sha = summary["ref_sha"]
     want(isinstance(sha, str) and SHA_RE.match(sha or ""),
          "ref_sha must be a 40-hex commit sha; an empty identity is not a result")
-    if exp["sha"]:
-        want(sha == exp["sha"],
-             f"ref_sha {sha} is not the ref the workflow asked for ({exp['sha']})")
+    # Not optional any more: without it any valid-looking 40-hex passes, and the
+    # workflow never supplied one (review R3-F4).
+    want(exp["sha"], "no expected commit was supplied; identity cannot be checked")
+    want(sha == exp["sha"],
+         f"ref_sha {sha} is not the commit the workflow resolved ({exp['sha']})")
 
     # ------------------------------------------------------------- recovery
     rec = summary["recovery"]
@@ -148,6 +180,20 @@ def check(summary, expected=None) -> str:
          f"worker expected {exp_races} race report(s), run scope says {exp['race_reports']}")
     reports_ok = (main_reports == exp_main > 0 and race_reports == exp_races > 0)
 
+    # Cross-check the claim against the artifacts themselves.
+    if exp["junit_dir"]:
+        root = pathlib.Path(exp["junit_dir"])
+        for phase, claimed, expected_count in (("recovery", main_counts, exp_main),
+                                               ("races", race_counts, exp_races)):
+            actual, problems = read_reports(root / phase)
+            want(not problems, f"{phase} JUnit unusable: {'; '.join(problems)[:200]}")
+            want(actual["reports"] == expected_count,
+                 f"{phase}: {actual['reports']} JUnit file(s) returned, "
+                 f"{expected_count} expected")
+            want(actual == claimed,
+                 f"{phase}: summary counts {claimed} do not match the returned "
+                 f"reports {actual}")
+
     counts_ok = suite_clean(main_counts) and suite_clean(race_counts)
     recovery_ok = main_rc == 0 and races_rc == 0 and reports_ok and counts_ok
     want((rec["status"] == "pass") == recovery_ok,
@@ -156,7 +202,7 @@ def check(summary, expected=None) -> str:
     # -------------------------------------------------------------- battery
     bat = summary["battery"]
     want(isinstance(bat, dict), "battery must be an object")
-    want(set(bat) == {"rc", "selected", "missing", "datasets",
+    want(set(bat) == {"rc", "selected", "missing", "datasets", "inventory_digest",
                       "private_cases", "skip_reason", "status"},
          f"unexpected battery keys: {sorted(bat)}")
     bat_rc = check_int(bat["rc"], "battery.rc", allow_none=True)
@@ -193,6 +239,13 @@ def check(summary, expected=None) -> str:
         want(sorted(bat["datasets"]) == sorted(exp["datasets"]),
              f"battery datasets {sorted(bat['datasets'])} != pinned {sorted(exp['datasets'])}")
         want(missing == 0, f"{missing} pinned fixture(s) missing")
+        # Case count and dataset names do not bind schedules, cuts or the
+        # restart seam; swapping the restart entry for an ordinary uniform run
+        # leaves both untouched (review R3-F4).
+        want(exp["battery_digest"],
+             "no expected battery inventory digest was supplied")
+        want(bat["inventory_digest"] == exp["battery_digest"],
+             "battery inventory digest does not match the admitted inventory")
         battery_ok = bat_rc == 0
         want((bat["status"] == "pass") == battery_ok,
              "battery.status disagrees with its return code")
@@ -217,6 +270,9 @@ def parse_args(argv):
     ap.add_argument("--expected-race-reports", type=int,
                     default=DEFAULT_EXPECTED["race_reports"])
     ap.add_argument("--expected-sha", default="")
+    ap.add_argument("--expected-battery-digest", default="")
+    ap.add_argument("--junit-dir", default="",
+                    help="directory holding the returned recovery/ and races/ reports")
     args = ap.parse_args(argv)
     return args, {
         "run_battery": args.run_battery.strip().lower() not in {"false", "0", "no"},
@@ -225,6 +281,8 @@ def parse_args(argv):
         "main_reports": args.expected_main_reports,
         "race_reports": args.expected_race_reports,
         "sha": args.expected_sha or None,
+        "battery_digest": args.expected_battery_digest or None,
+        "junit_dir": args.junit_dir or None,
     }
 
 

--- a/ci/p022_ec2_run.sh
+++ b/ci/p022_ec2_run.sh
@@ -1,198 +1,314 @@
 #!/usr/bin/env bash
-# P-022 §E v1 — the on-instance half of .github/workflows/certification-ec2.yml.
+# P-022 §E — the on-instance half of .github/workflows/certification-ec2.yml.
 #
-# The workflow never runs this locally; it invokes one phase at a time over SSM
-# (AWS-RunShellScript, no SSH) on the disposable worker that cdk/ciEc2.ts
-# launches. Each phase writes its FULL output to /var/log/polis-ci/<phase>.log
-# and prints only a bounded tail to stdout, because SSM truncates
-# GetCommandInvocation output at 24000 characters — the tail is a progress
-# signal, never the evidence.
+# ## What this is, after Astra's #2715 review (round 2)
+#
+# A SYNTHETIC job: the recovery matrix plus the replay battery restricted to the
+# repository's PUBLIC fixtures. It is not private certification and its verdict
+# is named so it cannot be mistaken for one. Round 1 staged the private
+# prod-derived bundle here and then shipped the raw log back to public Actions
+# artifacts (review E1/E2). Round 2 removes the private data path entirely:
+# there is no fixture bucket, the instance role cannot read one, and nothing
+# prod-derived is ever present on this box.
+#
+# ## Output discipline
+#
+# Every phase prints ONLY allowlisted status lines through `status()`:
+#
+#     p022 <phase> <key>=<value>
+#
+# with values restricted to a fixed character class. Nothing else reaches SSM
+# stdout — no log tails, no greps of candidate output, no exception text. Round
+# 1's `grep -E 'VERDICT|PASS|FAIL'` was not a sanitizer: arbitrary candidate
+# text matches it. Full logs stay in /var/log/polis-ci and die with the box.
+#
+# What does come back is structured and bounded: a fixed-schema summary.json
+# built from parsed integers and enums, and pytest's JUnit XML. Both are
+# public-safe by construction here, because this instance has access to nothing
+# that is not already public in the repository.
 #
 # Phases:
-#   recovery  make test-recovery + make test-recovery-races (P-022 §C matrix)
-#   battery   scripts/certify.py over certify_battery.json, restricted to the
-#             datasets actually present. The private prod-derived bundle is NOT
-#             in the repo; it is fetched from S3 by THIS instance (the GitHub
-#             role has no read access to it). Absent bundle => the private
-#             cases are skipped cleanly, the public ones still run.
-#   bundle    build the public-safe artifact tarball
-#   chunk N   emit base64 chunk N of that tarball (the only channel back)
-#
-# Public-safe means: recovery JUnit/logs (synthetic fixtures only) and the
-# certify VERDICT lines. Raw battery output is prod-derived and goes to the
-# private evidence bucket when one is configured, never to an Actions artifact.
+#   recovery  make test-recovery, then make test-recovery-races
+#   battery   scripts/certify.py over the PUBLIC subset of certify_battery.json
+#   summary   write summary.json from the phase results
+#   bundle    build the artifact tarball, print its length and sha256
+#   chunk N   emit base64 chunk N of that tarball
 set -euo pipefail
 
 REPO_ROOT="${POLIS_CI_REPO_ROOT:-/opt/polis}"
 LOG_DIR=/var/log/polis-ci
 ART_DIR="$LOG_DIR/artifacts"
+STATE_DIR="$LOG_DIR/state"
 BUNDLE="$LOG_DIR/polis-ci-artifacts.tar.gz"
-# 24000 chars is SSM's cap; stay under it with room for the framing below.
+# SSM truncates GetCommandInvocation output at 24000 characters. Stay well
+# under it: these phases emit a handful of status lines, and the bundle is
+# returned in explicit, verified chunks.
 CHUNK_CHARS=18000
 MAX_CHUNKS=64
-TAIL_LINES=120
 
-mkdir -p "$LOG_DIR" "$ART_DIR"
+mkdir -p "$LOG_DIR" "$ART_DIR" "$STATE_DIR"
 
-log_tail() {
-  # $1 = phase log file. Bounded, so a runaway test log cannot blow the cap.
-  echo "----- tail -n ${TAIL_LINES} of $1 -----"
-  tail -n "$TAIL_LINES" "$1" || true
+# The ONLY way anything reaches stdout. Deny by default: a value carrying any
+# character outside the class is replaced wholesale, never partially echoed.
+status() {
+  local phase="$1" key="$2" value="${3-}"
+  case "$value" in
+    *[!A-Za-z0-9._:/=+-]*) value='<redacted>' ;;
+  esac
+  if [ "${#value}" -gt 96 ]; then value='<redacted>'; fi
+  printf 'p022 %s %s=%s\n' "$phase" "$key" "$value"
 }
 
 phase_recovery() {
-  local out="$LOG_DIR/recovery.log"
   cd "$REPO_ROOT"
 
-  # P-022 §C landed these targets. If the tested ref predates them, say so
-  # instead of failing with an opaque "No rule to make target".
   if ! make -n test-recovery >/dev/null 2>&1; then
-    echo "FATAL: this checkout has no 'test-recovery' target."
-    echo "P-022 §C (the R01-R12 recovery matrix) is not present at the tested ref."
-    exit 78
+    status recovery result missing-target
+    status recovery detail p022-section-C-not-in-this-ref
+    return 78
   fi
 
-  local rc=0
-  {
-    echo "=== make test-recovery ==="
-    date -u --iso-8601=seconds
-    make test-recovery
-    echo "=== make test-recovery-races ==="
-    date -u --iso-8601=seconds
-    make test-recovery-races
-    echo "=== done ==="
-    date -u --iso-8601=seconds
-  } >"$out" 2>&1 || rc=$?
+  # JUnit regardless of what the Makefile itself passes to pytest.
+  export PYTEST_ADDOPTS="--junitxml=$LOG_DIR/recovery-junit.xml ${PYTEST_ADDOPTS:-}"
 
-  # Collect whatever JUnit the suites produced, wherever they put it.
-  find "$REPO_ROOT" -name 'junit*.xml' -o -name '*junit.xml' -o -name 'pytest*.xml' \
-    2>/dev/null | head -50 | while read -r f; do
-      cp "$f" "$ART_DIR/$(echo "${f#"$REPO_ROOT"/}" | tr '/' '_')" || true
-    done
-  cp "$out" "$ART_DIR/recovery.log" || true
+  # Each command's status is captured on its own. Round 1 wrapped both makes in
+  # a `{ ...; date; } || rc=$?` group, where errexit is suppressed inside an
+  # OR-list and the trailing successful command set the group's status — both
+  # makes could fail with rc 0 reported (review E4).
+  local rc_main=0 rc_races=0
+  make test-recovery >"$LOG_DIR/recovery.log" 2>&1 || rc_main=$?
+  status recovery main_rc "$rc_main"
 
-  # P-022 §C's recorded baseline: 235 passed, 1 skipped, 12 xfailed.
-  grep -Eo '[0-9]+ (passed|failed|skipped|xfailed|xpassed|error[s]?)' "$out" \
-    | sort -u >"$ART_DIR/recovery-counts.txt" || true
+  make test-recovery-races >"$LOG_DIR/recovery-races.log" 2>&1 || rc_races=$?
+  status recovery races_rc "$rc_races"
 
-  log_tail "$out"
-  return "$rc"
+  echo "$rc_main" >"$STATE_DIR/recovery_main_rc"
+  echo "$rc_races" >"$STATE_DIR/recovery_races_rc"
+
+  if [ -f "$LOG_DIR/recovery-junit.xml" ]; then
+    cp "$LOG_DIR/recovery-junit.xml" "$ART_DIR/recovery-junit.xml"
+    status recovery junit present
+  else
+    # A green pytest with no report is not evidence of anything.
+    status recovery junit missing
+    echo 1 >"$STATE_DIR/recovery_junit_missing"
+  fi
+
+  if [ "$rc_main" -ne 0 ] || [ "$rc_races" -ne 0 ] || [ -f "$STATE_DIR/recovery_junit_missing" ]; then
+    status recovery result fail
+    return 1
+  fi
+  status recovery result pass
 }
 
 phase_battery() {
-  local out="$LOG_DIR/battery.log"
   local delphi="$REPO_ROOT/delphi"
   cd "$delphi"
 
-  # Optional private bundle. POLIS_CI_FIXTURE_S3 is an s3:// URI supplied by the
-  # workflow; only THIS instance's role can read it.
-  if [ -n "${POLIS_CI_FIXTURE_S3:-}" ]; then
-    echo "staging private fixture bundle" >>"$out"
-    mkdir -p "$delphi/real_data/.local"
-    if ! aws s3 cp --recursive --only-show-errors \
-        "$POLIS_CI_FIXTURE_S3" "$delphi/real_data/.local/" >>"$out" 2>&1; then
-      echo "WARN: fixture bundle fetch failed; private battery cases will be skipped" | tee -a "$out"
-    fi
-  else
-    echo "no POLIS_CI_FIXTURE_S3 set; private battery cases will be skipped" | tee -a "$out"
-  fi
-
-  # Restrict the battery to datasets that actually resolve on this box. A slug
-  # resolves as real_data/*-<slug> (public) or real_data/.local/*-<slug>
-  # (private) — the same rule polismath/replay/real_data.py uses.
-  python3 - "$delphi" >"$LOG_DIR/battery-filter.json" <<'PY'
+  # The battery is restricted to the fixtures declared public in
+  # certify_datasets.json and checked into the repository. There is no private
+  # bundle to fetch and no credential that could fetch one. A private battery
+  # needs the isolated worker design in P-022-E-ci-spec.md, not this box.
+  python3 - "$delphi" >"$STATE_DIR/battery-selection.json" <<'PY'
 import json, pathlib, sys
 delphi = pathlib.Path(sys.argv[1])
 root = delphi / "real_data"
-battery = json.loads((delphi / "scripts" / "certify_battery.json").read_text())
-def present(slug):
-    return bool(list(root.glob(f"*-{slug}")) or list(root.glob(f".local/*-{slug}")))
-kept, skipped = [], []
-for entry in battery:
-    slug = entry.get("dataset")
-    (kept if present(slug) else skipped).append(entry)
-json.dump({"kept": kept, "skipped": sorted({e.get("dataset") for e in skipped})},
-          sys.stdout, indent=1)
+scripts = delphi / "scripts"
+datasets = json.loads((scripts / "certify_datasets.json").read_text())
+public = {f["slug"] for f in datasets["public_fixtures"]}
+battery = json.loads((scripts / "certify_battery.json").read_text())
+
+
+def resolves(slug):
+    # Public fixtures only: real_data/*-<slug>. The .local private tree is
+    # deliberately NOT consulted; if one were ever left on a box, it must not
+    # silently enlarge a synthetic run.
+    return bool(list(root.glob(f"*-{slug}")))
+
+
+selected = [e for e in battery if e.get("dataset") in public]
+missing = sorted({e["dataset"] for e in selected if not resolves(e["dataset"])})
+json.dump({
+    "public_slugs": sorted(public),
+    "selected": selected,
+    "selected_count": len(selected),
+    "missing": missing,
+    "private_skipped": sorted({e.get("dataset") for e in battery
+                               if e.get("dataset") not in public}),
+}, sys.stdout, indent=1)
 PY
 
-  python3 - <<'PY' >"$delphi/scripts/certify_battery.ci.json"
-import json, sys
-sel = json.load(open("/var/log/polis-ci/battery-filter.json"))
-json.dump(sel["kept"], sys.stdout, indent=1)
-PY
+  cp "$STATE_DIR/battery-selection.json" "$ART_DIR/battery-selection.json"
+  local selected missing
+  selected=$(python3 -c 'import json;print(json.load(open("/var/log/polis-ci/state/battery-selection.json"))["selected_count"])')
+  missing=$(python3 -c 'import json;print(len(json.load(open("/var/log/polis-ci/state/battery-selection.json"))["missing"]))')
+  status battery selected "$selected"
+  status battery missing "$missing"
 
-  cp "$LOG_DIR/battery-filter.json" "$ART_DIR/battery-selection.json" || true
-  local kept
-  kept=$(python3 -c 'import json;print(len(json.load(open("/var/log/polis-ci/battery-filter.json"))["kept"]))')
-  echo "battery cases selected: $kept" | tee -a "$out"
-  if [ "$kept" -eq 0 ]; then
-    echo "SKIPPED: no battery dataset resolves on this instance" | tee -a "$out"
-    echo "SKIPPED" >"$ART_DIR/battery-status.txt"
-    cp "$out" "$ART_DIR/battery.log" || true
-    log_tail "$out"
-    return 0
+  # Round 1 returned success for an empty selection, so a battery that silently
+  # shrank to nothing still reported green (review E5). An empty or incomplete
+  # public inventory is a failure, not a smaller run.
+  if [ "$selected" -eq 0 ]; then
+    status battery result empty-inventory
+    echo 1 >"$STATE_DIR/battery_rc"
+    return 1
   fi
+  if [ "$missing" -ne 0 ]; then
+    status battery result missing-fixtures
+    echo 1 >"$STATE_DIR/battery_rc"
+    return 1
+  fi
+
+  python3 - >"$delphi/scripts/certify_battery.public.json" <<'PY'
+import json, sys
+sel = json.load(open("/var/log/polis-ci/state/battery-selection.json"))
+json.dump(sel["selected"], sys.stdout, indent=1)
+PY
 
   # certify shells out to `uv run python scripts/replay_driver.py` and to
-  # `clojure -M:replay` (polismath/replay/certify.py), so both toolchains have
-  # to exist before the first case runs.
-  command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
+  # `clojure -M:replay` (polismath/replay/certify.py), so both toolchains must
+  # exist before the first case runs.
+  if ! command -v uv >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh 2>>"$LOG_DIR/battery.log" | sh >>"$LOG_DIR/battery.log" 2>&1
+  fi
   export PATH="$HOME/.local/bin:$PATH"
   if ! command -v clojure >/dev/null 2>&1; then
-    # This script is invoked as root over SSM, so no sudo is needed (and a
-    # sudo here would not cover the redirect anyway).
-    dnf install -y java-21-amazon-corretto-headless rlwrap >>"$out" 2>&1
+    # This script runs as root over SSM; no sudo (which would not cover the
+    # redirect anyway).
+    dnf install -y java-21-amazon-corretto-headless rlwrap >>"$LOG_DIR/battery.log" 2>&1
     curl -fsSL -o /tmp/linux-install.sh https://download.clojure.org/install/linux-install.sh
     chmod +x /tmp/linux-install.sh
-    /tmp/linux-install.sh >>"$out" 2>&1
+    /tmp/linux-install.sh >>"$LOG_DIR/battery.log" 2>&1
   fi
-  uv sync >>"$out" 2>&1 || uv venv >>"$out" 2>&1
+  uv sync >>"$LOG_DIR/battery.log" 2>&1 || uv venv >>"$LOG_DIR/battery.log" 2>&1
 
-  # Serial workers and fixed BLAS threads: P-022 §E requires a correctness
-  # baseline, not a throughput measurement.
+  # Serial workers and fixed BLAS threads: this is a correctness baseline, not
+  # a throughput measurement.
   export OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1
-  local run_root="$LOG_DIR/certify-run"
   local rc=0
   uv run python scripts/certify.py run \
-      --battery scripts/certify_battery.ci.json \
+      --battery scripts/certify_battery.public.json \
       --refresh-clj --refresh-py --strict --workers 1 \
-      --root "$run_root" >>"$out" 2>&1 || rc=$?
-
-  # Verdict lines only. The run directory holds prod-derived comparisons and
-  # must not reach a public artifact.
-  grep -E '^certify:|VERDICT|PASS|FAIL|INCOMPLETE' "$out" \
-    | tail -n 200 >"$ART_DIR/battery-verdicts.txt" || true
-  echo "$rc" >"$ART_DIR/battery-status.txt"
-
-  if [ -n "${POLIS_CI_EVIDENCE_S3:-}" ]; then
-    tar -czf /tmp/certify-evidence.tar.gz -C "$LOG_DIR" certify-run battery.log 2>/dev/null || true
-    aws s3 cp --only-show-errors /tmp/certify-evidence.tar.gz \
-      "${POLIS_CI_EVIDENCE_S3%/}/${POLIS_CI_RUN:-unknown}/certify-evidence.tar.gz" \
-      >>"$out" 2>&1 || echo "WARN: evidence upload failed" | tee -a "$out"
+      --root "$LOG_DIR/certify-run" >>"$LOG_DIR/battery.log" 2>&1 || rc=$?
+  echo "$rc" >"$STATE_DIR/battery_rc"
+  status battery rc "$rc"
+  if [ "$rc" -ne 0 ]; then
+    status battery result fail
+    return "$rc"
   fi
+  status battery result pass
+}
 
-  cp "$out" "$ART_DIR/battery.log" || true
-  log_tail "$out"
-  return "$rc"
+phase_summary() {
+  # A fixed schema built from parsed integers, enums and known fixture slugs.
+  # Nothing free-form from any log reaches this file.
+  python3 - "$REPO_ROOT" "$LOG_DIR" >"$ART_DIR/summary.json" <<'PY'
+import json, pathlib, re, sys
+
+repo, logdir = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+state = logdir / "state"
+
+
+def read_int(name, default=None):
+    p = state / name
+    if not p.exists():
+        return default
+    try:
+        return int(p.read_text().strip())
+    except ValueError:
+        return default
+
+
+def counts(path):
+    """pytest's terminal tallies only: integers keyed by a fixed word list."""
+    out = {k: 0 for k in
+           ("passed", "failed", "skipped", "xfailed", "xpassed", "errors")}
+    if not path.exists():
+        return out
+    text = path.read_text(errors="replace")[-20000:]
+    for n, word in re.findall(
+            r"(\d+) (passed|failed|skipped|xfailed|xpassed|errors?)", text):
+        key = "errors" if word.startswith("error") else word
+        out[key] = max(out[key], int(n))
+    return out
+
+
+sha = ""
+sha_file = pathlib.Path("/var/lib/polis-ci-sha")
+if sha_file.exists():
+    m = re.fullmatch(r"[0-9a-f]{40}", sha_file.read_text().strip())
+    sha = m.group(0) if m else ""
+
+sel_path = state / "battery-selection.json"
+sel = json.loads(sel_path.read_text()) if sel_path.exists() else {}
+slug = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
+
+main_rc = read_int("recovery_main_rc")
+races_rc = read_int("recovery_races_rc")
+battery_rc = read_int("battery_rc")
+recovery_ok = main_rc == 0 and races_rc == 0 and not (state / "recovery_junit_missing").exists()
+battery_ok = battery_rc == 0
+
+summary = {
+    "schema": "p022-synthetic/1",
+    "kind": "synthetic-recovery-and-public-fixture-battery",
+    "is_certification": False,
+    "ref_sha": sha,
+    "recovery": {
+        "main_rc": main_rc,
+        "races_rc": races_rc,
+        "junit": (state / "recovery_junit_missing").exists() is False,
+        "counts": counts(logdir / "recovery.log"),
+        "races_counts": counts(logdir / "recovery-races.log"),
+        "status": "pass" if recovery_ok else "fail",
+    },
+    "battery": {
+        "rc": battery_rc,
+        "selected": int(sel.get("selected_count", 0)),
+        "missing": len(sel.get("missing", [])),
+        "datasets": sorted(s for s in set(
+            e.get("dataset") for e in sel.get("selected", [])) if s and slug.match(s)),
+        "private_cases": "not-run",
+        "status": "pass" if battery_ok else ("skipped" if battery_rc is None else "fail"),
+    },
+    "verdict": "SYNTHETIC-PASS" if (recovery_ok and battery_rc in (0, None))
+               else "SYNTHETIC-FAIL",
+}
+json.dump(summary, sys.stdout, indent=1, sort_keys=True)
+PY
+  local verdict
+  verdict=$(python3 -c 'import json;print(json.load(open("/var/log/polis-ci/artifacts/summary.json"))["verdict"])')
+  status summary verdict "$verdict"
 }
 
 phase_bundle() {
-  # Everything in ART_DIR is public-safe by construction (see the header).
-  tar -czf "$BUNDLE" -C "$ART_DIR" . 2>/dev/null || true
+  tar -czf "$BUNDLE" -C "$ART_DIR" . || { status bundle result tar-failed; return 1; }
   base64 -w0 "$BUNDLE" >"$LOG_DIR/artifacts.b64"
-  local chars chunks
+  local chars chunks digest
   chars=$(wc -c <"$LOG_DIR/artifacts.b64")
   chunks=$(( (chars + CHUNK_CHARS - 1) / CHUNK_CHARS ))
+  digest=$(sha256sum "$BUNDLE" | cut -d' ' -f1)
+  # Round 1 truncated an oversized bundle and still succeeded. Evidence that
+  # does not fit is missing evidence: fail rather than ship a partial tarball.
   if [ "$chunks" -gt "$MAX_CHUNKS" ]; then
-    echo "TRUNCATED: artifact bundle is $chars b64 chars, cap is $((MAX_CHUNKS * CHUNK_CHARS))"
-    chunks="$MAX_CHUNKS"
+    status bundle result too-large
+    status bundle chars "$chars"
+    return 1
   fi
-  echo "CHUNKS=$chunks"
+  status bundle chunks "$chunks"
+  status bundle chars "$chars"
+  status bundle sha256 "$digest"
 }
 
 phase_chunk() {
   local n="$1"
-  # cut is byte-oriented here, which is what we want: base64 is ASCII.
+  case "$n" in ''|*[!0-9]*) status chunk result bad-index; return 2 ;; esac
+  if [ "$n" -lt 1 ] || [ "$n" -gt "$MAX_CHUNKS" ]; then
+    status chunk result bad-index
+    return 2
+  fi
+  # base64 is ASCII, so character offsets are byte offsets. This is the one
+  # place that prints something other than a status line, by design.
   cut -c "$(( (n - 1) * CHUNK_CHARS + 1 ))-$(( n * CHUNK_CHARS ))" \
     "$LOG_DIR/artifacts.b64"
 }
@@ -200,7 +316,8 @@ phase_chunk() {
 case "${1:-}" in
   recovery) phase_recovery ;;
   battery)  phase_battery ;;
+  summary)  phase_summary ;;
   bundle)   phase_bundle ;;
   chunk)    phase_chunk "${2:?chunk index required}" ;;
-  *) echo "usage: $0 {recovery|battery|bundle|chunk N}" >&2; exit 2 ;;
+  *) echo "usage: $0 {recovery|battery|summary|bundle|chunk N}" >&2; exit 2 ;;
 esac

--- a/ci/p022_ec2_run.sh
+++ b/ci/p022_ec2_run.sh
@@ -62,11 +62,37 @@ status() {
   printf 'p022 %s %s=%s\n' "$phase" "$key" "$value"
 }
 
-# An explicit target-existence oracle. `make -n` consults the catch-all pattern
-# rule and answers "yes" for anything; `make -qp` prints the rule database, in
-# which an explicitly declared target appears at the start of a line.
+# An explicit target-existence oracle.
+#
+# `make -n` consults the catch-all pattern rule and answers "yes" for anything,
+# so it cannot be used. `make -qp` prints the rule database, in which an
+# explicitly declared target appears at the start of a line — but round 3 piped
+# it into `grep -q` under `set -o pipefail`, and that rejected REAL targets two
+# ways (review R3-F2): question mode exits 1 when a target is out of date, and
+# `grep -q` closes the pipe early, killing make with SIGPIPE (141). Both looked
+# like an absent target.
+#
+# So: capture the whole database with no pipe, accept make's documented
+# question-mode statuses 0 and 1, treat anything else as a parse failure, and
+# search the captured bytes.
 has_target() {
-  make -qp 2>/dev/null | grep -Eq "^$1:( |\$)"
+  local db rc=0
+  db="$(mktemp)" || return 1
+  make -qp >"$db" 2>/dev/null || rc=$?
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+    rm -f "$db"
+    return 1
+  fi
+  if [ ! -s "$db" ]; then
+    rm -f "$db"
+    return 1
+  fi
+  if grep -Eq "^$1:( |\$)" "$db"; then
+    rm -f "$db"
+    return 0
+  fi
+  rm -f "$db"
+  return 1
 }
 
 # One JUnit file per pytest process, named uniquely, so nothing is overwritten.
@@ -166,7 +192,7 @@ phase_battery() {
   # certify_datasets.json and checked into the repository. There is no private
   # bundle to fetch and no credential that could fetch one.
   python3 - "$delphi" >"$STATE_DIR/battery-selection.json" <<'PY'
-import json, pathlib, sys
+import hashlib, json, pathlib, sys
 delphi = pathlib.Path(sys.argv[1])
 root = delphi / "real_data"
 scripts = delphi / "scripts"
@@ -184,11 +210,19 @@ def resolves(slug):
 
 selected = [e for e in battery if e.get("dataset") in public]
 missing = sorted({e["dataset"] for e in selected if not resolves(e["dataset"])})
+# Inventory digest. Case count plus dataset names do not bind schedules, cuts
+# or the restart seam; this does. Kept byte-identical to
+# ci/p022_battery_digest.py, which the runner uses to compute the expectation.
+FIELDS = ("dataset", "preset", "n_cuts", "schedule")
+rows = sorted([[f, "" if e.get(f) is None else str(e.get(f))] for f in FIELDS]
+              for e in selected)
+canonical = json.dumps(rows, sort_keys=True, separators=(",", ":"))
 json.dump({
     "public_slugs": sorted(public),
     "selected": selected,
     "selected_count": len(selected),
     "missing": missing,
+    "inventory_digest": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
     "private_skipped": sorted({e.get("dataset") for e in battery
                                if e.get("dataset") not in public}),
 }, sys.stdout, indent=1)
@@ -260,10 +294,11 @@ phase_summary() {
   # Nothing free-form from any log reaches this file. It is NOT independent
   # execution evidence: every field is produced by the recipe running here, and
   # the runner-side validator checks coherence and inventory, not authenticity.
-  python3 - "$REPO_ROOT" "$LOG_DIR" "$STATE_DIR" >"$ART_DIR/summary.json" <<'PY'
+  python3 - "$REPO_ROOT" "$LOG_DIR" "$STATE_DIR" "$ART_DIR" >"$ART_DIR/summary.json" <<'PY'
 import json, pathlib, re, sys
+import xml.etree.ElementTree as ET
 
-repo, logdir, state = (pathlib.Path(p) for p in sys.argv[1:4])
+repo, logdir, state, artdir = (pathlib.Path(p) for p in sys.argv[1:5])
 
 
 def read_int(name, default=None):
@@ -276,17 +311,31 @@ def read_int(name, default=None):
         return default
 
 
-def counts(path):
-    """pytest's terminal tallies only: integers keyed by a fixed word list."""
-    out = {k: 0 for k in
-           ("passed", "failed", "skipped", "xfailed", "xpassed", "errors")}
-    if not path.exists():
+def counts(phase):
+    """Aggregate over the phase's ACTUAL JUnit reports.
+
+    Round 3 took the maximum tally seen in the last 20000 characters of the
+    log, so twenty iterations of "2 passed, 1 xfailed" reported 2/1 rather than
+    40/20 — a number that cannot detect a race loop that stopped early (review
+    R3-F4). These are sums of the reports' own attributes, and the runner
+    re-parses the same files and must get the same numbers.
+    """
+    out = {k: 0 for k in ("reports", "tests", "failures", "errors", "skipped")}
+    directory = artdir / "junit" / phase
+    if not directory.is_dir():
         return out
-    text = path.read_text(errors="replace")[-20000:]
-    for n, word in re.findall(
-            r"(\d+) (passed|failed|skipped|xfailed|xpassed|errors?)", text):
-        key = "errors" if word.startswith("error") else word
-        out[key] = max(out[key], int(n))
+    for report in sorted(directory.glob("*.xml")):
+        try:
+            root = ET.parse(report).getroot()
+        except ET.ParseError:
+            out["reports"] += 1  # counted, but contributes no results
+            continue
+        out["reports"] += 1
+        suites = ([root] if root.tag == "testsuite"
+                  else list(root.iter("testsuite")))
+        for suite in suites:
+            for key in ("tests", "failures", "errors", "skipped"):
+                out[key] += int(suite.get(key, 0) or 0)
     return out
 
 
@@ -303,18 +352,25 @@ slug = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
 main_rc = read_int("recovery_main_rc")
 races_rc = read_int("recovery_races_rc")
 battery_rc = read_int("battery_rc")
-main_reports = read_int("recovery_reports", 0)
-race_reports = read_int("races_reports", 0)
+main_counts = counts("recovery")
+race_counts = counts("races")
+main_reports = main_counts["reports"]
+race_reports = race_counts["reports"]
 expected_main = read_int("expected_main_reports", 0)
 expected_races = read_int("expected_race_reports", 0)
 
+def suite_clean(c):
+    return c["tests"] > 0 and c["failures"] == 0 and c["errors"] == 0
+
+
 recovery_ok = (main_rc == 0 and races_rc == 0
                and main_reports == expected_main and main_reports > 0
-               and race_reports == expected_races and race_reports > 0)
+               and race_reports == expected_races and race_reports > 0
+               and suite_clean(main_counts) and suite_clean(race_counts))
 battery_ok = battery_rc == 0
 
 summary = {
-    "schema": "p022-synthetic/2",
+    "schema": "p022-synthetic/3",
     "kind": "synthetic-recovery-and-public-fixture-battery",
     "is_certification": False,
     "trust": "reviewed-recipe-self-reported",
@@ -326,8 +382,8 @@ summary = {
         "race_reports": race_reports,
         "expected_main_reports": expected_main,
         "expected_race_reports": expected_races,
-        "counts": counts(logdir / "recovery.log"),
-        "races_counts": counts(logdir / "recovery-races.log"),
+        "counts": main_counts,
+        "races_counts": race_counts,
         "status": "pass" if recovery_ok else "fail",
     },
     "battery": {
@@ -336,6 +392,9 @@ summary = {
         "missing": len(sel.get("missing", [])),
         "datasets": sorted(s for s in set(
             e.get("dataset") for e in sel.get("selected", [])) if s and slug.match(s)),
+        "inventory_digest": (sel.get("inventory_digest", "")
+                             if re.fullmatch(r"[0-9a-f]{64}",
+                                             str(sel.get("inventory_digest", ""))) else ""),
         "private_cases": "not-run",
         "skip_reason": "" if battery_rc is not None else "not-run-in-this-job",
         "status": "pass" if battery_ok else ("skipped" if battery_rc is None else "fail"),

--- a/ci/p022_ec2_run.sh
+++ b/ci/p022_ec2_run.sh
@@ -103,9 +103,20 @@ has_target() {
 install_junit_plugin() {
   mkdir -p /opt/polis-ci
   cat >/opt/polis-ci/p022_junit.py <<'PLUGIN'
+"""Per-invocation JUnit reports, and an XPASS is always a failure.
+
+`-o xfail_strict=true` does not override an explicit `@pytest.mark.xfail(
+strict=False)`, and JUnit renders such an XPASS as an ordinary passing test —
+so the round-4 move from terminal tallies to XML silently dropped the XPASS
+rejection round 3 had (review R4-F2). This hooks the report itself: any passing
+report carrying `wasxfail` is an XPASS, is recorded, and makes the process exit
+nonzero regardless of how the marker was written.
+"""
 import os
 import pathlib
 import uuid
+
+_XPASSED = []
 
 
 def pytest_load_initial_conftests(early_config, parser, args):
@@ -117,6 +128,24 @@ def pytest_load_initial_conftests(early_config, parser, args):
     name = "%s-%d-%s.xml" % (os.environ.get("P022_JUNIT_TAG", "run"),
                              os.getpid(), uuid.uuid4().hex[:8])
     early_config.option.xmlpath = str(directory / name)
+
+
+def pytest_runtest_logreport(report):
+    if report.when == "call" and report.passed and getattr(report, "wasxfail", None) is not None:
+        _XPASSED.append(report.nodeid)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if not _XPASSED:
+        return
+    target = os.environ.get("P022_XPASS_FILE")
+    if target:
+        # One line per XPASS. Only the COUNT ever leaves the instance; node ids
+        # are candidate-controlled text and stay in the log directory.
+        with open(target, "a", encoding="utf-8") as handle:
+            for node in _XPASSED:
+                handle.write(node + "\n")
+    session.exitstatus = 1
 PLUGIN
 }
 
@@ -154,7 +183,11 @@ phase_recovery() {
 
   install_junit_plugin
   export PYTHONPATH="/opt/polis-ci${PYTHONPATH:+:$PYTHONPATH}"
-  export PYTEST_ADDOPTS="-p p022_junit ${PYTEST_ADDOPTS:-}"
+  # `xfail_strict` makes an unmarked xfail strict; the plugin catches the rest,
+  # including an explicit strict=False that `xfail_strict` cannot override.
+  export PYTEST_ADDOPTS="-p p022_junit -o xfail_strict=true ${PYTEST_ADDOPTS:-}"
+  export P022_XPASS_FILE="$LOG_DIR/xpassed.txt"
+  rm -f "$P022_XPASS_FILE"
   rm -rf "$JUNIT_DIR"
   mkdir -p "$JUNIT_DIR/recovery" "$JUNIT_DIR/races"
 
@@ -171,13 +204,20 @@ phase_recovery() {
 
   echo "$rc_main" >"$STATE_DIR/recovery_main_rc"
   echo "$rc_races" >"$STATE_DIR/recovery_races_rc"
+  local xpassed=0
+  if [ -f "$P022_XPASS_FILE" ]; then
+    xpassed=$(wc -l <"$P022_XPASS_FILE" | tr -d " ")
+  fi
+  echo "$xpassed" >"$STATE_DIR/xpassed"
+  status recovery xpassed "$xpassed"
 
   collect_reports recovery "$JUNIT_DIR/recovery" "$EXPECTED_MAIN_REPORTS" || rc_reports=1
   collect_reports races "$JUNIT_DIR/races" "$EXPECTED_RACE_REPORTS" || rc_reports=1
   echo "$EXPECTED_RACE_REPORTS" >"$STATE_DIR/expected_race_reports"
   echo "$EXPECTED_MAIN_REPORTS" >"$STATE_DIR/expected_main_reports"
 
-  if [ "$rc_main" -ne 0 ] || [ "$rc_races" -ne 0 ] || [ "$rc_reports" -ne 0 ]; then
+  if [ "$rc_main" -ne 0 ] || [ "$rc_races" -ne 0 ] || [ "$rc_reports" -ne 0 ] \
+     || [ "$xpassed" -ne 0 ]; then
     status recovery result fail
     return 1
   fi
@@ -210,19 +250,73 @@ def resolves(slug):
 
 selected = [e for e in battery if e.get("dataset") in public]
 missing = sorted({e["dataset"] for e in selected if not resolves(e["dataset"])})
-# Inventory digest. Case count plus dataset names do not bind schedules, cuts
-# or the restart seam; this does. Kept byte-identical to
+# Inventory digest, kept byte-identical in behaviour to
 # ci/p022_battery_digest.py, which the runner uses to compute the expectation.
+# Types are preserved (8 and "8" are different inventories) and every referenced
+# schedule is hashed by CONTENT, so deleting a restart seam from a same-named
+# schedule moves the digest (review R4-F3).
 FIELDS = ("dataset", "preset", "n_cuts", "schedule")
-rows = sorted([[f, "" if e.get(f) is None else str(e.get(f))] for f in FIELDS]
-              for e in selected)
-canonical = json.dumps(rows, sort_keys=True, separators=(",", ":"))
+
+
+def canonical_json(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def read_schedule(name):
+    candidate = (scripts / name).resolve()
+    if scripts.resolve() not in candidate.parents and candidate != scripts.resolve():
+        return None
+    try:
+        return candidate.read_bytes()
+    except OSError:
+        return None
+
+
+def schedule_fingerprint(name):
+    if not name:
+        return None
+    raw = read_schedule(name)
+    if raw is None:
+        return "missing"
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return "unparseable:" + hashlib.sha256(raw).hexdigest()
+    return hashlib.sha256(canonical_json(parsed).encode("utf-8")).hexdigest()
+
+
+def declares_restart(name):
+    if not name:
+        return False
+    raw = read_schedule(name)
+    if raw is None:
+        return False
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return False
+    return isinstance(parsed, dict) and parsed.get("restart_after") is not None
+
+
+rows, restarts = [], 0
+for entry in selected:
+    row = {f: entry.get(f) for f in FIELDS}
+    row["schedule_sha256"] = schedule_fingerprint(entry.get("schedule"))
+    if declares_restart(entry.get("schedule")):
+        restarts += 1
+    rows.append(canonical_json(row))
+canonical = canonical_json({
+    "version": "p022-battery-inventory/2",
+    "entries": sorted(rows),
+    "public_fixtures": sorted(canonical_json(f) for f in datasets["public_fixtures"]),
+})
 json.dump({
     "public_slugs": sorted(public),
     "selected": selected,
     "selected_count": len(selected),
     "missing": missing,
     "inventory_digest": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+    "restart_cases": restarts,
     "private_skipped": sorted({e.get("dataset") for e in battery
                                if e.get("dataset") not in public}),
 }, sys.stdout, indent=1)
@@ -320,22 +414,35 @@ def counts(phase):
     R3-F4). These are sums of the reports' own attributes, and the runner
     re-parses the same files and must get the same numbers.
     """
-    out = {k: 0 for k in ("reports", "tests", "failures", "errors", "skipped")}
+    out = {k: 0 for k in ("reports", "tests", "failures", "errors", "skipped",
+                          "executed")}
+    out["min_executed"] = 0
     directory = artdir / "junit" / phase
     if not directory.is_dir():
         return out
+    per_report = []
     for report in sorted(directory.glob("*.xml")):
         try:
             root = ET.parse(report).getroot()
         except ET.ParseError:
             out["reports"] += 1  # counted, but contributes no results
+            per_report.append(0)
             continue
         out["reports"] += 1
         suites = ([root] if root.tag == "testsuite"
                   else list(root.iter("testsuite")))
+        this = {"tests": 0, "skipped": 0}
         for suite in suites:
             for key in ("tests", "failures", "errors", "skipped"):
                 out[key] += int(suite.get(key, 0) or 0)
+            this["tests"] += int(suite.get("tests", 0) or 0)
+            this["skipped"] += int(suite.get("skipped", 0) or 0)
+        per_report.append(this["tests"] - this["skipped"])
+    out["executed"] = out["tests"] - out["skipped"]
+    # `tests` includes skips, so an all-skipped report — or nineteen empty ones
+    # beside a single real test — used to satisfy "tests > 0" (review R4-F1).
+    # The MINIMUM over reports is what makes each invocation carry its weight.
+    out["min_executed"] = min(per_report) if per_report else 0
     return out
 
 
@@ -349,6 +456,7 @@ sel_path = state / "battery-selection.json"
 sel = json.loads(sel_path.read_text()) if sel_path.exists() else {}
 slug = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
 
+xpassed = read_int("xpassed", 0)
 main_rc = read_int("recovery_main_rc")
 races_rc = read_int("recovery_races_rc")
 battery_rc = read_int("battery_rc")
@@ -360,13 +468,15 @@ expected_main = read_int("expected_main_reports", 0)
 expected_races = read_int("expected_race_reports", 0)
 
 def suite_clean(c):
-    return c["tests"] > 0 and c["failures"] == 0 and c["errors"] == 0
+    return (c["executed"] > 0 and c["min_executed"] > 0
+            and c["failures"] == 0 and c["errors"] == 0)
 
 
 recovery_ok = (main_rc == 0 and races_rc == 0
                and main_reports == expected_main and main_reports > 0
                and race_reports == expected_races and race_reports > 0
-               and suite_clean(main_counts) and suite_clean(race_counts))
+               and suite_clean(main_counts) and suite_clean(race_counts)
+               and xpassed == 0)
 battery_ok = battery_rc == 0
 
 summary = {
@@ -384,6 +494,7 @@ summary = {
         "expected_race_reports": expected_races,
         "counts": main_counts,
         "races_counts": race_counts,
+        "xpassed": xpassed,
         "status": "pass" if recovery_ok else "fail",
     },
     "battery": {
@@ -395,6 +506,7 @@ summary = {
         "inventory_digest": (sel.get("inventory_digest", "")
                              if re.fullmatch(r"[0-9a-f]{64}",
                                              str(sel.get("inventory_digest", ""))) else ""),
+        "restart_cases": int(sel.get("restart_cases", 0) or 0),
         "private_cases": "not-run",
         "skip_reason": "" if battery_rc is not None else "not-run-in-this-job",
         "status": "pass" if battery_ok else ("skipped" if battery_rc is None else "fail"),

--- a/ci/p022_ec2_run.sh
+++ b/ci/p022_ec2_run.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# P-022 §E v1 — the on-instance half of .github/workflows/certification-ec2.yml.
+#
+# The workflow never runs this locally; it invokes one phase at a time over SSM
+# (AWS-RunShellScript, no SSH) on the disposable worker that cdk/ciEc2.ts
+# launches. Each phase writes its FULL output to /var/log/polis-ci/<phase>.log
+# and prints only a bounded tail to stdout, because SSM truncates
+# GetCommandInvocation output at 24000 characters — the tail is a progress
+# signal, never the evidence.
+#
+# Phases:
+#   recovery  make test-recovery + make test-recovery-races (P-022 §C matrix)
+#   battery   scripts/certify.py over certify_battery.json, restricted to the
+#             datasets actually present. The private prod-derived bundle is NOT
+#             in the repo; it is fetched from S3 by THIS instance (the GitHub
+#             role has no read access to it). Absent bundle => the private
+#             cases are skipped cleanly, the public ones still run.
+#   bundle    build the public-safe artifact tarball
+#   chunk N   emit base64 chunk N of that tarball (the only channel back)
+#
+# Public-safe means: recovery JUnit/logs (synthetic fixtures only) and the
+# certify VERDICT lines. Raw battery output is prod-derived and goes to the
+# private evidence bucket when one is configured, never to an Actions artifact.
+set -euo pipefail
+
+REPO_ROOT="${POLIS_CI_REPO_ROOT:-/opt/polis}"
+LOG_DIR=/var/log/polis-ci
+ART_DIR="$LOG_DIR/artifacts"
+BUNDLE="$LOG_DIR/polis-ci-artifacts.tar.gz"
+# 24000 chars is SSM's cap; stay under it with room for the framing below.
+CHUNK_CHARS=18000
+MAX_CHUNKS=64
+TAIL_LINES=120
+
+mkdir -p "$LOG_DIR" "$ART_DIR"
+
+log_tail() {
+  # $1 = phase log file. Bounded, so a runaway test log cannot blow the cap.
+  echo "----- tail -n ${TAIL_LINES} of $1 -----"
+  tail -n "$TAIL_LINES" "$1" || true
+}
+
+phase_recovery() {
+  local out="$LOG_DIR/recovery.log"
+  cd "$REPO_ROOT"
+
+  # P-022 §C landed these targets. If the tested ref predates them, say so
+  # instead of failing with an opaque "No rule to make target".
+  if ! make -n test-recovery >/dev/null 2>&1; then
+    echo "FATAL: this checkout has no 'test-recovery' target."
+    echo "P-022 §C (the R01-R12 recovery matrix) is not present at the tested ref."
+    exit 78
+  fi
+
+  local rc=0
+  {
+    echo "=== make test-recovery ==="
+    date -u --iso-8601=seconds
+    make test-recovery
+    echo "=== make test-recovery-races ==="
+    date -u --iso-8601=seconds
+    make test-recovery-races
+    echo "=== done ==="
+    date -u --iso-8601=seconds
+  } >"$out" 2>&1 || rc=$?
+
+  # Collect whatever JUnit the suites produced, wherever they put it.
+  find "$REPO_ROOT" -name 'junit*.xml' -o -name '*junit.xml' -o -name 'pytest*.xml' \
+    2>/dev/null | head -50 | while read -r f; do
+      cp "$f" "$ART_DIR/$(echo "${f#"$REPO_ROOT"/}" | tr '/' '_')" || true
+    done
+  cp "$out" "$ART_DIR/recovery.log" || true
+
+  # P-022 §C's recorded baseline: 235 passed, 1 skipped, 12 xfailed.
+  grep -Eo '[0-9]+ (passed|failed|skipped|xfailed|xpassed|error[s]?)' "$out" \
+    | sort -u >"$ART_DIR/recovery-counts.txt" || true
+
+  log_tail "$out"
+  return "$rc"
+}
+
+phase_battery() {
+  local out="$LOG_DIR/battery.log"
+  local delphi="$REPO_ROOT/delphi"
+  cd "$delphi"
+
+  # Optional private bundle. POLIS_CI_FIXTURE_S3 is an s3:// URI supplied by the
+  # workflow; only THIS instance's role can read it.
+  if [ -n "${POLIS_CI_FIXTURE_S3:-}" ]; then
+    echo "staging private fixture bundle" >>"$out"
+    mkdir -p "$delphi/real_data/.local"
+    if ! aws s3 cp --recursive --only-show-errors \
+        "$POLIS_CI_FIXTURE_S3" "$delphi/real_data/.local/" >>"$out" 2>&1; then
+      echo "WARN: fixture bundle fetch failed; private battery cases will be skipped" | tee -a "$out"
+    fi
+  else
+    echo "no POLIS_CI_FIXTURE_S3 set; private battery cases will be skipped" | tee -a "$out"
+  fi
+
+  # Restrict the battery to datasets that actually resolve on this box. A slug
+  # resolves as real_data/*-<slug> (public) or real_data/.local/*-<slug>
+  # (private) — the same rule polismath/replay/real_data.py uses.
+  python3 - "$delphi" >"$LOG_DIR/battery-filter.json" <<'PY'
+import json, pathlib, sys
+delphi = pathlib.Path(sys.argv[1])
+root = delphi / "real_data"
+battery = json.loads((delphi / "scripts" / "certify_battery.json").read_text())
+def present(slug):
+    return bool(list(root.glob(f"*-{slug}")) or list(root.glob(f".local/*-{slug}")))
+kept, skipped = [], []
+for entry in battery:
+    slug = entry.get("dataset")
+    (kept if present(slug) else skipped).append(entry)
+json.dump({"kept": kept, "skipped": sorted({e.get("dataset") for e in skipped})},
+          sys.stdout, indent=1)
+PY
+
+  python3 - <<'PY' >"$delphi/scripts/certify_battery.ci.json"
+import json, sys
+sel = json.load(open("/var/log/polis-ci/battery-filter.json"))
+json.dump(sel["kept"], sys.stdout, indent=1)
+PY
+
+  cp "$LOG_DIR/battery-filter.json" "$ART_DIR/battery-selection.json" || true
+  local kept
+  kept=$(python3 -c 'import json;print(len(json.load(open("/var/log/polis-ci/battery-filter.json"))["kept"]))')
+  echo "battery cases selected: $kept" | tee -a "$out"
+  if [ "$kept" -eq 0 ]; then
+    echo "SKIPPED: no battery dataset resolves on this instance" | tee -a "$out"
+    echo "SKIPPED" >"$ART_DIR/battery-status.txt"
+    cp "$out" "$ART_DIR/battery.log" || true
+    log_tail "$out"
+    return 0
+  fi
+
+  # certify shells out to `uv run python scripts/replay_driver.py` and to
+  # `clojure -M:replay` (polismath/replay/certify.py), so both toolchains have
+  # to exist before the first case runs.
+  command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+  if ! command -v clojure >/dev/null 2>&1; then
+    # This script is invoked as root over SSM, so no sudo is needed (and a
+    # sudo here would not cover the redirect anyway).
+    dnf install -y java-21-amazon-corretto-headless rlwrap >>"$out" 2>&1
+    curl -fsSL -o /tmp/linux-install.sh https://download.clojure.org/install/linux-install.sh
+    chmod +x /tmp/linux-install.sh
+    /tmp/linux-install.sh >>"$out" 2>&1
+  fi
+  uv sync >>"$out" 2>&1 || uv venv >>"$out" 2>&1
+
+  # Serial workers and fixed BLAS threads: P-022 §E requires a correctness
+  # baseline, not a throughput measurement.
+  export OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1
+  local run_root="$LOG_DIR/certify-run"
+  local rc=0
+  uv run python scripts/certify.py run \
+      --battery scripts/certify_battery.ci.json \
+      --refresh-clj --refresh-py --strict --workers 1 \
+      --root "$run_root" >>"$out" 2>&1 || rc=$?
+
+  # Verdict lines only. The run directory holds prod-derived comparisons and
+  # must not reach a public artifact.
+  grep -E '^certify:|VERDICT|PASS|FAIL|INCOMPLETE' "$out" \
+    | tail -n 200 >"$ART_DIR/battery-verdicts.txt" || true
+  echo "$rc" >"$ART_DIR/battery-status.txt"
+
+  if [ -n "${POLIS_CI_EVIDENCE_S3:-}" ]; then
+    tar -czf /tmp/certify-evidence.tar.gz -C "$LOG_DIR" certify-run battery.log 2>/dev/null || true
+    aws s3 cp --only-show-errors /tmp/certify-evidence.tar.gz \
+      "${POLIS_CI_EVIDENCE_S3%/}/${POLIS_CI_RUN:-unknown}/certify-evidence.tar.gz" \
+      >>"$out" 2>&1 || echo "WARN: evidence upload failed" | tee -a "$out"
+  fi
+
+  cp "$out" "$ART_DIR/battery.log" || true
+  log_tail "$out"
+  return "$rc"
+}
+
+phase_bundle() {
+  # Everything in ART_DIR is public-safe by construction (see the header).
+  tar -czf "$BUNDLE" -C "$ART_DIR" . 2>/dev/null || true
+  base64 -w0 "$BUNDLE" >"$LOG_DIR/artifacts.b64"
+  local chars chunks
+  chars=$(wc -c <"$LOG_DIR/artifacts.b64")
+  chunks=$(( (chars + CHUNK_CHARS - 1) / CHUNK_CHARS ))
+  if [ "$chunks" -gt "$MAX_CHUNKS" ]; then
+    echo "TRUNCATED: artifact bundle is $chars b64 chars, cap is $((MAX_CHUNKS * CHUNK_CHARS))"
+    chunks="$MAX_CHUNKS"
+  fi
+  echo "CHUNKS=$chunks"
+}
+
+phase_chunk() {
+  local n="$1"
+  # cut is byte-oriented here, which is what we want: base64 is ASCII.
+  cut -c "$(( (n - 1) * CHUNK_CHARS + 1 ))-$(( n * CHUNK_CHARS ))" \
+    "$LOG_DIR/artifacts.b64"
+}
+
+case "${1:-}" in
+  recovery) phase_recovery ;;
+  battery)  phase_battery ;;
+  bundle)   phase_bundle ;;
+  chunk)    phase_chunk "${2:?chunk index required}" ;;
+  *) echo "usage: $0 {recovery|battery|bundle|chunk N}" >&2; exit 2 ;;
+esac

--- a/ci/p022_ec2_run.sh
+++ b/ci/p022_ec2_run.sh
@@ -161,6 +161,19 @@ collect_reports() {
     status "$phase" reports_expected "$expected"
     return 1
   fi
+  # The plugin names each report <tag>-<pid>-<uuid>.xml. Distinct pids are what
+  # make these distinct pytest INVOCATIONS rather than copies of one run; the
+  # uuid alone would be satisfied by a loop inside a single process.
+  local pids
+  pids=$(find "$dir" -maxdepth 1 -name '*.xml' -exec basename {} \; \
+         | awk -F- '{print $2}' | sort -u | wc -l | tr -d ' ')
+  status "$phase" invocations "$pids"
+  echo "$pids" >"$STATE_DIR/${phase}_invocations"
+  if [ "$pids" -ne "$found" ]; then
+    status "$phase" reports_not_distinct "$pids"
+    return 1
+  fi
+
   mkdir -p "$ART_DIR/junit/$phase"
   cp "$dir"/*.xml "$ART_DIR/junit/$phase/" 2>/dev/null || true
   # A copy that loses a file to a name collision is the bug this replaced.
@@ -446,6 +459,15 @@ def counts(phase):
     return out
 
 
+# The schema version has exactly one definition, in ci/p022_check_summary.py.
+# Reading it here (rather than repeating the string) is what stops the writer
+# and the checker drifting apart again.
+schema_source = (repo / "ci" / "p022_check_summary.py").read_text()
+schema_match = re.search(r'^SCHEMA = "([^"]+)"', schema_source, re.M)
+if not schema_match:
+    raise SystemExit("cannot read SCHEMA from ci/p022_check_summary.py")
+SCHEMA = schema_match.group(1)
+
 sha = ""
 sha_file = pathlib.Path("/var/lib/polis-ci-sha")
 if sha_file.exists():
@@ -480,7 +502,7 @@ recovery_ok = (main_rc == 0 and races_rc == 0
 battery_ok = battery_rc == 0
 
 summary = {
-    "schema": "p022-synthetic/3",
+    "schema": SCHEMA,
     "kind": "synthetic-recovery-and-public-fixture-battery",
     "is_certification": False,
     "trust": "reviewed-recipe-self-reported",

--- a/ci/p022_ec2_run.sh
+++ b/ci/p022_ec2_run.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 # P-022 §E — the on-instance half of .github/workflows/certification-ec2.yml.
 #
-# ## What this is, after Astra's #2715 review (round 2)
+# ## What this is
 #
 # A SYNTHETIC job: the recovery matrix plus the replay battery restricted to the
-# repository's PUBLIC fixtures. It is not private certification and its verdict
-# is named so it cannot be mistaken for one. Round 1 staged the private
-# prod-derived bundle here and then shipped the raw log back to public Actions
-# artifacts (review E1/E2). Round 2 removes the private data path entirely:
-# there is no fixture bucket, the instance role cannot read one, and nothing
-# prod-derived is ever present on this box.
+# repository's PUBLIC fixtures. It is not private certification. There is no
+# fixture bucket, the instance role cannot read one, and nothing prod-derived is
+# ever present on this box.
 #
 # ## Output discipline
 #
@@ -18,31 +15,37 @@
 #     p022 <phase> <key>=<value>
 #
 # with values restricted to a fixed character class. Nothing else reaches SSM
-# stdout — no log tails, no greps of candidate output, no exception text. Round
-# 1's `grep -E 'VERDICT|PASS|FAIL'` was not a sanitizer: arbitrary candidate
-# text matches it. Full logs stay in /var/log/polis-ci and die with the box.
+# stdout — no log tails, no greps of candidate output, no exception text. Full
+# logs stay in /var/log/polis-ci and die with the box. What comes back is a
+# fixed-schema summary.json plus one JUnit report per pytest invocation.
 #
-# What does come back is structured and bounded: a fixed-schema summary.json
-# built from parsed integers and enums, and pytest's JUnit XML. Both are
-# public-safe by construction here, because this instance has access to nothing
-# that is not already public in the repository.
+# ## Round 3 (Astra #2715 R2-F2/F3)
 #
-# Phases:
-#   recovery  make test-recovery, then make test-recovery-races
-#   battery   scripts/certify.py over the PUBLIC subset of certify_battery.json
-#   summary   write summary.json from the phase results
-#   bundle    build the artifact tarball, print its length and sha256
-#   chunk N   emit base64 chunk N of that tarball
+#   * The recovery runtime is installed and VERIFIED in user-data, before the
+#     ready marker, because C's target runs host `uv run --no-sync pytest`. A
+#     phase that assumed the battery had installed uv first was unrunnable on a
+#     fresh box, and entirely unrunnable with run_battery=false.
+#   * `make -n <target>` is not a target-existence oracle: the repository
+#     Makefile has a `%: @true` catch-all, so the dry run succeeds for a target
+#     that does not exist. `has_target()` reads make's own database instead.
+#   * pytest writes ONE report per invocation into a per-phase directory, via a
+#     tiny `-p p022_junit` plugin. A single `--junitxml` path meant C's twenty
+#     race iterations overwrote each other and the matrix report — nineteen
+#     iterations of evidence silently lost on the success path.
 set -euo pipefail
 
-REPO_ROOT="${POLIS_CI_REPO_ROOT:-/opt/polis}"
-LOG_DIR=/var/log/polis-ci
-ART_DIR="$LOG_DIR/artifacts"
-STATE_DIR="$LOG_DIR/state"
+# All four are env-overridable so the phases can be exercised in isolation.
+REPO_ROOT="${POLIS_CI_REPO_ROOT:-${REPO_ROOT:-/opt/polis}}"
+LOG_DIR="${LOG_DIR:-/var/log/polis-ci}"
+ART_DIR="${ART_DIR:-$LOG_DIR/artifacts}"
+STATE_DIR="${STATE_DIR:-$LOG_DIR/state}"
+JUNIT_DIR="${JUNIT_DIR:-$LOG_DIR/junit}"
 BUNDLE="$LOG_DIR/polis-ci-artifacts.tar.gz"
-# SSM truncates GetCommandInvocation output at 24000 characters. Stay well
-# under it: these phases emit a handful of status lines, and the bundle is
-# returned in explicit, verified chunks.
+# How many pytest invocations each phase must produce. C's race target loops
+# twenty times; the collector fails if it does not see exactly that many.
+EXPECTED_MAIN_REPORTS="${P022_EXPECTED_MAIN_REPORTS:-1}"
+EXPECTED_RACE_REPORTS="${P022_EXPECTED_RACE_REPORTS:-20}"
+# SSM truncates GetCommandInvocation output at 24000 characters.
 CHUNK_CHARS=18000
 MAX_CHUNKS=64
 
@@ -59,42 +62,96 @@ status() {
   printf 'p022 %s %s=%s\n' "$phase" "$key" "$value"
 }
 
+# An explicit target-existence oracle. `make -n` consults the catch-all pattern
+# rule and answers "yes" for anything; `make -qp` prints the rule database, in
+# which an explicitly declared target appears at the start of a line.
+has_target() {
+  make -qp 2>/dev/null | grep -Eq "^$1:( |\$)"
+}
+
+# One JUnit file per pytest process, named uniquely, so nothing is overwritten.
+# The plugin sets the report path in `pytest_load_initial_conftests`, which runs
+# before the stock junitxml plugin reads it, and it works regardless of how
+# pytest is invoked (`uv run --no-sync pytest` included) because PYTHONPATH is
+# inherited.
+install_junit_plugin() {
+  mkdir -p /opt/polis-ci
+  cat >/opt/polis-ci/p022_junit.py <<'PLUGIN'
+import os
+import pathlib
+import uuid
+
+
+def pytest_load_initial_conftests(early_config, parser, args):
+    target = os.environ.get("P022_JUNIT_DIR")
+    if not target:
+        return
+    directory = pathlib.Path(target)
+    directory.mkdir(parents=True, exist_ok=True)
+    name = "%s-%d-%s.xml" % (os.environ.get("P022_JUNIT_TAG", "run"),
+                             os.getpid(), uuid.uuid4().hex[:8])
+    early_config.option.xmlpath = str(directory / name)
+PLUGIN
+}
+
+# Count the reports a phase produced and refuse anything but the exact number.
+# `find -newer` is not used: each phase gets its own directory, so a collision
+# or a missing invocation is a count mismatch, not a timestamp puzzle.
+collect_reports() {
+  local phase="$1" dir="$2" expected="$3" found
+  found=$(find "$dir" -maxdepth 1 -name '*.xml' 2>/dev/null | wc -l | tr -d ' ')
+  status "$phase" reports "$found"
+  echo "$found" >"$STATE_DIR/${phase}_reports"
+  if [ "$found" -ne "$expected" ]; then
+    status "$phase" reports_expected "$expected"
+    return 1
+  fi
+  mkdir -p "$ART_DIR/junit/$phase"
+  cp "$dir"/*.xml "$ART_DIR/junit/$phase/" 2>/dev/null || true
+  # A copy that loses a file to a name collision is the bug this replaced.
+  local copied
+  copied=$(find "$ART_DIR/junit/$phase" -maxdepth 1 -name '*.xml' | wc -l | tr -d ' ')
+  if [ "$copied" -ne "$found" ]; then
+    status "$phase" reports_collision "$copied"
+    return 1
+  fi
+}
+
 phase_recovery() {
   cd "$REPO_ROOT"
 
-  if ! make -n test-recovery >/dev/null 2>&1; then
+  if ! has_target test-recovery || ! has_target test-recovery-races; then
     status recovery result missing-target
     status recovery detail p022-section-C-not-in-this-ref
     return 78
   fi
 
-  # JUnit regardless of what the Makefile itself passes to pytest.
-  export PYTEST_ADDOPTS="--junitxml=$LOG_DIR/recovery-junit.xml ${PYTEST_ADDOPTS:-}"
+  install_junit_plugin
+  export PYTHONPATH="/opt/polis-ci${PYTHONPATH:+:$PYTHONPATH}"
+  export PYTEST_ADDOPTS="-p p022_junit ${PYTEST_ADDOPTS:-}"
+  rm -rf "$JUNIT_DIR"
+  mkdir -p "$JUNIT_DIR/recovery" "$JUNIT_DIR/races"
 
-  # Each command's status is captured on its own. Round 1 wrapped both makes in
-  # a `{ ...; date; } || rc=$?` group, where errexit is suppressed inside an
-  # OR-list and the trailing successful command set the group's status — both
-  # makes could fail with rc 0 reported (review E4).
-  local rc_main=0 rc_races=0
-  make test-recovery >"$LOG_DIR/recovery.log" 2>&1 || rc_main=$?
+  # Each command's status is captured on its own: a `{ a; b; date; } || rc=$?`
+  # group suppresses errexit and lets the trailing command set the result.
+  local rc_main=0 rc_races=0 rc_reports=0
+  P022_JUNIT_DIR="$JUNIT_DIR/recovery" P022_JUNIT_TAG=main \
+    make test-recovery >"$LOG_DIR/recovery.log" 2>&1 || rc_main=$?
   status recovery main_rc "$rc_main"
 
-  make test-recovery-races >"$LOG_DIR/recovery-races.log" 2>&1 || rc_races=$?
+  P022_JUNIT_DIR="$JUNIT_DIR/races" P022_JUNIT_TAG=race \
+    make test-recovery-races >"$LOG_DIR/recovery-races.log" 2>&1 || rc_races=$?
   status recovery races_rc "$rc_races"
 
   echo "$rc_main" >"$STATE_DIR/recovery_main_rc"
   echo "$rc_races" >"$STATE_DIR/recovery_races_rc"
 
-  if [ -f "$LOG_DIR/recovery-junit.xml" ]; then
-    cp "$LOG_DIR/recovery-junit.xml" "$ART_DIR/recovery-junit.xml"
-    status recovery junit present
-  else
-    # A green pytest with no report is not evidence of anything.
-    status recovery junit missing
-    echo 1 >"$STATE_DIR/recovery_junit_missing"
-  fi
+  collect_reports recovery "$JUNIT_DIR/recovery" "$EXPECTED_MAIN_REPORTS" || rc_reports=1
+  collect_reports races "$JUNIT_DIR/races" "$EXPECTED_RACE_REPORTS" || rc_reports=1
+  echo "$EXPECTED_RACE_REPORTS" >"$STATE_DIR/expected_race_reports"
+  echo "$EXPECTED_MAIN_REPORTS" >"$STATE_DIR/expected_main_reports"
 
-  if [ "$rc_main" -ne 0 ] || [ "$rc_races" -ne 0 ] || [ -f "$STATE_DIR/recovery_junit_missing" ]; then
+  if [ "$rc_main" -ne 0 ] || [ "$rc_races" -ne 0 ] || [ "$rc_reports" -ne 0 ]; then
     status recovery result fail
     return 1
   fi
@@ -107,8 +164,7 @@ phase_battery() {
 
   # The battery is restricted to the fixtures declared public in
   # certify_datasets.json and checked into the repository. There is no private
-  # bundle to fetch and no credential that could fetch one. A private battery
-  # needs the isolated worker design in P-022-E-ci-spec.md, not this box.
+  # bundle to fetch and no credential that could fetch one.
   python3 - "$delphi" >"$STATE_DIR/battery-selection.json" <<'PY'
 import json, pathlib, sys
 delphi = pathlib.Path(sys.argv[1])
@@ -121,8 +177,8 @@ battery = json.loads((scripts / "certify_battery.json").read_text())
 
 def resolves(slug):
     # Public fixtures only: real_data/*-<slug>. The .local private tree is
-    # deliberately NOT consulted; if one were ever left on a box, it must not
-    # silently enlarge a synthetic run.
+    # deliberately NOT consulted; a stray private directory must not silently
+    # enlarge a synthetic run.
     return bool(list(root.glob(f"*-{slug}")))
 
 
@@ -140,14 +196,17 @@ PY
 
   cp "$STATE_DIR/battery-selection.json" "$ART_DIR/battery-selection.json"
   local selected missing
-  selected=$(python3 -c 'import json;print(json.load(open("/var/log/polis-ci/state/battery-selection.json"))["selected_count"])')
-  missing=$(python3 -c 'import json;print(len(json.load(open("/var/log/polis-ci/state/battery-selection.json"))["missing"]))')
+  selected=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["selected_count"])' \
+    "$STATE_DIR/battery-selection.json")
+  missing=$(python3 -c 'import json,sys;print(len(json.load(open(sys.argv[1]))["missing"]))' \
+    "$STATE_DIR/battery-selection.json")
   status battery selected "$selected"
   status battery missing "$missing"
 
-  # Round 1 returned success for an empty selection, so a battery that silently
-  # shrank to nothing still reported green (review E5). An empty or incomplete
-  # public inventory is a failure, not a smaller run.
+  # An empty OR incomplete public inventory is a failure, not a smaller run.
+  # The pinned inventory length is additionally checked on the runner by
+  # ci/p022_check_summary.py, because a short-but-nonempty battery passes every
+  # guard that can be written here.
   if [ "$selected" -eq 0 ]; then
     status battery result empty-inventory
     echo 1 >"$STATE_DIR/battery_rc"
@@ -159,34 +218,31 @@ PY
     return 1
   fi
 
-  python3 - >"$delphi/scripts/certify_battery.public.json" <<'PY'
+  python3 - "$STATE_DIR/battery-selection.json" \
+    >"$delphi/scripts/certify_battery.public.json" <<'PY'
 import json, sys
-sel = json.load(open("/var/log/polis-ci/state/battery-selection.json"))
-json.dump(sel["selected"], sys.stdout, indent=1)
+json.dump(json.load(open(sys.argv[1]))["selected"], sys.stdout, indent=1)
 PY
 
-  # certify shells out to `uv run python scripts/replay_driver.py` and to
-  # `clojure -M:replay` (polismath/replay/certify.py), so both toolchains must
-  # exist before the first case runs.
-  if ! command -v uv >/dev/null 2>&1; then
-    curl -LsSf https://astral.sh/uv/install.sh 2>>"$LOG_DIR/battery.log" | sh >>"$LOG_DIR/battery.log" 2>&1
-  fi
-  export PATH="$HOME/.local/bin:$PATH"
-  if ! command -v clojure >/dev/null 2>&1; then
-    # This script runs as root over SSM; no sudo (which would not cover the
-    # redirect anyway).
-    dnf install -y java-21-amazon-corretto-headless rlwrap >>"$LOG_DIR/battery.log" 2>&1
-    curl -fsSL -o /tmp/linux-install.sh https://download.clojure.org/install/linux-install.sh
-    chmod +x /tmp/linux-install.sh
-    /tmp/linux-install.sh >>"$LOG_DIR/battery.log" 2>&1
-  fi
-  uv sync >>"$LOG_DIR/battery.log" 2>&1 || uv venv >>"$LOG_DIR/battery.log" 2>&1
+  # The toolchain is installed and verified in user-data, before the ready
+  # marker. Verify rather than install, so a phase never silently repairs a
+  # bootstrap that should have failed.
+  export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+  local tool
+  for tool in uv clojure java; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      status battery result missing-toolchain
+      status battery tool "$tool"
+      echo 1 >"$STATE_DIR/battery_rc"
+      return 1
+    fi
+  done
 
   # Serial workers and fixed BLAS threads: this is a correctness baseline, not
   # a throughput measurement.
   export OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1
   local rc=0
-  uv run python scripts/certify.py run \
+  uv run --no-sync python scripts/certify.py run \
       --battery scripts/certify_battery.public.json \
       --refresh-clj --refresh-py --strict --workers 1 \
       --root "$LOG_DIR/certify-run" >>"$LOG_DIR/battery.log" 2>&1 || rc=$?
@@ -201,12 +257,13 @@ PY
 
 phase_summary() {
   # A fixed schema built from parsed integers, enums and known fixture slugs.
-  # Nothing free-form from any log reaches this file.
-  python3 - "$REPO_ROOT" "$LOG_DIR" >"$ART_DIR/summary.json" <<'PY'
+  # Nothing free-form from any log reaches this file. It is NOT independent
+  # execution evidence: every field is produced by the recipe running here, and
+  # the runner-side validator checks coherence and inventory, not authenticity.
+  python3 - "$REPO_ROOT" "$LOG_DIR" "$STATE_DIR" >"$ART_DIR/summary.json" <<'PY'
 import json, pathlib, re, sys
 
-repo, logdir = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
-state = logdir / "state"
+repo, logdir, state = (pathlib.Path(p) for p in sys.argv[1:4])
 
 
 def read_int(name, default=None):
@@ -246,18 +303,29 @@ slug = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
 main_rc = read_int("recovery_main_rc")
 races_rc = read_int("recovery_races_rc")
 battery_rc = read_int("battery_rc")
-recovery_ok = main_rc == 0 and races_rc == 0 and not (state / "recovery_junit_missing").exists()
+main_reports = read_int("recovery_reports", 0)
+race_reports = read_int("races_reports", 0)
+expected_main = read_int("expected_main_reports", 0)
+expected_races = read_int("expected_race_reports", 0)
+
+recovery_ok = (main_rc == 0 and races_rc == 0
+               and main_reports == expected_main and main_reports > 0
+               and race_reports == expected_races and race_reports > 0)
 battery_ok = battery_rc == 0
 
 summary = {
-    "schema": "p022-synthetic/1",
+    "schema": "p022-synthetic/2",
     "kind": "synthetic-recovery-and-public-fixture-battery",
     "is_certification": False,
+    "trust": "reviewed-recipe-self-reported",
     "ref_sha": sha,
     "recovery": {
         "main_rc": main_rc,
         "races_rc": races_rc,
-        "junit": (state / "recovery_junit_missing").exists() is False,
+        "main_reports": main_reports,
+        "race_reports": race_reports,
+        "expected_main_reports": expected_main,
+        "expected_race_reports": expected_races,
         "counts": counts(logdir / "recovery.log"),
         "races_counts": counts(logdir / "recovery-races.log"),
         "status": "pass" if recovery_ok else "fail",
@@ -269,6 +337,7 @@ summary = {
         "datasets": sorted(s for s in set(
             e.get("dataset") for e in sel.get("selected", [])) if s and slug.match(s)),
         "private_cases": "not-run",
+        "skip_reason": "" if battery_rc is not None else "not-run-in-this-job",
         "status": "pass" if battery_ok else ("skipped" if battery_rc is None else "fail"),
     },
     "verdict": "SYNTHETIC-PASS" if (recovery_ok and battery_rc in (0, None))
@@ -277,7 +346,8 @@ summary = {
 json.dump(summary, sys.stdout, indent=1, sort_keys=True)
 PY
   local verdict
-  verdict=$(python3 -c 'import json;print(json.load(open("/var/log/polis-ci/artifacts/summary.json"))["verdict"])')
+  verdict=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["verdict"])' \
+    "$ART_DIR/summary.json")
   status summary verdict "$verdict"
 }
 
@@ -288,8 +358,8 @@ phase_bundle() {
   chars=$(wc -c <"$LOG_DIR/artifacts.b64")
   chunks=$(( (chars + CHUNK_CHARS - 1) / CHUNK_CHARS ))
   digest=$(sha256sum "$BUNDLE" | cut -d' ' -f1)
-  # Round 1 truncated an oversized bundle and still succeeded. Evidence that
-  # does not fit is missing evidence: fail rather than ship a partial tarball.
+  # Evidence that does not fit is missing evidence: fail rather than ship a
+  # partial tarball.
   if [ "$chunks" -gt "$MAX_CHUNKS" ]; then
     status bundle result too-large
     status bundle chars "$chars"

--- a/ci/p022_ssm.sh
+++ b/ci/p022_ssm.sh
@@ -1,31 +1,34 @@
 #!/usr/bin/env bash
-# P-022 §E v1 — send one shell command to the disposable certification worker
-# over SSM and block until it finishes. There is no SSH path to that box: the
-# security group has no inbound rules, the instance has no public IP and the
-# launch template carries no key pair, so this is the only channel.
+# P-022 §E — send one command to the disposable synthetic CI worker over SSM and
+# block until it finishes. There is no SSH path to that box: the security group
+# has no inbound rules, the instance has no public IP and the launch template
+# carries no key pair.
 #
 #   usage: ci/p022_ssm.sh <label> <remote-shell-command>
 #   env:   INSTANCE_ID   (required)  the worker
 #          AWS_REGION    (required)  set by configure-aws-credentials
 #          POLIS_SSM_TIMEOUT         execution timeout, seconds (default 21600)
-#          POLIS_SSM_RAW=1           print ONLY the command's stdout on stdout
-#                                    (diagnostics go to stderr) so callers can
-#                                    pipe it; default prints a framed report.
+#          POLIS_SSM_MODE            status | base64   (default status)
 #
-# Note the 24000-character truncation on GetCommandInvocation output: this
-# script reports what SSM returns, and the worker script is written to keep its
-# stdout under that cap. Full logs travel as the chunked artifact bundle.
+# ## Output discipline (Astra #2715 E1)
+#
+# Worker stdout is never echoed verbatim. In `status` mode only lines matching
+# the fixed `p022 <phase> <key>=<value>` grammar are printed; anything else is
+# counted and dropped. In `base64` mode only base64 characters are accepted.
+# Both are allowlists — a line that does not match is discarded, not truncated
+# or escaped. Worker stderr is never printed at all: it is the one channel most
+# likely to carry arbitrary text, and nothing on the box needs it to be public.
 set -euo pipefail
 
 LABEL="${1:?label required}"
 REMOTE="${2:?remote command required}"
 : "${INSTANCE_ID:?INSTANCE_ID required}"
 TIMEOUT="${POLIS_SSM_TIMEOUT:-21600}"
-RAW="${POLIS_SSM_RAW:-0}"
+MODE="${POLIS_SSM_MODE:-status}"
 
-note() { if [ "$RAW" = "1" ]; then echo "$*" >&2; else echo "$*"; fi; }
+note() { echo "$*" >&2; }
 
-# jq builds the parameter document so the remote command is never spliced into
+# jq builds the parameter document, so the remote command is never spliced into
 # a shell string on this side.
 params=$(jq -nc --arg c "$REMOTE" --arg t "$TIMEOUT" \
   '{commands: [$c], executionTimeout: [$t]}')
@@ -40,13 +43,16 @@ command_id=$(aws ssm send-command \
 
 note "ssm[$LABEL] command=$command_id instance=$INSTANCE_ID"
 
-status=Pending
 deadline=$(( $(date +%s) + TIMEOUT + 300 ))
+inv=''
+status=''
 while :; do
   sleep 15
   if [ "$(date +%s)" -gt "$deadline" ]; then
-    note "ssm[$LABEL] local deadline exceeded; cancelling"
-    aws ssm cancel-command --command-id "$command_id" >/dev/null 2>&1 || true
+    # No CancelCommand: the role no longer holds it (it cannot be scoped to a
+    # single command), and the instance's own hard deadline plus the expiry
+    # sweeper are the teardown guarantees. Fail loudly instead.
+    note "ssm[$LABEL] local deadline exceeded"
     exit 124
   fi
   # A just-created invocation can 400 with InvocationDoesNotExist; keep polling.
@@ -59,20 +65,37 @@ while :; do
   esac
 done
 
-out=$(echo "$inv" | jq -r '.StandardOutputContent // ""')
-err=$(echo "$inv" | jq -r '.StandardErrorContent // ""')
 code=$(echo "$inv" | jq -r '.ResponseCode // 1')
+out=$(echo "$inv" | jq -r '.StandardOutputContent // ""')
 
-if [ "$RAW" = "1" ]; then
-  printf '%s' "$out"
-else
-  echo "----- ssm[$LABEL] stdout -----"
-  printf '%s\n' "$out"
-fi
-if [ -n "$err" ]; then
-  echo "----- ssm[$LABEL] stderr -----" >&2
-  printf '%s\n' "$err" >&2
-fi
+case "$MODE" in
+  base64)
+    # Only base64 characters survive; anything else means the worker printed
+    # something it should not have, and the caller's digest check will fail.
+    printf '%s' "$out" | tr -cd 'A-Za-z0-9+/='
+    ;;
+  *)
+    dropped=0
+    while IFS= read -r line; do
+      if printf '%s' "$line" | grep -Eq '^p022 [a-z-]{1,24} [a-z_]{1,24}=[A-Za-z0-9._:/=+-]{1,96}$'; then
+        printf '%s\n' "$line"
+      else
+        dropped=$((dropped + 1))
+      fi
+    done <<<"$out"
+    if [ "$dropped" -gt 0 ]; then
+      note "ssm[$LABEL] dropped $dropped non-conforming output line(s)"
+    fi
+    ;;
+esac
+
 note "ssm[$LABEL] status=$status responseCode=$code"
 
-[ "$status" = "Success" ] || exit "${code:-1}"
+# Both must hold. Round 1 exited on the response code alone, so a non-Success
+# terminal status (TimedOut, Cancelled, Undeliverable) with responseCode 0 was
+# reported as success (review E4).
+if [ "$status" != "Success" ] || [ "$code" != "0" ]; then
+  note "ssm[$LABEL] FAILED"
+  if [ "$code" = "0" ]; then exit 1; fi
+  exit "$code"
+fi

--- a/ci/p022_ssm.sh
+++ b/ci/p022_ssm.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# P-022 §E v1 — send one shell command to the disposable certification worker
+# over SSM and block until it finishes. There is no SSH path to that box: the
+# security group has no inbound rules, the instance has no public IP and the
+# launch template carries no key pair, so this is the only channel.
+#
+#   usage: ci/p022_ssm.sh <label> <remote-shell-command>
+#   env:   INSTANCE_ID   (required)  the worker
+#          AWS_REGION    (required)  set by configure-aws-credentials
+#          POLIS_SSM_TIMEOUT         execution timeout, seconds (default 21600)
+#          POLIS_SSM_RAW=1           print ONLY the command's stdout on stdout
+#                                    (diagnostics go to stderr) so callers can
+#                                    pipe it; default prints a framed report.
+#
+# Note the 24000-character truncation on GetCommandInvocation output: this
+# script reports what SSM returns, and the worker script is written to keep its
+# stdout under that cap. Full logs travel as the chunked artifact bundle.
+set -euo pipefail
+
+LABEL="${1:?label required}"
+REMOTE="${2:?remote command required}"
+: "${INSTANCE_ID:?INSTANCE_ID required}"
+TIMEOUT="${POLIS_SSM_TIMEOUT:-21600}"
+RAW="${POLIS_SSM_RAW:-0}"
+
+note() { if [ "$RAW" = "1" ]; then echo "$*" >&2; else echo "$*"; fi; }
+
+# jq builds the parameter document so the remote command is never spliced into
+# a shell string on this side.
+params=$(jq -nc --arg c "$REMOTE" --arg t "$TIMEOUT" \
+  '{commands: [$c], executionTimeout: [$t]}')
+
+command_id=$(aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name AWS-RunShellScript \
+  --comment "$LABEL" \
+  --timeout-seconds 600 \
+  --parameters "$params" \
+  --query 'Command.CommandId' --output text)
+
+note "ssm[$LABEL] command=$command_id instance=$INSTANCE_ID"
+
+status=Pending
+deadline=$(( $(date +%s) + TIMEOUT + 300 ))
+while :; do
+  sleep 15
+  if [ "$(date +%s)" -gt "$deadline" ]; then
+    note "ssm[$LABEL] local deadline exceeded; cancelling"
+    aws ssm cancel-command --command-id "$command_id" >/dev/null 2>&1 || true
+    exit 124
+  fi
+  # A just-created invocation can 400 with InvocationDoesNotExist; keep polling.
+  inv=$(aws ssm get-command-invocation --command-id "$command_id" \
+        --instance-id "$INSTANCE_ID" --output json 2>/dev/null) || continue
+  status=$(echo "$inv" | jq -r '.Status')
+  case "$status" in
+    Pending|InProgress|Delayed) continue ;;
+    *) break ;;
+  esac
+done
+
+out=$(echo "$inv" | jq -r '.StandardOutputContent // ""')
+err=$(echo "$inv" | jq -r '.StandardErrorContent // ""')
+code=$(echo "$inv" | jq -r '.ResponseCode // 1')
+
+if [ "$RAW" = "1" ]; then
+  printf '%s' "$out"
+else
+  echo "----- ssm[$LABEL] stdout -----"
+  printf '%s\n' "$out"
+fi
+if [ -n "$err" ]; then
+  echo "----- ssm[$LABEL] stderr -----" >&2
+  printf '%s\n' "$err" >&2
+fi
+note "ssm[$LABEL] status=$status responseCode=$code"
+
+[ "$status" = "Success" ] || exit "${code:-1}"

--- a/ci/p022_teardown.py
+++ b/ci/p022_teardown.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""P-022 §E — terminate the disposable CI worker and PROVE it.
+
+Astra's #2715 review (E7) broke the round-1 shell version two ways, and both
+were the same mistake: treating the absence of evidence as evidence.
+
+  * a failed ``describe-instances`` produced empty output, which the lost-ID
+    branch read as "nothing was launched" and exited 0;
+  * a known ID whose describe returned the literal text ``None`` matched none
+    of the four active-state substrings, which the confirm loop read as
+    "terminated".
+
+So this is Python, it parses actual records rather than grepping text, and it
+distinguishes three outcomes that shell string-matching cannot:
+
+  * discovery succeeded and found nothing  -> nothing to do,
+  * discovery FAILED                       -> unresolved ownership, exit 1,
+  * discovery found instances              -> terminate and confirm each one.
+
+Confirmation means every expected instance ID is observed in state
+``terminated``. ``shutting-down`` is progress and keeps the loop running;
+``InvalidInstanceID.NotFound`` inside the polling window means the ID was never
+real, which is a failure, not a success. Nothing here ever concludes from a
+missing identity.
+
+  usage: p022_teardown.py --run-tag <run_id>-<attempt> [--instance-id i-...]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+ACTIVE = {"pending", "running", "stopping", "stopped"}
+IN_PROGRESS = {"shutting-down"}
+DONE = {"terminated"}
+
+
+class DiscoveryError(RuntimeError):
+    """describe-instances did not answer. Never conflate with an empty answer."""
+
+
+def aws(*args: str) -> str:
+    proc = subprocess.run(
+        ["aws", *args], capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise DiscoveryError(
+            f"aws {' '.join(args[:2])} failed rc={proc.returncode}: "
+            f"{proc.stderr.strip()[:300]}")
+    return proc.stdout
+
+
+def describe(instance_ids: list[str] | None, run_tag: str | None) -> dict[str, str]:
+    """Return {instance_id: state}. Raises DiscoveryError if the API did not answer."""
+    args = ["ec2", "describe-instances", "--output", "json",
+            "--query", "Reservations[].Instances[].{Id:InstanceId,State:State.Name}"]
+    if instance_ids:
+        args += ["--instance-ids", *instance_ids]
+    else:
+        args += ["--filters", f"Name=tag:polis:ci-run,Values={run_tag}"]
+    raw = aws(*args)
+    try:
+        records = json.loads(raw or "[]")
+    except json.JSONDecodeError as exc:
+        raise DiscoveryError(f"unparseable describe-instances response: {exc}") from exc
+    if not isinstance(records, list):
+        raise DiscoveryError("describe-instances did not return a list")
+    out: dict[str, str] = {}
+    for rec in records:
+        if not isinstance(rec, dict) or not rec.get("Id") or not rec.get("State"):
+            raise DiscoveryError(f"malformed instance record: {rec!r}")
+        out[rec["Id"]] = rec["State"]
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run-tag", required=True)
+    ap.add_argument("--instance-id", default="")
+    ap.add_argument("--attempts", type=int, default=60)
+    ap.add_argument("--interval", type=float, default=15.0)
+    args = ap.parse_args()
+
+    expected = [args.instance_id] if args.instance_id else []
+
+    if not expected:
+        # The launch step may have created an instance whose ID we lost. A
+        # discovery ERROR here is unresolved ownership and must fail the job:
+        # the expiry sweeper is then the only thing left, and someone should
+        # know that.
+        print(f"no instance id recorded; sweeping tag polis:ci-run={args.run_tag}")
+        try:
+            found = describe(None, args.run_tag)
+        except DiscoveryError as exc:
+            print(f"::error::could not determine whether an instance was launched: {exc}")
+            print("::error::ownership unresolved; the expiry sweeper must reap it")
+            return 1
+        if not found:
+            print("discovery succeeded and found no instance for this run")
+            return 0
+        expected = sorted(found)
+        print(f"discovered {expected}")
+
+    print(f"terminating: {expected}")
+    last_seen: dict[str, str] = {}
+    for attempt in range(1, args.attempts + 1):
+        try:
+            aws("ec2", "terminate-instances", "--instance-ids", *expected)
+        except DiscoveryError as exc:
+            # Terminate can legitimately fail once the instance is already gone;
+            # the confirmation below is the authority, not this call.
+            print(f"terminate attempt {attempt} did not succeed: {exc}")
+
+        try:
+            last_seen = describe(expected, None)
+        except DiscoveryError as exc:
+            print(f"confirmation attempt {attempt} could not read state: {exc}")
+            time.sleep(args.interval)
+            continue
+
+        missing = [i for i in expected if i not in last_seen]
+        if missing:
+            # Inside a ~15 minute window a real terminated instance is still
+            # visible; a missing ID means it was never valid.
+            print(f"::error::instance id(s) not present in describe output: {missing}")
+            return 1
+
+        states = {i: last_seen[i] for i in expected}
+        print(f"attempt {attempt}: {states}")
+        if all(s in DONE for s in states.values()):
+            print("termination confirmed: every instance is `terminated`")
+            return 0
+        unexpected = {i: s for i, s in states.items()
+                      if s not in DONE | IN_PROGRESS | ACTIVE}
+        if unexpected:
+            print(f"::error::unrecognised instance state(s): {unexpected}")
+            return 1
+        time.sleep(args.interval)
+
+    print(f"::error::could not confirm termination of {expected}; last seen {last_seen}")
+    print("::error::kill it by hand -- see docs/ci-ec2.md")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/p022_teardown.py
+++ b/ci/p022_teardown.py
@@ -23,7 +23,19 @@ Confirmation means every expected instance ID is observed in state
 real, which is a failure, not a success. Nothing here ever concludes from a
 missing identity.
 
+Round 3 closes two more ways of concluding absence too readily (review R2-F6):
+
+  * blank stdout from a "successful" describe was parsed as an empty inventory.
+    Blank output is not an empty answer; it is a malformed one.
+  * a lost launch acknowledgement accepted the FIRST empty tag query. EC2
+    describes are eventually consistent, so an instance that exists may not be
+    visible yet. Discovery now retries through a propagation window, and
+    ``--launch-attempted`` says whether there is anything to look for at all:
+    if a launch was attempted and discovery never resolves it, that is
+    unresolved ownership and a failure, not proof of absence.
+
   usage: p022_teardown.py --run-tag <run_id>-<attempt> [--instance-id i-...]
+                          [--launch-attempted 0|1]
 """
 from __future__ import annotations
 
@@ -61,8 +73,12 @@ def describe(instance_ids: list[str] | None, run_tag: str | None) -> dict[str, s
     else:
         args += ["--filters", f"Name=tag:polis:ci-run,Values={run_tag}"]
     raw = aws(*args)
+    # Blank output is a malformed answer, not an empty one. A "successful"
+    # command that printed nothing tells us nothing about what exists.
+    if not raw.strip():
+        raise DiscoveryError("describe-instances returned blank output")
     try:
-        records = json.loads(raw or "[]")
+        records = json.loads(raw)
     except json.JSONDecodeError as exc:
         raise DiscoveryError(f"unparseable describe-instances response: {exc}") from exc
     if not isinstance(records, list):
@@ -79,27 +95,51 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--run-tag", required=True)
     ap.add_argument("--instance-id", default="")
+    ap.add_argument("--launch-attempted", default="1",
+                    help="whether RunInstances was reached at all; default assumes yes")
     ap.add_argument("--attempts", type=int, default=60)
     ap.add_argument("--interval", type=float, default=15.0)
+    ap.add_argument("--discovery-attempts", type=int, default=12,
+                    help="reads across the EC2 describe propagation window")
     args = ap.parse_args()
 
+    launch_attempted = args.launch_attempted.strip().lower() not in {"0", "false", "no", ""}
     expected = [args.instance_id] if args.instance_id else []
 
     if not expected:
-        # The launch step may have created an instance whose ID we lost. A
-        # discovery ERROR here is unresolved ownership and must fail the job:
-        # the expiry sweeper is then the only thing left, and someone should
-        # know that.
+        if not launch_attempted:
+            # The job never reached RunInstances (a missing repository variable,
+            # a failed checkout). There is nothing to reconcile.
+            print("launch was never attempted; nothing to terminate")
+            return 0
+        # A launch WAS attempted and its ID was lost. EC2 describes are
+        # eventually consistent, so one empty answer is not absence: retry
+        # across the propagation window before concluding anything.
         print(f"no instance id recorded; sweeping tag polis:ci-run={args.run_tag}")
-        try:
-            found = describe(None, args.run_tag)
-        except DiscoveryError as exc:
-            print(f"::error::could not determine whether an instance was launched: {exc}")
+        found: dict[str, str] = {}
+        last_error = None
+        for probe in range(1, args.discovery_attempts + 1):
+            try:
+                found = describe(None, args.run_tag)
+            except DiscoveryError as exc:
+                last_error = exc
+                print(f"discovery attempt {probe} failed: {exc}")
+                found = {}
+            else:
+                if found:
+                    break
+                print(f"discovery attempt {probe}: nothing visible yet")
+            time.sleep(args.interval)
+        if not found:
+            # Unresolved, never "proven absent": a launch was attempted and we
+            # cannot say what it produced. The expiry sweeper is now the only
+            # thing standing between this and a running instance, and someone
+            # should know that.
+            print("::error::a launch was attempted but its instance never became "
+                  f"visible under polis:ci-run={args.run_tag}"
+                  + (f" (last error: {last_error})" if last_error else ""))
             print("::error::ownership unresolved; the expiry sweeper must reap it")
             return 1
-        if not found:
-            print("discovery succeeded and found no instance for this run")
-            return 0
         expected = sorted(found)
         print(f"discovered {expected}")
 

--- a/docs/ci-ec2.md
+++ b/docs/ci-ec2.md
@@ -31,7 +31,7 @@ code as root and could never have contained data it was given.
 | SSM send-and-wait helper, with the output allowlist | `ci/p022_ssm.sh` |
 | The phases that run on the worker | `ci/p022_ec2_run.sh` |
 | Teardown: terminate and prove it | `ci/p022_teardown.py` |
-| Fixed-schema summary validator | `ci/p022_check_summary.py` |
+| Fixed-schema summary validator, and the one definition of `SCHEMA` | `ci/p022_check_summary.py` |
 
 ## Enabling it
 
@@ -268,6 +268,14 @@ dataset slugs:
   than the pinned per-phase floor, or with **any single report** that executed
   nothing — a JUnit `tests` count includes skips, so an all-skipped run and
   nineteen empty race invocations both used to look healthy;
+- a report set that is not one report per pytest **invocation**. §C's race
+  target runs pytest twenty separate times; the plugin names each report
+  `<tag>-<pid>-<uuid>.xml` and the worker requires as many distinct pids as
+  reports, so twenty files written by one process is a failure rather than
+  twenty iterations. The expected counts (one matrix report, twenty race
+  reports) are pinned by this recipe and must be re-pinned if §C's loop count
+  changes — a mismatch fails the phase, it is never inferred from what turned
+  up;
 - any XPASS. A non-strict `@pytest.mark.xfail` that passes renders in JUnit as
   an ordinary pass, so `-o xfail_strict=true` and XML parsing between them
   cannot see it; the injected pytest plugin hooks the report itself, fails the

--- a/docs/ci-ec2.md
+++ b/docs/ci-ec2.md
@@ -60,6 +60,8 @@ npx cdk synth -c enableCiEc2=true
 | `ciEc2ShutdownMinutes` | `480` | Hard-deadline self-termination (see "Cost backstops"). |
 | `ciEc2GithubRepo` | `compdemocracy/polis` | Repository allowed to assume the OIDC role. |
 | `ciEc2GithubEnvironment` | `certification-synthetic` | Must equal the workflow job's `environment:`. The trust policy admits this subject and no other. |
+| `ciEc2WorkflowRefs` | this workflow at `edge`,`stable` | Exact `job_workflow_ref` claim values. Empty is refused at synth: an empty allowlist would silently drop the condition. |
+| `ciEc2EventNames` | `workflow_dispatch,schedule` | Exact `event_name` claim values. This is what excludes `pull_request` at the token. |
 | `ciEc2AllowedInstanceTypes` | `r8g.4xlarge,r8g.2xlarge` | Enforced in IAM via `ec2:InstanceType`, so a dispatch input cannot select arbitrary spend. |
 | `ciEc2SweeperMaxAgeMinutes` | `ciEc2ShutdownMinutes + 60` | Age past which the independent sweeper kills a CI instance. Must exceed the OS deadline. |
 
@@ -85,10 +87,32 @@ Also set `CERTIFY_REGION` (variable) if the stack is not in `us-east-1`.
 There is **no fixture or evidence secret**: this workflow has no private-data
 path at all.
 
-Create the `certification-synthetic` environment with `edge` as its only
-selected branch before the first run. The environment is not optional — the
-role's trust policy admits only `repo:<repo>:environment:certification-synthetic`,
-so without it the job cannot obtain credentials at all.
+### The environment is a control you must configure, not a name
+
+Create the `certification-synthetic` environment **before** the first run, with:
+
+- **Deployment branches and tags** limited to `edge` (and `stable` if you want
+  dispatches from there),
+- a **required reviewer**,
+- no admin bypass where your plan supports disabling it.
+
+Round 2's claim that "without the environment the job cannot obtain credentials"
+was wrong, and the correction matters: GitHub **automatically creates a
+referenced environment that does not exist, with no protection rules at all**.
+An environment name in YAML is not an approval gate.
+
+The environment subject also does **not** by itself exclude pull-request jobs —
+a job that references an environment gets the environment subject even on a PR.
+Three things exclude them, and all three are in place:
+
+1. the trust policy pins `event_name` to `workflow_dispatch` and `schedule`;
+2. it pins `job_workflow_ref` to this workflow file at `edge` or `stable`;
+3. the job itself refuses any ref that is not `edge` or `stable`.
+
+Verify (1) and (2) against your repository's actual OIDC claims before the first
+run — if immutable IDs or a customized subject template are enabled, the exact
+strings change. A wrong claim name makes the assume fail, which is the right
+direction to fail, but it will look like a broken workflow.
 
 Because the flag is a CDK **context** value, everyone who deploys the stack must
 pass it. If it is omitted on a later deploy, CloudFormation deletes the role,
@@ -149,20 +173,26 @@ Three, layered, because each covers a failure the others do not:
 1. **The job's `if: always()` teardown** (`ci/p022_teardown.py`) terminates the
    instance and then *proves* it: every expected instance ID must be observed in
    state `terminated`. `shutting-down` keeps it polling; a missing ID, an
-   unrecognised state, or a `describe-instances` that fails outright all **fail
-   the job**. A failed discovery is unresolved ownership, not "nothing was
-   launched" — that conflation was a real bug in round 1. The job re-assumes its
-   role immediately before this step, so a long run cannot arrive here without
+   unrecognised state, blank output, or a `describe-instances` that fails
+   outright all **fail the job**. When the instance ID was lost, discovery
+   retries across the EC2 describe propagation window before concluding
+   anything, and "a launch was attempted but never resolved" is unresolved
+   ownership — a failure — not proof of absence. The job re-assumes its role
+   immediately before this step, so a long run cannot arrive here without
    credentials.
 2. **The instance kills itself.** `InstanceInitiatedShutdownBehavior=terminate`,
    and the *first* user-data command is `shutdown -h +480`. Failing to arm that
    timer is fatal — the box powers off immediately rather than continuing
    unbounded — and a second, independent in-process timer backs it up.
-3. **An independent EventBridge sweeper.** An hourly Lambda terminates any
-   `polis:ci=disposable` instance older than the deadline. It does not care
-   whether the Actions run finished, was cancelled, lost its runner, or whether
-   the instance's kernel is alive. This is the only one of the three that
-   survives a wedged host, and it is why the tag is mandatory at launch.
+3. **An independent EventBridge sweeper.** Its hourly cadence is *additional*
+   to the age threshold, so an overdue box can live up to an hour past the
+   deadline, and a failed invocation is an operational gate of its own — alarm
+   on it. An hourly Lambda terminates any
+   It terminates any `polis:ci=disposable` instance older than the deadline,
+   regardless of whether the Actions run finished, was cancelled, lost its
+   runner, or whether the instance's kernel is alive. This is the only one of
+   the three that survives a wedged host, and it is why the tag is mandatory at
+   launch.
 
 ## Running it manually
 
@@ -179,6 +209,16 @@ The nightly cron only proceeds on `edge`: GitHub runs a scheduled workflow from
 the **default branch**, so the job carries `if: github.ref == 'refs/heads/edge'`
 rather than assuming it.
 
+### The trust model
+
+The summary is produced by the same recipe that ran the tests, so it is
+**self-reported**. `ci/p022_check_summary.py` checks that the record is
+coherent, complete and matches the run's declared scope — it does not and cannot
+establish that the tests really ran. The artifact says so itself:
+`trust: reviewed-recipe-self-reported`. That is the trust appropriate to a
+synthetic smoke over public fixtures; an adversarial certificate needs the
+independent control boundary in `P-022-E-ci-spec.md`, which is not built.
+
 ### What comes back, and what does not
 
 Artifacts (`synthetic-ec2-<run>-<attempt>`) contain a fixed-schema
@@ -194,11 +234,18 @@ worker stderr is never printed at all. The bundle is returned base64 in bounded
 chunks with a declared length and sha256, and a short or corrupt bundle fails
 the step rather than being quietly truncated.
 
-`ci/p022_check_summary.py` then **recomputes** the verdict from the component
-return codes and rejects extra keys, wrong types, control characters,
-out-of-range integers and any dataset slug that is not a public fixture. A
-worker cannot declare its own PASS, and cannot smuggle text out through a field
-the schema does not allow.
+`ci/p022_check_summary.py` is then given the run's **declared scope** and
+rejects, on top of extra keys, wrong types, control characters and non-public
+dataset slugs:
+
+- a "pass" with any `failed`, `errors` or `xpassed`, or with zero tests executed;
+- a report inventory that is not exactly one JUnit file for the matrix and one
+  per race iteration — so nineteen overwritten reports cannot look complete;
+- a battery shortened from the six pinned public cases, or with a dataset set
+  that is not the pinned one;
+- an absent battery result claiming to be an intentional skip, unless the
+  *caller* declared `--run-battery false`;
+- a blank or mismatched candidate SHA.
 
 ## Killing a stuck instance by tag
 
@@ -248,14 +295,27 @@ Cannot: read any S3 object, use KMS, reach Secrets Manager, create a launch
 template version, attach a key pair, touch any deployment role, or terminate
 anything untagged.
 
-Two residuals are stated rather than hidden. `ssm:GetCommandInvocation` and
-`ssm:DescribeInstanceInformation` support no resource types and no condition
-keys in the AWS service authorization reference, so they cannot be narrowed by
-any policy — `ListCommands`, `ListCommandInvocations` and `CancelCommand` were
-dropped outright rather than kept on `*` for convenience. And the tag-scoped
-`TerminateInstances` on the base role can reach another concurrent campaign's
-box; the session policy removes that for the normal path, and the grant remains
-so the lost-ID sweep and the operator runbook still work.
+### Residuals, stated rather than hidden
+
+**`ssm:GetCommandInvocation` cannot be scoped.** It supports no resource types
+and no condition keys, and it returns a command's **stdout and stderr** — not
+just metadata. For any command-id/instance-id pair this role can guess or learn,
+it can read that command's output anywhere in the account. Dropping
+`ListCommands` and `ListCommandInvocations` removed discoverability, not
+authorisation. `ssm:DescribeInstanceInformation` is unscopable for the same
+reason. **Only running this in an isolated account closes it**, which is why
+that remains the activation gate.
+
+**The base role's SendCommand and TerminateInstances reach any instance sharing
+the CI tag**, because an identity policy cannot name an instance that does not
+exist yet. What is fixed is that no *live session* carries that reach: the
+launch session subtracts SSM entirely, the working session pins SendCommand and
+TerminateInstances to the one instance ARN, and the teardown session holds no
+SSM at all and pins terminate to the instance when its ID is known. A tag is
+still not a run-ownership fence.
+
+**The worker can read AWS-owned SSM documents** (`document/AWS-*`), which the
+agent needs. It can no longer read this account's private documents.
 
 The worker's role is an explicit minimal SSM-agent policy — deliberately **not**
 `AmazonSSMManagedInstanceCore`, which also grants `ssm:GetParameter` and

--- a/docs/ci-ec2.md
+++ b/docs/ci-ec2.md
@@ -1,19 +1,25 @@
-# Certification CI on a disposable EC2 worker
+# Synthetic recovery CI on a disposable EC2 worker
 
-The Delphi certification battery and the P-022 §C recovery matrix are too heavy
-and too data-sensitive for a GitHub-hosted runner: the battery replays real
-conversations against both the Clojure and the Python engine, and the fixture
-bundle it replays is private production-derived data that must never reach a
-public runner or a public artifact.
+> **This is not private certification.** It runs the P-022 §C recovery matrix
+> and the replay battery restricted to the repository's **public** fixtures
+> (`vw`, `biodiversity`), and its verdict is `SYNTHETIC-PASS` precisely so it
+> cannot be mistaken for a release certificate. Private certification — the
+> prod-derived fixture bundle, a baked trusted AMI, an isolated account and VPC,
+> and a signed summary GitHub reads but cannot influence — is specified in
+> `cost-reduction/04-plans/P-022-E-ci-spec.md` and **is not implemented**.
+
+The recovery matrix and the replay battery are too heavy for a GitHub-hosted
+runner: the battery replays conversations against both the Clojure and the
+Python engine.
 
 `.github/workflows/certification-ec2.yml` therefore launches **one disposable
 EC2 instance per run**, drives it over SSM, and destroys it. The instance is
-never registered as a GitHub runner, has no public IP, no inbound security-group
-rule and no SSH key.
-
-This is P-022 §E **v1 ("minimal")**. The v2 admission controller (Lambda,
-per-run JWT capabilities, a baked trusted AMI, a signed safe-summary publisher)
-is deliberately not built. See `cost-reduction/04-plans/P-022-E-ci-spec.md`.
+never registered as a GitHub runner, has no public IP, no inbound
+security-group rule and no SSH key. It also has **no credential that can reach
+private data**: there is no fixture bucket and no evidence bucket in this
+design, so there is nothing on the box that is not already public in this
+repository. That is the data boundary — not the instance, which runs repository
+code as root and could never have contained data it was given.
 
 ## Pieces
 
@@ -22,8 +28,10 @@ is deliberately not built. See `cost-reduction/04-plans/P-022-E-ci-spec.md`.
 | IAM role GitHub assumes, worker instance role, launch template | `cdk/ciEc2.ts` |
 | Wiring, behind the `enableCiEc2` context flag | `cdk/lib/cdk-stack.ts` |
 | The workflow | `.github/workflows/certification-ec2.yml` |
-| SSM send-and-wait helper (runs on the GitHub runner) | `ci/p022_ssm.sh` |
+| SSM send-and-wait helper, with the output allowlist | `ci/p022_ssm.sh` |
 | The phases that run on the worker | `ci/p022_ec2_run.sh` |
+| Teardown: terminate and prove it | `ci/p022_teardown.py` |
+| Fixed-schema summary validator | `ci/p022_check_summary.py` |
 
 ## Enabling it
 
@@ -37,7 +45,7 @@ cd cdk
 # unchanged stack (126 resources)
 npx cdk synth
 
-# with the CI worker (132 resources; the 6 additions are all under CertificationCi/)
+# with the CI worker (139 resources; the 13 additions are all under CertificationCi/)
 npx cdk synth -c enableCiEc2=true
 ```
 
@@ -51,17 +59,16 @@ npx cdk synth -c enableCiEc2=true
 | `ciEc2VolumeGiB` | `200` | Encrypted gp3 root volume. |
 | `ciEc2ShutdownMinutes` | `480` | Hard-deadline self-termination (see "Cost backstops"). |
 | `ciEc2GithubRepo` | `compdemocracy/polis` | Repository allowed to assume the OIDC role. |
-| `ciEc2FixtureBucket` / `ciEc2FixturePrefix` | unset / `p022/bundle/` | Private fixture bundle the **worker** may read. |
-| `ciEc2EvidenceBucket` / `ciEc2EvidencePrefix` | unset / `p022/evidence/` | Private raw evidence the **worker** may write. |
+| `ciEc2GithubEnvironment` | `certification-synthetic` | Must equal the workflow job's `environment:`. The trust policy admits this subject and no other. |
+| `ciEc2AllowedInstanceTypes` | `r8g.4xlarge,r8g.2xlarge` | Enforced in IAM via `ec2:InstanceType`, so a dispatch input cannot select arbitrary spend. |
+| `ciEc2SweeperMaxAgeMinutes` | `ciEc2ShutdownMinutes + 60` | Age past which the independent sweeper kills a CI instance. Must exceed the OS deadline. |
 
 ### One-time deploy
 
 ```bash
 cd cdk
 npx cdk diff   -c enableCiEc2=true      # read this before deploying
-npx cdk deploy -c enableCiEc2=true \
-  -c ciEc2FixtureBucket=<private-bundle-bucket> \
-  -c ciEc2EvidenceBucket=<private-evidence-bucket>
+npx cdk deploy -c enableCiEc2=true
 ```
 
 The deploy prints three outputs. Set the first two as **repository variables**
@@ -73,17 +80,15 @@ The deploy prints three outputs. Set the first two as **repository variables**
 | `CertifyLaunchTemplateId` | `CERTIFY_LAUNCH_TEMPLATE_ID` |
 | `CertifyWorkerRoleArn` | (record only — GitHub never assumes it) |
 
-Also set, if you have them:
+Also set `CERTIFY_REGION` (variable) if the stack is not in `us-east-1`.
 
-- `CERTIFY_REGION` (variable) — defaults to `us-east-1`.
-- `CERTIFY_FIXTURE_S3_URI` (**secret**) — `s3://bucket/prefix/` of the private
-  bundle. Unset is fine: the battery then runs only the public `vw` and
-  `biodiversity` fixtures and reports the private cases as skipped.
-- `CERTIFY_EVIDENCE_S3_URI` (variable) — `s3://bucket/prefix/` for raw run
-  evidence. The worker writes it; GitHub cannot read it back.
+There is **no fixture or evidence secret**: this workflow has no private-data
+path at all.
 
-Create the `certification-private` environment with a required reviewer and
-`edge` as its only selected branch before the first real run.
+Create the `certification-synthetic` environment with `edge` as its only
+selected branch before the first run. The environment is not optional — the
+role's trust policy admits only `repo:<repo>:environment:certification-synthetic`,
+so without it the job cannot obtain credentials at all.
 
 Because the flag is a CDK **context** value, everyone who deploys the stack must
 pass it. If it is omitted on a later deploy, CloudFormation deletes the role,
@@ -139,30 +144,34 @@ artifacts are kept 7 days.
 
 ## Cost backstops
 
-Two independent ones, because neither is sufficient alone:
+Three, layered, because each covers a failure the others do not:
 
-1. **The job's `if: always()` teardown** terminates the instance, polls until it
-   observes the instance leave `pending/running/stopping/stopped`, and **fails
-   the job** if it cannot confirm that — a green run with an unconfirmed
-   termination would be the expensive kind of green. If the launch step lost its
-   response, the teardown sweeps by the `polis:ci-run` tag first.
-2. **The instance kills itself.** The launch template sets
-   `InstanceInitiatedShutdownBehavior=terminate`, and the *first* command in
-   user-data — before docker, before the clone, before anything that can fail —
-   is `shutdown -h +480`. A cancelled Actions run, a dead runner or a broken
-   bootstrap therefore still costs at most the deadline.
-
-Neither covers a host whose kernel dies without terminating. P-022 §E flags an
-account-level expiry sweeper as a remaining requirement before private
-activation; this v1 does not provide one.
+1. **The job's `if: always()` teardown** (`ci/p022_teardown.py`) terminates the
+   instance and then *proves* it: every expected instance ID must be observed in
+   state `terminated`. `shutting-down` keeps it polling; a missing ID, an
+   unrecognised state, or a `describe-instances` that fails outright all **fail
+   the job**. A failed discovery is unresolved ownership, not "nothing was
+   launched" — that conflation was a real bug in round 1. The job re-assumes its
+   role immediately before this step, so a long run cannot arrive here without
+   credentials.
+2. **The instance kills itself.** `InstanceInitiatedShutdownBehavior=terminate`,
+   and the *first* user-data command is `shutdown -h +480`. Failing to arm that
+   timer is fatal — the box powers off immediately rather than continuing
+   unbounded — and a second, independent in-process timer backs it up.
+3. **An independent EventBridge sweeper.** An hourly Lambda terminates any
+   `polis:ci=disposable` instance older than the deadline. It does not care
+   whether the Actions run finished, was cancelled, lost its runner, or whether
+   the instance's kernel is alive. This is the only one of the three that
+   survives a wedged host, and it is why the tag is mandatory at launch.
 
 ## Running it manually
 
-Actions → **Certification (EC2)** → Run workflow. Inputs:
+Actions → **Synthetic recovery and public-fixture battery (EC2)** → Run
+workflow. Inputs:
 
 | Input | Default | Notes |
 |---|---|---|
-| `instance_type` | `r8g.4xlarge` | Must be arm64 unless the stack was deployed with `ciEc2Arch=x86_64`. |
+| `instance_type` | `r8g.4xlarge` | A dropdown, and IAM enforces the same allowlist. |
 | `ref` | the workflow's own ref | Git ref checked out **on the worker**. |
 | `run_battery` | `true` | Set false to run only the recovery matrix (much cheaper). |
 
@@ -170,9 +179,26 @@ The nightly cron only proceeds on `edge`: GitHub runs a scheduled workflow from
 the **default branch**, so the job carries `if: github.ref == 'refs/heads/edge'`
 rather than assuming it.
 
-Artifacts (`certification-ec2-<run>-<attempt>`) contain the recovery log, its
-JUnit XML, a counts summary and the certify verdict lines. They deliberately do
-**not** contain raw battery output.
+### What comes back, and what does not
+
+Artifacts (`synthetic-ec2-<run>-<attempt>`) contain a fixed-schema
+`summary.json`, pytest's JUnit XML and the battery's dataset selection. They do
+**not** contain any log. The worker prints only lines matching
+
+```
+p022 <phase> <key>=<value>
+```
+
+and `ci/p022_ssm.sh` drops anything that does not match rather than escaping it;
+worker stderr is never printed at all. The bundle is returned base64 in bounded
+chunks with a declared length and sha256, and a short or corrupt bundle fails
+the step rather than being quietly truncated.
+
+`ci/p022_check_summary.py` then **recomputes** the verdict from the component
+return codes and rejects extra keys, wrong types, control characters,
+out-of-range integers and any dataset slug that is not a public fixture. A
+worker cannot declare its own PASS, and cannot smuggle text out through a field
+the schema does not allow.
 
 ## Killing a stuck instance by tag
 
@@ -204,18 +230,34 @@ cannot touch the web, math, delphi or ollama tiers.
 
 ## What the GitHub role can and cannot do
 
-Can: `RunInstances` from **this one** launch template with **this one** instance
-profile and IMDSv2 required; tag that launch (three fixed keys, `RunInstances`
-only); `PassRole` for the worker role to EC2 only; EC2 `Describe*`;
-`TerminateInstances` on `polis:ci=disposable`; `ssm:SendCommand` with
-`AWS-RunShellScript` against `polis:ci=disposable` instances, and read those
-commands' results.
+Can: `RunInstances` from **this one** launch template, with **this one**
+instance profile, IMDSv2 required, an IAM-enforced instance-type allowlist and
+the `polis:ci=disposable` and `polis:ci-run` tags mandatory; tag that launch
+(three fixed keys, `RunInstances` only); `PassRole` for the worker role to EC2
+only; `ec2:DescribeInstances`/`DescribeInstanceStatus`; `TerminateInstances` on
+`polis:ci=disposable`; `ssm:SendCommand` with `AWS-RunShellScript` against
+instances tagged `ssm:resourceTag/polis:ci=disposable`; and
+`ssm:GetCommandInvocation`/`DescribeInstanceInformation`.
 
-Cannot: read the private fixture bundle or the evidence bucket, create a launch
-template version, attach a key pair, reach Secrets Manager, touch any deployment
-role, or terminate anything untagged.
+After the launch the workflow **re-assumes with an inline session policy** that
+pins SendCommand and TerminateInstances to the single instance ARN it just
+created, because a tag is shared by every concurrent campaign and was never
+proof of run ownership.
 
-The worker's own role is SSM core plus, when configured, prefix-bound read of
-the fixture bundle and prefix-bound write of the evidence prefix. The two roles
-are disjoint on purpose: private data is readable by the box, never by the
-runner.
+Cannot: read any S3 object, use KMS, reach Secrets Manager, create a launch
+template version, attach a key pair, touch any deployment role, or terminate
+anything untagged.
+
+Two residuals are stated rather than hidden. `ssm:GetCommandInvocation` and
+`ssm:DescribeInstanceInformation` support no resource types and no condition
+keys in the AWS service authorization reference, so they cannot be narrowed by
+any policy — `ListCommands`, `ListCommandInvocations` and `CancelCommand` were
+dropped outright rather than kept on `*` for convenience. And the tag-scoped
+`TerminateInstances` on the base role can reach another concurrent campaign's
+box; the session policy removes that for the normal path, and the grant remains
+so the lost-ID sweep and the operator runbook still work.
+
+The worker's role is an explicit minimal SSM-agent policy — deliberately **not**
+`AmazonSSMManagedInstanceCore`, which also grants `ssm:GetParameter` and
+`ssm:GetParameters` on `*`. It has no S3, no KMS and no Secrets Manager access
+of any kind.

--- a/docs/ci-ec2.md
+++ b/docs/ci-ec2.md
@@ -90,8 +90,8 @@ path at all.
 
 Create the `certification-synthetic` environment **before** the first run, with:
 
-- **Deployment branches and tags** limited to `edge` (and `stable` if you want
-  dispatches from there),
+- **Deployment branches and tags** limited to `edge` and `stable` (the trust
+  policy's `ref` allowlist admits both; keep the two in step),
 - a **required reviewer**,
 - no admin bypass where your plan supports disabling it.
 
@@ -102,11 +102,25 @@ An environment name in YAML is not an approval gate.
 
 The environment subject also does **not** by itself exclude pull-request jobs —
 a job that references an environment gets the environment subject even on a PR.
-Two things exclude them, and both are in place:
+Be precise about what excludes them, because the trust policy alone does not:
 
-1. the trust policy pins the `ref` claim to `refs/heads/edge` /
-   `refs/heads/stable` — a pull-request job's ref is `refs/pull/<n>/merge`;
-2. the job itself refuses any other ref, on every event.
+1. the `ref` claim pins `refs/heads/edge` / `refs/heads/stable`, which excludes
+   an **ordinary** pull-request job — its ref is `refs/pull/<n>/merge`;
+2. **this workflow file has no pull-request trigger at all**, only
+   `workflow_dispatch` and `schedule`;
+3. the environment's **deployment-branch rule and required reviewer** gate every
+   job that references it.
+
+(2) and (3) are load-bearing, not decoration. A `pull_request_target` job runs
+trusted default-branch code and can carry an allowed base-branch ref, and
+neither the repository claim nor the environment-form subject distinguishes it —
+so any *other* trusted workflow in this repository that references
+`certification-synthetic` could match this trust policy. Nothing in the role
+prevents that; reviewing what may use the environment does. If strict
+per-workflow isolation is ever required, the answer is a dedicated reviewed
+reusable-workflow boundary (whose token then really does carry
+`job_workflow_ref`) or a customized subject — not a claim key AWS does not
+support.
 
 An earlier revision pinned `job_workflow_ref` and `event_name` instead. Both
 were wrong and worth recording: `job_workflow_ref` is the claim a job gets when
@@ -214,7 +228,7 @@ workflow. Inputs:
 | Input | Default | Notes |
 |---|---|---|
 | `instance_type` | `r8g.4xlarge` | A dropdown, and IAM enforces the same allowlist. |
-| `ref` | the workflow's own ref | Git ref checked out **on the worker**. |
+| `ref` | the workflow's own ref | A branch **short name** (`edge`) or a full 40-hex commit. Fully-qualified refs and tags are rejected before launch; the value is resolved once to an immutable commit. |
 | `run_battery` | `true` | Only an **explicit manual false** selects recovery-only. A scheduled run has no inputs and always runs the full battery. |
 
 The nightly cron only proceeds on `edge`: GitHub runs a scheduled workflow from
@@ -250,7 +264,14 @@ the step rather than being quietly truncated.
 rejects, on top of extra keys, wrong types, control characters and non-public
 dataset slugs:
 
-- a "pass" with any `failed`, `errors` or `xpassed`, or with zero tests executed;
+- a "pass" with any failure or error, with fewer executed (non-skipped) tests
+  than the pinned per-phase floor, or with **any single report** that executed
+  nothing — a JUnit `tests` count includes skips, so an all-skipped run and
+  nineteen empty race invocations both used to look healthy;
+- any XPASS. A non-strict `@pytest.mark.xfail` that passes renders in JUnit as
+  an ordinary pass, so `-o xfail_strict=true` and XML parsing between them
+  cannot see it; the injected pytest plugin hooks the report itself, fails the
+  process, and reports the count;
 - a report inventory that is not exactly one JUnit file for the matrix and one
   per race iteration — so nineteen overwritten reports cannot look complete;
 - a battery shortened from the six pinned public cases, or with a dataset set
@@ -261,10 +282,14 @@ dataset slugs:
   resolved once, on the runner, to an immutable commit that is both the launch
   tag and the validation expectation, and the worker no longer falls back to
   `edge` if its tag read fails;
-- a battery whose **inventory digest** (dataset, preset, cut count, schedule
-  file over the public entries) is not the admitted one — six cases over two
-  datasets does not bind the `vw` restart seam, and swapping it for an ordinary
-  uniform run used to pass;
+- a battery whose **inventory digest** is not the admitted one. The digest
+  covers each public entry with its value **types preserved** (`8` and `"8"` are
+  different inventories) plus the canonical **contents** of every referenced
+  schedule file — so deleting `restart_after` from a same-named schedule moves
+  it — and the public fixture descriptors;
+- a battery that declares fewer restart seams than the admitted inventory does,
+  so a candidate whose schedules stopped restarting cannot quietly shrink the
+  smoke;
 - report counts that disagree with the JUnit files actually returned. The
   validator re-parses them: a summary claiming twenty-one reports with no XML
   present is rejected, and the counts are aggregates over every report rather

--- a/docs/ci-ec2.md
+++ b/docs/ci-ec2.md
@@ -60,8 +60,7 @@ npx cdk synth -c enableCiEc2=true
 | `ciEc2ShutdownMinutes` | `480` | Hard-deadline self-termination (see "Cost backstops"). |
 | `ciEc2GithubRepo` | `compdemocracy/polis` | Repository allowed to assume the OIDC role. |
 | `ciEc2GithubEnvironment` | `certification-synthetic` | Must equal the workflow job's `environment:`. The trust policy admits this subject and no other. |
-| `ciEc2WorkflowRefs` | this workflow at `edge`,`stable` | Exact `job_workflow_ref` claim values. Empty is refused at synth: an empty allowlist would silently drop the condition. |
-| `ciEc2EventNames` | `workflow_dispatch,schedule` | Exact `event_name` claim values. This is what excludes `pull_request` at the token. |
+| `ciEc2Refs` | `refs/heads/edge,refs/heads/stable` | Exact `ref` claim values. This is what excludes pull-request jobs at the token. Empty or non-branch entries are refused at synth. |
 | `ciEc2AllowedInstanceTypes` | `r8g.4xlarge,r8g.2xlarge` | Enforced in IAM via `ec2:InstanceType`, so a dispatch input cannot select arbitrary spend. |
 | `ciEc2SweeperMaxAgeMinutes` | `ciEc2ShutdownMinutes + 60` | Age past which the independent sweeper kills a CI instance. Must exceed the OS deadline. |
 
@@ -103,16 +102,25 @@ An environment name in YAML is not an approval gate.
 
 The environment subject also does **not** by itself exclude pull-request jobs —
 a job that references an environment gets the environment subject even on a PR.
-Three things exclude them, and all three are in place:
+Two things exclude them, and both are in place:
 
-1. the trust policy pins `event_name` to `workflow_dispatch` and `schedule`;
-2. it pins `job_workflow_ref` to this workflow file at `edge` or `stable`;
-3. the job itself refuses any ref that is not `edge` or `stable`.
+1. the trust policy pins the `ref` claim to `refs/heads/edge` /
+   `refs/heads/stable` — a pull-request job's ref is `refs/pull/<n>/merge`;
+2. the job itself refuses any other ref, on every event.
 
-Verify (1) and (2) against your repository's actual OIDC claims before the first
-run — if immutable IDs or a customized subject template are enabled, the exact
-strings change. A wrong claim name makes the assume fail, which is the right
-direction to fail, but it will look like a broken workflow.
+An earlier revision pinned `job_workflow_ref` and `event_name` instead. Both
+were wrong and worth recording: `job_workflow_ref` is the claim a job gets when
+it **calls a reusable workflow**, and this job runs directly on a runner, so the
+condition could never match — the trust policy could not admit its own workflow.
+`event_name` is emitted by GitHub but is not among the context keys AWS makes
+available for this provider, so it was not a gate STS would evaluate. Only
+claims AWS documents as supported are used now: `sub`, `aud`, `ref`,
+`repository`.
+
+Verify those against your repository's actual OIDC claims before the first run —
+if immutable IDs or a customized subject template are enabled, the exact strings
+change. A wrong claim value makes the assume fail, which is the right direction
+to fail, but it will look like a broken workflow.
 
 Because the flag is a CDK **context** value, everyone who deploys the stack must
 pass it. If it is omitted on a later deploy, CloudFormation deletes the role,
@@ -170,8 +178,12 @@ artifacts are kept 7 days.
 
 Three, layered, because each covers a failure the others do not:
 
-1. **The job's `if: always()` teardown** (`ci/p022_teardown.py`) terminates the
-   instance and then *proves* it: every expected instance ID must be observed in
+1. **The job's `if: always()` teardown** (`ci/p022_teardown.py`), gated on a
+   teardown session policy that was actually built — if the builder fails, no
+   credentials are issued (an empty `inline-session-policy` becomes *no* session
+   policy, i.e. full base-role reach) and the job fails, saying the sweeper must
+   reap the instance. It terminates the
+   terminates the instance and then *proves* it: every expected instance ID must be observed in
    state `terminated`. `shutting-down` keeps it polling; a missing ID, an
    unrecognised state, blank output, or a `describe-instances` that fails
    outright all **fail the job**. When the instance ID was lost, discovery
@@ -203,7 +215,7 @@ workflow. Inputs:
 |---|---|---|
 | `instance_type` | `r8g.4xlarge` | A dropdown, and IAM enforces the same allowlist. |
 | `ref` | the workflow's own ref | Git ref checked out **on the worker**. |
-| `run_battery` | `true` | Set false to run only the recovery matrix (much cheaper). |
+| `run_battery` | `true` | Only an **explicit manual false** selects recovery-only. A scheduled run has no inputs and always runs the full battery. |
 
 The nightly cron only proceeds on `edge`: GitHub runs a scheduled workflow from
 the **default branch**, so the job carries `if: github.ref == 'refs/heads/edge'`
@@ -245,7 +257,18 @@ dataset slugs:
   that is not the pinned one;
 - an absent battery result claiming to be an intentional skip, unless the
   *caller* declared `--run-battery false`;
-- a blank or mismatched candidate SHA.
+- a candidate SHA that is not the commit the workflow resolved — the ref is
+  resolved once, on the runner, to an immutable commit that is both the launch
+  tag and the validation expectation, and the worker no longer falls back to
+  `edge` if its tag read fails;
+- a battery whose **inventory digest** (dataset, preset, cut count, schedule
+  file over the public entries) is not the admitted one — six cases over two
+  datasets does not bind the `vw` restart seam, and swapping it for an ordinary
+  uniform run used to pass;
+- report counts that disagree with the JUnit files actually returned. The
+  validator re-parses them: a summary claiming twenty-one reports with no XML
+  present is rejected, and the counts are aggregates over every report rather
+  than a maximum scraped from the tail of a log.
 
 ## Killing a stuck instance by tag
 

--- a/docs/ci-ec2.md
+++ b/docs/ci-ec2.md
@@ -1,0 +1,221 @@
+# Certification CI on a disposable EC2 worker
+
+The Delphi certification battery and the P-022 §C recovery matrix are too heavy
+and too data-sensitive for a GitHub-hosted runner: the battery replays real
+conversations against both the Clojure and the Python engine, and the fixture
+bundle it replays is private production-derived data that must never reach a
+public runner or a public artifact.
+
+`.github/workflows/certification-ec2.yml` therefore launches **one disposable
+EC2 instance per run**, drives it over SSM, and destroys it. The instance is
+never registered as a GitHub runner, has no public IP, no inbound security-group
+rule and no SSH key.
+
+This is P-022 §E **v1 ("minimal")**. The v2 admission controller (Lambda,
+per-run JWT capabilities, a baked trusted AMI, a signed safe-summary publisher)
+is deliberately not built. See `cost-reduction/04-plans/P-022-E-ci-spec.md`.
+
+## Pieces
+
+| Piece | Where |
+|---|---|
+| IAM role GitHub assumes, worker instance role, launch template | `cdk/ciEc2.ts` |
+| Wiring, behind the `enableCiEc2` context flag | `cdk/lib/cdk-stack.ts` |
+| The workflow | `.github/workflows/certification-ec2.yml` |
+| SSM send-and-wait helper (runs on the GitHub runner) | `ci/p022_ssm.sh` |
+| The phases that run on the worker | `ci/p022_ec2_run.sh` |
+
+## Enabling it
+
+Everything is off by default. A normal `npx cdk synth` / `cdk deploy` produces
+exactly the stack it produced before this landed — the construct is not
+instantiated at all unless the context flag is set.
+
+```bash
+cd cdk
+
+# unchanged stack (126 resources)
+npx cdk synth
+
+# with the CI worker (132 resources; the 6 additions are all under CertificationCi/)
+npx cdk synth -c enableCiEc2=true
+```
+
+### Context flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `enableCiEc2` | `false` | Master switch. Nothing below matters while this is false. |
+| `ciEc2InstanceType` | `r8g.4xlarge` | 16 vCPU / 128 GiB, the class P-022 §E asks for. |
+| `ciEc2Arch` | `arm64` | Must match the instance type. `x86_64` picks the x86 AL2023 AMI. |
+| `ciEc2VolumeGiB` | `200` | Encrypted gp3 root volume. |
+| `ciEc2ShutdownMinutes` | `480` | Hard-deadline self-termination (see "Cost backstops"). |
+| `ciEc2GithubRepo` | `compdemocracy/polis` | Repository allowed to assume the OIDC role. |
+| `ciEc2FixtureBucket` / `ciEc2FixturePrefix` | unset / `p022/bundle/` | Private fixture bundle the **worker** may read. |
+| `ciEc2EvidenceBucket` / `ciEc2EvidencePrefix` | unset / `p022/evidence/` | Private raw evidence the **worker** may write. |
+
+### One-time deploy
+
+```bash
+cd cdk
+npx cdk diff   -c enableCiEc2=true      # read this before deploying
+npx cdk deploy -c enableCiEc2=true \
+  -c ciEc2FixtureBucket=<private-bundle-bucket> \
+  -c ciEc2EvidenceBucket=<private-evidence-bucket>
+```
+
+The deploy prints three outputs. Set the first two as **repository variables**
+(Settings → Secrets and variables → Actions → Variables):
+
+| Output | Repository variable |
+|---|---|
+| `CertifyOidcRoleArn` | `CERTIFY_OIDC_ROLE_ARN` |
+| `CertifyLaunchTemplateId` | `CERTIFY_LAUNCH_TEMPLATE_ID` |
+| `CertifyWorkerRoleArn` | (record only — GitHub never assumes it) |
+
+Also set, if you have them:
+
+- `CERTIFY_REGION` (variable) — defaults to `us-east-1`.
+- `CERTIFY_FIXTURE_S3_URI` (**secret**) — `s3://bucket/prefix/` of the private
+  bundle. Unset is fine: the battery then runs only the public `vw` and
+  `biodiversity` fixtures and reports the private cases as skipped.
+- `CERTIFY_EVIDENCE_S3_URI` (variable) — `s3://bucket/prefix/` for raw run
+  evidence. The worker writes it; GitHub cannot read it back.
+
+Create the `certification-private` environment with a required reviewer and
+`edge` as its only selected branch before the first real run.
+
+Because the flag is a CDK **context** value, everyone who deploys the stack must
+pass it. If it is omitted on a later deploy, CloudFormation deletes the role,
+launch template and security group and the workflow stops working. Consider
+adding `"enableCiEc2": true` to `cdk/cdk.json`'s `context` block once the
+feature is accepted, so it is not a per-invocation footgun.
+
+## Why Graviton
+
+The worker is arm64 (`r8g.4xlarge`, Amazon Linux 2023 arm64 AMI):
+
+- The math tier this certifies is already Graviton (`instanceTypeMathWorker` is
+  `r8g.2xlarge` in `cdk/ec2.ts`), and P-022 §E asks for a worker matching the
+  existing math architecture.
+- The compose bootstrap in `cdk/launchTemplates.ts` has been architecture
+  agnostic since #2699 — it downloads `docker-compose-linux-$(uname -m)`, which
+  resolves to `aarch64` here. The same idiom is reused in `cdk/ciEc2.ts`.
+- Nothing in `docker-compose*.yml`, `delphi/Dockerfile*` or `math/Dockerfile*`
+  pins `platform:` or `linux/amd64`, and both toolchains the battery shells out
+  to (`uv run python`, `clojure -M:replay` on Corretto 21) publish aarch64
+  builds.
+
+Set `-c ciEc2Arch=x86_64 -c ciEc2InstanceType=r7i.4xlarge` if a dependency turns
+out to lack an aarch64 wheel. Architecture is a certificate input: record which
+one produced a given certificate.
+
+## Cost per run
+
+Published us-east-1 on-demand rates (AWS Price List API, queried while writing
+this; re-check before quoting):
+
+| Item | Rate |
+|---|---|
+| `r8g.4xlarge` (16 vCPU, 128 GiB) | $0.94256 / instance-hour |
+| `r8g.2xlarge` (8 vCPU, 64 GiB) | $0.47128 / instance-hour |
+| gp3 storage | $0.08 / GB-month → 200 GiB ≈ $0.022 / hour |
+| NAT gateway data processing | $0.045 / GB (the gateway itself already exists) |
+
+So a `r8g.4xlarge` run costs roughly **$0.97 per wall-clock hour**. Against the
+P-022 six-hour compute budget that is about **$5.80 per campaign**, and the
+absolute worst case a single run can reach — the 480-minute shutdown backstop
+firing on a wedged box — is about **$7.75**. Add a few tens of cents of NAT
+egress for the docker/pip/Maven pulls.
+
+The nightly cron is the number to watch: 30 six-hour runs is on the order of
+**$175/month**. Turn the schedule off, shorten it, or drop to `r8g.2xlarge`
+(halving the instance line) if the battery fits in 64 GiB — but size down only
+from measured peaks, per P-022 §E.
+
+Storage costs only while the instance lives: the root volume is
+`DeleteOnTermination`, so a terminated run leaves nothing behind. Actions
+artifacts are kept 7 days.
+
+## Cost backstops
+
+Two independent ones, because neither is sufficient alone:
+
+1. **The job's `if: always()` teardown** terminates the instance, polls until it
+   observes the instance leave `pending/running/stopping/stopped`, and **fails
+   the job** if it cannot confirm that — a green run with an unconfirmed
+   termination would be the expensive kind of green. If the launch step lost its
+   response, the teardown sweeps by the `polis:ci-run` tag first.
+2. **The instance kills itself.** The launch template sets
+   `InstanceInitiatedShutdownBehavior=terminate`, and the *first* command in
+   user-data — before docker, before the clone, before anything that can fail —
+   is `shutdown -h +480`. A cancelled Actions run, a dead runner or a broken
+   bootstrap therefore still costs at most the deadline.
+
+Neither covers a host whose kernel dies without terminating. P-022 §E flags an
+account-level expiry sweeper as a remaining requirement before private
+activation; this v1 does not provide one.
+
+## Running it manually
+
+Actions → **Certification (EC2)** → Run workflow. Inputs:
+
+| Input | Default | Notes |
+|---|---|---|
+| `instance_type` | `r8g.4xlarge` | Must be arm64 unless the stack was deployed with `ciEc2Arch=x86_64`. |
+| `ref` | the workflow's own ref | Git ref checked out **on the worker**. |
+| `run_battery` | `true` | Set false to run only the recovery matrix (much cheaper). |
+
+The nightly cron only proceeds on `edge`: GitHub runs a scheduled workflow from
+the **default branch**, so the job carries `if: github.ref == 'refs/heads/edge'`
+rather than assuming it.
+
+Artifacts (`certification-ec2-<run>-<attempt>`) contain the recovery log, its
+JUnit XML, a counts summary and the certify verdict lines. They deliberately do
+**not** contain raw battery output.
+
+## Killing a stuck instance by tag
+
+Every CI instance carries `polis:ci=disposable`, applied by the launch template
+and re-applied by the workflow, and the IAM policy makes that tag the condition
+on `ec2:TerminateInstances` — so this is both the runbook and the only thing the
+CI role is allowed to kill.
+
+```bash
+# what is running
+aws ec2 describe-instances \
+  --filters "Name=tag:polis:ci,Values=disposable" \
+            "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+  --query 'Reservations[].Instances[].{Id:InstanceId,Type:InstanceType,Launched:LaunchTime,Run:Tags[?Key==`polis:ci-run`]|[0].Value}' \
+  --output table
+
+# kill them
+aws ec2 terminate-instances --instance-ids $(
+  aws ec2 describe-instances \
+    --filters "Name=tag:polis:ci,Values=disposable" \
+              "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+    --query 'Reservations[].Instances[].InstanceId' --output text)
+```
+
+Add `"Name=tag:polis:ci-run,Values=<run_id>-<attempt>"` to target one run.
+
+Nothing outside the CI worker carries `polis:ci`, so a blind sweep of that tag
+cannot touch the web, math, delphi or ollama tiers.
+
+## What the GitHub role can and cannot do
+
+Can: `RunInstances` from **this one** launch template with **this one** instance
+profile and IMDSv2 required; tag that launch (three fixed keys, `RunInstances`
+only); `PassRole` for the worker role to EC2 only; EC2 `Describe*`;
+`TerminateInstances` on `polis:ci=disposable`; `ssm:SendCommand` with
+`AWS-RunShellScript` against `polis:ci=disposable` instances, and read those
+commands' results.
+
+Cannot: read the private fixture bundle or the evidence bucket, create a launch
+template version, attach a key pair, reach Secrets Manager, touch any deployment
+role, or terminate anything untagged.
+
+The worker's own role is SSM core plus, when configured, prefix-bound read of
+the fixture bundle and prefix-bound write of the evidence prefix. The two roles
+are disjoint on purpose: private data is readable by the box, never by the
+runner.


### PR DESCRIPTION
Part of the Clojure-deprecation verification program (P-022-E v1, "minimal": OIDC role + launch template; the controller is v2 and is not built here). Nothing here deploys or runs by default.

- `cdk/ciEc2.ts`, wired behind the CDK context flag `enableCiEc2` (default off). With the flag off the synthesized stack is unchanged (126 resources); with it on, exactly six resources are added: a GitHub OIDC role and policy (reusing the account's existing OIDC provider), a worker role + instance profile, a security group with no inbound, and a launch template. The GitHub role can only launch from that one template with IMDSv2 and the `polis:ci=disposable` tag enforced as conditions, terminate by tag, and run `AWS-RunShellScript` over SSM on tagged instances. The private fixture bucket is readable by the worker, never by the runner.
- `.github/workflows/certification-ec2.yml`: manual dispatch (+ optional nightly cron on edge), assumes the OIDC role, launches a Graviton `r8g.4xlarge` (the math tier is already r8g; the compose bootstrap is arch-aware since #2699), waits for SSM, runs the recovery matrix and the certification battery, collects artifacts, and ALWAYS terminates the instance, failing the job if termination cannot be confirmed. Concurrency group prevents double launches. Instance-initiated shutdown with a hard deadline is the cost backstop.
- `docs/ci-ec2.md`: enabling, one-time deploy, cost (~$5.80 per 6-hour campaign; ~$175/mo if the nightly full battery runs), manual runs, killing a stuck instance by tag.

Validation: `cdk synth` both flag states with an exact set-difference check; actionlint + shellcheck clean on the workflow and helpers; `bash -n` on the user-data extracted from the synthesized template.

Known limits, stated in the notes: the recovery phase exits 78 until #2702 lands `make test-recovery`; the battery has not yet been run on ARM (argued from pins and published wheels); no sweeper for an orphaned box beyond the two backstops; eight deliberate divergences from the v1 spec are enumerated in `cost-reduction/04-plans/P-022-E-implementation-notes.md` (private notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s