### PR TITLE
fix(server): six availability defects surfaced by the API characterization harness (P-029)

### DIFF
--- a/server/__tests__/integration/bounded-response.test.ts
+++ b/server/__tests__/integration/bounded-response.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression tests for the two routes that never answered at all.
+ *
+ * POST /api/v3/votes-bulk threw `new Error("Unauthorized")` at the top of an
+ * async handler, outside its own try/catch. Express 3.21.2 invokes a route
+ * callback and moves on (express/lib/router/index.js:164) — it neither awaits
+ * the returned promise nor attaches a catch — so nothing was ever written to
+ * the response and the rejection surfaced on the process instead.
+ *
+ * POST /api/v3/conversation/close fired the UPDATE and returned without
+ * touching `res` on its only success path, so the owner's request hung.
+ * Its sibling handle_POST_conversation_reopen answers 200 {}.
+ */
+import { beforeAll, describe, expect, test } from "@jest/globals";
+import {
+  getJwtAuthenticatedAgent,
+  setupAuthAndConvo,
+} from "../setup/api-test-helpers";
+
+describe("routes that used to hang", () => {
+  let ownerAgent: any;
+  let conversationId: string;
+
+  beforeAll(async () => {
+    const setup = await setupAuthAndConvo({ commentCount: 1 });
+    conversationId = setup.conversationId;
+    const { agent } = await getJwtAuthenticatedAgent(setup.testUser);
+    ownerAgent = agent;
+  });
+
+  test("POST /api/v3/votes-bulk answers when delphi is not enabled", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onRejection);
+
+    try {
+      // The pooled test users are not in the simulator's delphi_enabled list
+      // (oidc-simulator/rules/add-custom-claims.js), so req.p.delphiEnabled is
+      // falsy — the branch that used to throw outside the try.
+      const response = await ownerAgent
+        .post("/api/v3/votes-bulk")
+        .timeout({ response: 10000, deadline: 15000 })
+        .send({
+          conversation_id: conversationId,
+          csv: "comment-id,participant-id,vote\n1,1,1\n",
+        });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_votes_bulk_delphi_disabled"
+      );
+
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(rejections).toHaveLength(0);
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+  });
+
+  test("POST /api/v3/conversation/close answers 200 and really closes", async () => {
+    const response = await ownerAgent
+      .post("/api/v3/conversation/close")
+      .timeout({ response: 10000, deadline: 15000 })
+      .send({ conversation_id: conversationId });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({});
+
+    const after = await ownerAgent.get(
+      `/api/v3/conversations?conversation_id=${conversationId}`
+    );
+    expect(after.status).toBe(200);
+    const conversation = Array.isArray(after.body) ? after.body[0] : after.body;
+    expect(conversation.is_active).toBe(false);
+  });
+
+  test("POST /api/v3/conversation/close answers for an unknown conversation too", async () => {
+    const response = await ownerAgent
+      .post("/api/v3/conversation/close")
+      .timeout({ response: 10000, deadline: 15000 })
+      .send({ conversation_id: "p029nosuchconvo" });
+
+    // A conversation the caller does not own resolves to no rows; the route
+    // already answered on that path and must keep doing so.
+    expect([400, 500]).toContain(response.status);
+  });
+});

--- a/server/__tests__/integration/contributors.test.ts
+++ b/server/__tests__/integration/contributors.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression test for POST /api/v3/contributors.
+ *
+ * The handler inserts into `contributor_agreement_signatures`, a relation that
+ * no migration in server/postgres/migrations creates. On every schema built
+ * from this repository the insert fails with 42P01 (undefined_table), which
+ * the handler reported as the generic polis_err_POST_contributors_misc 500.
+ * The route now names the real condition, and — with the duplicate pg
+ * rejection fixed — answers without raising a process-level unhandled
+ * rejection.
+ */
+import { describe, expect, test } from "@jest/globals";
+import { newAgent } from "../setup/api-test-helpers";
+
+describe("POST /api/v3/contributors", () => {
+  test("answers 503 with a code naming the missing relation", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onRejection);
+
+    try {
+      const agent = await newAgent();
+      const response = await agent.post("/api/v3/contributors").send({
+        agreement_version: 1,
+        name: "P-029 Regression",
+        email: "p029.contributor@polis.test",
+        github_id: "p029",
+        company_name: "None",
+      });
+
+      expect(response.status).toBe(503);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_contributors_unavailable"
+      );
+
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(rejections).toHaveLength(0);
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+  });
+
+  test("the relation really is absent from the schema", async () => {
+    const pg = (await import("../../src/db/pg-query")).default;
+    const rows = (await pg.queryP(
+      "select to_regclass('public.contributor_agreement_signatures') as rel;",
+      []
+    )) as Array<{ rel: string | null }>;
+
+    expect(rows[0].rel).toBeNull();
+  });
+});

