### PR TITLE
cdk: observe-only Delphi queue demand metrics (P-003 S1, flag-gated)

### DIFF
--- a/cdk/.gitignore
+++ b/cdk/.gitignore
@@ -6,3 +6,7 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+# Python bytecode (observer Lambda handler and its tests)
+__pycache__/
+*.pyc

--- a/cdk/delphiDemandObserver.ts
+++ b/cdk/delphiDemandObserver.ts
@@ -1,0 +1,124 @@
+import * as cdk from 'aws-cdk-lib';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import { Construct } from 'constructs';
+
+import { createDelphiObserverRole } from './iamRoles';
+
+/**
+ * Delphi queue demand observer — P-003 slice S1, observe-only.
+ *
+ * A one-minute scheduled Lambda that scans `Delphi_JobQueue`, classifies every
+ * row against the P-003 wake table, and publishes gauges to the CloudWatch
+ * namespace `Polis/DelphiQueue`.
+ *
+ * It takes NO scaling action and it does not read, reference or depend on the
+ * Delphi ASG. Adding `SetDesiredCapacity` is slice S7; per review item G2 the
+ * `DesiredCapacity` property on `AsgDelphiSmall` must not be touched here,
+ * because removing it on a stack update defaults desired capacity to MinSize.
+ *
+ * Everything is gated behind the `enableDelphiDemandObserver` CDK context
+ * flag, which defaults to false, so the synthesized template is byte-identical
+ * to the current one unless the flag is passed.
+ */
+
+export const DELPHI_QUEUE_METRIC_NAMESPACE = 'Polis/DelphiQueue';
+export const DELPHI_QUEUE_TABLE_NAME = 'Delphi_JobQueue';
+const FUNCTION_NAME = 'polis-delphi-demand-observer';
+
+export interface DelphiDemandObserverProps {
+  /** DynamoDB table the observer scans. Defaults to `Delphi_JobQueue`. */
+  queueTableName?: string;
+  /** Value of the fixed `Environment` metric dimension. */
+  environmentName?: string;
+}
+
+/**
+ * Reads the `enableDelphiDemandObserver` context flag. Absent, or anything
+ * other than a literal `true`, means off — an enable flag must default to off
+ * when it is not present (P-003 F17).
+ */
+export const delphiDemandObserverEnabled = (scope: Construct): boolean => {
+  const raw = scope.node.tryGetContext('enableDelphiDemandObserver');
+  if (typeof raw === 'boolean') return raw;
+  return typeof raw === 'string' && raw.toLowerCase() === 'true';
+};
+
+const createDelphiDemandObserver = (
+  self: Construct,
+  props: DelphiDemandObserverProps = {},
+) => {
+  const stack = cdk.Stack.of(self);
+  const queueTableName = props.queueTableName ?? DELPHI_QUEUE_TABLE_NAME;
+
+  // Exactly one table, by name. Not the `Delphi_*` wildcard the shared
+  // instanceRole uses, and no `/index/*` suffix: the observer reads the base
+  // table only. Region is pinned the same way iamRoles.ts pins the shared
+  // Delphi grant, so both name the same physical table.
+  const queueTableArn = cdk.Arn.format({
+    service: 'dynamodb',
+    region: 'us-east-1',
+    resource: 'table',
+    resourceName: queueTableName,
+  }, stack);
+
+  // The log group is created explicitly (rather than implicitly by Lambda) so
+  // the role's logs statement can name it, and so retention is bounded.
+  const logGroup = new logs.LogGroup(self, 'DelphiDemandObserverLogGroup', {
+    logGroupName: `/aws/lambda/${FUNCTION_NAME}`,
+    retention: logs.RetentionDays.ONE_MONTH,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  });
+
+  const role = createDelphiObserverRole(self, {
+    queueTableArn,
+    logGroupArn: logGroup.logGroupArn,
+    metricNamespace: DELPHI_QUEUE_METRIC_NAMESPACE,
+  });
+
+  const observer = new lambda.Function(self, 'DelphiDemandObserver', {
+    functionName: FUNCTION_NAME,
+    description:
+      'P-003 S1: observes Delphi_JobQueue demand and publishes Polis/DelphiQueue metrics. Takes no scaling action.',
+    runtime: lambda.Runtime.PYTHON_3_12,
+    handler: 'index.lambda_handler',
+    // Plain asset, no bundling: the handler needs only boto3, which the Lambda
+    // Python runtime already provides. Keeps `cdk synth` free of Docker.
+    code: lambda.Code.fromAsset('lambda/delphi-demand-observer'),
+    role,
+    // Outside the VPC. The queue is DynamoDB-backed in /1, so the observer
+    // needs no private connectivity and adds no NAT cost. A future Postgres
+    // adapter (P-024) would have to re-enter the VPC.
+    timeout: cdk.Duration.seconds(50),
+    memorySize: 256,
+    // No overlapping invocations. A duplicate scheduled delivery throttling
+    // against this limit is benign and informational, not an error: a late
+    // retry simply reads current state.
+    reservedConcurrentExecutions: 1,
+    environment: {
+      DELPHI_QUEUE_TABLE: queueTableName,
+      POLIS_ENVIRONMENT: props.environmentName ?? 'prod',
+      DELPHI_WORKER_CLASS: 'delphi-small',
+      // Pre-projection byte budget, not a row count: DynamoDB bills a Scan on
+      // item size before the projection is applied. ~1.11 MB measured, so this
+      // is ~15x headroom. A budget hit with pages remaining is an incomplete
+      // observation, which publishes ObserverHealthy=0 and no demand sample.
+      MAX_SCAN_BYTES: String(16 * 1024 * 1024),
+      MAX_SCAN_PAGES: '100',
+      SCAN_DEADLINE_SECONDS: '30',
+    },
+    logGroup,
+  });
+
+  new events.Rule(self, 'DelphiDemandObserverScheduleRule', {
+    description: 'Runs the Delphi queue demand observer every minute (P-003 S1).',
+    schedule: events.Schedule.rate(cdk.Duration.minutes(1)),
+    targets: [new targets.LambdaFunction(observer)],
+  });
+
+  return { observer, role, logGroup };
+};
+
+export default createDelphiDemandObserver;

--- a/cdk/iamRoles.ts
+++ b/cdk/iamRoles.ts
@@ -61,3 +61,60 @@ export default (self: Construct) => {
 
   return { instanceRole, codeDeployRole, dbBackupLambdaRole }
 }
+
+/**
+ * Dedicated role for the Delphi queue demand observer (P-003 slice S1).
+ *
+ * Deliberately narrow, and deliberately NOT the shared `instanceRole`:
+ * P-003 requires that scaling permissions are never attached to the role the
+ * web/math/Delphi hosts share.
+ *
+ * Contains exactly three statements:
+ *   - `dynamodb:Scan` on the one queue table (no indexes: the observer reads
+ *     the base table so it can see rows absent from every GSI, and it has no
+ *     `Query` permission at all in S1).
+ *   - `cloudwatch:PutMetricData`. PutMetricData supports no resource-level
+ *     permissions, so `Resource: '*'` is unavoidable and is constrained by the
+ *     `cloudwatch:namespace` condition key instead. Written as a resource ARN
+ *     the policy would simply not work; written as a bare `*` it would grant
+ *     the whole account's metric namespace.
+ *   - Writes to its own log group only.
+ *
+ * There is no `autoscaling:*` permission of any kind. S1 is observe-only; the
+ * ASG-scoped `SetDesiredCapacity` grant belongs to slice S7.
+ */
+export const createDelphiObserverRole = (
+  self: Construct,
+  opts: { queueTableArn: string; logGroupArn: string; metricNamespace: string },
+) => {
+  const role = new iam.Role(self, 'DelphiDemandObserverRole', {
+    assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    description: 'Read-only Delphi queue observer (P-003 S1). No scaling permissions.',
+  });
+
+  role.addToPolicy(new iam.PolicyStatement({
+    sid: 'ScanDelphiJobQueue',
+    effect: iam.Effect.ALLOW,
+    actions: ['dynamodb:Scan'],
+    resources: [opts.queueTableArn],
+  }));
+
+  role.addToPolicy(new iam.PolicyStatement({
+    sid: 'PublishDelphiQueueMetrics',
+    effect: iam.Effect.ALLOW,
+    actions: ['cloudwatch:PutMetricData'],
+    resources: ['*'],
+    conditions: {
+      StringEquals: { 'cloudwatch:namespace': opts.metricNamespace },
+    },
+  }));
+
+  role.addToPolicy(new iam.PolicyStatement({
+    sid: 'WriteOwnLogs',
+    effect: iam.Effect.ALLOW,
+    actions: ['logs:CreateLogStream', 'logs:PutLogEvents'],
+    resources: [opts.logGroupArn, `${opts.logGroupArn}:*`],
+  }));
+
+  return role;
+}

