### PR TITLE
fix(certify): count a declared empty checkpoint as a cut (edge is red)

### DIFF
--- a/delphi/docs/CERTIFICATION.md
+++ b/delphi/docs/CERTIFICATION.md
@@ -197,7 +197,9 @@ nothing about whether the bundle covers what it claims, so `push`, `pull` and
   satisfy the same stress predicate the missing production role was defined by;
 - each pinned schedule's `expected_checkpoints` is DERIVED by
   `schedule.resolved_cut_count` — the same resolution `schedule.slice_schedule`
-  runs, so duplicate and degenerate cut entries collapse identically — and a
+  runs, so duplicate cut entries collapse identically and a `0` cut counts as
+  the real empty checkpoint it is whenever `empty_checkpoint: true` was
+  declared (only an undeclared `0` is degenerate and dropped) — and a
   schedule whose cuts only a dataset can resolve (`"end"`, `timestamp`,
   `fraction`) is refused rather than certified with a count nobody computed;
   at least one schedule is pinned;

--- a/delphi/polismath/replay/schedule.py
+++ b/delphi/polismath/replay/schedule.py
@@ -208,9 +208,12 @@ def resolved_cut_count(cuts: dict[str, Any]) -> int | None:
 
     One step per resolved cut slot, so this is also the checkpoint count a
     schedule pinned in a certification manifest must declare. It mirrors
-    :func:`resolve_cut_slots` exactly — degenerate 0-slots dropped, duplicates
-    collapsed — so the manifest's count is DERIVED from the same resolution the
-    replay driver runs, not asserted alongside it.
+    :func:`resolve_cut_slots` exactly — duplicates collapsed, and a 0-slot
+    dropped as degenerate ONLY when ``empty_checkpoint`` was not declared. An
+    explicit ``empty_checkpoint: true`` makes the zero cut a real step (the
+    empty compute the certification battery contracts on), so it is counted
+    here too — otherwise the manifest would derive a checkpoint inventory the
+    replay driver does not produce.
 
     ``"end"``, ``timestamp`` and ``fraction`` all resolve against ``dataset.n``
     and therefore return ``None``: only a real dataset can count those.
@@ -224,7 +227,10 @@ def resolved_cut_count(cuts: dict[str, Any]) -> int | None:
     at = cuts.get("at", [])
     if any(a == _END for a in at):
         return None
-    return len({int(a) for a in at if int(a) > 0})
+    slots = dict.fromkeys(int(a) for a in at)
+    if not cuts.get("empty_checkpoint", False):
+        slots.pop(0, None)
+    return len(slots)
 
 
 def _count_votes_up_to(votes: list[VoteEvent], t_ms: int) -> int:

--- a/delphi/tests/test_certify_bundle.py
+++ b/delphi/tests/test_certify_bundle.py
@@ -973,9 +973,12 @@ def test_pinned_checkpoints_match_what_the_replay_driver_actually_slices(
     spec_json = {
         "dataset": "synthetic-restart", "schedule_id": "uniform4-restart0",
         "source": "votes-csv",
-        # A duplicate and a degenerate 0 slot: schedule.py collapses both, so
-        # the manifest's derived count has to collapse them too.
-        "cuts": {"mode": "vote-count", "at": [0, 15, 15, 30, 45, n_votes]},
+        # A duplicate slot, collapsed under the explicit opt-in schedule.py now
+        # requires, so the manifest's derived count has to collapse it too.
+        # (A 0 slot is no longer degenerate: it is a real empty checkpoint and
+        # needs its own `empty_checkpoint` opt-in, covered separately.)
+        "cuts": {"mode": "vote-count", "at": [15, 15, 30, 45, n_votes],
+                 "deduplicate": True},
         "moderation": "none", "clojure": {"warm_start": "chain"}, "notes": "",
         "restart_after": 0,
     }


### PR DESCRIPTION
`edge` is red since #2701 and #2705 were rebase-merged together: the Delphi pytest job fails 24 tests + 7 errors, all with `schedule 'schedules/pc-zerovote-01-empty.json' declares no cuts`. Each PR was green alone.

Cause: #2701 added `resolved_cut_count()` and the admission rule that a bundle must pin at least one cut; at that commit a 0-slot was dropped by `resolve_cut_slots`, so the count mirrored it. #2705 then made a 0-slot a legal, retained step under `empty_checkpoint: true` and shipped a schedule with `at: [0]`, but left `resolved_cut_count` on the old semantics, so the manifest pins `n_cuts = 0` for a schedule the driver slices into one step, and #2701's rule correctly refuses it.

Fix: `resolved_cut_count` drops the 0-slot only when `empty_checkpoint` is undeclared, deduplicating order-preservingly. The admission rule from #2701 is not loosened. One #2701 test that relied on "0 and duplicates both collapse" now declares `deduplicate: true`; its assertions are unchanged. One CERTIFICATION.md bullet updated.

Verified locally on the same selection CI runs: before, the failure reproduced exactly; after, 734 passed, 6 skipped across the bundle, config, and replay-harness suites.

Merge this before #2702, whose check goes green once edge is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s