--- a/server/__tests__/integration/empty-update.test.ts
+++ b/server/__tests__/integration/empty-update.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression test for the two routes that built invalid SQL from an empty
+ * update set.
+ *
+ * PUT /api/v3/users takes `email` and `hname` as want() parameters, so a
+ * request may carry neither. handle_PUT_users passed the resulting empty
+ * object to sql_users.update(), which rendered "UPDATE users SET  WHERE
+ * uid = …" and Postgres answered 42601 (syntax error at or near "WHERE").
+ * PUT /api/v3/participants_extended had the identical defect on its single
+ * want() column.
+ *
+ * Both now refuse the request with a 400 before any SQL is built, and neither
+ * sends malformed SQL to the database.
+ */
+import { beforeAll, describe, expect, test } from "@jest/globals";
+import {
+  getJwtAuthenticatedAgent,
+  setupAuthAndConvo,
+  type TestUser,
+} from "../setup/api-test-helpers";
+import { getPooledTestUser } from "../setup/test-user-helpers";
+
+describe("empty update requests", () => {
+  let ownerAgent: any;
+  let conversationId: string;
+  let convoAgent: any;
+
+  beforeAll(async () => {
+    const pooled = getPooledTestUser(3);
+    const user: TestUser = {
+      email: pooled.email,
+      hname: pooled.name,
+      password: pooled.password,
+    } as TestUser;
+    const { agent } = await getJwtAuthenticatedAgent(user);
+    ownerAgent = agent;
+
+    const setup = await setupAuthAndConvo({ commentCount: 1 });
+    conversationId = setup.conversationId;
+    const jwtAgent = await getJwtAuthenticatedAgent(setup.testUser);
+    convoAgent = jwtAgent.agent;
+  });
+
+  describe("PUT /api/v3/users", () => {
+    test("a body with nothing to update is a 400, not invalid SQL", async () => {
+      const response = await ownerAgent.put("/api/v3/users").send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_param_missing_user_fields"
+      );
+      // A 42601 would have arrived as the generic put-user 500.
+      expect(response.body).not.toHaveProperty("error", "polis_err_put_user");
+    });
+
+    test("a body naming a field still updates and returns 200", async () => {
+      const pooled = getPooledTestUser(3);
+      const response = await ownerAgent
+        .put("/api/v3/users")
+        .send({ hname: pooled.name });
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("PUT /api/v3/participants_extended", () => {
+    test("a body with nothing to update is a 400, not invalid SQL", async () => {
+      const response = await convoAgent
+        .put("/api/v3/participants_extended")
+        .send({ conversation_id: conversationId });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_param_missing_show_translation_activated"
+      );
+      expect(response.body).not.toHaveProperty(
+        "error",
+        "polis_err_put_participants_extended"
+      );
+    });
+
+    test("a body naming the field is still accepted", async () => {
+      const response = await convoAgent
+        .put("/api/v3/participants_extended")
+        .send({
+          conversation_id: conversationId,
+          show_translation_activated: true,
+        });
+
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/server/__tests__/integration/pg-query-rejections.test.ts
+++ b/server/__tests__/integration/pg-query-rejections.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression test for the duplicate rejection every failing query produced.
+ *
+ * queryImpl (server/src/db/pg-query.ts) both invokes the caller's callback and
+ * settles a promise it returns. queryP_impl — the base of queryP,
+ * queryP_readOnly and everything built on them — supplies a callback and
+ * discards that promise, so every failed query rejected twice: once through
+ * the promise the caller awaits, and once into a promise nobody ever observed.
+ * The second one reached the process 'unhandledRejection' handler, which is
+ * why the characterization harness recorded "process error during case" on
+ * routes that had answered correctly (42601, 42P01, 23505, 23502, 22P02).
+ */
+import { describe, expect, test } from "@jest/globals";
+import pg from "../../src/db/pg-query";
+
+describe("pg-query error propagation", () => {
+  test("a failing queryP rejects its caller and nothing else", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onRejection);
+
+    try {
+      await expect(
+        pg.queryP("select * from p029_no_such_relation;", [])
+      ).rejects.toMatchObject({ code: "42P01" });
+
+      // Two turns of the loop: an unobserved rejection is reported on the next
+      // tick after the promise settles.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(rejections).toHaveLength(0);
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+  });
+
+  test("a failing callback-style query reports through the callback only", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onRejection);
+
+    try {
+      const err = await new Promise<any>((resolve) => {
+        pg.query("select * from p029_no_such_relation;", [], (e: any) =>
+          resolve(e)
+        );
+      });
+
+      expect(err).toBeTruthy();
+      expect(err.code).toBe("42P01");
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(rejections).toHaveLength(0);
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+  });
+});

--- a/server/__tests__/integration/trashes.test.ts
+++ b/server/__tests__/integration/trashes.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Availability regression test for POST /api/v3/trashes.
+ *
+ * The insert into `trashes` had no RETURNING clause, but its pg callback read
+ * `result.rows[0].created`. pg invokes that callback from its own socket
+ * handler — outside Express 3's dispatch and outside any promise — so the
+ * TypeError became a process-level 'uncaughtException', and
+ * setupGlobalProcessHandlers (server/src/server-middleware.ts) calls
+ * process.exit(1) for anything that is not a 23505. Any authenticated
+ * participant of any conversation could therefore terminate the web process
+ * with one request.
+ *
+ * Before the fix this file does not merely fail: the Jest worker is killed
+ * mid-run, because the exit path is the same one the server takes.
+ */
+import { beforeAll, describe, expect, test } from "@jest/globals";
+import {
+  initializeParticipant,
+  setupAuthAndConvo,
+  submitVote,
+} from "../setup/api-test-helpers";
+
+describe("POST /api/v3/trashes", () => {
+  let conversationId: string;
+  let commentId: number;
+  let participantAgent: any;
+
+  beforeAll(async () => {
+    const setup = await setupAuthAndConvo({ commentCount: 1 });
+    conversationId = setup.conversationId;
+    commentId = setup.commentIds[0];
+
+    const participant = await initializeParticipant(conversationId);
+    participantAgent = participant.agent;
+
+    // Voting materializes the participants row that getPidForParticipant
+    // requires on the trashes route.
+    const vote = await submitVote(participantAgent, {
+      conversation_id: conversationId,
+      tid: commentId,
+      vote: 0,
+    });
+    expect(vote.status).toBe(200);
+  });
+
+  test("answers the request and leaves the process serving", async () => {
+    const uncaught: unknown[] = [];
+    const onUncaught = (err: unknown) => uncaught.push(err);
+    process.on("uncaughtException", onUncaught);
+
+    try {
+      const response = await participantAgent.post("/api/v3/trashes").send({
+        conversation_id: conversationId,
+        tid: commentId,
+        trashed: 1,
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({});
+
+      // The insert really happened and the request really completed; now show
+      // the process is still answering requests afterwards.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      const stillUp = await participantAgent.get("/api/v3/testConnection");
+      expect(stillUp.status).toBe(200);
+      expect(stillUp.body).toEqual({ status: "ok" });
+
+      expect(uncaught).toHaveLength(0);
+    } finally {
+      process.off("uncaughtException", onUncaught);
+    }
+  });
+
+  test("a second trash for the same comment is also answered", async () => {
+    // trashes keeps complete history rather than enforcing uniqueness, so this
+    // is another successful insert — and another trip through the callback
+    // that used to throw.
+    const response = await participantAgent.post("/api/v3/trashes").send({
+      conversation_id: conversationId,
+      tid: commentId,
+      trashed: 0,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({});
+  });
+
+  test("a missing trashed parameter is a 400, not a crash", async () => {
+    const response = await participantAgent.post("/api/v3/trashes").send({
+      conversation_id: conversationId,
+      tid: commentId,
+    });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/server/__tests__/integration/verify-einvite.test.ts
+++ b/server/__tests__/integration/verify-einvite.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression test for GET /api/v3/verify.
+ *
+ * When the einvite was unknown the handler called failJson and then fell
+ * through to `rows[0].email`. The resulting TypeError was caught by the
+ * chain's .catch, which called failJson a second time, and Express raised
+ * ERR_HTTP_HEADERS_SENT ("Cannot set headers after they are sent to the
+ * client") as an unhandled rejection on the process.
+ *
+ * The response the client sees is unchanged — 500
+ * polis_err_verification_missing — but it is now written exactly once.
+ */
+import { describe, expect, test } from "@jest/globals";
+import { newAgent } from "../setup/api-test-helpers";
+
+describe("GET /api/v3/verify", () => {
+  test("an unknown einvite answers once and sets no headers twice", async () => {
+    const rejections: unknown[] = [];
+    const uncaught: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    const onUncaught = (err: unknown) => uncaught.push(err);
+    process.on("unhandledRejection", onRejection);
+    process.on("uncaughtException", onUncaught);
+
+    try {
+      const agent = await newAgent();
+      const response = await agent.get(
+        `/api/v3/verify?e=p029-no-such-einvite-${Date.now()}`
+      );
+
+      expect(response.status).toBe(500);
+      expect(response.body).toHaveProperty(
+        "error",
+        "polis_err_verification_missing"
+      );
+      // The success continuation must not have run.
+      expect(response.text).not.toContain("Email verified!");
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const headersSent = [...rejections, ...uncaught].filter((e: any) =>
+        String(e?.code ?? e).includes("ERR_HTTP_HEADERS_SENT")
+      );
+      expect(headersSent).toHaveLength(0);
+      expect(rejections).toHaveLength(0);
+      expect(uncaught).toHaveLength(0);
+    } finally {
+      process.off("unhandledRejection", onRejection);
+      process.off("uncaughtException", onUncaught);
+    }
+  });
+});

--- a/server/src/db/pg-query.ts
+++ b/server/src/db/pg-query.ts
@@ -112,8 +112,14 @@ function queryImpl(pool: Pool, queryString: string, ...args: any[]) {
   // every failing queryP produced a *second*, permanently unobserved rejection
   // in addition to the one it hands its own caller. Marking it handled here
   // stops each failed query from raising a process-level 'unhandledRejection'.
-  // Callers that omit a callback still get an unhandled rejection if they drop
-  // the returned promise, which is the behaviour worth keeping.
+  //
+  // The `if (callback)` is a guard on the code below, not a second supported
+  // calling convention: the argument parser above throws
+  // "unexpected db query syntax" synchronously when no function argument is
+  // present, so there is no callback-free path that reaches this line. A
+  // caller that awaits the returned promise directly, alongside its callback,
+  // still receives the identical rejection — attaching a handler does not
+  // consume it for other consumers.
   if (callback) {
     promise.catch(() => {});
   }

--- a/server/src/db/pg-query.ts
+++ b/server/src/db/pg-query.ts
@@ -82,7 +82,7 @@ function queryImpl(pool: Pool, queryString: string, ...args: any[]) {
   // Not sure whether we have to be this careful in calling release for these query results. There may or may
   // not have been a good reason why Mike did this. If just using pool.query works and doesn't exhibit scale
   // under load, might be worth stripping
-  return new Promise((resolve, reject) => {
+  const promise = new Promise((resolve, reject) => {
     pool.connect((err, client, release) => {
       if (err) {
         if (callback) callback(err);
@@ -106,6 +106,19 @@ function queryImpl(pool: Pool, queryString: string, ...args: any[]) {
       });
     });
   });
+
+  // Every caller that supplies a callback receives the failure through it and
+  // ignores this promise — queryP_impl below is the largest such caller, so
+  // every failing queryP produced a *second*, permanently unobserved rejection
+  // in addition to the one it hands its own caller. Marking it handled here
+  // stops each failed query from raising a process-level 'unhandledRejection'.
+  // Callers that omit a callback still get an unhandled rejection if they drop
+  // the returned promise, which is the behaviour worth keeping.
+  if (callback) {
+    promise.catch(() => {});
+  }
+
+  return promise;
 }
 
 const pgPoolLevelRanks = ["info", "verbose"]; // TODO investigate

--- a/server/src/routes/commentMod.ts
+++ b/server/src/routes/commentMod.ts
@@ -204,8 +204,11 @@ function handle_POST_trashes(
     };
   }
 ) {
+  // RETURNING created is required: the callback below reads the inserted row's
+  // created timestamp, and without it pg hands back an empty rows array. This
+  // matches the stars insert in server-helpers.addStar.
   const query =
-    "INSERT INTO trashes (pid, zid, tid, trashed, created) VALUES ($1, $2, $3, $4, default);";
+    "INSERT INTO trashes (pid, zid, tid, trashed, created) VALUES ($1, $2, $3, $4, default) RETURNING created;";
   const params = [req.p.pid, req.p.zid, req.p.tid, req.p.trashed];
   pg.query(
     query,
@@ -220,12 +223,22 @@ function handle_POST_trashes(
         return;
       }
 
-      const createdTimeMillis = safeTimestampToMillis(result.rows[0].created);
-      setTimeout(function () {
-        updateConversationModifiedTime(req.p.zid, createdTimeMillis);
-      }, 100);
+      // pg invokes this callback from its own socket handler, outside any
+      // Express or promise boundary, so anything thrown here reaches
+      // process 'uncaughtException' and kills the web process. Keep the
+      // whole body inside a try/catch that answers instead.
+      try {
+        const createdTimeMillis = safeTimestampToMillis(
+          result?.rows?.[0]?.created
+        );
+        setTimeout(function () {
+          updateConversationModifiedTime(req.p.zid, createdTimeMillis);
+        }, 100);
 
-      res.status(200).json({}); // TODO don't stop after the first one, map the inserts to deferreds.
+        res.status(200).json({}); // TODO don't stop after the first one, map the inserts to deferreds.
+      } catch (e) {
+        failJson(res, 500, "polis_err_trashes", e);
+      }
     }
   );
 }

--- a/server/src/routes/conversations.ts
+++ b/server/src/routes/conversations.ts
@@ -764,10 +764,21 @@ function handle_POST_conversation_close(
         return;
       }
       const conv = rows[0];
-      pg.queryP(
-        "update conversations set is_active = false where zid = ($1);",
-        [conv.zid]
-      );
+      // The update was fired and forgotten, so the owner's request never
+      // received a response and hung until the client timed out. Answer once
+      // the close has actually been written, exactly as
+      // handle_POST_conversation_reopen does.
+      return pg
+        .queryP(
+          "update conversations set is_active = false where zid = ($1);",
+          [conv.zid]
+        )
+        .then(function () {
+          res.status(200).json({});
+        })
+        .catch(function (err: any) {
+          failJson(res, 500, "polis_err_closing_conversation2", err);
+        });
     })
     .catch(function (err: any) {
       failJson(res, 500, "polis_err_closing_conversation", err);

--- a/server/src/routes/participation.ts
+++ b/server/src/routes/participation.ts
@@ -466,6 +466,14 @@ function handle_PUT_participants_extended(
     fields.show_translation_activated = req.p.show_translation_activated;
   }
 
+  // Same defect as PUT /api/v3/users: the only assignable column comes from a
+  // want() parameter, so an empty update renders
+  // "UPDATE participants_extended SET  WHERE …" and Postgres answers 42601.
+  if (_.isEmpty(fields)) {
+    failJson(res, 400, "polis_err_param_missing_show_translation_activated");
+    return;
+  }
+
   const q = sql_participants_extended
     .update(fields)
     .where(sql_participants_extended.zid.equals(zid))

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -102,6 +102,15 @@ async function handle_PUT_users(
     fields.hname = hname;
   }
 
+  // Both `email` and `hname` are want() parameters, so a request may carry
+  // neither. sql_users.update({}) renders "UPDATE users SET  WHERE uid = …",
+  // which Postgres rejects with a 42601 syntax error. Refuse the request
+  // before any SQL is built rather than sending malformed SQL to the database.
+  if (_.isEmpty(fields)) {
+    failJson(res, 400, "polis_err_param_missing_user_fields");
+    return;
+  }
+
   try {
     const query = sql_users.update(fields).where(sql_users.uid.equals(uid));
     const result = await pg.queryP(query.toString(), []);

--- a/server/src/routes/votes.ts
+++ b/server/src/routes/votes.ts
@@ -356,8 +356,14 @@ async function handle_POST_votes_bulk(
   req: RequestWithP,
   res: Response & { json: (data: any) => void }
 ): Promise<void> {
+  // Express 3.21.2 invokes a route callback and moves on
+  // (express/lib/router/index.js:164): it neither awaits the returned promise
+  // nor attaches a catch. Throwing here — outside the try below — produced no
+  // response at all, so the request hung until the client gave up and the
+  // rejection surfaced as an unhandled rejection on the process. Answer.
   if (!req.p.delphiEnabled) {
-    throw new Error("Unauthorized");
+    failJson(res, 403, "polis_err_votes_bulk_delphi_disabled");
+    return;
   }
   const { zid, uid } = req.p;
   const csv = req.body.csv;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -738,6 +738,17 @@ Thanks for using Polis!
         res.json({});
       },
       (err: any) => {
+        // contributor_agreement_signatures is not created by any migration in
+        // server/postgres/migrations, so on a schema built from this repo the
+        // insert always fails with 42601-adjacent 42P01 (undefined_table).
+        // Answer with a code that names the real condition instead of the
+        // generic misc 500. See P-029 notes: the route has no caller in
+        // client-admin, client-participation-alpha, client-report or e2e and
+        // is a remove-or-410 candidate.
+        if (err && err.code === "42P01") {
+          failJson(res, 503, "polis_err_contributors_unavailable", err);
+          return;
+        }
         failJson(res, 500, "polis_err_POST_contributors_misc", err);
       }
     );

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -399,6 +399,10 @@ ${message}`;
     return emailTeam("Polis Bad Problems!!!", body);
   }
 
+  // Sentinel used to leave the verification chain without letting the
+  // success continuation run and write a second response.
+  const VERIFICATION_MISSING = "polis_err_verification_missing";
+
   function handle_GET_verification(
     req: { p: { e: any } },
     res: {
@@ -410,7 +414,12 @@ ${message}`;
     pg.queryP("select * from einvites where einvite = ($1);", [einvite])
       .then(function (rows: string | any[]) {
         if (!rows.length) {
-          failJson(res, 500, "polis_err_verification_missing");
+          // Without this the chain continued: rows[0].email threw, the catch
+          // below sent a second response, and Express raised
+          // ERR_HTTP_HEADERS_SENT. Reject instead, so exactly one response is
+          // written and it is the same 500 polis_err_verification_missing the
+          // route already produced.
+          throw VERIFICATION_MISSING;
         }
         const email = rows[0].email;
         return pg
@@ -438,6 +447,10 @@ Email verified! You can close this tab or hit the back button.
         );
       })
       .catch(function (err: any) {
+        if (err === VERIFICATION_MISSING) {
+          failJson(res, 500, "polis_err_verification_missing");
+          return;
+        }
         failJson(res, 500, "polis_err_verification", err);
       });
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -564,6 +564,13 @@ Email verified! You can close this tab or hit the back button.
           failJson(res, 500, "polis_err_get_email_db", err);
           return;
         }
+        // Same hazard as POST /api/v3/trashes: this callback runs outside any
+        // Express or promise boundary, so dereferencing a missing row here
+        // would surface as an uncaughtException and kill the web process.
+        if (!results?.rows?.length) {
+          failJson(res, 500, "polis_err_get_email_db");
+          return;
+        }
         const email = results.rows[0].email;
         const fullname = results.rows[0].hname;
 


### PR DESCRIPTION
The API characterization harness (#2712) surfaced pre-existing server defects unrelated to the math migration. One commit per defect, each with a regression test verified to go red when the fix is reverted.

1. **`POST /api/v3/trashes` killed the web process.** The INSERT had no `RETURNING`, and the callback read `rows[0].created` inside pg's own socket handler, outside any Express or promise boundary, so the throw became `uncaughtException` and the process exited. Fixed, and the one sibling with the same fatal shape (the created-link email path) guarded. Test asserts the response and that the process is still serving afterwards.
2. **Empty `PUT /api/v3/users` (and its sibling) built invalid SQL** (`SET  WHERE`). Now 400; no caller in any client or e2e test sends an empty body.
3. **Every failed query rejected twice.** The internal query function returned a promise the callback wrapper discarded, so each SQL error also surfaced as an `unhandledRejection`. Handled only when a callback is supplied; behaviour for promise callers unchanged.
4. **`/api/v3/contributors` queried a table that exists in no migration.** Now a 503 with a named error instead of a raw 42P01. The route has no callers; removal or 410 is noted as a separate decision.
5. **Email verify double-set headers.** The failure branch did not leave the promise chain, so the success HTML was also sent. Fixed via a sentinel; success bytes unchanged.
6. **Two routes never answered.** votes-bulk threw outside its try boundary (the #2706 class; a sweep found it the last route-level instance) and conversation/close ran its UPDATE without ever touching the response. Both now answer.

tsc, eslint, prettier clean. Jest with two workers: 52 suites / 366 tests, 360 passed, the same flaky pair (`invites.test.ts` under emulated SES on arm64) as on `edge`.

Follow-ups noted in the private notes: contributors route removal, an inconsistent Unauthorized status on one delphi route, and a swallowed 23505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s