--- a/cdk/lambda/delphi-demand-observer/index.py
+++ b/cdk/lambda/delphi-demand-observer/index.py
@@ -1,0 +1,550 @@
+"""Delphi queue demand observer (P-003 slice S1) — observe only.
+
+Reads the ``Delphi_JobQueue`` DynamoDB base table with a projected, fully
+paginated scan, classifies every row against the P-003 wake table, and
+publishes the resulting gauges to the CloudWatch namespace
+``Polis/DelphiQueue``.
+
+This function performs **no scaling action**. It holds no Auto Scaling
+permission and contains no capacity-mutation code path, not even a disabled
+one; capacity reconciliation is slice S7 of the plan and a unit test asserts
+that this module never grows an Auto Scaling client.
+
+Design notes that matter for review:
+
+* The **base table** is scanned rather than the three status GSI partitions.
+  A ``Query`` against ``StatusCreatedIndex`` cannot see a row that has no
+  ``status`` attribute, and the measured table has exactly such rows. The
+  scan is a strict superset of the GSI partitions at this scale.
+* ``ProjectionExpression`` is a *privacy* control, not a cost control:
+  DynamoDB bills a Scan on the pre-projection item size. Growth is therefore
+  bounded by **pre-projection bytes**, derived from the billed read units that
+  ``ReturnConsumedCapacity=TOTAL`` reports, not by row count or by the size of
+  the returned JSON. One eventually-consistent read unit covers 4 KB at 0.5
+  units, i.e. 8 KB of billed table data per unit.
+* ``job_id`` is read only so that rows can be de-duplicated across pages. It
+  is never logged and never becomes a metric dimension.
+* A failed or incomplete observation publishes ``ObserverHealthy=0`` and **no**
+  demand samples. It must never look like an empty queue.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+try:  # pragma: no cover - boto3 is always present in the Lambda runtime
+    import boto3
+except ImportError:  # keeps the pure classification importable for unit tests
+    boto3 = None
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+METRIC_NAMESPACE = "Polis/DelphiQueue"
+
+# DynamoDB bills an eventually-consistent read at 0.5 units per 4 KB of
+# pre-projection item data, so one reported capacity unit == 8 KB of table
+# bytes actually read. This is the conversion the byte budget uses.
+# https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.CapacityUnits
+BYTES_PER_EVENTUAL_READ_UNIT = 8192
+
+# Statuses the Delphi poller and batch checker actually write.
+#   delphi/scripts/job_poller.py:461-470, 503-520, 578-583, 640
+#   delphi/umap_narrative/803_check_batch_status.py:235-258
+STATUS_PENDING = "PENDING"
+STATUS_AWAITING_RECHECK = "AWAITING_RECHECK"
+STATUS_PROCESSING = "PROCESSING"
+STATUS_LOCKED_FOR_CHECKING = "LOCKED_FOR_CHECKING"
+STATUS_COMPLETED = "COMPLETED"
+STATUS_FAILED = "FAILED"
+
+# P-003 "Queue observation and wake reconciliation" wake table.
+DEMAND_STATUSES = frozenset(
+    {STATUS_PENDING, STATUS_AWAITING_RECHECK, STATUS_PROCESSING}
+)
+# Rows whose age feeds OldestPendingAgeSeconds (oldest actionable age).
+ACTIONABLE_STATUSES = frozenset({STATUS_PENDING, STATUS_AWAITING_RECHECK})
+TERMINAL_STATUSES = frozenset({STATUS_COMPLETED, STATUS_FAILED})
+KNOWN_STATUSES = (
+    DEMAND_STATUSES | TERMINAL_STATUSES | frozenset({STATUS_LOCKED_FOR_CHECKING})
+)
+
+# Anomaly kinds. Any row carrying at least one of these counts once towards
+# AnomalyRows and inhibits retirement in the later slices.
+ANOMALY_MISSING_STATUS = "missing_status"
+ANOMALY_UNKNOWN_STATUS = "unknown_status"
+ANOMALY_MISSING_CREATED_AT = "missing_created_at"
+ANOMALY_MALFORMED_TIMESTAMP = "malformed_timestamp"
+ANOMALY_STALE_LOCKED = "stale_locked"
+ANOMALY_MALFORMED_OWNERSHIP = "malformed_ownership"
+
+ANOMALY_KINDS = (
+    ANOMALY_MISSING_STATUS,
+    ANOMALY_UNKNOWN_STATUS,
+    ANOMALY_MISSING_CREATED_AT,
+    ANOMALY_MALFORMED_TIMESTAMP,
+    ANOMALY_STALE_LOCKED,
+    ANOMALY_MALFORMED_OWNERSHIP,
+)
+
+# Only scheduling, ownership and lineage metadata. No text, no conversation or
+# report identifiers. "status" and "version" are DynamoDB reserved words.
+PROJECTION_ATTRIBUTES = (
+    "job_id",
+    "status",
+    "job_type",
+    "created_at",
+    "updated_at",
+    "started_at",
+    "completed_at",
+    "lock_expires_at",
+    "last_checked",
+    "worker_id",
+    "version",
+)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Ignoring non-integer %s; using default %s", name, default)
+        return default
+
+
+def _aws(service: str):
+    """Build a boto3 client. Only ever called with 'dynamodb' or 'cloudwatch'."""
+    if boto3 is None:  # pragma: no cover - unreachable in the Lambda runtime
+        raise RuntimeError("boto3 is unavailable; pass an explicit client")
+    return boto3.client(service)
+
+
+class ObservationIncomplete(Exception):
+    """The scan could not be completed within its configured budget."""
+
+
+# --------------------------------------------------------------------------
+# Pure classification / aggregation. Unit tested without any AWS calls.
+# --------------------------------------------------------------------------
+
+
+def parse_timestamp(value: Any) -> Optional[datetime]:
+    """Parse an ISO-8601 queue timestamp. Returns None if unparseable."""
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _age_seconds(when: Optional[datetime], now: datetime) -> Optional[float]:
+    if when is None:
+        return None
+    return max(0.0, (now - when).total_seconds())
+
+
+def classify_row(row: Mapping[str, Any], now: datetime) -> Dict[str, Any]:
+    """Classify one queue row against the P-003 wake table.
+
+    Returns a dict with:
+      ``demand``          -- counts towards WakeDemand
+      ``locked``          -- LOCKED_FOR_CHECKING (non-demand by itself)
+      ``anomalies``       -- list of anomaly kinds (may be empty)
+      ``actionable_age``  -- seconds, for PENDING / AWAITING_RECHECK rows
+      ``heartbeat_age``   -- seconds since last observed worker progress, for
+                             PROCESSING rows (G3 of the round-2 review)
+      ``locked_age``      -- seconds since the lock was last refreshed
+    """
+    anomalies: List[str] = []
+
+    has_status = "status" in row
+    status = row.get("status")
+    if not has_status or status is None or status == "":
+        anomalies.append(ANOMALY_MISSING_STATUS)
+        status = None
+    elif status not in KNOWN_STATUSES:
+        anomalies.append(ANOMALY_UNKNOWN_STATUS)
+
+    created_at_raw = row.get("created_at")
+    if created_at_raw is None or created_at_raw == "":
+        anomalies.append(ANOMALY_MISSING_CREATED_AT)
+        created_at = None
+    else:
+        created_at = parse_timestamp(created_at_raw)
+        if created_at is None:
+            anomalies.append(ANOMALY_MALFORMED_TIMESTAMP)
+
+    # Any other timestamp we rely on must parse if it is present at all.
+    for field in ("updated_at", "started_at", "lock_expires_at", "last_checked"):
+        raw = row.get(field)
+        if raw not in (None, "") and parse_timestamp(raw) is None:
+            if ANOMALY_MALFORMED_TIMESTAMP not in anomalies:
+                anomalies.append(ANOMALY_MALFORMED_TIMESTAMP)
+
+    demand = status in DEMAND_STATUSES
+    locked = status == STATUS_LOCKED_FOR_CHECKING
+
+    actionable_age = None
+    if status in ACTIONABLE_STATUSES:
+        actionable_age = _age_seconds(created_at, now)
+
+    heartbeat_age = None
+    if status == STATUS_PROCESSING:
+        # The poller has no dedicated heartbeat attribute. It refreshes
+        # updated_at on every log flush (job_poller.py:626) and writes
+        # started_at when it claims (job_poller.py:508), so the newest of
+        # those is the best available evidence of a live owner.
+        # created_at is deliberately NOT a progress mark: it says when the job
+        # was enqueued, not that anything is still alive. It is used only as a
+        # last resort for a row that was never properly claimed, which the
+        # ownership check below flags anyway.
+        marks = [
+            parse_timestamp(row.get("updated_at")),
+            parse_timestamp(row.get("started_at")),
+        ]
+        newest = max((m for m in marks if m is not None), default=None)
+        heartbeat_age = _age_seconds(newest if newest is not None else created_at, now)
+        # A PROCESSING row with no owner or no lease is malformed ownership:
+        # nothing can prove whether the work is live.
+        if not row.get("worker_id") or not row.get("lock_expires_at"):
+            anomalies.append(ANOMALY_MALFORMED_OWNERSHIP)
+
+    locked_age = None
+    if locked:
+        lock_expires_at = parse_timestamp(row.get("lock_expires_at"))
+        last_checked = parse_timestamp(row.get("last_checked"))
+        # Age since the checker last touched the row. created_at is only the
+        # fallback for a locked row that was never checked at all.
+        locked_age = _age_seconds(
+            last_checked if last_checked is not None else created_at, now
+        )
+        # The checker refreshes lock_expires_at on every pass
+        # (803_check_batch_status.py:242). An absent or expired lease means no
+        # checker is paired with this row; it is an anomaly to reconcile, never
+        # a row to silently treat as completed.
+        if lock_expires_at is None or lock_expires_at <= now:
+            anomalies.append(ANOMALY_STALE_LOCKED)
+
+    return {
+        "demand": demand,
+        "locked": locked,
+        "anomalies": anomalies,
+        "actionable_age": actionable_age,
+        "heartbeat_age": heartbeat_age,
+        "locked_age": locked_age,
+    }
+
+
+def compute_demand(
+    rows: Iterable[Mapping[str, Any]], now: Optional[datetime] = None
+) -> Dict[str, Any]:
+    """Aggregate classified rows into the observation the adapter returns.
+
+    ``WakeDemand`` is the count of nonterminal work that needs a worker now or
+    will need one: PENDING, AWAITING_RECHECK, and PROCESSING at any lease age.
+    ``SecondsToNextEligible`` is 0 while there is demand and ``None`` when
+    there is none — the null case is exported by omitting the sample, never by
+    manufacturing a negative or zero delay.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    seen_job_ids = set()
+    wake_demand = 0
+    locked_rows = 0
+    anomaly_rows = 0
+    rows_scanned = 0
+    anomaly_counts = {kind: 0 for kind in ANOMALY_KINDS}
+    oldest_actionable: Optional[float] = None
+    oldest_heartbeat: Optional[float] = None
+    oldest_locked: Optional[float] = None
+
+    for row in rows:
+        # Count by full job_id so a row appearing on two pages, or moving
+        # state mid-scan, cannot be counted twice.
+        job_id = row.get("job_id")
+        if job_id is not None:
+            if job_id in seen_job_ids:
+                continue
+            seen_job_ids.add(job_id)
+        rows_scanned += 1
+
+        result = classify_row(row, now)
+
+        if result["demand"]:
+            wake_demand += 1
+        if result["locked"]:
+            locked_rows += 1
+        if result["anomalies"]:
+            anomaly_rows += 1
+            for kind in result["anomalies"]:
+                anomaly_counts[kind] += 1
+
+        for key, current in (
+            ("actionable_age", oldest_actionable),
+            ("heartbeat_age", oldest_heartbeat),
+            ("locked_age", oldest_locked),
+        ):
+            value = result[key]
+            if value is None:
+                continue
+            if current is None or value > current:
+                if key == "actionable_age":
+                    oldest_actionable = value
+                elif key == "heartbeat_age":
+                    oldest_heartbeat = value
+                else:
+                    oldest_locked = value
+
+    return {
+        "complete": True,
+        "observedAt": now.isoformat(),
+        "WakeDemand": wake_demand,
+        "SecondsToNextEligible": 0.0 if wake_demand > 0 else None,
+        "OldestPendingAgeSeconds": oldest_actionable,
+        "OldestProcessingHeartbeatAgeSeconds": oldest_heartbeat,
+        "OldestLockedAgeSeconds": oldest_locked,
+        "AnomalyRows": anomaly_rows,
+        "LockedForCheckingRows": locked_rows,
+        "RowsScanned": rows_scanned,
+        "AnomalyCounts": anomaly_counts,
+    }
+
+
+def build_metric_data(
+    observation: Mapping[str, Any], dimensions: Sequence[Mapping[str, str]]
+) -> List[Dict[str, Any]]:
+    """Render an observation as CloudWatch MetricDatum entries.
+
+    Gauges that have no meaningful sample (the age metrics when their set is
+    empty, ``SecondsToNextEligible`` when there is no demand) are **omitted**
+    rather than published as 0. Alarms on those must use
+    ``treatMissingData: notBreaching``.
+    """
+    dims = list(dimensions)
+    timestamp = parse_timestamp(observation.get("observedAt")) or datetime.now(
+        timezone.utc
+    )
+
+    def datum(name: str, value: float, unit: str) -> Dict[str, Any]:
+        return {
+            "MetricName": name,
+            "Dimensions": dims,
+            "Timestamp": timestamp,
+            "Value": float(value),
+            "Unit": unit,
+        }
+
+    if not observation.get("complete"):
+        # An incomplete observation publishes health only. Never a zero depth.
+        return [datum("ObserverHealthy", 0, "None")]
+
+    data = [
+        datum("ObserverHealthy", 1, "None"),
+        datum("WakeDemand", observation["WakeDemand"], "Count"),
+        datum("AnomalyRows", observation["AnomalyRows"], "Count"),
+        datum("LockedForCheckingRows", observation["LockedForCheckingRows"], "Count"),
+        datum("RowsScanned", observation["RowsScanned"], "Count"),
+    ]
+    for name in (
+        "SecondsToNextEligible",
+        "OldestPendingAgeSeconds",
+        "OldestProcessingHeartbeatAgeSeconds",
+        "OldestLockedAgeSeconds",
+    ):
+        value = observation.get(name)
+        if value is not None:
+            data.append(datum(name, value, "Seconds"))
+
+    # rev3: "validate with actual ConsumedCapacity during S1". Published so the
+    # ~139 units/scan estimate and the byte budget can be checked against
+    # reality rather than re-derived from the table size.
+    consumed = observation.get("consumedCapacityUnits")
+    if consumed is not None:
+        data.append(datum("ScanConsumedCapacityUnits", consumed, "Count"))
+    return data
+
+
+# --------------------------------------------------------------------------
+# AWS plumbing
+# --------------------------------------------------------------------------
+
+
+def _projection() -> Dict[str, Any]:
+    names = {f"#a{i}": attr for i, attr in enumerate(PROJECTION_ATTRIBUTES)}
+    return {
+        "ProjectionExpression": ", ".join(names.keys()),
+        "ExpressionAttributeNames": names,
+    }
+
+
+def scan_queue(table_name: str, client=None) -> Dict[str, Any]:
+    """Fully paginate a projected scan of the queue base table.
+
+    Bounded by **pre-projection bytes scanned** (converted from the billed read
+    units DynamoDB reports, which is what it actually charges), by page count,
+    and by a wall-clock deadline. Hitting a budget with pages remaining raises
+    ``ObservationIncomplete``: an incomplete read is a failed observation,
+    never a truncated one.
+
+    The measured table is ~1.11 MB / ~139 eventual read units per scan, so the
+    16 MiB default leaves roughly 15x headroom before the guard fires.
+    """
+    ddb = client if client is not None else _aws("dynamodb")
+    max_bytes = _env_int("MAX_SCAN_BYTES", 16 * 1024 * 1024)
+    max_pages = _env_int("MAX_SCAN_PAGES", 100)
+    deadline_seconds = _env_int("SCAN_DEADLINE_SECONDS", 30)
+
+    started = time.monotonic()
+    kwargs: Dict[str, Any] = {
+        "TableName": table_name,
+        "ConsistentRead": False,
+        "ReturnConsumedCapacity": "TOTAL",
+        **_projection(),
+    }
+
+    items: List[Dict[str, Any]] = []
+    consumed = 0.0
+    pages = 0
+    last_key = None
+
+    while True:
+        if last_key:
+            kwargs["ExclusiveStartKey"] = last_key
+        response = ddb.scan(**kwargs)
+        pages += 1
+        items.extend(response.get("Items", []))
+        consumed += float(
+            (response.get("ConsumedCapacity") or {}).get("CapacityUnits", 0.0)
+        )
+        last_key = response.get("LastEvaluatedKey")
+        if not last_key:
+            break
+        # Budgets are only checked when pages remain: a scan that finished
+        # inside its final page is complete regardless of how large it was.
+        scanned_bytes = consumed * BYTES_PER_EVENTUAL_READ_UNIT
+        if scanned_bytes > max_bytes:
+            raise ObservationIncomplete(
+                f"byte budget exceeded: {scanned_bytes:.0f} > {max_bytes} "
+                f"pre-projection bytes after {pages} page(s)"
+            )
+        if pages >= max_pages:
+            raise ObservationIncomplete(f"page budget exceeded: {pages} >= {max_pages}")
+        if time.monotonic() - started > deadline_seconds:
+            raise ObservationIncomplete(
+                f"scan deadline exceeded after {pages} page(s)"
+            )
+
+    return {
+        "items": items,
+        "consumedCapacityUnits": consumed,
+        "scannedBytes": consumed * BYTES_PER_EVENTUAL_READ_UNIT,
+        "pages": pages,
+    }
+
+
+def _plain(item: Mapping[str, Any]) -> Dict[str, Any]:
+    """Flatten a low-level DynamoDB item to plain Python values.
+
+    Only S / N / BOOL / NULL appear in the projected attributes; anything else
+    is passed through as-is and will simply fail the classifier's type checks,
+    which is the conservative outcome.
+    """
+    out: Dict[str, Any] = {}
+    for key, value in item.items():
+        if not isinstance(value, Mapping) or len(value) != 1:
+            out[key] = value
+            continue
+        (kind, raw), = value.items()
+        if kind == "S":
+            out[key] = raw
+        elif kind == "N":
+            out[key] = float(raw) if "." in str(raw) else int(raw)
+        elif kind == "BOOL":
+            out[key] = bool(raw)
+        elif kind == "NULL":
+            out[key] = None
+        else:
+            out[key] = raw
+    return out
+
+
+def _dimensions() -> List[Dict[str, str]]:
+    # Fixed environment / queue / worker-class dimensions only. No job,
+    # conversation or report identifiers ever become a dimension.
+    return [
+        {"Name": "Environment", "Value": os.environ.get("POLIS_ENVIRONMENT", "prod")},
+        {
+            "Name": "Queue",
+            "Value": os.environ.get("DELPHI_QUEUE_TABLE", "Delphi_JobQueue"),
+        },
+        {
+            "Name": "WorkerClass",
+            "Value": os.environ.get("DELPHI_WORKER_CLASS", "delphi-small"),
+        },
+    ]
+
+
+def publish(metric_data: Sequence[Dict[str, Any]], client=None) -> None:
+    cw = client if client is not None else _aws("cloudwatch")
+    data = list(metric_data)
+    for start in range(0, len(data), 20):
+        cw.put_metric_data(
+            Namespace=METRIC_NAMESPACE, MetricData=data[start : start + 20]
+        )
+
+
+def lambda_handler(event, context):  # noqa: ARG001 - AWS entry point
+    """Observe the queue and publish. Never scales anything."""
+    table_name = os.environ.get("DELPHI_QUEUE_TABLE", "Delphi_JobQueue")
+    dimensions = _dimensions()
+
+    try:
+        scan = scan_queue(table_name)
+        rows = [_plain(item) for item in scan["items"]]
+        observation = compute_demand(rows)
+        observation["consumedCapacityUnits"] = scan["consumedCapacityUnits"]
+        observation["scannedBytes"] = scan["scannedBytes"]
+        observation["pages"] = scan["pages"]
+    except Exception as exc:  # noqa: BLE001 - any failure is an unhealthy read
+        logger.error("Observation failed: %s", exc, exc_info=True)
+        observation = {"complete": False, "observedAt": datetime.now(timezone.utc).isoformat()}
+        try:
+            publish(build_metric_data(observation, dimensions))
+        except Exception:  # noqa: BLE001
+            # Inability to publish is itself alarm-worthy; surface it as a
+            # Lambda error so both signals exist.
+            logger.error("Failed to publish ObserverHealthy=0", exc_info=True)
+            raise
+        return observation
+
+    publish(build_metric_data(observation, dimensions))
+
+    # Aggregates only. No job identifiers are ever logged.
+    logger.info(
+        "observation complete rows=%s wake_demand=%s anomalies=%s locked=%s "
+        "read_units=%.1f scanned_bytes=%.0f pages=%s anomaly_counts=%s",
+        observation["RowsScanned"],
+        observation["WakeDemand"],
+        observation["AnomalyRows"],
+        observation["LockedForCheckingRows"],
+        observation["consumedCapacityUnits"],
+        observation["scannedBytes"],
+        observation["pages"],
+        observation["AnomalyCounts"],
+    )
+    return observation

--- a/cdk/lambda/delphi-demand-observer/index.py
+++ b/cdk/lambda/delphi-demand-observer/index.py
@@ -80,6 +80,7 @@ ANOMALY_UNKNOWN_STATUS = "unknown_status"
 ANOMALY_MISSING_CREATED_AT = "missing_created_at"
 ANOMALY_MALFORMED_TIMESTAMP = "malformed_timestamp"
 ANOMALY_STALE_LOCKED = "stale_locked"
+ANOMALY_UNPAIRED_LOCKED = "unpaired_locked"
 ANOMALY_MALFORMED_OWNERSHIP = "malformed_ownership"
 
 ANOMALY_KINDS = (
@@ -88,6 +89,7 @@ ANOMALY_KINDS = (
     ANOMALY_MISSING_CREATED_AT,
     ANOMALY_MALFORMED_TIMESTAMP,
     ANOMALY_STALE_LOCKED,
+    ANOMALY_UNPAIRED_LOCKED,
     ANOMALY_MALFORMED_OWNERSHIP,
 )
 
@@ -105,6 +107,18 @@ PROJECTION_ATTRIBUTES = (
     "last_checked",
     "worker_id",
     "version",
+    # Lineage. A checker job row points at the parent it is checking:
+    # 801_narrative_report_batch.py:1457-1470 writes a row with
+    # job_type=AWAITING_NARRATIVE_BATCH and batch_job_id=<parent job_id>, and
+    # the poller runs it against that parent (job_poller.py:711). This is the
+    # only edge in the table, and it is what lets a LOCKED_FOR_CHECKING parent
+    # be paired with a live checker descendant.
+    #
+    # Adding an attribute to the projection costs nothing: DynamoDB bills a
+    # Scan on pre-projection item size, so the byte budget is unaffected.
+    # `batch_id` (the provider's batch identifier) is deliberately NOT
+    # projected — pairing needs only the in-table edge.
+    "batch_job_id",
 )
 
 
@@ -242,6 +256,12 @@ def classify_row(row: Mapping[str, Any], now: datetime) -> Dict[str, Any]:
     return {
         "demand": demand,
         "locked": locked,
+        # Not terminal, from this row's point of view. Unknown and missing
+        # statuses count as nonterminal on purpose: an unclassifiable row may
+        # still be live work, and assuming it is finished is the one error that
+        # loses jobs. Such a row raises its own anomaly regardless.
+        "nonterminal": status not in TERMINAL_STATUSES,
+        "parent_ref": row.get("batch_job_id") or None,
         "anomalies": anomalies,
         "actionable_age": actionable_age,
         "heartbeat_age": heartbeat_age,
@@ -259,56 +279,93 @@ def compute_demand(
     ``SecondsToNextEligible`` is 0 while there is demand and ``None`` when
     there is none — the null case is exported by omitting the sample, never by
     manufacturing a negative or zero delay.
+
+    A scan has no snapshot isolation, so the same ``job_id`` can appear more
+    than once and in more than one state. Repeat observations of one job are
+    **merged conservatively** — demand and anomalies OR together, ages take the
+    maximum — rather than resolved by arrival order. "First seen" is not a
+    state authority: a terminal row read before a pending row for the same job
+    must not erase that job's demand.
     """
     if now is None:
         now = datetime.now(timezone.utc)
 
-    seen_job_ids = set()
+    merged: Dict[Any, Dict[str, Any]] = {}
+    order: List[Any] = []
+
+    for position, row in enumerate(rows):
+        # job_id is the table's partition key, so it is present on every real
+        # row. The positional surrogate only keeps a malformed fixture from
+        # collapsing several distinct rows into one.
+        job_id = row.get("job_id")
+        key = job_id if job_id is not None else ("\0no-job-id", position)
+
+        result = classify_row(row, now)
+        previous = merged.get(key)
+        if previous is None:
+            merged[key] = result
+            order.append(key)
+            continue
+
+        previous["demand"] = previous["demand"] or result["demand"]
+        previous["locked"] = previous["locked"] or result["locked"]
+        previous["nonterminal"] = previous["nonterminal"] or result["nonterminal"]
+        previous["parent_ref"] = previous["parent_ref"] or result["parent_ref"]
+        for kind in result["anomalies"]:
+            if kind not in previous["anomalies"]:
+                previous["anomalies"].append(kind)
+        for field in ("actionable_age", "heartbeat_age", "locked_age"):
+            candidate = result[field]
+            if candidate is None:
+                continue
+            if previous[field] is None or candidate > previous[field]:
+                previous[field] = candidate
+
+    # Pairing pass. A LOCKED_FOR_CHECKING row is a parent waiting on a provider
+    # batch; its checker is a separate row pointing back at it via
+    # batch_job_id. A locked parent with no live descendant is unpaired: no
+    # process is going to advance it, whatever its lease says. Rev3 requires
+    # that this be an anomaly rather than silently non-demand, and an unexpired
+    # lease is not evidence of a live checker — nothing renews it once the
+    # checker is gone.
+    active_parent_refs = {
+        entry["parent_ref"]
+        for entry in merged.values()
+        if entry["nonterminal"] and entry["parent_ref"] is not None
+    }
+    for key in order:
+        entry = merged[key]
+        if entry["locked"] and key not in active_parent_refs:
+            if ANOMALY_UNPAIRED_LOCKED not in entry["anomalies"]:
+                entry["anomalies"].append(ANOMALY_UNPAIRED_LOCKED)
+
     wake_demand = 0
     locked_rows = 0
     anomaly_rows = 0
-    rows_scanned = 0
+    rows_scanned = len(order)
     anomaly_counts = {kind: 0 for kind in ANOMALY_KINDS}
     oldest_actionable: Optional[float] = None
     oldest_heartbeat: Optional[float] = None
     oldest_locked: Optional[float] = None
 
-    for row in rows:
-        # Count by full job_id so a row appearing on two pages, or moving
-        # state mid-scan, cannot be counted twice.
-        job_id = row.get("job_id")
-        if job_id is not None:
-            if job_id in seen_job_ids:
-                continue
-            seen_job_ids.add(job_id)
-        rows_scanned += 1
+    def _newer(current: Optional[float], candidate: Optional[float]):
+        if candidate is None:
+            return current
+        return candidate if current is None or candidate > current else current
 
-        result = classify_row(row, now)
-
-        if result["demand"]:
+    for key in order:
+        entry = merged[key]
+        if entry["demand"]:
             wake_demand += 1
-        if result["locked"]:
+        if entry["locked"]:
             locked_rows += 1
-        if result["anomalies"]:
+        if entry["anomalies"]:
             anomaly_rows += 1
-            for kind in result["anomalies"]:
+            for kind in entry["anomalies"]:
                 anomaly_counts[kind] += 1
-
-        for key, current in (
-            ("actionable_age", oldest_actionable),
-            ("heartbeat_age", oldest_heartbeat),
-            ("locked_age", oldest_locked),
-        ):
-            value = result[key]
-            if value is None:
-                continue
-            if current is None or value > current:
-                if key == "actionable_age":
-                    oldest_actionable = value
-                elif key == "heartbeat_age":
-                    oldest_heartbeat = value
-                else:
-                    oldest_locked = value
+        oldest_actionable = _newer(oldest_actionable, entry["actionable_age"])
+        oldest_heartbeat = _newer(oldest_heartbeat, entry["heartbeat_age"])
+        oldest_locked = _newer(oldest_locked, entry["locked_age"])
 
     return {
         "complete": True,

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -37,6 +37,7 @@ import createAutoScalingAndAlarms from '../autoscaling';
 import createCodedeployConfig from '../codedeploy';
 import createALBAndDNS from '../dns';
 import createSecretsAndDependencies from '../secrets';
+import createDelphiDemandObserver, { delphiDemandObserverEnabled } from '../delphiDemandObserver';
 import { ImportWorkerService } from './import-worker-service';
 
 interface PolisStackProps extends cdk.StackProps {
@@ -359,6 +360,14 @@ export class CdkStack extends cdk.Stack {
     });
 
     db.connections.allowFrom(lambda, ec2.Port.tcp(5432), 'Allow connection from backup Lambda');
+
+    // --- Delphi queue demand observer (P-003 slice S1, observe-only).
+    // Off unless synthesized with `-c enableDelphiDemandObserver=true`. It
+    // publishes queue-demand metrics and takes no scaling action; nothing
+    // about the Delphi ASGs changes either way.
+    if (delphiDemandObserverEnabled(this)) {
+      createDelphiDemandObserver(this);
+    }
 
     // ALB & DNS
     const {

--- a/cdk/test/delphi-demand-observer.test.ts
+++ b/cdk/test/delphi-demand-observer.test.ts
@@ -1,0 +1,168 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+
+import createDelphiDemandObserver, {
+  DELPHI_QUEUE_METRIC_NAMESPACE,
+  delphiDemandObserverEnabled,
+} from '../delphiDemandObserver';
+
+const synth = () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'TestStack', {
+    env: { account: '123456789012', region: 'us-east-1' },
+  });
+  createDelphiDemandObserver(stack);
+  return Template.fromStack(stack);
+};
+
+describe('enableDelphiDemandObserver context flag', () => {
+  const enabledWith = (value: unknown) => {
+    const app = new cdk.App(
+      value === undefined ? {} : { context: { enableDelphiDemandObserver: value } },
+    );
+    return delphiDemandObserverEnabled(new cdk.Stack(app, 'S'));
+  };
+
+  test('defaults to off when the flag is absent', () => {
+    expect(enabledWith(undefined)).toBe(false);
+  });
+
+  test('accepts the string the CLI passes for -c flag=true', () => {
+    expect(enabledWith('true')).toBe(true);
+    expect(enabledWith('TRUE')).toBe(true);
+    expect(enabledWith(true)).toBe(true);
+  });
+
+  test('anything else is off', () => {
+    expect(enabledWith('false')).toBe(false);
+    expect(enabledWith('1')).toBe(false);
+    expect(enabledWith('yes')).toBe(false);
+    expect(enabledWith(null)).toBe(false);
+  });
+});
+
+describe('observer resources', () => {
+  test('runs on a one-minute schedule with no overlapping invocations', () => {
+    const template = synth();
+    template.hasResourceProperties('AWS::Events::Rule', {
+      ScheduleExpression: 'rate(1 minute)',
+      State: 'ENABLED',
+    });
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Runtime: 'python3.12',
+      Handler: 'index.lambda_handler',
+      ReservedConcurrentExecutions: 1,
+    });
+  });
+
+  test('runs outside the VPC', () => {
+    // DynamoDB-backed in /1, so no private connectivity and no NAT cost.
+    const fns = synth().findResources('AWS::Lambda::Function');
+    for (const fn of Object.values(fns)) {
+      expect((fn as any).Properties.VpcConfig).toBeUndefined();
+    }
+  });
+
+  test('bounds the scan by pre-projection bytes, not by row count', () => {
+    synth().hasResourceProperties('AWS::Lambda::Function', {
+      Environment: {
+        Variables: Match.objectLike({
+          DELPHI_QUEUE_TABLE: 'Delphi_JobQueue',
+          MAX_SCAN_BYTES: '16777216',
+        }),
+      },
+    });
+  });
+});
+
+const toArray = (value: any): string[] =>
+  Array.isArray(value) ? value : [value];
+
+describe('observer IAM role', () => {
+  const statements = () => {
+    const policies = synth().findResources('AWS::IAM::Policy');
+    return Object.values(policies).flatMap(
+      (p: any) => p.Properties.PolicyDocument.Statement as any[],
+    );
+  };
+
+  test('PutMetricData is constrained by the cloudwatch:namespace condition', () => {
+    // PutMetricData supports no resource-level permissions, so Resource '*'
+    // is unavoidable; the namespace condition is the only real constraint.
+    const metric = statements().filter((s) =>
+      toArray(s.Action).includes('cloudwatch:PutMetricData'),
+    );
+    expect(metric).toHaveLength(1);
+    expect(metric[0].Resource).toEqual('*');
+    expect(metric[0].Condition).toEqual({
+      StringEquals: { 'cloudwatch:namespace': DELPHI_QUEUE_METRIC_NAMESPACE },
+    });
+  });
+
+  test('DynamoDB access is Scan on the one table, with no index access', () => {
+    const ddb = statements().filter((s) =>
+      toArray(s.Action).some((a) => a.startsWith('dynamodb:')),
+    );
+    expect(ddb).toHaveLength(1);
+    expect(ddb[0].Action).toEqual('dynamodb:Scan');
+    expect(JSON.stringify(ddb[0].Resource)).toContain('table/Delphi_JobQueue');
+    expect(JSON.stringify(ddb[0].Resource)).not.toContain('index');
+    expect(JSON.stringify(ddb[0].Resource)).not.toContain('Delphi_*');
+  });
+
+  test('grants no autoscaling permission of any kind', () => {
+    // S1 is observe-only. SetDesiredCapacity arrives at S7, ASG-scoped.
+    const actions = statements().flatMap((s) => toArray(s.Action));
+    expect(actions.filter((a) => a.startsWith('autoscaling:'))).toEqual([]);
+    expect(actions.filter((a) => a.startsWith('ec2:'))).toEqual([]);
+  });
+
+  test('grants no queue writes and no secrets access', () => {
+    const actions = statements().flatMap((s) => toArray(s.Action));
+    for (const forbidden of [
+      'dynamodb:PutItem',
+      'dynamodb:UpdateItem',
+      'dynamodb:DeleteItem',
+      'dynamodb:Query',
+      'secretsmanager:GetSecretValue',
+    ]) {
+      expect(actions).not.toContain(forbidden);
+    }
+  });
+
+  test('log writes are scoped to its own log group', () => {
+    const logStatements = statements().filter((s) =>
+      toArray(s.Action).some((a) => a.startsWith('logs:')),
+    );
+    expect(logStatements).toHaveLength(1);
+    expect(logStatements[0].Action.sort()).toEqual([
+      'logs:CreateLogStream',
+      'logs:PutLogEvents',
+    ]);
+    // Resolves to the observer's own log group, not a wildcard.
+    const resource = JSON.stringify(logStatements[0].Resource);
+    expect(resource).toContain('DelphiDemandObserverLogGroup');
+    expect(resource).not.toContain('log-group:*');
+    synth().hasResourceProperties('AWS::Logs::LogGroup', {
+      LogGroupName: '/aws/lambda/polis-delphi-demand-observer',
+    });
+  });
+
+  test('attaches no AWS managed policies', () => {
+    const roles = synth().findResources('AWS::IAM::Role');
+    for (const role of Object.values(roles)) {
+      expect((role as any).Properties.ManagedPolicyArns ?? []).toEqual([]);
+    }
+  });
+});
+
+describe('the observer never touches the ASG', () => {
+  test('synthesizes no autoscaling resources at all', () => {
+    // Review item G2: removing DesiredCapacity from the template defaults it
+    // to MinSize on the update. S1 must not go near the ASG.
+    const template = synth();
+    template.resourceCountIs('AWS::AutoScaling::AutoScalingGroup', 0);
+    template.resourceCountIs('AWS::AutoScaling::ScalingPolicy', 0);
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 0);
+  });
+});

--- a/cdk/test/python/test_delphi_demand_observer.py
+++ b/cdk/test/python/test_delphi_demand_observer.py
@@ -51,6 +51,20 @@ def row(job_id, status=index.STATUS_PENDING, **overrides):
     return item
 
 
+def checker(job_id, parent, status=index.STATUS_PENDING, **overrides):
+    """A batch-status-check row pointing back at the parent it is checking.
+
+    Shape taken from 801_narrative_report_batch.py:1457-1470.
+    """
+    return row(
+        job_id,
+        status,
+        job_type="AWAITING_NARRATIVE_BATCH",
+        batch_job_id=parent,
+        **overrides,
+    )
+
+
 class TestStatusCoverage(unittest.TestCase):
     """Every status the poller and batch checker write, one fixture each."""
 
@@ -227,15 +241,17 @@ class TestComputeDemand(unittest.TestCase):
             row("c", index.STATUS_AWAITING_RECHECK, created_at=iso(45)),
             row("d", index.STATUS_PROCESSING),
             row("e", index.STATUS_LOCKED_FOR_CHECKING),
+            # e's live checker, which is what makes it a healthy locked parent.
+            checker("e-check", parent="e"),
             row("f", index.STATUS_COMPLETED),
             row("g", index.STATUS_FAILED),
         ]
         observation = index.compute_demand(rows, now=NOW)
         self.assertTrue(observation["complete"])
-        self.assertEqual(observation["WakeDemand"], 4)
+        self.assertEqual(observation["WakeDemand"], 5)
         self.assertEqual(observation["LockedForCheckingRows"], 1)
         self.assertEqual(observation["AnomalyRows"], 0)
-        self.assertEqual(observation["RowsScanned"], 7)
+        self.assertEqual(observation["RowsScanned"], 8)
         self.assertEqual(observation["SecondsToNextEligible"], 0.0)
         self.assertAlmostEqual(observation["OldestPendingAgeSeconds"], 5400.0)
 
@@ -258,6 +274,141 @@ class TestComputeDemand(unittest.TestCase):
         observation = index.compute_demand(rows, now=NOW)
         self.assertEqual(observation["RowsScanned"], 1)
         self.assertEqual(observation["WakeDemand"], 1)
+
+
+class TestDuplicateMerging(unittest.TestCase):
+    """A scan has no snapshot isolation, so arrival order is not authority.
+
+    Astra review of #2718, finding 1: taking the first-seen row for a job id
+    let a terminal observation erase a later pending one, making the result
+    order-dependent and, in one direction, optimistic. Demand and anomalies now
+    OR together and ages take the maximum.
+    """
+
+    def test_terminal_then_pending_keeps_the_demand(self):
+        rows = [row("j", index.STATUS_COMPLETED), row("j", index.STATUS_PENDING)]
+        self.assertEqual(index.compute_demand(rows, now=NOW)["WakeDemand"], 1)
+
+    def test_result_is_independent_of_arrival_order(self):
+        completed = row("j", index.STATUS_COMPLETED)
+        pending = row("j", index.STATUS_PENDING)
+        forwards = index.compute_demand([completed, pending], now=NOW)
+        backwards = index.compute_demand([pending, completed], now=NOW)
+        self.assertEqual(forwards["WakeDemand"], backwards["WakeDemand"])
+        self.assertEqual(forwards["AnomalyRows"], backwards["AnomalyRows"])
+        self.assertEqual(forwards["RowsScanned"], backwards["RowsScanned"])
+        self.assertEqual(forwards["WakeDemand"], 1)
+
+    def test_anomalies_union_across_observations(self):
+        rows = [
+            row("j", index.STATUS_COMPLETED),
+            {"job_id": "j"},  # same job seen with no attributes
+        ]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertEqual(observation["RowsScanned"], 1)
+        self.assertEqual(observation["AnomalyRows"], 1)
+        self.assertEqual(observation["AnomalyCounts"][index.ANOMALY_MISSING_STATUS], 1)
+
+    def test_ages_take_the_maximum(self):
+        rows = [
+            row("j", index.STATUS_PENDING, created_at=iso(5)),
+            row("j", index.STATUS_PENDING, created_at=iso(120)),
+        ]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertAlmostEqual(observation["OldestPendingAgeSeconds"], 7200.0)
+
+    def test_two_attribute_less_rows_do_not_collapse_into_one(self):
+        observation = index.compute_demand([{}, {}], now=NOW)
+        self.assertEqual(observation["RowsScanned"], 2)
+        self.assertEqual(observation["AnomalyRows"], 2)
+
+
+class TestLockedPairing(unittest.TestCase):
+    """Astra review of #2718, finding 2: an unpaired locked parent.
+
+    A LOCKED_FOR_CHECKING row is a parent waiting on a provider batch. Its
+    checker is a separate row pointing back at it through `batch_job_id`
+    (801_narrative_report_batch.py:1457-1470). If no live descendant references
+    it, nothing is going to advance it — and an unexpired lease proves nothing,
+    because nothing renews the lease once the checker is gone.
+    """
+
+    def test_locked_parent_with_a_live_checker_is_clean(self):
+        rows = [
+            row("parent", index.STATUS_LOCKED_FOR_CHECKING),
+            checker("parent-check", parent="parent"),
+        ]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertEqual(observation["AnomalyRows"], 0)
+        self.assertEqual(observation["LockedForCheckingRows"], 1)
+        # The checker itself is the demand; the locked parent is not.
+        self.assertEqual(observation["WakeDemand"], 1)
+
+    def test_unpaired_locked_parent_with_a_future_lease_is_an_anomaly(self):
+        # The exact case the stale-lease rule could not see.
+        rows = [row("parent", index.STATUS_LOCKED_FOR_CHECKING)]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertEqual(observation["WakeDemand"], 0)
+        self.assertEqual(observation["AnomalyRows"], 1)
+        self.assertEqual(
+            observation["AnomalyCounts"][index.ANOMALY_UNPAIRED_LOCKED], 1
+        )
+        self.assertEqual(observation["AnomalyCounts"][index.ANOMALY_STALE_LOCKED], 0)
+
+    def test_a_finished_checker_does_not_pair_its_parent(self):
+        rows = [
+            row("parent", index.STATUS_LOCKED_FOR_CHECKING),
+            checker("parent-check", parent="parent", status=index.STATUS_COMPLETED),
+        ]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertEqual(
+            observation["AnomalyCounts"][index.ANOMALY_UNPAIRED_LOCKED], 1
+        )
+
+    def test_an_unclassifiable_checker_is_assumed_live(self):
+        # Conservative: an unknown-status descendant might still be running, so
+        # it pairs the parent. It raises its own anomaly either way.
+        rows = [
+            row("parent", index.STATUS_LOCKED_FOR_CHECKING),
+            checker("parent-check", parent="parent", status="WAT"),
+        ]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertEqual(
+            observation["AnomalyCounts"][index.ANOMALY_UNPAIRED_LOCKED], 0
+        )
+        self.assertEqual(observation["AnomalyRows"], 1)  # the checker only
+
+    def test_stale_and_unpaired_are_reported_separately(self):
+        rows = [
+            row(
+                "parent",
+                index.STATUS_LOCKED_FOR_CHECKING,
+                lock_expires_at=iso(90),
+                last_checked=iso(90),
+            )
+        ]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertEqual(observation["AnomalyRows"], 1)
+        self.assertEqual(observation["AnomalyCounts"][index.ANOMALY_STALE_LOCKED], 1)
+        self.assertEqual(
+            observation["AnomalyCounts"][index.ANOMALY_UNPAIRED_LOCKED], 1
+        )
+
+    def test_a_checker_for_an_unrelated_parent_does_not_pair(self):
+        rows = [
+            row("parent", index.STATUS_LOCKED_FOR_CHECKING),
+            checker("other-check", parent="some-other-parent"),
+        ]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertEqual(
+            observation["AnomalyCounts"][index.ANOMALY_UNPAIRED_LOCKED], 1
+        )
+
+    def test_lineage_attribute_is_projected(self):
+        self.assertIn("batch_job_id", index.PROJECTION_ATTRIBUTES)
+        # The provider's own batch identifier is not needed for pairing and is
+        # deliberately left unprojected.
+        self.assertNotIn("batch_id", index.PROJECTION_ATTRIBUTES)
 
     def test_measured_five_row_anomaly_shape(self):
         """Reproduces the shape the reviewer measured on the live table.
@@ -285,6 +436,9 @@ class TestComputeDemand(unittest.TestCase):
         self.assertEqual(observation["LockedForCheckingRows"], 3)
         self.assertEqual(observation["AnomalyCounts"][index.ANOMALY_STALE_LOCKED], 3)
         self.assertEqual(observation["AnomalyCounts"][index.ANOMALY_MISSING_STATUS], 2)
+        # No job has been created since 2026-08, so those three locked parents
+        # have no live checker either: both rules fire, on the same 3 rows.
+        self.assertEqual(observation["AnomalyCounts"][index.ANOMALY_UNPAIRED_LOCKED], 3)
 
     def test_a_row_with_several_anomalies_counts_once(self):
         rows = [{"job_id": "z", "status": "WAT"}]

--- a/cdk/test/python/test_delphi_demand_observer.py
+++ b/cdk/test/python/test_delphi_demand_observer.py
@@ -1,0 +1,483 @@
+"""Unit tests for the Delphi demand observer's classification (P-003 S1).
+
+Pure functions only: no AWS calls, no boto3 session, no network.
+
+Run from the `cdk` directory with either:
+    python3 -m unittest discover -s test/python -v
+    python3 -m pytest test/python -v
+"""
+
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "..", "..", "lambda", "delphi-demand-observer"),
+)
+
+import index  # noqa: E402
+
+
+NOW = datetime(2026, 9, 8, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def iso(minutes_ago):
+    return (NOW - timedelta(minutes=minutes_ago)).isoformat()
+
+
+def iso_ahead(minutes):
+    return (NOW + timedelta(minutes=minutes)).isoformat()
+
+
+def row(job_id, status=index.STATUS_PENDING, **overrides):
+    """A well-formed row of the given status, before overrides."""
+    item = {"job_id": job_id, "status": status, "created_at": iso(30), "version": 1}
+    if status == index.STATUS_PROCESSING:
+        item.update(
+            {
+                "worker_id": "worker-a",
+                "started_at": iso(5),
+                "updated_at": iso(1),
+                "lock_expires_at": iso_ahead(10),
+            }
+        )
+    if status == index.STATUS_LOCKED_FOR_CHECKING:
+        item.update({"last_checked": iso(1), "lock_expires_at": iso_ahead(10)})
+    if status in (index.STATUS_COMPLETED, index.STATUS_FAILED):
+        item.update({"started_at": iso(20), "completed_at": iso(10)})
+    item.update(overrides)
+    return item
+
+
+class TestStatusCoverage(unittest.TestCase):
+    """Every status the poller and batch checker write, one fixture each."""
+
+    def test_known_statuses_match_the_poller(self):
+        # job_poller.py:461-470, 503-520, 578-583, 640 and
+        # 803_check_batch_status.py:235-258.
+        self.assertEqual(
+            index.KNOWN_STATUSES,
+            frozenset(
+                {
+                    "PENDING",
+                    "AWAITING_RECHECK",
+                    "PROCESSING",
+                    "LOCKED_FOR_CHECKING",
+                    "COMPLETED",
+                    "FAILED",
+                }
+            ),
+        )
+
+    def test_pending_is_demand(self):
+        result = index.classify_row(row("j1", index.STATUS_PENDING), NOW)
+        self.assertTrue(result["demand"])
+        self.assertEqual(result["anomalies"], [])
+        self.assertAlmostEqual(result["actionable_age"], 1800.0)
+
+    def test_awaiting_recheck_is_demand(self):
+        # The finder has no due-time scheduling, so a recheck row needs a
+        # worker now, not at some future eligibility.
+        result = index.classify_row(row("j2", index.STATUS_AWAITING_RECHECK), NOW)
+        self.assertTrue(result["demand"])
+        self.assertEqual(result["anomalies"], [])
+        self.assertAlmostEqual(result["actionable_age"], 1800.0)
+
+    def test_processing_is_demand_at_any_lease_age(self):
+        fresh = index.classify_row(row("j3", index.STATUS_PROCESSING), NOW)
+        expired = index.classify_row(
+            row("j4", index.STATUS_PROCESSING, lock_expires_at=iso(60)), NOW
+        )
+        self.assertTrue(fresh["demand"])
+        self.assertTrue(expired["demand"])
+        # Neither is an anomaly: an expired lease is ordinary zombie recovery,
+        # and recovery is exactly what needs a worker.
+        self.assertEqual(expired["anomalies"], [])
+
+    def test_locked_for_checking_is_not_demand_by_itself(self):
+        result = index.classify_row(row("j5", index.STATUS_LOCKED_FOR_CHECKING), NOW)
+        self.assertFalse(result["demand"])
+        self.assertTrue(result["locked"])
+        self.assertEqual(result["anomalies"], [])
+
+    def test_completed_and_failed_are_not_demand(self):
+        for status in (index.STATUS_COMPLETED, index.STATUS_FAILED):
+            with self.subTest(status=status):
+                result = index.classify_row(row("j6", status), NOW)
+                self.assertFalse(result["demand"])
+                self.assertEqual(result["anomalies"], [])
+
+    def test_processing_rows_do_not_contribute_actionable_age(self):
+        # OldestPendingAgeSeconds is the oldest *actionable* age; a claimed row
+        # is tracked by its heartbeat instead.
+        result = index.classify_row(row("j7", index.STATUS_PROCESSING), NOW)
+        self.assertIsNone(result["actionable_age"])
+
+
+class TestAnomalies(unittest.TestCase):
+    def test_attribute_less_row(self):
+        # The measured table holds rows with no status/created_at/job_type at
+        # all. No GSI query can see them; only a base-table scan can.
+        result = index.classify_row({"job_id": "j8"}, NOW)
+        self.assertFalse(result["demand"])
+        self.assertIn(index.ANOMALY_MISSING_STATUS, result["anomalies"])
+        self.assertIn(index.ANOMALY_MISSING_CREATED_AT, result["anomalies"])
+
+    def test_unknown_status(self):
+        result = index.classify_row(row("j9", "SOMETHING_ELSE"), NOW)
+        self.assertFalse(result["demand"])
+        self.assertEqual(result["anomalies"], [index.ANOMALY_UNKNOWN_STATUS])
+
+    def test_empty_status_string_counts_as_missing(self):
+        result = index.classify_row(row("j10", ""), NOW)
+        self.assertIn(index.ANOMALY_MISSING_STATUS, result["anomalies"])
+
+    def test_stale_locked_for_checking_expired_lease(self):
+        result = index.classify_row(
+            row(
+                "j11",
+                index.STATUS_LOCKED_FOR_CHECKING,
+                lock_expires_at=iso(90),
+                last_checked=iso(120),
+            ),
+            NOW,
+        )
+        self.assertFalse(result["demand"])
+        self.assertTrue(result["locked"])
+        self.assertEqual(result["anomalies"], [index.ANOMALY_STALE_LOCKED])
+        self.assertAlmostEqual(result["locked_age"], 7200.0)
+
+    def test_locked_for_checking_with_no_lease_is_unpaired(self):
+        item = row("j12", index.STATUS_LOCKED_FOR_CHECKING)
+        del item["lock_expires_at"]
+        result = index.classify_row(item, NOW)
+        self.assertEqual(result["anomalies"], [index.ANOMALY_STALE_LOCKED])
+
+    def test_processing_without_owner_is_malformed_ownership(self):
+        item = row("j13", index.STATUS_PROCESSING)
+        del item["worker_id"]
+        result = index.classify_row(item, NOW)
+        # Still demand — an unownable claimed row is exactly the recovery case.
+        self.assertTrue(result["demand"])
+        self.assertEqual(result["anomalies"], [index.ANOMALY_MALFORMED_OWNERSHIP])
+
+    def test_malformed_timestamp(self):
+        result = index.classify_row(row("j14", created_at="not-a-date"), NOW)
+        self.assertIn(index.ANOMALY_MALFORMED_TIMESTAMP, result["anomalies"])
+        self.assertIsNone(result["actionable_age"])
+
+    def test_malformed_timestamp_on_a_secondary_field(self):
+        result = index.classify_row(row("j15", updated_at="not-a-timestamp"), NOW)
+        self.assertIn(index.ANOMALY_MALFORMED_TIMESTAMP, result["anomalies"])
+
+
+class TestHeartbeatAge(unittest.TestCase):
+    """G3: a worker dying while holding PROCESSING keeps demand >= 1 forever.
+
+    WakeDemand can therefore never fall to 0 and the protected-idle ceiling can
+    never trip. The heartbeat age is the metric that actually detects it.
+    """
+
+    def test_uses_the_newest_progress_mark(self):
+        result = index.classify_row(
+            row(
+                "j16",
+                index.STATUS_PROCESSING,
+                created_at=iso(600),
+                started_at=iso(300),
+                updated_at=iso(7),
+            ),
+            NOW,
+        )
+        self.assertAlmostEqual(result["heartbeat_age"], 420.0)
+
+    def test_dead_worker_holding_processing_shows_a_growing_age(self):
+        item = row(
+            "j17",
+            index.STATUS_PROCESSING,
+            started_at=iso(240),
+            updated_at=iso(240),
+            lock_expires_at=iso(225),
+        )
+        observation = index.compute_demand([item], now=NOW)
+        # Demand stays at 1 indefinitely — that is the trap G3 describes.
+        self.assertEqual(observation["WakeDemand"], 1)
+        self.assertAlmostEqual(
+            observation["OldestProcessingHeartbeatAgeSeconds"], 14400.0
+        )
+
+    def test_falls_back_to_started_at_when_no_log_flush_happened(self):
+        item = row("j18", index.STATUS_PROCESSING, started_at=iso(45))
+        del item["updated_at"]
+        result = index.classify_row(item, NOW)
+        self.assertAlmostEqual(result["heartbeat_age"], 2700.0)
+
+    def test_no_processing_rows_means_no_heartbeat_sample(self):
+        observation = index.compute_demand([row("j19", index.STATUS_PENDING)], now=NOW)
+        self.assertIsNone(observation["OldestProcessingHeartbeatAgeSeconds"])
+
+
+class TestComputeDemand(unittest.TestCase):
+    def test_mixed_queue(self):
+        rows = [
+            row("a", index.STATUS_PENDING, created_at=iso(90)),
+            row("b", index.STATUS_PENDING, created_at=iso(10)),
+            row("c", index.STATUS_AWAITING_RECHECK, created_at=iso(45)),
+            row("d", index.STATUS_PROCESSING),
+            row("e", index.STATUS_LOCKED_FOR_CHECKING),
+            row("f", index.STATUS_COMPLETED),
+            row("g", index.STATUS_FAILED),
+        ]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertTrue(observation["complete"])
+        self.assertEqual(observation["WakeDemand"], 4)
+        self.assertEqual(observation["LockedForCheckingRows"], 1)
+        self.assertEqual(observation["AnomalyRows"], 0)
+        self.assertEqual(observation["RowsScanned"], 7)
+        self.assertEqual(observation["SecondsToNextEligible"], 0.0)
+        self.assertAlmostEqual(observation["OldestPendingAgeSeconds"], 5400.0)
+
+    def test_empty_queue_publishes_zero_demand_and_no_delay(self):
+        observation = index.compute_demand([], now=NOW)
+        self.assertEqual(observation["WakeDemand"], 0)
+        # Null is exported by omitting the sample, never as a negative or a
+        # manufactured zero delay.
+        self.assertIsNone(observation["SecondsToNextEligible"])
+        self.assertIsNone(observation["OldestPendingAgeSeconds"])
+
+    def test_terminal_only_queue_is_zero_demand(self):
+        rows = [row("a", index.STATUS_COMPLETED), row("b", index.STATUS_FAILED)]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertEqual(observation["WakeDemand"], 0)
+        self.assertIsNone(observation["SecondsToNextEligible"])
+
+    def test_duplicate_job_ids_across_pages_are_counted_once(self):
+        rows = [row("dup", index.STATUS_PENDING), row("dup", index.STATUS_PROCESSING)]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertEqual(observation["RowsScanned"], 1)
+        self.assertEqual(observation["WakeDemand"], 1)
+
+    def test_measured_five_row_anomaly_shape(self):
+        """Reproduces the shape the reviewer measured on the live table.
+
+        227 COMPLETED, 23 FAILED, 3 stale LOCKED_FOR_CHECKING and 2 rows with
+        no status attribute -> AnomalyRows == 5, WakeDemand == 0.
+        """
+        rows = [row(f"c{i}", index.STATUS_COMPLETED) for i in range(227)]
+        rows += [row(f"f{i}", index.STATUS_FAILED) for i in range(23)]
+        rows += [
+            row(
+                f"l{i}",
+                index.STATUS_LOCKED_FOR_CHECKING,
+                lock_expires_at=iso(50000),
+                last_checked=iso(50000),
+            )
+            for i in range(3)
+        ]
+        rows += [{"job_id": "x0"}, {"job_id": "x1"}]
+
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertEqual(observation["RowsScanned"], 255)
+        self.assertEqual(observation["WakeDemand"], 0)
+        self.assertEqual(observation["AnomalyRows"], 5)
+        self.assertEqual(observation["LockedForCheckingRows"], 3)
+        self.assertEqual(observation["AnomalyCounts"][index.ANOMALY_STALE_LOCKED], 3)
+        self.assertEqual(observation["AnomalyCounts"][index.ANOMALY_MISSING_STATUS], 2)
+
+    def test_a_row_with_several_anomalies_counts_once(self):
+        rows = [{"job_id": "z", "status": "WAT"}]
+        observation = index.compute_demand(rows, now=NOW)
+        self.assertEqual(observation["AnomalyRows"], 1)
+        self.assertEqual(observation["AnomalyCounts"][index.ANOMALY_UNKNOWN_STATUS], 1)
+        self.assertEqual(
+            observation["AnomalyCounts"][index.ANOMALY_MISSING_CREATED_AT], 1
+        )
+
+
+class TestMetricRendering(unittest.TestCase):
+    DIMS = [{"Name": "Environment", "Value": "prod"}]
+
+    def _by_name(self, data):
+        return {d["MetricName"]: d["Value"] for d in data}
+
+    def test_complete_observation_publishes_the_expected_metric_set(self):
+        observation = index.compute_demand(
+            [row("a", index.STATUS_PENDING), row("b", index.STATUS_PROCESSING)],
+            now=NOW,
+        )
+        observation["consumedCapacityUnits"] = 139.0
+        data = index.build_metric_data(observation, self.DIMS)
+        names = self._by_name(data)
+        self.assertEqual(
+            set(names),
+            {
+                "ObserverHealthy",
+                "WakeDemand",
+                "AnomalyRows",
+                "LockedForCheckingRows",
+                "RowsScanned",
+                "SecondsToNextEligible",
+                "OldestPendingAgeSeconds",
+                "OldestProcessingHeartbeatAgeSeconds",
+                "ScanConsumedCapacityUnits",
+            },
+        )
+        self.assertEqual(names["ObserverHealthy"], 1.0)
+        self.assertEqual(names["WakeDemand"], 2.0)
+        self.assertEqual(names["ScanConsumedCapacityUnits"], 139.0)
+
+    def test_empty_queue_omits_the_age_samples_but_states_zero_demand(self):
+        data = index.build_metric_data(index.compute_demand([], now=NOW), self.DIMS)
+        names = self._by_name(data)
+        self.assertEqual(names["WakeDemand"], 0.0)
+        self.assertNotIn("SecondsToNextEligible", names)
+        self.assertNotIn("OldestPendingAgeSeconds", names)
+        self.assertNotIn("OldestProcessingHeartbeatAgeSeconds", names)
+
+    def test_incomplete_observation_publishes_health_only(self):
+        # A failed or truncated read must never look like an empty queue.
+        data = index.build_metric_data(
+            {"complete": False, "observedAt": NOW.isoformat()}, self.DIMS
+        )
+        names = self._by_name(data)
+        self.assertEqual(names, {"ObserverHealthy": 0.0})
+
+    def test_dimensions_carry_no_identifiers(self):
+        observation = index.compute_demand([row("secret-job-id")], now=NOW)
+        data = index.build_metric_data(observation, self.DIMS)
+        self.assertTrue(all(d["Dimensions"] == self.DIMS for d in data))
+
+
+class TestScanBudget(unittest.TestCase):
+    class FakeDdb:
+        """Returns `pages` pages, each reporting `units_per_page` capacity."""
+
+        def __init__(self, pages, units_per_page=139.0, items_per_page=1):
+            self.pages = pages
+            self.units_per_page = units_per_page
+            self.items_per_page = items_per_page
+            self.calls = 0
+
+        def scan(self, **kwargs):
+            self.calls += 1
+            last = self.calls >= self.pages
+            response = {
+                "Items": [
+                    {"job_id": {"S": f"p{self.calls}-{i}"}, "status": {"S": "PENDING"}}
+                    for i in range(self.items_per_page)
+                ],
+                "ConsumedCapacity": {"CapacityUnits": self.units_per_page},
+            }
+            if not last:
+                response["LastEvaluatedKey"] = {"job_id": {"S": f"p{self.calls}"}}
+            return response
+
+    def test_single_page_scan_is_complete(self):
+        fake = self.FakeDdb(pages=1, units_per_page=139.0, items_per_page=3)
+        result = index.scan_queue("Delphi_JobQueue", client=fake)
+        self.assertEqual(len(result["items"]), 3)
+        self.assertEqual(result["pages"], 1)
+        self.assertAlmostEqual(result["consumedCapacityUnits"], 139.0)
+        self.assertAlmostEqual(
+            result["scannedBytes"], 139.0 * index.BYTES_PER_EVENTUAL_READ_UNIT
+        )
+
+    def test_projection_excludes_payload_attributes(self):
+        fake = self.FakeDdb(pages=1)
+        index.scan_queue("Delphi_JobQueue", client=fake)
+        self.assertNotIn("logs", index.PROJECTION_ATTRIBUTES)
+        self.assertNotIn("conversation_id", index.PROJECTION_ATTRIBUTES)
+        self.assertNotIn("result", index.PROJECTION_ATTRIBUTES)
+
+    def test_byte_budget_failure_is_incomplete_not_truncated(self):
+        os.environ["MAX_SCAN_BYTES"] = str(16 * 1024)  # 2 read units
+        try:
+            fake = self.FakeDdb(pages=5, units_per_page=139.0)
+            with self.assertRaises(index.ObservationIncomplete):
+                index.scan_queue("Delphi_JobQueue", client=fake)
+        finally:
+            del os.environ["MAX_SCAN_BYTES"]
+
+    def test_page_budget_failure(self):
+        os.environ["MAX_SCAN_PAGES"] = "2"
+        try:
+            fake = self.FakeDdb(pages=10, units_per_page=0.5)
+            with self.assertRaises(index.ObservationIncomplete):
+                index.scan_queue("Delphi_JobQueue", client=fake)
+        finally:
+            del os.environ["MAX_SCAN_PAGES"]
+
+    def test_a_large_but_single_page_scan_is_not_failed(self):
+        # Budgets are only enforced while pages remain.
+        os.environ["MAX_SCAN_BYTES"] = "1"
+        try:
+            fake = self.FakeDdb(pages=1, units_per_page=9999.0)
+            result = index.scan_queue("Delphi_JobQueue", client=fake)
+            self.assertEqual(result["pages"], 1)
+        finally:
+            del os.environ["MAX_SCAN_BYTES"]
+
+
+class TestItemFlattening(unittest.TestCase):
+    def test_flattens_dynamodb_typed_values(self):
+        flat = index._plain(
+            {
+                "job_id": {"S": "j"},
+                "status": {"S": "PENDING"},
+                "version": {"N": "3"},
+                "worker_id": {"NULL": True},
+            }
+        )
+        self.assertEqual(flat["status"], "PENDING")
+        self.assertEqual(flat["version"], 3)
+        self.assertIsNone(flat["worker_id"])
+
+    def test_flattened_attribute_less_row_still_classifies(self):
+        flat = index._plain({"job_id": {"S": "j"}})
+        result = index.classify_row(flat, NOW)
+        self.assertIn(index.ANOMALY_MISSING_STATUS, result["anomalies"])
+
+
+class TestNoScalingCode(unittest.TestCase):
+    """S1 is observe-only: the scaling path must not exist, not even disabled."""
+
+    def test_module_has_no_autoscaling_surface(self):
+        source_path = os.path.join(
+            os.path.dirname(index.__file__), os.path.basename(index.__file__)
+        )
+        with open(source_path, encoding="utf-8") as handle:
+            source = handle.read()
+        for forbidden in (
+            "SetDesiredCapacity",
+            "set_desired_capacity",
+            "update_auto_scaling_group",
+            "boto3.client(\"autoscaling\")",
+            "boto3.client('autoscaling')",
+        ):
+            self.assertNotIn(forbidden, source, f"S1 must not reference {forbidden}")
+
+
+class TestTimestampParsing(unittest.TestCase):
+    def test_accepts_z_suffix_and_naive_values(self):
+        self.assertEqual(
+            index.parse_timestamp("2026-09-08T12:00:00Z"),
+            datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            index.parse_timestamp("2026-09-08T12:00:00"),
+            datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc),
+        )
+
+    def test_rejects_junk_without_raising(self):
+        for value in ("", None, "yesterday", 17, {"S": "x"}):
+            self.assertIsNone(index.parse_timestamp(value))
+
+    def test_clock_skew_does_not_produce_a_negative_age(self):
+        result = index.classify_row(row("future", created_at=iso(-15)), NOW)
+        self.assertEqual(result["actionable_age"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/delphi-demand-observer.md
+++ b/docs/delphi-demand-observer.md
@@ -31,7 +31,7 @@ attribute, and the table currently holds exactly such rows. A scan sees them.
 | `PENDING` | Yes | Waiting for a claim. |
 | `AWAITING_RECHECK` | Yes | The poller has no due-time scheduling, so a recheck row needs a worker now. |
 | `PROCESSING`, any lease age | Yes | Recovering a vanished owner needs a worker even before the 15-minute lease expires. |
-| `LOCKED_FOR_CHECKING` | No, by itself | A parent/checker coordination state, not a ready unit of compute. Counted and aged separately. |
+| `LOCKED_FOR_CHECKING` | No, by itself | A parent/checker coordination state, not a ready unit of compute. Counted and aged separately, and paired against its checker (below). |
 | `COMPLETED` / `FAILED` | No | Terminal. |
 | Missing or unknown `status`, malformed scheduling/ownership fields | No | Counted as an anomaly. Unknown work must inhibit retirement, never be inferred as absent. |
 
@@ -41,11 +41,45 @@ Anomaly kinds, all of which contribute to `AnomalyRows`:
 - `unknown_status` — a status the poller does not write
 - `missing_created_at` — nothing to age the row by
 - `malformed_timestamp` — a timestamp field that will not parse
-- `stale_locked` — `LOCKED_FOR_CHECKING` whose lease is absent or expired, i.e. no checker is paired with it
+- `stale_locked` — `LOCKED_FOR_CHECKING` whose lease is absent or expired
+- `unpaired_locked` — `LOCKED_FOR_CHECKING` with no live checker descendant, whatever its lease says
 - `malformed_ownership` — `PROCESSING` with no `worker_id` or no lease
 
 A row with several anomalies counts once towards `AnomalyRows`; the per-kind
 breakdown goes to the log line.
+
+### Parent/checker pairing
+
+A `LOCKED_FOR_CHECKING` row is a parent waiting on a provider batch. Its checker
+is a *separate row* that points back at it: `801_narrative_report_batch.py`
+writes a row with `job_type=AWAITING_NARRATIVE_BATCH` and
+`batch_job_id=<parent job_id>`, and the poller runs that row against the parent.
+
+So a locked parent is classified by looking for a live descendant, not by its
+lease. If no non-terminal row references it, it is `unpaired_locked` — nothing
+is going to advance it. An unexpired lease is not evidence to the contrary,
+because nothing renews the lease once the checker is gone; that is why the
+stale-lease rule alone could not see this case.
+
+A descendant with an unknown or missing status counts as live, deliberately:
+assuming unclassifiable work has finished is the one error that loses jobs. It
+raises its own anomaly regardless.
+
+Pairing needs one extra projected attribute, `batch_job_id`, which costs
+nothing — see [Cost](#cost). The provider's own batch identifier is not
+projected; the in-table edge is all the pairing needs.
+
+### Duplicate observations
+
+A `Scan` has no snapshot isolation, so the same `job_id` can be returned more
+than once and in more than one state. Repeat observations of one job are merged
+conservatively — demand and anomalies OR together, ages take the maximum —
+rather than resolved by arrival order. Arrival order is not a state authority:
+a terminal row read before a pending row for the same job must not erase that
+job's demand. The result of an observation does not depend on the order rows
+came back in.
+
+No single scan, however complete, certifies that retirement is safe.
 
 ### Metrics
 
@@ -72,7 +106,11 @@ Two rules about absent samples:
   never publishes `WakeDemand=0`. A scan error must not be readable as an empty
   queue.
 - **Age gauges are omitted, not zeroed, when their set is empty.** Alarms built
-  on them must use `treatMissingData: notBreaching`.
+  on them must use `treatMissingData: notBreaching` — and note that this alone
+  does not immediately clear an alarm, since CloudWatch may still evaluate
+  older actual datapoints in the window. No automated action should key on an
+  omitted age alone; pair it with an explicit no-demand condition and with
+  fresh `ObserverHealthy` / `Errors` / missing-sample alarms.
 
 ### Which alarm detects a dead worker
 
@@ -163,11 +201,11 @@ At the measured table size (255 items, 1,134,230 bytes, PAY_PER_REQUEST) and a
 | Component | Basis | $/month |
 |---|---|---|
 | DynamoDB scans | 1.11 MB ÷ 8 KB ≈ **139 eventually-consistent read units** per scan × 43,200 = 6.0M RRU at $0.125/M | **0.75** |
-| CloudWatch custom metrics | 7 metrics on a quiet queue, up to 10 when the age gauges have samples, at $0.30 each | **2.10 – 3.00** |
+| CloudWatch custom metrics | 6 on a fully quiet queue (7 on today's table, which has locked rows), up to 10 when every age gauge has samples, at $0.30 each. Budget the full 10: a series published once can persist for the month. | **1.80 – 3.00** |
 | `PutMetricData` requests | 43,200 at $0.01 per 1,000 | **0.43** |
 | Lambda | 43,200 × 256 MB × ~1 s ≈ 10,800 GB-s (free tier usually absorbs this) | **0.00 – 0.19** |
 | CloudWatch Logs | ~13 MB ingest | **0.01** |
-| **Total** | | **≈ $3.30 – 4.40** |
+| **Total** | | **≈ $3.00 – 4.40** |
 
 Two things worth knowing about that DynamoDB line:
 
@@ -176,7 +214,8 @@ Two things worth knowing about that DynamoDB line:
   attributes limits what the observer can see but not what it pays. The
   projection is there because the observer has no business reading job payloads
   or `logs` blobs. Growth is bounded in bytes, from the reported consumed
-  capacity, for the same reason.
+  capacity, for the same reason — and adding an attribute to the projection,
+  as the parent/checker pairing does, costs nothing.
 - **Queue reads go down overall, not up.** Each running worker's poller today
   runs three fully paginated GSI queries *every 2 seconds*. One scan per minute
   is a small fraction of that.

--- a/docs/delphi-demand-observer.md
+++ b/docs/delphi-demand-observer.md
@@ -1,0 +1,197 @@
+# Delphi demand observer
+
+A scheduled Lambda that watches the Delphi job queue and publishes what it sees
+to CloudWatch. It is **observe-only**: it holds no Auto Scaling permission, it
+contains no capacity-mutation code, and it changes nothing about how the Delphi
+workers run today.
+
+It exists because CPU utilisation is not evidence that a worker can be
+terminated. Before the small Delphi pool can be allowed to scale to zero, we
+need a durable, measured answer to "is there outstanding work?" that survives a
+worker dying, a job being enqueued by another job rather than by an HTTP
+request, and rows that no status index can see. This Lambda produces that
+answer and nothing else.
+
+It is off by default. See [Enabling it](#enabling-it).
+
+## What it measures
+
+Every 60 seconds it runs one projected, fully paginated `Scan` of the
+`Delphi_JobQueue` DynamoDB table, classifies each row, and publishes gauges to
+the CloudWatch namespace **`Polis/DelphiQueue`**.
+
+The base table is scanned rather than the status GSI partitions on purpose. A
+`Query` against `StatusCreatedIndex` cannot return a row that has no `status`
+attribute, and the table currently holds exactly such rows. A scan sees them.
+
+### Row classification
+
+| Row state | Counts as demand? | Notes |
+|---|---|---|
+| `PENDING` | Yes | Waiting for a claim. |
+| `AWAITING_RECHECK` | Yes | The poller has no due-time scheduling, so a recheck row needs a worker now. |
+| `PROCESSING`, any lease age | Yes | Recovering a vanished owner needs a worker even before the 15-minute lease expires. |
+| `LOCKED_FOR_CHECKING` | No, by itself | A parent/checker coordination state, not a ready unit of compute. Counted and aged separately. |
+| `COMPLETED` / `FAILED` | No | Terminal. |
+| Missing or unknown `status`, malformed scheduling/ownership fields | No | Counted as an anomaly. Unknown work must inhibit retirement, never be inferred as absent. |
+
+Anomaly kinds, all of which contribute to `AnomalyRows`:
+
+- `missing_status` — no `status` attribute, or an empty one
+- `unknown_status` — a status the poller does not write
+- `missing_created_at` — nothing to age the row by
+- `malformed_timestamp` — a timestamp field that will not parse
+- `stale_locked` — `LOCKED_FOR_CHECKING` whose lease is absent or expired, i.e. no checker is paired with it
+- `malformed_ownership` — `PROCESSING` with no `worker_id` or no lease
+
+A row with several anomalies counts once towards `AnomalyRows`; the per-kind
+breakdown goes to the log line.
+
+### Metrics
+
+Namespace `Polis/DelphiQueue`. Fixed dimensions on every datum:
+`Environment`, `Queue`, `WorkerClass`. No job, conversation or report
+identifier is ever a dimension, a log field, or a metric.
+
+| Metric | Unit | Meaning |
+|---|---|---|
+| `ObserverHealthy` | None | 1 for a complete observation, 0 for a failed or budget-truncated one. |
+| `WakeDemand` | Count | Rows needing a worker now or on recovery. The number the wake decision will eventually read. |
+| `SecondsToNextEligible` | Seconds | 0 while there is demand. **Omitted** when there is none. |
+| `OldestPendingAgeSeconds` | Seconds | Age of the oldest actionable (`PENDING` / `AWAITING_RECHECK`) row. Omitted when there are none. |
+| `OldestProcessingHeartbeatAgeSeconds` | Seconds | Time since the newest progress mark (`updated_at`, else `started_at`) on any `PROCESSING` row. Omitted when there are none. |
+| `AnomalyRows` | Count | Rows failing at least one triage rule. |
+| `LockedForCheckingRows` | Count | `LOCKED_FOR_CHECKING` rows, valid ones included. |
+| `OldestLockedAgeSeconds` | Seconds | Age of the least recently checked locked row. Omitted when there are none. |
+| `RowsScanned` | Count | Distinct `job_id`s seen this pass. |
+| `ScanConsumedCapacityUnits` | Count | Billed read units the scan actually cost, for validating the cost model and the growth guard. |
+
+Two rules about absent samples:
+
+- **A failed observation publishes `ObserverHealthy=0` and nothing else.** It
+  never publishes `WakeDemand=0`. A scan error must not be readable as an empty
+  queue.
+- **Age gauges are omitted, not zeroed, when their set is empty.** Alarms built
+  on them must use `treatMissingData: notBreaching`.
+
+### Which alarm detects a dead worker
+
+`OldestProcessingHeartbeatAgeSeconds` is the **primary** crash detector, and it
+is the reason the metric exists.
+
+A worker that dies while holding a claimed row leaves that row in `PROCESSING`
+forever. `PROCESSING` counts as demand at any lease age, so `WakeDemand` stays
+at 1 permanently — which means the planned "instance is InService, protected,
+and `WakeDemand=0` for 20 minutes" alarm can *never* fire for precisely the
+crash it was written to catch. That ceiling is **secondary** coverage, useful
+only for a crash while idle. Watch the heartbeat age.
+
+Lambda `Throttles` are informational, not an error condition: with reserved
+concurrency 1, a duplicate scheduled delivery throttles by design and the next
+invocation simply reads current state. Alarm on `Errors` and on missing
+`ObserverHealthy` samples instead.
+
+No alarms are created by this change. The metrics come first so that thresholds
+can be set from observed behaviour rather than guessed.
+
+## Enabling it
+
+Everything is behind a CDK context flag that defaults to **false**. Absent, or
+anything other than the literal string `true`, means off.
+
+```bash
+cd cdk
+
+# Off (default): the synthesized template is byte-identical to one without
+# this feature at all.
+npx cdk synth
+
+# On: adds a Lambda, its log group, a dedicated role and policy, an
+# EventBridge rule and the rule's invoke permission. Nothing else changes.
+npx cdk synth -c enableDelphiDemandObserver=true
+
+# Always confirm the ASG is untouched before deploying.
+npx cdk diff -c enableDelphiDemandObserver=true
+```
+
+Configuration is by Lambda environment variable, all with working defaults:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DELPHI_QUEUE_TABLE` | `Delphi_JobQueue` | Table to scan. |
+| `POLIS_ENVIRONMENT` | `prod` | `Environment` metric dimension. |
+| `DELPHI_WORKER_CLASS` | `delphi-small` | `WorkerClass` metric dimension. |
+| `MAX_SCAN_BYTES` | 16 MiB | Pre-projection byte budget per invocation. |
+| `MAX_SCAN_PAGES` | 100 | Page budget per invocation. |
+| `SCAN_DEADLINE_SECONDS` | 30 | Wall-clock budget per invocation. |
+
+Exceeding any budget while pages remain fails the observation rather than
+truncating it: `ObserverHealthy=0`, no demand sample. If that starts happening,
+the table has outgrown a per-invocation full scan and needs a reviewed
+audit/cursor design — not a bigger budget.
+
+### Permissions
+
+The observer gets its own role. It is deliberately *not* the shared
+`instanceRole`, and it holds exactly three statements:
+
+```json
+{"Effect": "Allow", "Action": "dynamodb:Scan",
+ "Resource": "arn:aws:dynamodb:us-east-1:<account>:table/Delphi_JobQueue"}
+
+{"Effect": "Allow", "Action": "cloudwatch:PutMetricData", "Resource": "*",
+ "Condition": {"StringEquals": {"cloudwatch:namespace": "Polis/DelphiQueue"}}}
+
+{"Effect": "Allow", "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+ "Resource": "<its own log group>"}
+```
+
+`cloudwatch:PutMetricData` supports no resource-level permissions at all. The
+`Resource: "*"` is unavoidable and the `cloudwatch:namespace` condition key is
+the only thing that constrains it — written as a resource ARN the policy would
+simply never match, and written as a bare `*` it would grant the entire
+account's metric namespace.
+
+There is **no** `dynamodb:Query`, no write of any kind, no secrets access, no
+`autoscaling:*` and no attached AWS managed policy.
+
+## Cost
+
+At the measured table size (255 items, 1,134,230 bytes, PAY_PER_REQUEST) and a
+60-second schedule — 43,200 invocations per month:
+
+| Component | Basis | $/month |
+|---|---|---|
+| DynamoDB scans | 1.11 MB ÷ 8 KB ≈ **139 eventually-consistent read units** per scan × 43,200 = 6.0M RRU at $0.125/M | **0.75** |
+| CloudWatch custom metrics | 7 metrics on a quiet queue, up to 10 when the age gauges have samples, at $0.30 each | **2.10 – 3.00** |
+| `PutMetricData` requests | 43,200 at $0.01 per 1,000 | **0.43** |
+| Lambda | 43,200 × 256 MB × ~1 s ≈ 10,800 GB-s (free tier usually absorbs this) | **0.00 – 0.19** |
+| CloudWatch Logs | ~13 MB ingest | **0.01** |
+| **Total** | | **≈ $3.30 – 4.40** |
+
+Two things worth knowing about that DynamoDB line:
+
+- **The projection is a privacy control, not a cost control.** DynamoDB bills a
+  `Scan` on the *pre-projection* item size, so restricting the returned
+  attributes limits what the observer can see but not what it pays. The
+  projection is there because the observer has no business reading job payloads
+  or `logs` blobs. Growth is bounded in bytes, from the reported consumed
+  capacity, for the same reason.
+- **Queue reads go down overall, not up.** Each running worker's poller today
+  runs three fully paginated GSI queries *every 2 seconds*. One scan per minute
+  is a small fraction of that.
+
+## Source
+
+- Handler: `cdk/lambda/delphi-demand-observer/index.py`
+- Infrastructure: `cdk/delphiDemandObserver.ts`, role in `cdk/iamRoles.ts`
+- Tests: `cdk/test/python/test_delphi_demand_observer.py` (classification),
+  `cdk/test/delphi-demand-observer.test.ts` (template and IAM shape)
+
+Run them with:
+
+```bash
+cd cdk
+python3 -m unittest discover -s test/python   # no boto3 or AWS required
+npx jest
+```


### PR DESCRIPTION
Slice S1 of the Delphi scale-to-zero design (P-003, accepted after two review rounds): a scheduled Lambda that measures the Delphi job queue and publishes metrics to CloudWatch namespace `Polis/DelphiQueue`. It performs no scaling action, and a test fails if the module ever grows an autoscaling client.

Behind the CDK context flag `enableDelphiDemandObserver` (default off). With the flag off the synthesized template is byte-identical to `edge`, and `cdk diff` against the deployed stack reports no differences. With it on, six resources are added: the Lambda (Python 3.12, reserved concurrency 1), its log group, a dedicated role and policy (Scan on the one table ARN; `PutMetricData` constrained by the `cloudwatch:namespace` condition key; logs to its own group), a 1-minute EventBridge rule and its permission. All autoscaling resources are unchanged.

Metrics: `WakeDemand`, `SecondsToNextEligible`, `OldestPendingAgeSeconds`, `OldestProcessingHeartbeatAgeSeconds`, `AnomalyRows`, `LockedForCheckingRows`, `OldestLockedAgeSeconds`, `RowsScanned`, `ScanConsumedCapacityUnits`, `ObserverHealthy`. A failed or truncated scan publishes `ObserverHealthy=0` and no demand sample.

Tests: 40 Python unit tests (including a reconstruction of the measured table shape: 5 anomaly rows, 3 stale locked rows, demand 0) and 13 jest tests for the construct. Cost with the flag on: about $3.30–4.40/month, dominated by custom metrics.

Not in this slice, stated in the docs: no GSI-vs-scan disagreement check (scan is a superset at this scale); no launch-suppression metric (needs an autoscaling read the role deliberately lacks; that arrives with S2); age gauges are omitted rather than zeroed when the queue is empty, so alarms should treat missing data as not breaching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s