### PR TITLE
feat: Postgres job-queue substrate, first slice (noop-only, flag-gated) (P-024)

### DIFF
--- a/delphi/polismath/queue/__init__.py
+++ b/delphi/polismath/queue/__init__.py
@@ -1,0 +1,11 @@
+"""Transitional polis-queue/1 executor for the P-024 Postgres queue substrate.
+
+Separate from ``polismath.poller`` and from ``scripts/job_poller.py`` on purpose:
+nothing in either of those imports this package, and nothing here imports them,
+so rolling this back is stopping a process.
+
+Note on the package name: this is ``polismath.queue``, not the standard library's
+``queue``. Python 3 resolves ``import queue`` inside ``polismath`` to the standard
+library, so ``polismath.poller.worker_pool`` is unaffected; refer to this package
+by its full dotted path.
+"""

--- a/delphi/polismath/queue/executor.py
+++ b/delphi/polismath/queue/executor.py
@@ -1,0 +1,475 @@
+"""Standalone transitional executor for polis-queue/1 synthetic ``noop`` jobs.
+
+P-024 first slice. Claims a job with ``pq_claim``, renews its lease with
+``pq_heartbeat``, and finalizes with ``pq_finalize``; reserves one bounded
+reaper opportunity per cycle through ``pq_due`` plus one committed
+``pq_reap_one`` per job. Nothing else.
+
+Boundaries this module keeps, all of them deliberate:
+
+* It touches neither existing poller. ``polismath.poller`` and
+  ``scripts/job_poller.py`` neither import this nor are imported by it, so
+  rollback is stopping a process.
+* The stage is ``noop`` and its output is exactly its fixed synthetic input
+  descriptor. It never follows the input URI, reads a file named by a job,
+  starts a child process, loads science code or calls a provider. A job whose
+  descriptor is not the expected synthetic one is failed permanently rather
+  than executed.
+* It refuses to run on a broad database login. The connection must be a member
+  of ``polis_queue_executor`` and must NOT hold a direct write on the queue
+  tables, so the migration's grant boundary is what constrains it.
+* One active job and one connection at a time. Every RPC opens and commits its
+  own short transaction, including the reaper's per-job mutations.
+* The set of statements it can issue is a closed inventory with fixed argument
+  casts. Values are always bound, never interpolated.
+
+Not claimed: the Rust adapter, gates A1-A8, a severed-COMMIT certificate, or a
+recovery certificate. The reaper cursor lives in memory, so a restart begins a
+pass again, which is safe because every mutation rechecks current state.
+
+Run it directly; see docs/queue-substrate.md.
+"""
+
+import argparse
+import hashlib
+import logging
+import os
+import re
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import psycopg2
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "polis-queue/1"
+
+#: SHA-256 of ``server/postgres/migrations/000019_create_polis_queue.sql`` as
+#: this adapter was written against it. Round 4 requires both adapters to pin
+#: the SQL so that neither is silently upgraded by a schema change; the Node
+#: adapter pins the same value in ``server/src/queue/protocol.ts``. This pins
+#: the repository file, and is not runtime attestation about the live catalog.
+QUEUE_SQL_SHA256 = "e8ad0d3212809b1da92e9ab2f4d24930101e2de4507b095cf953746a341fcce9"
+
+#: The fixed synthetic input descriptor of the /1 noop stage. The enqueuer pins
+#: it and this executor refuses anything else.
+NOOP_URI = "synthetic:polis-queue-noop/1"
+NOOP_SHA256 = hashlib.sha256(b"polis-queue-noop/1\n").hexdigest()
+NOOP_IMAGE = "synthetic-noop/1"
+
+#: Repeating weighted lane slots. 0 is most urgent; the cycle guarantees lane 2
+#: is visited at least once every six claim opportunities.
+LANES: Tuple[int, ...] = (0, 0, 0, 1, 1, 2)
+
+#: Closed field set of an ordinary reply.
+ORDINARY_FIELDS = frozenset(
+    "schema_version outcome env job_id run_id attempt_id owner_id lease_epoch "
+    "version mgmt_version locked_until state output_sha256 published stage "
+    "stage_instance attempt_count max_attempts parked_attempt_count eligible_at "
+    "first_parked_at last_error_code input".split()
+)
+INPUT_FIELDS = frozenset(("uri", "sha256", "config_sha256", "code_image_digest"))
+
+#: Closed field set of the separate head-status envelope.
+HEAD_STATUS_FIELDS = frozenset(
+    "schema_version outcome env product_key found desired_run_id desired_state "
+    "published_run_id published_generation published_sha256".split()
+)
+
+#: Closed statement inventory with fixed casts. There is no path to arbitrary
+#: SQL: a name outside this mapping raises before any connection is opened.
+RPC: Dict[str, Tuple[str, ...]] = {
+    "pq_claim": ("text", "smallint", "uuid", "uuid", "integer"),
+    "pq_heartbeat": ("text", "uuid", "uuid", "uuid", "bigint", "integer"),
+    "pq_finalize": ("text", "uuid", "uuid", "uuid", "bigint", "text", "text"),
+    "pq_fail": ("text", "uuid", "uuid", "uuid", "bigint", "boolean", "text"),
+    "pq_release": ("text", "uuid", "uuid", "uuid", "bigint"),
+    "pq_park": ("text", "uuid", "uuid", "uuid", "bigint", "text"),
+    "pq_job_status": ("text", "uuid"),
+    "pq_head_status": ("text", "text"),
+    "pq_due": ("text", "uuid", "integer"),
+    "pq_reap_one": ("text", "uuid"),
+}
+
+#: Transient SQLSTATEs the design document admits for a bounded retry.
+RETRYABLE_SQLSTATES = frozenset(("40001", "40P01", "55P03", "57014"))
+MAX_RETRIES = 3
+
+#: dev or test, optionally suffixed for per-run isolation in tests.
+_ENV_NAMESPACE = re.compile(r"^(dev|test)(-[a-z0-9][a-z0-9-]{0,48})?$")
+_TRUTHY = frozenset(("true", "1", "yes", "on"))
+
+_SESSION_POLICY = (
+    "SET LOCAL TIME ZONE 'UTC';"
+    " SET LOCAL lock_timeout='500ms';"
+    " SET LOCAL statement_timeout='5s';"
+    " SET LOCAL idle_in_transaction_session_timeout='5s';"
+    " SELECT set_config('transaction_timeout','10s',true)"
+    " WHERE current_setting('server_version_num')::int >= 170000"
+)
+
+_BOUNDARY_SQL = (
+    "SELECT pg_has_role(current_user,'polis_queue_executor','MEMBER'),"
+    " has_table_privilege(current_user,'public.polis_queue_jobs','UPDATE')"
+)
+
+
+class ProtocolError(ValueError):
+    """A reply that is not an ordinary polis-queue/1 result."""
+
+
+class ExecutorRefused(RuntimeError):
+    """A precondition that must never be worked around at runtime."""
+
+
+class CommitOutcomeUnknown(RuntimeError):
+    """A COMMIT that did not report success.
+
+    The transaction may or may not be durable. Keep the SELECT's reply so the
+    caller can reconcile the identity it already holds; never infer a rollback.
+    """
+
+    def __init__(self, reply: Any):
+        super().__init__("queue_commit_outcome_unknown")
+        self.reply = reply
+
+
+def validate(reply: Any) -> Dict[str, Any]:
+    """Reject a reply that is not an ordinary polis-queue/1 result.
+
+    Missing and unknown fields both fail: the field set is frozen by the
+    migration, not by the version string.
+    """
+    if not isinstance(reply, dict) or set(reply) != ORDINARY_FIELDS:
+        raise ProtocolError("queue_wire_fields")
+    if reply["schema_version"] != SCHEMA_VERSION:
+        raise ProtocolError("queue_wire_version")
+    if type(reply["published"]) is not bool:
+        raise ProtocolError("queue_wire_published")
+    for key in ("lease_epoch", "version", "mgmt_version"):
+        value = reply[key]
+        if value is not None and (
+            not isinstance(value, str) or re.fullmatch(r"[0-9]+", value) is None
+        ):
+            raise ProtocolError("queue_wire_counter")
+    for key in ("attempt_count", "max_attempts", "parked_attempt_count"):
+        value = reply[key]
+        if value is not None and (
+            type(value) is not int or not 0 <= value <= 2147483647
+        ):
+            raise ProtocolError("queue_wire_count")
+    for key in ("locked_until", "eligible_at", "first_parked_at"):
+        value = reply[key]
+        if value is not None and (
+            not isinstance(value, str) or not value.endswith("+00:00")
+        ):
+            raise ProtocolError("queue_wire_timestamp")
+    for key in (
+        "env",
+        "job_id",
+        "run_id",
+        "attempt_id",
+        "owner_id",
+        "state",
+        "output_sha256",
+        "stage",
+        "stage_instance",
+        "last_error_code",
+        "outcome",
+    ):
+        if reply[key] is not None and not isinstance(reply[key], str):
+            raise ProtocolError("queue_wire_text")
+    descriptor = reply["input"]
+    if descriptor is not None and (
+        not isinstance(descriptor, dict)
+        or set(descriptor) != INPUT_FIELDS
+        or not all(isinstance(v, str) for v in descriptor.values())
+    ):
+        raise ProtocolError("queue_wire_input")
+    return reply
+
+
+def validate_head_status(reply: Any) -> Dict[str, Any]:
+    """Reject a reply that is not the closed pq_head_status envelope."""
+    if not isinstance(reply, dict) or set(reply) != HEAD_STATUS_FIELDS:
+        raise ProtocolError("queue_wire_head_fields")
+    if reply["schema_version"] != SCHEMA_VERSION or reply["outcome"] != "head_status":
+        raise ProtocolError("queue_wire_head_version")
+    if type(reply["found"]) is not bool:
+        raise ProtocolError("queue_wire_head_found")
+    generation = reply["published_generation"]
+    if generation is not None and (
+        not isinstance(generation, str) or re.fullmatch(r"[0-9]+", generation) is None
+    ):
+        raise ProtocolError("queue_wire_head_generation")
+    return reply
+
+
+def _enabled() -> bool:
+    if os.environ.get("NODE_ENV") == "production":
+        return False
+    return os.environ.get("POLIS_QUEUE_SUBSTRATE_ENABLED", "").lower() in _TRUTHY
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Connection and environment settings for one executor process.
+
+    ``dsn`` must name a login that is a member of ``polis_queue_executor``; the
+    boundary is verified on every connection, not only at startup.
+    """
+
+    dsn: str
+    env: str
+    connect_timeout: int = 5
+
+    def check(self) -> None:
+        if not _enabled():
+            raise ExecutorRefused(
+                "queue_noop_disabled: set POLIS_QUEUE_SUBSTRATE_ENABLED outside production"
+            )
+        if _ENV_NAMESPACE.fullmatch(self.env) is None:
+            raise ExecutorRefused("queue_noop_environment")
+        if not self.dsn:
+            raise ExecutorRefused("queue_noop_dsn")
+
+
+class Database:
+    """One short transaction per call, on its own connection.
+
+    A connection is never pooled or reused across calls: a session whose
+    transaction outcome is uncertain must not be handed to the next statement.
+    """
+
+    def __init__(self, settings: Settings):
+        settings.check()
+        self.settings = settings
+
+    def call(self, name: str, args: List[Any]) -> Any:
+        casts = RPC[name]  # KeyError here is a programming error, not input
+        if len(args) != len(casts):
+            raise ValueError("queue_rpc_arity")
+        placeholders = ",".join("%s::" + cast for cast in casts)
+        statement = (
+            "SELECT "
+            + ("job_id FROM " if name == "pq_due" else "")
+            + "public."
+            + name
+            + "("
+            + placeholders
+            + ")"
+        )
+        conn = psycopg2.connect(
+            self.settings.dsn,
+            connect_timeout=self.settings.connect_timeout,
+            application_name="polis-queue-noop/1",
+        )
+        try:
+            conn.set_session(isolation_level="READ COMMITTED")
+            with conn.cursor() as cur:
+                cur.execute(_SESSION_POLICY)
+                cur.execute(_BOUNDARY_SQL)
+                member, direct_write = cur.fetchone()
+                if not member or direct_write:
+                    raise ExecutorRefused(
+                        "queue_noop_requires_restricted_executor_login"
+                    )
+                cur.execute(statement, args)
+                if name == "pq_due":
+                    reply: Any = [str(row[0]) for row in cur.fetchall()]
+                else:
+                    reply = cur.fetchone()[0]
+                    if reply is None:
+                        # Only pq_reap_one is specified to return SQL NULL.
+                        if name != "pq_reap_one":
+                            raise ProtocolError("queue_unexpected_null_reply")
+                    elif name == "pq_head_status":
+                        validate_head_status(reply)
+                    else:
+                        validate(reply)
+            try:
+                conn.commit()
+            except psycopg2.Error as exc:
+                raise CommitOutcomeUnknown(reply) from exc
+            return reply
+        finally:
+            conn.close()
+
+
+class Executor:
+    """One executor process: at most one active job, one connection at a time."""
+
+    def __init__(
+        self,
+        database: Database,
+        env: str,
+        sleep: Callable[[float], None] = time.sleep,
+        lease_seconds: int = 60,
+    ):
+        if _ENV_NAMESPACE.fullmatch(env) is None:
+            raise ExecutorRefused("queue_noop_environment")
+        self.db = database
+        self.env = env
+        self.sleep = sleep
+        self.lease_seconds = lease_seconds
+        self.owner = str(uuid.uuid4())
+        self.slot = 0
+        self.after_job: Optional[str] = None
+
+    def call(self, name: str, args: List[Any], reconcile: bool = True) -> Any:
+        """Call one RPC, retrying a bounded number of transient failures.
+
+        The retry always repeats the SAME identity. ``reconcile=False`` is for
+        pq_claim, whose uncertain COMMIT must never be repeated: see run_once.
+        """
+        for retry in range(MAX_RETRIES + 1):
+            try:
+                return self.db.call(name, args)
+            except CommitOutcomeUnknown:
+                if not reconcile or retry == MAX_RETRIES:
+                    raise
+            except psycopg2.Error as exc:
+                if exc.pgcode not in RETRYABLE_SQLSTATES or retry == MAX_RETRIES:
+                    raise
+            self.sleep(
+                min(300, 5 * 2**retry) + uuid.UUID(self.owner).bytes[-1] % 5
+            )
+        raise AssertionError("unreachable")
+
+    def token(self, job: Dict[str, Any]) -> List[Any]:
+        """The active token: (env, job, owner, attempt, lease_epoch)."""
+        return [
+            self.env,
+            job["job_id"],
+            self.owner,
+            job["attempt_id"],
+            job["lease_epoch"],
+        ]
+
+    def reap_page(self) -> int:
+        """One bounded reaper pass: discovery commits, then one tx per job."""
+        ids = self.call("pq_due", [self.env, self.after_job, 100])
+        for job_id in ids:
+            self.call("pq_reap_one", [self.env, job_id])
+        # Persist the cursor only after the page is handled, and reset it on a
+        # short page so a following empty page starts the next pass over.
+        self.after_job = ids[-1] if len(ids) == 100 else None
+        return len(ids)
+
+    def run_once(self) -> str:
+        """Reserve maintenance, then claim and complete at most one job."""
+        self.reap_page()
+        preferred = LANES[self.slot]
+        self.slot = (self.slot + 1) % len(LANES)
+        lanes = [preferred] + [lane for lane in range(3) if lane != preferred]
+        for priority in lanes:
+            attempt = str(uuid.uuid4())
+            try:
+                job = self.call(
+                    "pq_claim",
+                    [self.env, priority, self.owner, attempt, self.lease_seconds],
+                    reconcile=False,
+                )
+            except CommitOutcomeUnknown as exc:
+                # Never repeat pq_claim: its first COMMIT may already have taken
+                # ownership of a job, and a second claim would take a second one
+                # while the first lease runs unattended. Renew the exact token
+                # the uncertain reply named instead, on a fresh connection.
+                job = validate(exc.reply)
+                if job["outcome"] != "owned":
+                    raise
+                job = self.call("pq_heartbeat", self.token(job) + [self.lease_seconds])
+                if job["outcome"] != "owned":
+                    return str(job["outcome"])
+            if job["outcome"] == "none":
+                continue
+            if job["outcome"] == "fenced":
+                return "fenced"
+            if (
+                job["outcome"] != "owned"
+                or job["env"] != self.env
+                or job["owner_id"] != self.owner
+            ):
+                raise ProtocolError("queue_claim_identity")
+            return self._execute(job)
+        return "none"
+
+    def _execute(self, job: Dict[str, Any]) -> str:
+        expected = {
+            "uri": NOOP_URI,
+            "sha256": NOOP_SHA256,
+            "config_sha256": NOOP_SHA256,
+            "code_image_digest": NOOP_IMAGE,
+        }
+        if (
+            job["stage"] != "noop"
+            or job["stage_instance"] is not None
+            or job["input"] != expected
+        ):
+            # Refuse rather than execute: this executor admits exactly one
+            # synthetic descriptor and never dereferences a job-supplied URI.
+            return str(
+                self.call(
+                    "pq_fail",
+                    self.token(job) + [True, "invalid_synthetic_descriptor"],
+                )["outcome"]
+            )
+        renewed = self.call("pq_heartbeat", self.token(job) + [self.lease_seconds])
+        if renewed["outcome"] == "fenced":
+            return "fenced"
+        if renewed["outcome"] != "owned":
+            raise ProtocolError("queue_renewal_outcome")
+        # The noop stage's output is exactly its fixed input. No long work, no
+        # child process, no network call is performed while holding this lease.
+        result = self.call(
+            "pq_finalize", self.token(job) + [NOOP_URI, NOOP_SHA256]
+        )
+        outcome = str(result["outcome"])
+        if outcome not in {"succeeded", "already_succeeded", "fenced", "invalid_output"}:
+            raise ProtocolError("queue_finalize_outcome")
+        if outcome in {"succeeded", "already_succeeded"} and (
+            result["job_id"] != job["job_id"]
+            or result["attempt_id"] != job["attempt_id"]
+            or result["output_sha256"] != NOOP_SHA256
+        ):
+            # Success must match identity AND content, not merely a succeeded
+            # state: another attempt's success cannot be borrowed.
+            raise ProtocolError("queue_finalize_identity")
+        return outcome
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="polis-queue/1 noop executor")
+    parser.add_argument(
+        "--dsn",
+        required=True,
+        help="libpq DSN for a login that is a member of polis_queue_executor",
+    )
+    parser.add_argument("--env", required=True, help="queue env namespace: dev or test")
+    parser.add_argument(
+        "--once", action="store_true", help="run one cycle and exit"
+    )
+    parser.add_argument("--interval", type=float, default=1.0)
+    args = parser.parse_args(argv)
+    try:
+        executor = Executor(Database(Settings(args.dsn, args.env)), args.env)
+        while True:
+            outcome = executor.run_once()
+            print(outcome, flush=True)
+            if args.once:
+                return 0 if outcome in {"succeeded", "already_succeeded", "none"} else 3
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        # No external effect is in flight; a mid-attempt interrupt leaves its
+        # lease to expire and be reaped.
+        return 0
+    except Exception as exc:  # noqa: BLE001 - never echo DSN or bound values
+        print(f"queue_noop_error:{type(exc).__name__}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/delphi/polismath/queue/executor.py
+++ b/delphi/polismath/queue/executor.py
@@ -15,9 +15,13 @@ Boundaries this module keeps, all of them deliberate:
   starts a child process, loads science code or calls a provider. A job whose
   descriptor is not the expected synthetic one is failed permanently rather
   than executed.
-* It refuses to run on a broad database login. The connection must be a member
-  of ``polis_queue_executor`` and must NOT hold a direct write on the queue
-  tables, so the migration's grant boundary is what constrains it.
+* It refuses to run on a broad database login. Every connection asserts
+  membership in ``polis_queue_executor``, the absence of ANY table-level or
+  column-level privilege on all five queue tables, and the inability to reach
+  ``polis_queue_owner`` by inheritance or SET ROLE. One denied UPDATE on one
+  table would not be proof of the boundary: executor membership plus UPDATE on
+  ``polis_queue_heads`` would pass that and still move a published pointer
+  behind the functions' backs.
 * One active job and one connection at a time. Every RPC opens and commits its
   own short transaction, including the reaper's per-job mutations.
 * The set of statements it can issue is a closed inventory with fixed argument
@@ -52,7 +56,7 @@ SCHEMA_VERSION = "polis-queue/1"
 #: the SQL so that neither is silently upgraded by a schema change; the Node
 #: adapter pins the same value in ``server/src/queue/protocol.ts``. This pins
 #: the repository file, and is not runtime attestation about the live catalog.
-QUEUE_SQL_SHA256 = "e8ad0d3212809b1da92e9ab2f4d24930101e2de4507b095cf953746a341fcce9"
+QUEUE_SQL_SHA256 = "c229a7fb41dbc86a5a5ae637772f70ebfbb469cfc52f8e40a61303c82b428617"
 
 #: The fixed synthetic input descriptor of the /1 noop stage. The enqueuer pins
 #: it and this executor refuses anything else.
@@ -111,9 +115,32 @@ _SESSION_POLICY = (
     " WHERE current_setting('server_version_num')::int >= 170000"
 )
 
+#: Every table the executor must reach only through the granted RPCs.
+QUEUE_TABLES = (
+    "public.polis_queue_runs",
+    "public.polis_queue_heads",
+    "public.polis_queue_jobs",
+    "public.polis_queue_attempts",
+    "public.polis_queue_requests",
+)
+
+#: The admission gate, re-checked on every connection. A single denied UPDATE on
+#: one table is not proof of the grant boundary: a login with executor
+#: membership plus UPDATE on polis_queue_heads would pass that and still be able
+#: to move a published pointer behind the functions' backs. So this asks, for
+#: each of the five tables, whether the login holds ANY table-level or
+#: column-level privilege, and separately whether it can reach polis_queue_owner
+#: by inheritance or SET ROLE, which would hand it everything anyway.
 _BOUNDARY_SQL = (
-    "SELECT pg_has_role(current_user,'polis_queue_executor','MEMBER'),"
-    " has_table_privilege(current_user,'public.polis_queue_jobs','UPDATE')"
+    "SELECT pg_has_role(current_user,'polis_queue_executor','MEMBER') AS member,"
+    " (SELECT COALESCE(bool_or("
+    "   has_table_privilege(current_user,t,"
+    "     'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')"
+    "   OR has_any_column_privilege(current_user,t,"
+    "     'SELECT,INSERT,UPDATE,REFERENCES')),false)"
+    "  FROM unnest(%s::text[]) t) AS direct_access,"
+    " pg_has_role(current_user,'polis_queue_owner','USAGE')"
+    "  OR pg_has_role(current_user,'polis_queue_owner','MEMBER') AS owner_escape"
 )
 
 
@@ -271,12 +298,14 @@ class Database:
             conn.set_session(isolation_level="READ COMMITTED")
             with conn.cursor() as cur:
                 cur.execute(_SESSION_POLICY)
-                cur.execute(_BOUNDARY_SQL)
-                member, direct_write = cur.fetchone()
-                if not member or direct_write:
-                    raise ExecutorRefused(
-                        "queue_noop_requires_restricted_executor_login"
-                    )
+                cur.execute(_BOUNDARY_SQL, [list(QUEUE_TABLES)])
+                member, direct_access, owner_escape = cur.fetchone()
+                if not member:
+                    raise ExecutorRefused("queue_noop_requires_executor_membership")
+                if direct_access:
+                    raise ExecutorRefused("queue_noop_login_has_direct_table_access")
+                if owner_escape:
+                    raise ExecutorRefused("queue_noop_login_can_become_queue_owner")
                 cur.execute(statement, args)
                 if name == "pq_due":
                     reply: Any = [str(row[0]) for row in cur.fetchall()]
@@ -378,9 +407,12 @@ class Executor:
                 # ownership of a job, and a second claim would take a second one
                 # while the first lease runs unattended. Renew the exact token
                 # the uncertain reply named instead, on a fresh connection.
+                # The identity of that reply is checked BEFORE it is used as a
+                # token, not after.
                 job = validate(exc.reply)
                 if job["outcome"] != "owned":
                     raise
+                self._assert_claim_identity(job, attempt)
                 job = self.call("pq_heartbeat", self.token(job) + [self.lease_seconds])
                 if job["outcome"] != "owned":
                     return str(job["outcome"])
@@ -388,14 +420,25 @@ class Executor:
                 continue
             if job["outcome"] == "fenced":
                 return "fenced"
-            if (
-                job["outcome"] != "owned"
-                or job["env"] != self.env
-                or job["owner_id"] != self.owner
-            ):
-                raise ProtocolError("queue_claim_identity")
+            self._assert_claim_identity(job, attempt)
             return self._execute(job)
         return "none"
+
+    def _assert_claim_identity(self, job: Dict[str, Any], attempt: str) -> None:
+        """The reply must name the token this process asked for.
+
+        The attempt UUID is minted here and is half of the fence, so a reply
+        carrying a different one is not this claim's job and its token must not
+        be used. Comparing the finalize reply against an already-wrong claim
+        reply is not equivalent: the two would simply agree with each other.
+        """
+        if (
+            job["outcome"] != "owned"
+            or job["env"] != self.env
+            or job["owner_id"] != self.owner
+            or job["attempt_id"] != attempt
+        ):
+            raise ProtocolError("queue_claim_identity")
 
     def _execute(self, job: Dict[str, Any]) -> str:
         expected = {

--- a/delphi/tests/test_queue_noop_executor.py
+++ b/delphi/tests/test_queue_noop_executor.py
@@ -14,8 +14,10 @@ hands us) is only used to apply the migration and to act as the producer.
 Not claimed: gates A1-A8. No COMMIT is severed here and no Rust adapter exists.
 """
 
+import contextlib
 import os
 import re
+import sys
 import uuid
 
 import pytest
@@ -118,35 +120,81 @@ def _executor_dsn(url: str, user: str, password: str) -> str:
     return re.sub(r"^(postgres(?:ql)?://)[^@]*@", rf"\1{user}:{password}@", url)
 
 
-@pytest.fixture(scope="module")
-def queue_db():
-    """A Postgres with the queue migration applied, plus a restricted login.
+def _release(conn, created):
+    """Drop only what this fixture actually created, and never raise.
 
-    The configured test database may be shared with other runs, so teardown
-    removes ONLY this fixture's own env namespace, its own conversation and its
-    own role, and runs in ``finally`` so a partially completed setup still
-    cleans up after itself. A wildcard over the ``ENV`` prefix would delete a
-    concurrent run's rows.
+    R1: cleanup used to run unconditionally, so a setup that skipped before
+    creating anything still issued DELETEs. On a login without CREATEROLE -
+    the case the skip exists for - those DELETEs raise InsufficientPrivilege
+    from inside `finally`, and that error replaces the intentional
+    `pytest.skip`, turning a supported situation into an error. The same shape
+    hides a failure that happens before the migration creates the tables.
+
+    So each step is guarded by the flag set after its create succeeded, and a
+    cleanup failure is collected rather than thrown from a `finally` that may
+    be unwinding something more important.
+    """
+    failures = []
+
+    def step(label, statement, args=()):
+        try:
+            with conn.cursor() as cur:
+                cur.execute(statement, args or None)
+        except Exception as exc:  # noqa: BLE001 - cleanup must not mask
+            failures.append(f"{label}: {exc}")
+
+    if created["migration"]:
+        for table in (
+            "polis_queue_requests",
+            "polis_queue_attempts",
+            "polis_queue_jobs",
+            "polis_queue_heads",
+            "polis_queue_runs",
+        ):
+            # Exact namespace only: never a LIKE over the shared prefix.
+            step(
+                f"delete {table}",
+                f"DELETE FROM public.{table} WHERE env = %s",
+                (created["env"],),
+            )
+    if created["zid"] is not None:
+        step(
+            "delete conversation",
+            "DELETE FROM conversations WHERE zid = %s",
+            (created["zid"],),
+        )
+    if created["role"] is not None:
+        step("drop owned", f"DROP OWNED BY {created['role']}")
+        step("drop role", f"DROP ROLE IF EXISTS {created['role']}")
+    return failures
+
+
+def _provision_queue_db():
+    """Generator behind the `queue_db` fixture, so the tests can drive it.
+
+    Yields once. Everything it creates is recorded as it is created, and only
+    those things are released; a prerequisite skip or a mid-setup failure
+    reaches the caller intact.
     """
     import psycopg2
 
-    if MIGRATION is None:
-        # Same packaging fact as the SQL pin: no checkout, no migration to
-        # apply. Skip before taking a connection or starting a container.
-        pytest.skip(
-            "no polis checkout above these tests and POLIS_MIGRATIONS_DIR is "
-            "unset, so server/postgres/migrations/000019_create_polis_queue.sql "
-            "cannot be read; run from a checkout or set POLIS_MIGRATIONS_DIR"
-        )
+    # An explicit POLIS_MIGRATIONS_DIR that does not resolve is operator error
+    # and fails here too, exactly as it does for the SQL pin; only the
+    # no-checkout case skips.
+    migration_path = require_migration()
 
     with require_polis_postgres() as url:
         suffix = uuid.uuid4().hex[:8]
         role = f"pq_x_{suffix}"
-        env = f"{ENV}-{suffix}"
-        zid = None
-        role_created = False
+        created = {
+            "env": f"{ENV}-{suffix}",
+            "role": None,
+            "zid": None,
+            "migration": False,
+        }
         conn = psycopg2.connect(url)
         conn.autocommit = True
+        clean_exit = False
         try:
             with conn.cursor() as cur:
                 cur.execute(
@@ -159,48 +207,48 @@ def queue_db():
                     "the test Postgres login can neither create roles nor apply "
                     "the queue migration; provide a superuser or CREATEROLE login"
                 )
-            with open(MIGRATION, "r", encoding="utf-8") as handle:
+            with open(migration_path, "r", encoding="utf-8") as handle:
                 migration_sql = handle.read()
             with conn.cursor() as cur:
                 cur.execute(migration_sql)
+                created["migration"] = True
                 cur.execute(
                     f"CREATE ROLE {role} LOGIN NOSUPERUSER NOCREATEROLE "
                     f"PASSWORD '{LOCAL_ROLE_PASSWORD}' IN ROLE polis_queue_executor"
                 )
-                role_created = True
+                created["role"] = role
                 cur.execute(
                     "INSERT INTO conversations (topic) VALUES (%s) RETURNING zid",
                     (f"p024 queue noop {suffix}",),
                 )
-                zid = cur.fetchone()[0]
+                created["zid"] = cur.fetchone()[0]
             yield {
                 "url": url,
-                "zid": zid,
-                "env": env,
+                "zid": created["zid"],
+                "env": created["env"],
                 "executor_dsn": _executor_dsn(url, role, LOCAL_ROLE_PASSWORD),
                 "role": role,
             }
+            clean_exit = True
         finally:
-            try:
-                with conn.cursor() as cur:
-                    for table in (
-                        "polis_queue_requests",
-                        "polis_queue_attempts",
-                        "polis_queue_jobs",
-                        "polis_queue_heads",
-                        "polis_queue_runs",
-                    ):
-                        # Exact namespace only: never a LIKE over the prefix.
-                        cur.execute(
-                            f"DELETE FROM public.{table} WHERE env = %s", (env,)
-                        )
-                    if zid is not None:
-                        cur.execute("DELETE FROM conversations WHERE zid=%s", (zid,))
-                    if role_created:
-                        cur.execute(f"DROP OWNED BY {role}")
-                        cur.execute(f"DROP ROLE IF EXISTS {role}")
-            finally:
-                conn.close()
+            failures = _release(conn, created)
+            conn.close()
+            # Only surface a cleanup problem when nothing else is in flight.
+            if failures and clean_exit:
+                raise RuntimeError(
+                    "queue fixture cleanup failed: " + "; ".join(failures)
+                )
+
+
+@pytest.fixture(scope="module")
+def queue_db():
+    """A Postgres with the queue migration applied, plus a restricted login.
+
+    The configured test database may be shared with other runs, so teardown
+    removes only this fixture's own env namespace, its own conversation and its
+    own role.
+    """
+    yield from _provision_queue_db()
 
 
 @pytest.fixture(autouse=True)
@@ -224,7 +272,15 @@ def _admin(queue_db, statement, args=()):
 
 
 def _enqueue(
-    queue_db, key, *, uri=None, sha=None, image=None, max_attempts=3, priority=1
+    queue_db,
+    key,
+    *,
+    uri=None,
+    sha=None,
+    image=None,
+    max_attempts=3,
+    priority=1,
+    env=None,
 ):
     """Produce one job as the provisioning login, mirroring the Node adapter."""
     import psycopg2
@@ -240,7 +296,7 @@ def _enqueue(
                 "%s::text,%s::uuid,%s::uuid,%s::text,%s::text,%s::text,%s::text,"
                 "%s::smallint,%s::integer)",
                 [
-                    queue_db["env"],
+                    env or queue_db["env"],
                     queue_db["zid"],
                     PRODUCT,
                     ACTOR,
@@ -641,3 +697,127 @@ def test_reaper_pages_101_parked_jobs_and_resets_its_cursor(queue_db):
     assert executor.reap_page() == 1
     assert executor.after_job is None
     assert executor.reap_page() == 0
+
+
+def _use_provider(monkeypatch, dsn):
+    """Point the fixture's prerequisite discovery at one explicit DSN."""
+
+    @contextlib.contextmanager
+    def provider():
+        yield dsn
+
+    monkeypatch.setattr(sys.modules[__name__], "require_polis_postgres", provider)
+
+
+def test_an_unprivileged_login_skips_rather_than_erroring(queue_db, monkeypatch):
+    """R1: the intentional prerequisite skip must survive teardown.
+
+    A login without CREATEROLE cannot apply the migration, which is exactly why
+    the fixture skips. Cleanup that runs regardless raises InsufficientPrivilege
+    from the `finally` and replaces that skip with an error.
+    """
+    limited = f"pq_lim_{uuid.uuid4().hex[:8]}"
+    _admin(
+        queue_db,
+        f"CREATE ROLE {limited} LOGIN NOSUPERUSER NOCREATEROLE "
+        f"PASSWORD '{LOCAL_ROLE_PASSWORD}' IN ROLE polis_queue_executor",
+    )
+    try:
+        _use_provider(
+            monkeypatch, _executor_dsn(queue_db["url"], limited, LOCAL_ROLE_PASSWORD)
+        )
+        with pytest.raises(pytest.skip.Exception):
+            next(_provision_queue_db())
+    finally:
+        _admin(queue_db, f"DROP OWNED BY {limited}")
+        _admin(queue_db, f"DROP ROLE IF EXISTS {limited}")
+
+
+def test_teardown_removes_its_own_namespace_and_leaves_a_sibling(queue_db, monkeypatch):
+    sibling = f"{ENV}-sibling-{uuid.uuid4().hex[:8]}"
+
+    def rows(env):
+        return _admin(
+            queue_db,
+            "SELECT count(*) FROM public.polis_queue_jobs WHERE env = %s",
+            (env,),
+        )[0][0]
+
+    assert _enqueue(queue_db, "sibling", env=sibling)["outcome"] == "enqueued"
+    assert rows(sibling) == 1
+    try:
+        _use_provider(monkeypatch, queue_db["url"])
+        generator = _provision_queue_db()
+        inner = next(generator)
+        assert _enqueue(inner, "inner")["outcome"] == "enqueued"
+        assert rows(inner["env"]) == 1
+        with pytest.raises(StopIteration):
+            next(generator)
+        assert rows(inner["env"]) == 0
+        assert rows(sibling) == 1
+    finally:
+        for table in (
+            "polis_queue_requests",
+            "polis_queue_attempts",
+            "polis_queue_jobs",
+            "polis_queue_heads",
+            "polis_queue_runs",
+        ):
+            _admin(
+                queue_db,
+                f"DELETE FROM public.{table} WHERE env = %s",
+                (sibling,),
+            )
+
+
+def test_a_mid_setup_failure_releases_only_what_it_created(queue_db, monkeypatch):
+    """A failure after the creates still frees them, and deletes nothing else."""
+    sibling = f"{ENV}-sibling-{uuid.uuid4().hex[:8]}"
+
+    def counts():
+        return (
+            _admin(
+                queue_db,
+                "SELECT count(*) FROM pg_roles WHERE rolname LIKE 'pq\\_x\\_%'",
+            )[0][0],
+            _admin(
+                queue_db,
+                "SELECT count(*) FROM conversations WHERE topic LIKE 'p024 queue noop %'",
+            )[0][0],
+            _admin(
+                queue_db,
+                "SELECT count(*) FROM public.polis_queue_jobs WHERE env = %s",
+                (sibling,),
+            )[0][0],
+        )
+
+    assert _enqueue(queue_db, "sibling-partial", env=sibling)["outcome"] == "enqueued"
+    before = counts()
+    assert before[2] == 1
+    try:
+        _use_provider(monkeypatch, queue_db["url"])
+        # Fails after the migration, the role and the conversation exist, and
+        # before the fixture yields.
+        monkeypatch.setattr(
+            sys.modules[__name__],
+            "_executor_dsn",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                RuntimeError("synthetic setup failure")
+            ),
+        )
+        with pytest.raises(RuntimeError, match="synthetic setup failure"):
+            next(_provision_queue_db())
+        assert counts() == before
+    finally:
+        for table in (
+            "polis_queue_requests",
+            "polis_queue_attempts",
+            "polis_queue_jobs",
+            "polis_queue_heads",
+            "polis_queue_runs",
+        ):
+            _admin(
+                queue_db,
+                f"DELETE FROM public.{table} WHERE env = %s",
+                (sibling,),
+            )

--- a/delphi/tests/test_queue_noop_executor.py
+++ b/delphi/tests/test_queue_noop_executor.py
@@ -1,0 +1,350 @@
+"""P-024 first slice: the transitional polis-queue/1 noop executor against Postgres.
+
+Opt-in integration test. It uses the repository's existing prerequisite
+discovery (``tests.conftest.require_polis_postgres``), so it skips cleanly when
+neither ``POLIS_TEST_POSTGRES_URL`` nor docker is available, then applies
+``server/postgres/migrations/000019_create_polis_queue.sql`` itself - a replay
+when the service image already baked it in, a fresh apply otherwise.
+
+The executor runs under a dedicated login that is a member of
+``polis_queue_executor`` and holds no direct table write, which is the boundary
+the migration's grants define. The provisioning login (the one the fixture
+hands us) is only used to apply the migration and to act as the producer.
+
+Not claimed: gates A1-A8. No COMMIT is severed here and no Rust adapter exists.
+"""
+
+import os
+import re
+import uuid
+
+import pytest
+
+from tests.conftest import require_polis_postgres
+
+pytestmark = pytest.mark.integration
+
+MIGRATION = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "server",
+    "postgres",
+    "migrations",
+    "000019_create_polis_queue.sql",
+)
+
+ENV = "test-p024-py"
+PRODUCT = "product-noop"
+ACTOR = "synthetic-actor"
+LOCAL_ROLE_PASSWORD = "pq-local-test"
+
+
+def _executor_dsn(url: str, user: str, password: str) -> str:
+    """Swap the login in a postgres URL, leaving host/port/database alone."""
+    return re.sub(r"^(postgres(?:ql)?://)[^@]*@", rf"\1{user}:{password}@", url)
+
+
+@pytest.fixture(scope="module")
+def queue_db():
+    """A Postgres with the queue migration applied, plus a restricted login."""
+    import psycopg2
+
+    with require_polis_postgres() as url:
+        suffix = uuid.uuid4().hex[:8]
+        role = f"pq_x_{suffix}"
+        conn = psycopg2.connect(url)
+        conn.autocommit = True
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT rolsuper OR rolcreaterole FROM pg_roles WHERE rolname=current_user")
+                privileged = cur.fetchone()[0]
+            if not privileged:
+                pytest.skip(
+                    "the test Postgres login can neither create roles nor apply "
+                    "the queue migration; provide a superuser or CREATEROLE login"
+                )
+            with open(MIGRATION, "r", encoding="utf-8") as handle:
+                migration_sql = handle.read()
+            with conn.cursor() as cur:
+                cur.execute(migration_sql)
+                cur.execute(
+                    f"CREATE ROLE {role} LOGIN NOSUPERUSER NOCREATEROLE "
+                    f"PASSWORD '{LOCAL_ROLE_PASSWORD}' IN ROLE polis_queue_executor"
+                )
+                cur.execute(
+                    "INSERT INTO conversations (topic) VALUES (%s) RETURNING zid",
+                    (f"p024 queue noop {suffix}",),
+                )
+                zid = cur.fetchone()[0]
+            yield {
+                "url": url,
+                "zid": zid,
+                "env": f"{ENV}-{suffix}",
+                "executor_dsn": _executor_dsn(url, role, LOCAL_ROLE_PASSWORD),
+                "role": role,
+            }
+            with conn.cursor() as cur:
+                for table in (
+                    "polis_queue_requests",
+                    "polis_queue_attempts",
+                    "polis_queue_jobs",
+                    "polis_queue_heads",
+                    "polis_queue_runs",
+                ):
+                    cur.execute(
+                        f"DELETE FROM public.{table} WHERE env LIKE %s", (f"{ENV}-%",)
+                    )
+                cur.execute("DELETE FROM conversations WHERE zid=%s", (zid,))
+                cur.execute(f"DROP OWNED BY {role}")
+                cur.execute(f"DROP ROLE IF EXISTS {role}")
+        finally:
+            conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _opt_in(monkeypatch):
+    monkeypatch.setenv("POLIS_QUEUE_SUBSTRATE_ENABLED", "true")
+    monkeypatch.delenv("NODE_ENV", raising=False)
+
+
+def _enqueue(queue_db, key, *, uri=None, sha=None, image=None, max_attempts=3):
+    """Produce one job as the provisioning login, mirroring the Node adapter."""
+    import psycopg2
+
+    from polismath.queue import executor as ex
+
+    conn = psycopg2.connect(queue_db["url"])
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT public.pq_enqueue(%s::text,%s::integer,%s::text,%s::text,%s::text,"
+                "%s::text,%s::uuid,%s::uuid,%s::text,%s::text,%s::text,%s::text,"
+                "%s::smallint,%s::integer)",
+                [
+                    queue_db["env"],
+                    queue_db["zid"],
+                    PRODUCT,
+                    ACTOR,
+                    key,
+                    "1" * 64,
+                    str(uuid.uuid4()),
+                    str(uuid.uuid4()),
+                    uri or ex.NOOP_URI,
+                    sha or ex.NOOP_SHA256,
+                    sha or ex.NOOP_SHA256,
+                    image or ex.NOOP_IMAGE,
+                    1,
+                    max_attempts,
+                ],
+            )
+            return cur.fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _make_executor(queue_db, env=None):
+    from polismath.queue import executor as ex
+
+    settings = ex.Settings(dsn=queue_db["executor_dsn"], env=env or queue_db["env"])
+    return ex.Executor(ex.Database(settings), settings.env, sleep=lambda _: None)
+
+
+def test_sql_pin_matches_the_migration_on_disk():
+    """Round 4: both adapters pin the SQL they were written against."""
+    import hashlib
+
+    from polismath.queue import executor as ex
+
+    with open(MIGRATION, "rb") as handle:
+        assert hashlib.sha256(handle.read()).hexdigest() == ex.QUEUE_SQL_SHA256
+
+
+def test_refuses_without_the_opt_in_flag(monkeypatch):
+    from polismath.queue import executor as ex
+
+    monkeypatch.delenv("POLIS_QUEUE_SUBSTRATE_ENABLED", raising=False)
+    with pytest.raises(ex.ExecutorRefused):
+        ex.Settings(dsn="postgresql://localhost/x", env="test").check()
+
+
+def test_refuses_in_production(monkeypatch):
+    from polismath.queue import executor as ex
+
+    monkeypatch.setenv("NODE_ENV", "production")
+    with pytest.raises(ex.ExecutorRefused):
+        ex.Settings(dsn="postgresql://localhost/x", env="test").check()
+
+
+def test_refuses_an_env_outside_the_dev_test_namespace():
+    from polismath.queue import executor as ex
+
+    with pytest.raises(ex.ExecutorRefused):
+        ex.Settings(dsn="postgresql://localhost/x", env="prod").check()
+
+
+def test_wire_validator_rejects_unknown_and_missing_fields():
+    from polismath.queue import executor as ex
+
+    ordinary = {field: None for field in ex.ORDINARY_FIELDS}
+    ordinary.update(
+        schema_version="polis-queue/1", outcome="none", published=False, input=None
+    )
+    assert ex.validate(dict(ordinary)) is not None
+    with pytest.raises(ex.ProtocolError):
+        ex.validate(dict(ordinary, extra="x"))
+    missing = dict(ordinary)
+    del missing["first_parked_at"]
+    with pytest.raises(ex.ProtocolError):
+        ex.validate(missing)
+    with pytest.raises(ex.ProtocolError):
+        ex.validate(dict(ordinary, schema_version="polis-queue/2"))
+    with pytest.raises(ex.ProtocolError):
+        ex.validate(dict(ordinary, published=None))
+    with pytest.raises(ex.ProtocolError):
+        ex.validate(dict(ordinary, lease_epoch=7))
+    with pytest.raises(ex.ProtocolError):
+        ex.validate(dict(ordinary, locked_until="2026-01-01T00:00:00-08:00"))
+
+
+def test_only_the_closed_rpc_inventory_is_callable(queue_db):
+    from polismath.queue import executor as ex
+
+    database = ex.Database(
+        ex.Settings(dsn=queue_db["executor_dsn"], env=queue_db["env"])
+    )
+    with pytest.raises(KeyError):
+        database.call("pq_reap", [queue_db["env"], None, 1])
+    with pytest.raises(ValueError):
+        database.call("pq_job_status", [queue_db["env"]])
+
+
+def test_refuses_a_broad_login(queue_db):
+    """The provisioning login can write the tables directly, so it is refused."""
+    from polismath.queue import executor as ex
+
+    database = ex.Database(ex.Settings(dsn=queue_db["url"], env=queue_db["env"]))
+    with pytest.raises(ex.ExecutorRefused):
+        database.call("pq_head_status", [queue_db["env"], PRODUCT])
+
+
+def test_restricted_login_has_no_direct_table_write(queue_db):
+    import psycopg2
+
+    conn = psycopg2.connect(queue_db["executor_dsn"])
+    try:
+        with conn.cursor() as cur:
+            with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+                cur.execute("UPDATE public.polis_queue_jobs SET state='queued'")
+    finally:
+        conn.close()
+
+
+def test_claims_heartbeats_and_finalizes_one_noop_job(queue_db):
+    reply = _enqueue(queue_db, "cycle")
+    assert reply["outcome"] == "enqueued"
+    executor = _make_executor(queue_db)
+    assert executor.run_once() == "succeeded"
+    # The product head moved to this run, and the queue is empty afterwards.
+    status = executor.call("pq_head_status", [queue_db["env"], PRODUCT])
+    assert status["published_run_id"] == reply["run_id"]
+    assert status["published_sha256"] is not None
+    assert executor.run_once() == "none"
+    job = executor.call("pq_job_status", [queue_db["env"], reply["job_id"]])
+    assert job["state"] == "succeeded"
+    assert job["owner_id"] is None
+
+
+def test_permanently_fails_a_job_whose_descriptor_is_not_the_synthetic_one(queue_db):
+    """It never dereferences a job-supplied URI; it refuses the job instead."""
+    reply = _enqueue(
+        queue_db,
+        "foreign-descriptor",
+        uri="https://example.invalid/not-followed",
+        sha="2" * 64,
+        max_attempts=1,
+    )
+    assert reply["outcome"] == "enqueued"
+    executor = _make_executor(queue_db)
+    assert executor.run_once() == "dead"
+    job = executor.call("pq_job_status", [queue_db["env"], reply["job_id"]])
+    assert job["state"] == "dead"
+    assert job["last_error_code"] == "invalid_synthetic_descriptor"
+
+
+def test_reaper_recovers_an_expired_lease_without_a_new_enqueue(queue_db):
+    import psycopg2
+
+    reply = _enqueue(queue_db, "expired")
+    executor = _make_executor(queue_db)
+    claimed = executor.call(
+        "pq_claim", [queue_db["env"], 1, executor.owner, str(uuid.uuid4()), 60]
+    )
+    assert claimed["outcome"] == "owned"
+    conn = psycopg2.connect(queue_db["url"])
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE public.polis_queue_jobs SET locked_until=clock_timestamp()"
+                " - interval '1 second' WHERE env=%s AND job_id=%s",
+                (queue_db["env"], reply["job_id"]),
+            )
+    finally:
+        conn.close()
+    # A stale token is fenced, the reaper returns the job, and the next cycle
+    # completes it. No new enqueue is involved.
+    assert (
+        executor.call("pq_heartbeat", executor.token(claimed) + [60])["outcome"]
+        == "fenced"
+    )
+    assert executor.reap_page() >= 1
+    # The reaper schedules a backoff, which is deliberate; bring it forward so
+    # the test does not sleep through the retry interval.
+    conn = psycopg2.connect(queue_db["url"])
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE public.polis_queue_jobs SET eligible_at=clock_timestamp()"
+                " - interval '1 second' WHERE env=%s AND job_id=%s",
+                (queue_db["env"], reply["job_id"]),
+            )
+    finally:
+        conn.close()
+    assert executor.run_once() == "succeeded"
+
+
+def test_an_uncertain_claim_commit_reconciles_instead_of_claiming_again(queue_db):
+    """A claim whose COMMIT outcome is unknown must renew, never re-claim.
+
+    Repeating pq_claim would take a second job while the first lease ran
+    unattended, so the executor heartbeats the exact token the uncertain reply
+    named. Only the COMMIT is made to fail; the SELECT really did own the job.
+    """
+    from polismath.queue import executor as ex
+
+    reply = _enqueue(queue_db, "uncertain")
+    executor = _make_executor(queue_db)
+    real_call = executor.db.call
+    calls = []
+    owned_claims = []
+
+    def flaky(name, args):
+        calls.append(name)
+        result = real_call(name, args)
+        # Only the claim that actually took ownership loses its acknowledgement:
+        # an empty lane is not the interesting case.
+        if name == "pq_claim" and result["outcome"] == "owned":
+            owned_claims.append(result)
+            if len(owned_claims) == 1:
+                raise ex.CommitOutcomeUnknown(result)
+        return result
+
+    executor.db.call = flaky  # type: ignore[method-assign]
+    assert executor.run_once() == "succeeded"
+    assert len(owned_claims) == 1
+    assert "pq_heartbeat" in calls
+    job = executor.call("pq_job_status", [queue_db["env"], reply["job_id"]])
+    assert job["state"] == "succeeded"

--- a/delphi/tests/test_queue_noop_executor.py
+++ b/delphi/tests/test_queue_noop_executor.py
@@ -24,15 +24,88 @@ from tests.conftest import require_polis_postgres
 
 pytestmark = pytest.mark.integration
 
-MIGRATION = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    "..",
-    "server",
-    "postgres",
-    "migrations",
-    "000019_create_polis_queue.sql",
-)
+# Locate the checkout rather than counting ".." segments. The Delphi Python CI
+# job copies only `delphi/tests` into `/app/tests` inside the delphi image
+# (.github/workflows/python-ci.yml step 6), where two levels up is `/` and the
+# polis checkout genuinely does not exist. Counting segments there silently
+# produced `/server/postgres/migrations` and failed the SQL pin for a packaging
+# reason rather than a real drift. Same shape as the recovery matrix's conftest.
+_MIGRATIONS_SUBPATH = ("server", "postgres", "migrations")
+MIGRATION_FILENAME = "000019_create_polis_queue.sql"
+
+
+def _find_repo_root(start):
+    """The polis checkout at or above ``start``, identified by what we need."""
+    path = os.path.abspath(start)
+    while True:
+        if os.path.isdir(os.path.join(path, *_MIGRATIONS_SUBPATH)):
+            return path
+        parent = os.path.dirname(path)
+        if parent == path:
+            return None
+        path = parent
+
+
+#: The polis checkout root, or None when these tests run outside one.
+REPO_ROOT = _find_repo_root(os.path.dirname(__file__))
+
+_NO_CHECKOUT_MESSAGE = """
+This test reads {needed} from the polis checkout, and no checkout was found at
+or above {here}.
+
+That is a packaging fact, not a configuration one: the Delphi Python CI job
+copies only `delphi/tests` into `/app/tests` inside the delphi image, so the
+checkout is genuinely absent there and nothing inside the image can supply it.
+
+Run the test from a checkout, or point at the migrations explicitly:
+
+    cd delphi && pytest tests/test_queue_noop_executor.py
+    POLIS_MIGRATIONS_DIR=/app/migrations pytest tests/test_queue_noop_executor.py
+"""
+
+_BAD_OVERRIDE_MESSAGE = """
+POLIS_MIGRATIONS_DIR resolves to {path!r}, which is not there.
+
+An explicit override that does not resolve is operator error, so this FAILS
+rather than skipping. Unset it to fall back to the checkout's
+server/postgres/migrations.
+"""
+
+
+def _resolve_migration():
+    """``(path, problem)``; exactly one of the two is None.
+
+    An explicit override that does not resolve fails; an absent checkout skips.
+    Neither weakens the pin when the file IS present.
+    """
+    override = os.environ.get("POLIS_MIGRATIONS_DIR")
+    if override:
+        candidate = os.path.join(os.path.abspath(override), MIGRATION_FILENAME)
+        if not os.path.isfile(candidate):
+            return None, ("fail", _BAD_OVERRIDE_MESSAGE.format(path=candidate))
+        return candidate, None
+    if REPO_ROOT is None:
+        return None, (
+            "skip",
+            _NO_CHECKOUT_MESSAGE.format(
+                needed=os.path.join(*_MIGRATIONS_SUBPATH, MIGRATION_FILENAME),
+                here=os.path.dirname(os.path.abspath(__file__)),
+            ),
+        )
+    return os.path.join(REPO_ROOT, *_MIGRATIONS_SUBPATH, MIGRATION_FILENAME), None
+
+
+MIGRATION, _MIGRATION_PROBLEM = _resolve_migration()
+
+
+def require_migration():
+    """The migration path, or a clean skip / loud failure saying why not."""
+    if _MIGRATION_PROBLEM is not None:
+        kind, message = _MIGRATION_PROBLEM
+        if kind == "fail":
+            pytest.fail(message, pytrace=False)
+        pytest.skip(message)
+    return MIGRATION
 
 ENV = "test-p024-py"
 PRODUCT = "product-noop"
@@ -56,6 +129,15 @@ def queue_db():
     concurrent run's rows.
     """
     import psycopg2
+
+    if MIGRATION is None:
+        # Same packaging fact as the SQL pin: no checkout, no migration to
+        # apply. Skip before taking a connection or starting a container.
+        pytest.skip(
+            "no polis checkout above these tests and POLIS_MIGRATIONS_DIR is "
+            "unset, so server/postgres/migrations/000019_create_polis_queue.sql "
+            "cannot be read; run from a checkout or set POLIS_MIGRATIONS_DIR"
+        )
 
     with require_polis_postgres() as url:
         suffix = uuid.uuid4().hex[:8]
@@ -187,12 +269,18 @@ def _make_executor(queue_db, env=None):
 
 
 def test_sql_pin_matches_the_migration_on_disk():
-    """Round 4: both adapters pin the SQL they were written against."""
+    """Round 4: both adapters pin the SQL they were written against.
+
+    The pin is not weakened where the file exists. Where no checkout exists at
+    all - the delphi image, which carries only `delphi/tests` - there is nothing
+    to compare against, so this skips with the reason and the fixing command.
+    """
     import hashlib
 
     from polismath.queue import executor as ex
 
-    with open(MIGRATION, "rb") as handle:
+    path = require_migration()
+    with open(path, "rb") as handle:
         assert hashlib.sha256(handle.read()).hexdigest() == ex.QUEUE_SQL_SHA256
 
 

--- a/delphi/tests/test_queue_noop_executor.py
+++ b/delphi/tests/test_queue_noop_executor.py
@@ -47,17 +47,30 @@ def _executor_dsn(url: str, user: str, password: str) -> str:
 
 @pytest.fixture(scope="module")
 def queue_db():
-    """A Postgres with the queue migration applied, plus a restricted login."""
+    """A Postgres with the queue migration applied, plus a restricted login.
+
+    The configured test database may be shared with other runs, so teardown
+    removes ONLY this fixture's own env namespace, its own conversation and its
+    own role, and runs in ``finally`` so a partially completed setup still
+    cleans up after itself. A wildcard over the ``ENV`` prefix would delete a
+    concurrent run's rows.
+    """
     import psycopg2
 
     with require_polis_postgres() as url:
         suffix = uuid.uuid4().hex[:8]
         role = f"pq_x_{suffix}"
+        env = f"{ENV}-{suffix}"
+        zid = None
+        role_created = False
         conn = psycopg2.connect(url)
         conn.autocommit = True
         try:
             with conn.cursor() as cur:
-                cur.execute("SELECT rolsuper OR rolcreaterole FROM pg_roles WHERE rolname=current_user")
+                cur.execute(
+                    "SELECT rolsuper OR rolcreaterole FROM pg_roles"
+                    " WHERE rolname=current_user"
+                )
                 privileged = cur.fetchone()[0]
             if not privileged:
                 pytest.skip(
@@ -72,6 +85,7 @@ def queue_db():
                     f"CREATE ROLE {role} LOGIN NOSUPERUSER NOCREATEROLE "
                     f"PASSWORD '{LOCAL_ROLE_PASSWORD}' IN ROLE polis_queue_executor"
                 )
+                role_created = True
                 cur.execute(
                     "INSERT INTO conversations (topic) VALUES (%s) RETURNING zid",
                     (f"p024 queue noop {suffix}",),
@@ -80,26 +94,31 @@ def queue_db():
             yield {
                 "url": url,
                 "zid": zid,
-                "env": f"{ENV}-{suffix}",
+                "env": env,
                 "executor_dsn": _executor_dsn(url, role, LOCAL_ROLE_PASSWORD),
                 "role": role,
             }
-            with conn.cursor() as cur:
-                for table in (
-                    "polis_queue_requests",
-                    "polis_queue_attempts",
-                    "polis_queue_jobs",
-                    "polis_queue_heads",
-                    "polis_queue_runs",
-                ):
-                    cur.execute(
-                        f"DELETE FROM public.{table} WHERE env LIKE %s", (f"{ENV}-%",)
-                    )
-                cur.execute("DELETE FROM conversations WHERE zid=%s", (zid,))
-                cur.execute(f"DROP OWNED BY {role}")
-                cur.execute(f"DROP ROLE IF EXISTS {role}")
         finally:
-            conn.close()
+            try:
+                with conn.cursor() as cur:
+                    for table in (
+                        "polis_queue_requests",
+                        "polis_queue_attempts",
+                        "polis_queue_jobs",
+                        "polis_queue_heads",
+                        "polis_queue_runs",
+                    ):
+                        # Exact namespace only: never a LIKE over the prefix.
+                        cur.execute(
+                            f"DELETE FROM public.{table} WHERE env = %s", (env,)
+                        )
+                    if zid is not None:
+                        cur.execute("DELETE FROM conversations WHERE zid=%s", (zid,))
+                    if role_created:
+                        cur.execute(f"DROP OWNED BY {role}")
+                        cur.execute(f"DROP ROLE IF EXISTS {role}")
+            finally:
+                conn.close()
 
 
 @pytest.fixture(autouse=True)
@@ -108,7 +127,23 @@ def _opt_in(monkeypatch):
     monkeypatch.delenv("NODE_ENV", raising=False)
 
 
-def _enqueue(queue_db, key, *, uri=None, sha=None, image=None, max_attempts=3):
+def _admin(queue_db, statement, args=()):
+    """Run one statement as the provisioning login and return its rows."""
+    import psycopg2
+
+    conn = psycopg2.connect(queue_db["url"])
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(statement, args or None)
+            return cur.fetchall() if cur.description else None
+    finally:
+        conn.close()
+
+
+def _enqueue(
+    queue_db, key, *, uri=None, sha=None, image=None, max_attempts=3, priority=1
+):
     """Produce one job as the provisioning login, mirroring the Node adapter."""
     import psycopg2
 
@@ -135,7 +170,7 @@ def _enqueue(queue_db, key, *, uri=None, sha=None, image=None, max_attempts=3):
                     sha or ex.NOOP_SHA256,
                     sha or ex.NOOP_SHA256,
                     image or ex.NOOP_IMAGE,
-                    1,
+                    priority,
                     max_attempts,
                 ],
             )
@@ -348,3 +383,173 @@ def test_an_uncertain_claim_commit_reconciles_instead_of_claiming_again(queue_db
     assert "pq_heartbeat" in calls
     job = executor.call("pq_job_status", [queue_db["env"], reply["job_id"]])
     assert job["state"] == "succeeded"
+
+
+def test_a_claim_reply_naming_another_attempt_is_rejected():
+    """The minted attempt UUID is half of the fence, so the reply must name it.
+
+    A reply that carries a different attempt is not this claim's job and its
+    token must not be used. Checking the finalize reply against an already-wrong
+    claim reply is not equivalent: the two would simply agree with each other.
+    """
+    from polismath.queue import executor as ex
+
+    class WrongAttempt:
+        def call(self, name, args):
+            if name == "pq_due":
+                return []
+            if name != "pq_claim":
+                raise AssertionError(f"reached {name} with an unverified token")
+            job = {field: None for field in ex.ORDINARY_FIELDS}
+            job.update(
+                schema_version=ex.SCHEMA_VERSION,
+                outcome="owned",
+                published=False,
+                env="test",
+                owner_id=args[2],
+                attempt_id=str(uuid.uuid4()),
+                job_id=str(uuid.uuid4()),
+                lease_epoch="1",
+                stage="noop",
+                input={
+                    "uri": ex.NOOP_URI,
+                    "sha256": ex.NOOP_SHA256,
+                    "config_sha256": ex.NOOP_SHA256,
+                    "code_image_digest": ex.NOOP_IMAGE,
+                },
+            )
+            assert job["attempt_id"] != args[3]
+            return job
+
+    executor = ex.Executor(WrongAttempt(), "test", sleep=lambda _: None)
+    with pytest.raises(ex.ProtocolError):
+        executor.run_once()
+
+
+def test_a_head_writer_with_executor_membership_is_refused(queue_db):
+    """One denied UPDATE on one table is not proof of the grant boundary."""
+    from polismath.queue import executor as ex
+
+    role = queue_db["role"]
+    database = ex.Database(
+        ex.Settings(dsn=queue_db["executor_dsn"], env=queue_db["env"])
+    )
+    _admin(queue_db, f"GRANT UPDATE ON public.polis_queue_heads TO {role}")
+    try:
+        with pytest.raises(ex.ExecutorRefused):
+            database.call("pq_job_status", [queue_db["env"], str(uuid.uuid4())])
+    finally:
+        _admin(queue_db, f"REVOKE UPDATE ON public.polis_queue_heads FROM {role}")
+    # And it works again once the extra grant is gone.
+    assert database.call("pq_job_status", [queue_db["env"], str(uuid.uuid4())])
+
+
+def test_a_login_that_can_become_the_queue_owner_is_refused(queue_db):
+    from polismath.queue import executor as ex
+
+    role = queue_db["role"]
+    database = ex.Database(
+        ex.Settings(dsn=queue_db["executor_dsn"], env=queue_db["env"])
+    )
+    _admin(queue_db, f"GRANT polis_queue_owner TO {role}")
+    try:
+        with pytest.raises(ex.ExecutorRefused):
+            database.call("pq_job_status", [queue_db["env"], str(uuid.uuid4())])
+    finally:
+        _admin(queue_db, f"REVOKE polis_queue_owner FROM {role}")
+    assert database.call("pq_job_status", [queue_db["env"], str(uuid.uuid4())])
+
+
+def test_a_suppressed_finalize_acknowledgement_replays_the_exact_token(queue_db):
+    """A lost finalize reply is retried with the same token and digest.
+
+    The retry must return already_succeeded from the committed first attempt,
+    not a second publication and not a rollback.
+    """
+    from polismath.queue import executor as ex
+
+    _enqueue(queue_db, "lost-finalize")
+    executor = _make_executor(queue_db)
+    real_call = executor.db.call
+    finals = []
+    suppressed = []
+
+    def flaky(name, args):
+        result = real_call(name, args)
+        if name == "pq_finalize":
+            finals.append(list(args))
+            if not suppressed:
+                suppressed.append(True)
+                raise ex.CommitOutcomeUnknown(result)
+        return result
+
+    executor.db.call = flaky  # type: ignore[method-assign]
+    assert executor.run_once() == "already_succeeded"
+    assert len(finals) == 2
+    assert finals[0] == finals[1]
+
+
+def test_weighted_lanes_visit_every_priority_under_backlog(queue_db):
+    """Continuous urgent arrivals must not starve lane 2."""
+    from polismath.queue import executor as ex
+
+    for lane in range(3):
+        for index in range(7):
+            _enqueue(queue_db, f"lane-{lane}-{index}", priority=lane)
+    executor = _make_executor(queue_db)
+    real_call = executor.db.call
+    seen = []
+
+    def observe(name, args):
+        result = real_call(name, args)
+        if name == "pq_claim" and result["outcome"] == "owned":
+            seen.append(args[1])
+        return result
+
+    executor.db.call = observe  # type: ignore[method-assign]
+    for _ in range(len(ex.LANES)):
+        assert executor.run_once() == "succeeded"
+    assert seen == list(ex.LANES)
+
+
+def test_reaper_pages_101_parked_jobs_and_resets_its_cursor(queue_db):
+    """Discovery is bounded at 100, and a short page resets the cursor."""
+    env = queue_db["env"]
+    # Retire this module's remaining backlog so the pages are this test's rows.
+    _admin(
+        queue_db,
+        "UPDATE public.polis_queue_jobs SET state='dead'"
+        " WHERE env=%s AND state IN ('queued','retry_wait')",
+        (env,),
+    )
+    executor = _make_executor(queue_db)
+    for index in range(101):
+        _enqueue(queue_db, f"park-{index}")
+        job = executor.call(
+            "pq_claim", [env, 1, executor.owner, str(uuid.uuid4()), 60]
+        )
+        assert job["outcome"] == "owned"
+        assert (
+            executor.call("pq_park", executor.token(job) + ["synthetic"])["outcome"]
+            == "parked"
+        )
+    _admin(
+        queue_db,
+        "UPDATE public.polis_queue_jobs SET eligible_at=clock_timestamp()"
+        " - interval '1 second' WHERE env=%s AND state='parked'",
+        (env,),
+    )
+    assert executor.reap_page() == 100
+    assert executor.after_job is not None
+    assert (
+        _admin(
+            queue_db,
+            "SELECT count(*) FROM public.polis_queue_jobs"
+            " WHERE env=%s AND state='queued'",
+            (env,),
+        )[0][0]
+        == 100
+    )
+    assert executor.reap_page() == 1
+    assert executor.after_job is None
+    assert executor.reap_page() == 0

--- a/docs/queue-substrate.md
+++ b/docs/queue-substrate.md
@@ -104,9 +104,15 @@ work.
 `delphi/polismath/queue/executor.py` is a standalone process: claim, heartbeat,
 finalize, plus one bounded reaper opportunity per cycle. It refuses to start
 unless `POLIS_QUEUE_SUBSTRATE_ENABLED` is set, `NODE_ENV` is not `production`,
-the env is in the dev/test namespace, and the database login is a member of
-`polis_queue_executor` **and** holds no direct write on the queue tables. The
-last check runs on every connection, not only at startup.
+and the env is in the dev/test namespace.
+
+Every connection then re-checks the grant boundary, not only the first one. The
+login must be a member of `polis_queue_executor`, must hold **no** table-level
+or column-level privilege on **any** of the five queue tables, and must not be
+able to reach `polis_queue_owner` by inheritance or `SET ROLE`. A single denied
+`UPDATE` on one table would not be proof of the boundary: a login with executor
+membership plus `UPDATE` on `polis_queue_heads` passes that and can still move a
+published pointer behind the functions' backs.
 
 ```sh
 POLIS_QUEUE_SUBSTRATE_ENABLED=true python -m polismath.queue.executor \
@@ -149,6 +155,15 @@ available, in which case it starts a throwaway `postgres:17`):
 ```sh
 cd delphi && pytest tests/test_queue_noop_executor.py
 ```
+
+The migration is located by walking up from the test file for a directory that
+holds `server/postgres/migrations`, so it works from any checkout depth. The
+Delphi Python CI job copies only `delphi/tests` into `/app/tests` inside the
+delphi image, where no checkout exists above the tests; there the migration-
+dependent cases skip with that reason rather than failing the SQL pin for a
+packaging reason. `POLIS_MIGRATIONS_DIR` overrides the location and makes them
+run in that image too - and an override that does not resolve fails, because
+that is operator error rather than an absent prerequisite.
 
 The language-neutral specification harness stays outside the repository, in the
 cost-reduction notes (`scripts/p024-queue-sql-smoke.py`). This repository's

--- a/docs/queue-substrate.md
+++ b/docs/queue-substrate.md
@@ -1,0 +1,182 @@
+# Postgres queue substrate (P-024, contract `polis-queue/1`)
+
+This is the first slice of a Postgres-native job queue. It is **noop only** and
+**wired to nothing**: no HTTP route calls it, no poller reads it, and no real
+Delphi or math work can be routed through it. Installing the migration and
+leaving the flag off changes nothing about how the server behaves.
+
+Read this before touching it. The design, its four review rounds and the open
+acceptance gates live outside this repository, in the cost-reduction working
+notes (`P-024-queue-substrate.md` revision 4 and its review rounds).
+
+## What exists
+
+| Piece | Where |
+|---|---|
+| The schema: 5 tables, 21 `pq_` functions, 2 NOLOGIN roles | `server/postgres/migrations/000019_create_polis_queue.sql` |
+| The closed `polis-queue/1` wire boundary for Node | `server/src/queue/protocol.ts` |
+| Dev/test-only noop enqueue | `server/src/queue/enqueue.ts` |
+| `withTransaction` on the read-write pool | `server/src/db/pg-query.ts` |
+| The flag | `server/src/config.ts`, `POLIS_QUEUE_SUBSTRATE_ENABLED` |
+| 40 ported smoke checks plus 4 adapter checks | `server/__tests__/integration/queue-substrate.test.ts` |
+| Transitional Python executor | `delphi/polismath/queue/executor.py` |
+| Its Postgres test | `delphi/tests/test_queue_noop_executor.py` |
+
+The protocol is **at-least-once work, fenced publication, idempotent effects**.
+A successful function return is provisional until its transaction commits.
+
+Twelve of the twenty-one functions are granted to `polis_queue_executor`:
+`pq_enqueue`, `pq_claim`, `pq_heartbeat`, `pq_finalize`, `pq_fail`,
+`pq_release`, `pq_park`, `pq_due`, `pq_reap_one`, `pq_cancel`, `pq_job_status`,
+`pq_head_status`. The rest, including the page driver `pq_reap` and the
+terminalization and policy helpers, are private to `polis_queue_owner`. The
+executor role holds **no** direct read or write on any queue table.
+
+## What is not wired
+
+* `server/src/routes/delphi/jobs.ts` is untouched. It still resolves the zid in
+  Postgres and writes DynamoDB.
+* `delphi/scripts/job_poller.py` and `delphi/polismath/poller/*` are untouched
+  and neither import nor are imported by the new executor. Rolling the executor
+  back is stopping a process.
+* Nothing calls `enqueueNoopJob` outside tests.
+* No coordinator, no reaper daemon, no LISTEN loop, no Rust adapter.
+
+## Applying the migration
+
+A **fresh** container applies it automatically: the postgres image copies
+`server/postgres/migrations/*.sql` into `/docker-entrypoint-initdb.d`, so
+`make start` on a new volume comes up with the schema present and the flag off.
+
+An **existing** database needs the file applied by hand, exactly as
+[docs/migrations.md](migrations.md) describes. Apply this file alone; never
+replay the migrations directory as an upgrade mechanism.
+
+```sh
+docker exec -i polis-dev-postgres-1 psql -v ON_ERROR_STOP=1 -U postgres -d polis-dev \
+  < server/postgres/migrations/000019_create_polis_queue.sql
+```
+
+The applying login must be able to `SET ROLE` to the object owner. On a first
+apply that creates the roles it needs `CREATEROLE` (or superuser); on every
+apply it needs SET-capable membership in `polis_queue_owner`, `CREATE` and
+`USAGE` on `public` with grant option, and `SELECT`, `UPDATE(topic)`,
+`REFERENCES(zid)` on `public.conversations` with grant option. Owning
+`conversations` satisfies the last of those. An applier that is a member of
+`polis_queue_owner` *without* SET fails with a readable precondition rather
+than half-applying: PostgreSQL 17 lets a role creator hold ADMIN without SET.
+
+Re-applying is safe against the schema the file created. It is **not** safe
+against a drifted one, and that is deliberate: the file fingerprints the
+enumerated catalog before and after the DDL and aborts the transaction if
+anything differs, so `CREATE ... IF NOT EXISTS` can never quietly bless an
+incompatible object. A drift abort names the table or the check that failed and
+carries the observed catalog in the error DETAIL. Repairing drift is a human
+decision; the migration will not do it for you.
+
+If you change the schema, regenerate the fingerprints in the same reviewed
+change: apply the new DDL to a disposable PostgreSQL 17, recompute the three
+`md5(...)` values the guard functions compare, and update the signature array.
+Then update `QUEUE_SQL_SHA256` in **both** adapters
+(`server/src/queue/protocol.ts` and `delphi/polismath/queue/executor.py`); two
+tests fail until you do.
+
+## The flag
+
+`POLIS_QUEUE_SUBSTRATE_ENABLED` (default off) makes
+`server/src/queue/enqueue.ts` usable. It is forced off whenever `NODE_ENV` is
+`production`, regardless of the variable. Turning it on does not start a worker,
+does not add a route and does not change any served bytes; it only lets
+dev/test code call `enqueueNoopJob`.
+
+The env namespace is restricted to `dev` or `test`, optionally suffixed
+(`test-p024-3f2a`), so a synthetic job cannot be addressed at another
+environment's product heads.
+
+The Node enqueuer runs on the server's existing broad read-write login. The
+grant boundary in the migration is real in the database, but it is not what
+constrains this caller today. A dedicated service login with
+`polis_queue_executor` membership is separate, separately reviewed provisioning
+work.
+
+## The executor
+
+`delphi/polismath/queue/executor.py` is a standalone process: claim, heartbeat,
+finalize, plus one bounded reaper opportunity per cycle. It refuses to start
+unless `POLIS_QUEUE_SUBSTRATE_ENABLED` is set, `NODE_ENV` is not `production`,
+the env is in the dev/test namespace, and the database login is a member of
+`polis_queue_executor` **and** holds no direct write on the queue tables. The
+last check runs on every connection, not only at startup.
+
+```sh
+POLIS_QUEUE_SUBSTRATE_ENABLED=true python -m polismath.queue.executor \
+  --dsn "postgresql://queue_executor:...@localhost:5432/polis-dev" \
+  --env dev --once
+```
+
+It executes nothing. The noop stage's output is exactly its fixed synthetic
+input descriptor; the executor never follows the input URI, reads a job-named
+file, starts a child process, loads science code or calls a provider. A job
+whose descriptor is not the expected synthetic one is failed permanently.
+
+Two behaviours are worth knowing because they are not obvious:
+
+* A `pq_claim` whose COMMIT outcome is unknown is **never repeated**. The first
+  COMMIT may already have taken ownership, and a second claim would take a
+  second job while the first lease ran unattended. The executor renews the exact
+  token the uncertain reply named instead.
+* The reaper cursor is in memory, so a restart begins a pass again. That is safe
+  because every mutation rechecks current state, but it is not a recovery
+  certificate.
+
+## Running the tests
+
+Server (needs the test stack from `docker-compose.test.yml`; the queue suite
+applies the migration itself in setup):
+
+```sh
+cd server && npm run test:integration
+```
+
+If your test database login cannot create roles or databases, set
+`POLIS_QUEUE_TEST_SKIP_ROLE_PROVISIONING=true`; the apply/replay and
+plans-at-scale suites then report as skipped with the reason in the suite name,
+and the protocol suite still runs.
+
+Delphi (skips cleanly when neither `POLIS_TEST_POSTGRES_URL` nor docker is
+available, in which case it starts a throwaway `postgres:17`):
+
+```sh
+cd delphi && pytest tests/test_queue_noop_executor.py
+```
+
+The language-neutral specification harness stays outside the repository, in the
+cost-reduction notes (`scripts/p024-queue-sql-smoke.py`). This repository's
+regression test is the server integration suite.
+
+## Gates still open
+
+None of the eight acceptance gates has been earned. They must run from both
+psycopg and a Rust adapter against a pinned PostgreSQL 17 and shared
+fixture/SQL/contract hashes, each with its named failing negative control,
+before any real work is routed here.
+
+| Gate | What it must show |
+|---|---|
+| A1 concurrent claims and progress | N claimers over M jobs: no duplicate live ownership, fair progress while a row is locked. A read-then-unconditional-update claim must double-claim. |
+| A2 query plan | Real inner claim plan and rows examined over seeded terminal history and all priority lanes, without forcing `enable_seqscan=off`. |
+| A3 lease transfer | Suspend the owner, expire, reap, reclaim; every stale-token seam fenced and the new owner succeeding. |
+| A4 lost commit acknowledgement | Kill the process after the finalize COMMIT and before its reply; restart must obtain `already_succeeded` with the exact attempt and digest and publish nothing twice. **No COMMIT has ever been severed here.** |
+| A5 enqueue and rollback | Same key repeats the original, changed digest conflicts, a kill leaves a complete request+run+job+head or none. |
+| A6 publication policy | Older completes after newer, desired run fails, repeated finalization: no regression and the prior pointer persists. |
+| A7 HOT and vacuum | 10,000 heartbeats with stats flushed and vacuum observed, against an admitted HOT ratio and dead-tuple bound. |
+| A8 budgets and quiet recovery | Exhausted rows leave the ready index and become dead; parked and expired work reconciles without a new enqueue, across cursor pages. |
+
+Beyond the gates, and before any real job: durable input capture, the provider
+`custom_id` and request-map repair, per-conversation routing exclusivity and
+drain, a consistent backup and a restore rehearsal, and the two open product
+questions (Q20 reaper/policy placement, Q21 admitted output descriptor). Both
+questions were built for as small deltas; neither is answered here.
+
+Two claims this slice does **not** make: that anything has been tested against
+the deployed `conversations` schema, and that A4 has been earned.

--- a/server/__tests__/integration/queue-substrate.test.ts
+++ b/server/__tests__/integration/queue-substrate.test.ts
@@ -457,36 +457,115 @@ function requireProvisioning(): void {
  * the main login survive.
  */
 async function dropCreatedRoles(): Promise<void> {
+  const failures: string[] = [];
   const client = await mainPool.connect();
+  // A client whose session principal is unknown must not be pooled.
+  let discard = false;
   try {
+    const principal = async (): Promise<string> => {
+      const answer = await client.query("SELECT current_user AS role");
+      return answer.rows[0].role;
+    };
+    const login = await principal();
+
     for (const role of created.roles) {
-      await client.query(`SET ROLE ${role}`).catch(() => undefined);
-      await client
-        .query(
+      // The two REVOKEs below are grantor-specific: they are correct only while
+      // the session actually IS this role. If the switch fails the session is
+      // still the main login, and running them would withdraw grants this run
+      // never made - the migration's own grants to polis_queue_owner and
+      // polis_queue_executor - damaging the shared test schema during cleanup
+      // of a faulted run. So a failed switch revokes nothing at all.
+      try {
+        await client.query(`SET ROLE ${role}`);
+      } catch (err) {
+        failures.push(
+          `${role}: SET ROLE failed (${String(
+            err
+          )}); its grants were left in place`
+        );
+        if ((await principal()) !== login) {
+          failures.push(
+            `session principal is not ${login} after a failed SET ROLE`
+          );
+          discard = true;
+          break;
+        }
+        continue;
+      }
+      if ((await principal()) !== role) {
+        failures.push(`SET ROLE ${role} reported success without switching`);
+        discard = true;
+        break;
+      }
+
+      try {
+        // Only the grantor can revoke what it granted, and only while it still
+        // holds the grant option, so this runs before DROP OWNED BY takes the
+        // option away. It removes this role's ACL entries and no others.
+        await client.query(
           "REVOKE ALL ON SCHEMA public FROM polis_queue_owner, polis_queue_executor CASCADE"
-        )
-        .catch(() => undefined);
-      await client
-        .query(
+        );
+        await client.query(
           "REVOKE ALL ON public.conversations FROM polis_queue_owner CASCADE"
-        )
-        .catch(() => undefined);
-      await client.query("RESET ROLE").catch(() => undefined);
-      await client.query(`DROP OWNED BY ${role}`).catch(() => undefined);
-      await client.query(`DROP ROLE IF EXISTS ${role}`).catch(() => undefined);
+        );
+      } catch (err) {
+        // A role that granted nothing here holds no privilege to revoke, and
+        // PostgreSQL answers that with insufficient_privilege. That is the
+        // normal case for the roles which never replayed the migration, not a
+        // cleanup failure. If a revoke was genuinely needed and did not happen,
+        // the role keeps its grantor dependency and the leaked-role check below
+        // catches it.
+        if ((err as { code?: string }).code !== "42501") {
+          failures.push(
+            `${role}: revoking its own grants failed (${String(err)})`
+          );
+        }
+      }
+
+      // Restore the principal, and verify it: everything after this point runs
+      // as the main login, and so does the next iteration.
+      try {
+        await client.query("RESET ROLE");
+      } catch (err) {
+        failures.push(`${role}: RESET ROLE failed (${String(err)})`);
+        discard = true;
+        break;
+      }
+      if ((await principal()) !== login) {
+        failures.push(`RESET ROLE did not restore ${login} after ${role}`);
+        discard = true;
+        break;
+      }
+
+      try {
+        await client.query(`DROP OWNED BY ${role}`);
+        await client.query(`DROP ROLE IF EXISTS ${role}`);
+      } catch (err) {
+        failures.push(`${role}: could not be dropped (${String(err)})`);
+      }
     }
-    const leaked = await client.query(
-      "SELECT rolname FROM pg_roles WHERE rolname = ANY($1::text[])",
-      [created.roles]
-    );
-    if (leaked.rowCount) {
-      console.warn(
-        "queue substrate suite left roles behind: " +
-          leaked.rows.map((row) => row.rolname).join(", ")
+
+    if (!discard) {
+      const leaked = await client.query(
+        "SELECT rolname FROM pg_roles WHERE rolname = ANY($1::text[])",
+        [created.roles]
       );
+      if (leaked.rowCount) {
+        failures.push(
+          "roles left behind: " +
+            leaked.rows.map((row) => row.rolname).join(", ")
+        );
+      }
     }
   } finally {
-    client.release();
+    client.release(discard);
+  }
+  // Incomplete cleanup fails the suite rather than printing a warning nobody
+  // reads: a leaked role or a half-restored session is a real defect.
+  if (failures.length > 0) {
+    throw new Error(
+      "queue substrate suite cleanup failed: " + failures.join("; ")
+    );
   }
 }
 

--- a/server/__tests__/integration/queue-substrate.test.ts
+++ b/server/__tests__/integration/queue-substrate.test.ts
@@ -137,7 +137,7 @@ async function runMigration(pool: Pool): Promise<void> {
 
 /** One-statement helper on a fresh pooled connection, as the owning login. */
 async function sql(
-  pool: Pool,
+  pool: { query(text: string, values?: unknown[]): Promise<any> },
   text: string,
   values: unknown[] = []
 ): Promise<any> {
@@ -456,11 +456,27 @@ function requireProvisioning(): void {
  * removes only the entries that role granted; the ones the migration made as
  * the main login survive.
  */
-async function dropCreatedRoles(): Promise<void> {
+/** The pool shape dropCreatedRoles needs, so a control can supply a fake one. */
+interface CleanupPool {
+  connect(): Promise<{
+    query(text: string, values?: unknown[]): Promise<any>;
+    release(destroy?: boolean): void;
+  }>;
+}
+
+async function dropCreatedRoles(
+  pool: CleanupPool = mainPool,
+  roles: { roles: string[] } = created
+): Promise<void> {
   const failures: string[] = [];
-  const client = await mainPool.connect();
-  // A client whose session principal is unknown must not be pooled.
+  const client = await pool.connect();
+  // A client whose session principal is not provably the login must not be
+  // pooled. This is set BEFORE any identity-changing statement and cleared only
+  // by a verified reset, so no path out of the loop can return an unverified
+  // session to the pool - including one where the verification query itself
+  // fails, which is unknown state rather than evidence that pooling is safe.
   let discard = false;
+  let stop = false;
   try {
     const principal = async (): Promise<string> => {
       const answer = await client.query("SELECT current_user AS role");
@@ -468,7 +484,31 @@ async function dropCreatedRoles(): Promise<void> {
     };
     const login = await principal();
 
-    for (const role of created.roles) {
+    /** Restore the login and prove it. Never throws; false means unknown. */
+    const restore = async (role: string): Promise<boolean> => {
+      try {
+        await client.query("RESET ROLE");
+      } catch (err) {
+        failures.push(`${role}: RESET ROLE failed (${String(err)})`);
+        return false;
+      }
+      try {
+        if ((await principal()) !== login) {
+          failures.push(`RESET ROLE did not restore ${login} after ${role}`);
+          return false;
+        }
+      } catch (err) {
+        failures.push(
+          `${role}: could not verify the session principal after RESET ROLE (${String(
+            err
+          )})`
+        );
+        return false;
+      }
+      return true;
+    };
+
+    for (const role of roles.roles) {
       // The two REVOKEs below are grantor-specific: they are correct only while
       // the session actually IS this role. If the switch fails the session is
       // still the main login, and running them would withdraw grants this run
@@ -483,59 +523,72 @@ async function dropCreatedRoles(): Promise<void> {
             err
           )}); its grants were left in place`
         );
-        if ((await principal()) !== login) {
+        // The session identity did not change, but that has to be established
+        // rather than assumed, and the read itself can fail.
+        try {
+          if ((await principal()) !== login) {
+            failures.push(
+              `session principal is not ${login} after a failed SET ROLE`
+            );
+            discard = true;
+            break;
+          }
+        } catch (readErr) {
           failures.push(
-            `session principal is not ${login} after a failed SET ROLE`
+            `${role}: could not verify the session principal after a failed SET ROLE (${String(
+              readErr
+            )})`
           );
           discard = true;
           break;
         }
         continue;
       }
-      if ((await principal()) !== role) {
-        failures.push(`SET ROLE ${role} reported success without switching`);
-        discard = true;
-        break;
-      }
 
+      // Identity changed. Unsafe to pool until a verified reset says otherwise,
+      // whatever happens in between.
+      discard = true;
       try {
-        // Only the grantor can revoke what it granted, and only while it still
-        // holds the grant option, so this runs before DROP OWNED BY takes the
-        // option away. It removes this role's ACL entries and no others.
-        await client.query(
-          "REVOKE ALL ON SCHEMA public FROM polis_queue_owner, polis_queue_executor CASCADE"
-        );
-        await client.query(
-          "REVOKE ALL ON public.conversations FROM polis_queue_owner CASCADE"
-        );
-      } catch (err) {
-        // A role that granted nothing here holds no privilege to revoke, and
-        // PostgreSQL answers that with insufficient_privilege. That is the
-        // normal case for the roles which never replayed the migration, not a
-        // cleanup failure. If a revoke was genuinely needed and did not happen,
-        // the role keeps its grantor dependency and the leaked-role check below
-        // catches it.
-        if ((err as { code?: string }).code !== "42501") {
-          failures.push(
-            `${role}: revoking its own grants failed (${String(err)})`
+        if ((await principal()) !== role) {
+          throw new Error(
+            `SET ROLE ${role} reported success without switching`
           );
         }
-      }
-
-      // Restore the principal, and verify it: everything after this point runs
-      // as the main login, and so does the next iteration.
-      try {
-        await client.query("RESET ROLE");
+        try {
+          // Only the grantor can revoke what it granted, and only while it
+          // still holds the grant option, so this runs before DROP OWNED BY
+          // takes the option away. It removes this role's entries and no
+          // others.
+          await client.query(
+            "REVOKE ALL ON SCHEMA public FROM polis_queue_owner, polis_queue_executor CASCADE"
+          );
+          await client.query(
+            "REVOKE ALL ON public.conversations FROM polis_queue_owner CASCADE"
+          );
+        } catch (err) {
+          // A role that granted nothing here holds no privilege to revoke, and
+          // PostgreSQL answers that with insufficient_privilege. That is the
+          // normal case for the roles which never replayed the migration, not a
+          // cleanup failure. If a revoke was genuinely needed and did not
+          // happen, the role keeps its grantor dependency and the leaked-role
+          // check below catches it.
+          if ((err as { code?: string }).code !== "42501") {
+            failures.push(
+              `${role}: revoking its own grants failed (${String(err)})`
+            );
+          }
+        }
       } catch (err) {
-        failures.push(`${role}: RESET ROLE failed (${String(err)})`);
-        discard = true;
-        break;
+        failures.push(`${role}: cleanup as that role failed (${String(err)})`);
+      } finally {
+        // Every path out of the switched section restores and re-verifies.
+        if (await restore(role)) {
+          discard = false;
+        } else {
+          stop = true;
+        }
       }
-      if ((await principal()) !== login) {
-        failures.push(`RESET ROLE did not restore ${login} after ${role}`);
-        discard = true;
-        break;
-      }
+      if (stop) break;
 
       try {
         await client.query(`DROP OWNED BY ${role}`);
@@ -548,12 +601,14 @@ async function dropCreatedRoles(): Promise<void> {
     if (!discard) {
       const leaked = await client.query(
         "SELECT rolname FROM pg_roles WHERE rolname = ANY($1::text[])",
-        [created.roles]
+        [roles.roles]
       );
       if (leaked.rowCount) {
         failures.push(
           "roles left behind: " +
-            leaked.rows.map((row) => row.rolname).join(", ")
+            leaked.rows
+              .map((row: { rolname: string }) => row.rolname)
+              .join(", ")
         );
       }
     }
@@ -768,6 +823,61 @@ describeProvisioned(
         await pool.end();
       }
     }, 60000);
+
+    it("never pools a session whose principal it could not verify", async () => {
+      requireProvisioning();
+      // Astra's 22012 injection: the verification read fails AFTER SET ROLE has
+      // succeeded. The connection is fine, so "the query failed" is not
+      // evidence that the socket is gone - the session is simply still acting
+      // as the helper, and returning it to the pool hands that identity to the
+      // next borrower.
+      const helper = `pq_t_ver_${RUN_ID}`;
+      const login = await sql(mainPool, "SELECT current_user");
+      await mainPool.query(`CREATE ROLE ${helper}`);
+      const raw = await mainPool.connect();
+      let reads = 0;
+      let released: boolean | undefined;
+      const injected: CleanupPool = {
+        connect: async () => ({
+          query: async (text: string, values?: unknown[]) => {
+            if (text === "SELECT current_user AS role" && (reads += 1) === 2) {
+              return raw.query("SELECT 1/0");
+            }
+            return raw.query(text, values as unknown[]);
+          },
+          // Record the decision instead of acting on it, so the session can be
+          // inspected afterwards.
+          release: (destroy?: boolean) => {
+            released = destroy;
+          },
+        }),
+      };
+      try {
+        await expect(
+          dropCreatedRoles(injected, { roles: [helper] })
+        ).rejects.toThrow(/cleanup failed/);
+        const principal = await sql(raw, "SELECT current_user");
+        // The invariant: a session is pooled only when it is provably the
+        // login again. Either it was restored and verified, or it is destroyed.
+        if (released === false) {
+          expect(principal).toBe(login);
+        } else {
+          expect(released).toBe(true);
+        }
+        // Nothing was revoked on the way through.
+        expect(
+          await sql(
+            mainPool,
+            "SELECT has_schema_privilege('polis_queue_owner','public','USAGE')"
+          )
+        ).toBe(true);
+      } finally {
+        raw.release(true);
+        await mainPool
+          .query(`DROP ROLE IF EXISTS ${helper}`)
+          .catch(() => undefined);
+      }
+    }, 30000);
 
     it("refuses an unprovisioned login with a readable precondition", async () => {
       requireProvisioning();

--- a/server/__tests__/integration/queue-substrate.test.ts
+++ b/server/__tests__/integration/queue-substrate.test.ts
@@ -107,6 +107,18 @@ function databaseNameOf(url: string): string {
 
 let mainPool: Pool;
 let scratchPool: Pool;
+/**
+ * Set when role/database provisioning could not be done at all. CI's Postgres
+ * login is the superuser, so this stays undefined there; a login that cannot
+ * CREATE ROLE or CREATE DATABASE gets a named, actionable failure from the
+ * tests that need it instead of an opaque "permission denied" mid-test.
+ */
+let provisioningFailure: Error | undefined;
+/** Only what provisioning actually created is torn down. */
+const created = {
+  roles: [] as string[],
+  scratchDatabase: false,
+};
 /** Real conversations.zid used by every protocol check. */
 let zid = 0;
 /** Synthetic parent zid inside the scratch database. */
@@ -415,6 +427,69 @@ function nodes(plan: any): any[] {
   return out;
 }
 
+/**
+ * Guard for the tests that need a provisioning-capable login. Deliberately a
+ * failure and not a silent pass: a missing capability is a real gap, and the
+ * message says exactly how to report these as skipped instead.
+ */
+function requireProvisioning(): void {
+  if (provisioningFailure) {
+    throw new Error(
+      "this test needs a test database login that can CREATE ROLE and CREATE " +
+        "DATABASE; provisioning failed with: " +
+        provisioningFailure.message +
+        ". Set POLIS_QUEUE_TEST_SKIP_ROLE_PROVISIONING=true to report the " +
+        "apply/replay and plans-at-scale suites as skipped instead."
+    );
+  }
+}
+
+/**
+ * Drop the roles this run created, leaving nothing behind in a shared cluster.
+ *
+ * The replayer applies the migration with grant option, so the grants it makes
+ * are recorded with it as the grantor and hold a shared dependency on it -
+ * DROP ROLE then fails with "privileges for schema public". Only the grantor
+ * can revoke those (REVOKE ... GRANTED BY requires the grantor to be the
+ * current user), and only while it still holds the grant option, so the revoke
+ * happens as that role and BEFORE DROP OWNED BY takes the option away. It
+ * removes only the entries that role granted; the ones the migration made as
+ * the main login survive.
+ */
+async function dropCreatedRoles(): Promise<void> {
+  const client = await mainPool.connect();
+  try {
+    for (const role of created.roles) {
+      await client.query(`SET ROLE ${role}`).catch(() => undefined);
+      await client
+        .query(
+          "REVOKE ALL ON SCHEMA public FROM polis_queue_owner, polis_queue_executor CASCADE"
+        )
+        .catch(() => undefined);
+      await client
+        .query(
+          "REVOKE ALL ON public.conversations FROM polis_queue_owner CASCADE"
+        )
+        .catch(() => undefined);
+      await client.query("RESET ROLE").catch(() => undefined);
+      await client.query(`DROP OWNED BY ${role}`).catch(() => undefined);
+      await client.query(`DROP ROLE IF EXISTS ${role}`).catch(() => undefined);
+    }
+    const leaked = await client.query(
+      "SELECT rolname FROM pg_roles WHERE rolname = ANY($1::text[])",
+      [created.roles]
+    );
+    if (leaked.rowCount) {
+      console.warn(
+        "queue substrate suite left roles behind: " +
+          leaked.rows.map((row) => row.rolname).join(", ")
+      );
+    }
+  } finally {
+    client.release();
+  }
+}
+
 async function expectSqlState(
   promise: Promise<unknown>,
   code: string
@@ -440,15 +515,29 @@ beforeAll(async () => {
 
   if (SKIP_PROVISIONING) return;
 
+  try {
+    await provision();
+  } catch (err) {
+    // Recorded rather than thrown: the protocol suite needs none of this and
+    // must still run, and the tests that do need it then say so by name.
+    provisioningFailure = err instanceof Error ? err : new Error(String(err));
+  }
+}, 180000);
+
+/** Everything the apply/replay and plans-at-scale suites need. */
+async function provision(): Promise<void> {
   await mainPool.query(
     `CREATE ROLE ${ROLE_MIGRATOR} LOGIN NOSUPERUSER NOCREATEROLE PASSWORD '${ROLE_PASSWORD}'`
   );
+  created.roles.push(ROLE_MIGRATOR);
   await mainPool.query(
     `CREATE ROLE ${ROLE_REPLAYER} LOGIN NOSUPERUSER NOCREATEROLE PASSWORD '${ROLE_PASSWORD}'`
   );
+  created.roles.push(ROLE_REPLAYER);
   await mainPool.query(
     `CREATE ROLE ${ROLE_STRANGER} LOGIN NOSUPERUSER NOCREATEROLE PASSWORD '${ROLE_PASSWORD}'`
   );
+  created.roles.push(ROLE_STRANGER);
   // ADMIN without SET reproduces the PostgreSQL 17 shape that broke revision 3:
   // the migration must grant itself WITH SET TRUE before it can SET LOCAL ROLE.
   await mainPool.query(
@@ -466,6 +555,7 @@ beforeAll(async () => {
       `TO ${ROLE_REPLAYER} WITH GRANT OPTION`
   );
   await mainPool.query(`CREATE DATABASE ${SCRATCH_DB}`);
+  created.scratchDatabase = true;
   await mainPool.query(
     `GRANT USAGE, CREATE ON SCHEMA public TO ${ROLE_MIGRATOR} WITH GRANT OPTION`
   );
@@ -490,7 +580,7 @@ beforeAll(async () => {
   await scratchPool.query(
     "INSERT INTO public.conversations VALUES (1,'synthetic',NULL),(2,'synthetic',NULL)"
   );
-}, 180000);
+}
 
 afterAll(async () => {
   if (mainPool) {
@@ -514,17 +604,22 @@ afterAll(async () => {
     }
   }
   if (scratchPool) await scratchPool.end().catch(() => undefined);
-  if (mainPool && !SKIP_PROVISIONING) {
+  if (mainPool && created.scratchDatabase) {
+    // A leftover connection makes DROP DATABASE fail and leaks the database
+    // into a shared cluster, so close them first.
+    await mainPool
+      .query(
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1",
+        [SCRATCH_DB]
+      )
+      .catch(() => undefined);
     await mainPool
       .query(`DROP DATABASE IF EXISTS ${SCRATCH_DB}`)
       .catch(() => undefined);
-    for (const role of [ROLE_MIGRATOR, ROLE_REPLAYER, ROLE_STRANGER]) {
-      await mainPool.query(`DROP OWNED BY ${role}`).catch(() => undefined);
-      await mainPool
-        .query(`DROP ROLE IF EXISTS ${role}`)
-        .catch(() => undefined);
-    }
   }
+  // Only roles this run actually created, so a half-finished provisioning
+  // still releases what it made and touches nothing else.
+  if (mainPool && created.roles.length > 0) await dropCreatedRoles();
   if (mainPool) await mainPool.end().catch(() => undefined);
 }, 120000);
 
@@ -536,6 +631,7 @@ describeProvisioned(
     : "P-024 migration apply and replay",
   () => {
     it("applies fresh over a representative parent fixture as a non-superuser migrator", async () => {
+      requireProvisioning();
       // The NOLOGIN roles already exist cluster-wide, so this exercises fresh
       // object creation, the ADMIN-without-SET self-grant and the parent grants,
       // not first-time role creation.
@@ -552,6 +648,7 @@ describeProvisioned(
     }, 60000);
 
     it("replays for the same non-superuser migrator against a matching schema", async () => {
+      requireProvisioning();
       await runMigration(scratchPool);
       expect(
         await sql(
@@ -563,6 +660,7 @@ describeProvisioned(
     }, 60000);
 
     it("replays for a superuser against the real conversations schema", async () => {
+      requireProvisioning();
       await runMigration(mainPool);
       expect(
         await sql(mainPool, "SELECT to_regclass('public.polis_queue_runs')")
@@ -570,6 +668,7 @@ describeProvisioned(
     }, 60000);
 
     it("replays for a non-owner login through explicitly provisioned owner membership", async () => {
+      requireProvisioning();
       const pool = new Pool({
         connectionString: urlFor(
           databaseNameOf(BASE_DATABASE_URL),
@@ -592,6 +691,7 @@ describeProvisioned(
     }, 60000);
 
     it("refuses an unprovisioned login with a readable precondition", async () => {
+      requireProvisioning();
       const pool = new Pool({
         connectionString: urlFor(
           databaseNameOf(BASE_DATABASE_URL),
@@ -1434,6 +1534,7 @@ describeProvisioned(
     : "P-024 queue substrate plans at scale",
   () => {
     it("30. uses the ready index with 20,000 terminal and other-lane rows", async () => {
+      requireProvisioning();
       const a = await enqueue(scratchPool, "r3-plan");
       await scratchPool.query(
         "INSERT INTO public.polis_queue_jobs(env,job_id,run_id,stage,stage_instance,state,priority,max_attempts) " +
@@ -1460,6 +1561,7 @@ describeProvisioned(
     }, 180000);
 
     it("38. uses a zid index for both parent lookups at 20,000 rows and restricts parent deletion", async () => {
+      requireProvisioning();
       await scratchPool.query(
         "INSERT INTO public.conversations(zid,topic) SELECT g,'synthetic' FROM generate_series(3,20002) g"
       );

--- a/server/__tests__/integration/queue-substrate.test.ts
+++ b/server/__tests__/integration/queue-substrate.test.ts
@@ -1,0 +1,1453 @@
+/**
+ * P-024 Postgres queue substrate, first slice (noop only).
+ *
+ * The forty checks of cost-reduction/scripts/p024-queue-sql-smoke.py, ported to
+ * run against the migrated schema rather than against the uninstalled SQL
+ * specification. cost-reduction/scripts/p024-queue-sql-smoke.py stays as the
+ * language-neutral spec harness; this file is the repository's regression test
+ * for server/postgres/migrations/000019_create_polis_queue.sql.
+ *
+ * Two databases are used, for the same reason the harness provisions its own:
+ *
+ *   * The configured test database (DATABASE_URL). The migration is applied
+ *     here in setup - a replay when the postgres image already baked it in from
+ *     docker-entrypoint-initdb.d, a fresh apply otherwise - and every protocol,
+ *     wire, lock and privilege check runs against the REAL public.conversations
+ *     shape. Rows are namespaced by a per-run env prefix and removed afterwards.
+ *
+ *   * A scratch database created for this run, holding the harness's synthetic
+ *     parent fixture. The fresh non-superuser apply and the two plan checks at
+ *     20,000 rows live there: they insert 20,000 conversations and 20,000 jobs
+ *     and delete parent rows, which must not happen in a shared test database.
+ *
+ * Requirements on the test login: it must be able to SET ROLE to
+ * polis_queue_owner and polis_queue_executor, CREATE ROLE and CREATE DATABASE.
+ * The repository's test.env and CI both use the postgres superuser, so this
+ * holds. If yours does not, set POLIS_QUEUE_TEST_SKIP_ROLE_PROVISIONING=true:
+ * the apply/replay and scale suites then report as skipped, with the reason in
+ * the suite name, and the protocol suite still runs.
+ *
+ * Not claimed here: gates A1-A8. In particular no COMMIT has been severed, so
+ * check 11 is a successful-function replay and not the A4 lost-acknowledgement
+ * certificate, exactly as the harness says.
+ */
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import dotenv from "dotenv";
+import { Pool, PoolClient } from "pg";
+
+dotenv.config({ override: false });
+
+// The Node adapter's own wire pinning is the oracle for every reply below, so
+// the adapter and the migration are checked against each other rather than
+// against a second copy of the field list.
+type EnqueueModule = typeof import("../../src/queue/enqueue");
+type ProtocolModule = typeof import("../../src/queue/protocol");
+let queue: EnqueueModule;
+let protocol: ProtocolModule;
+
+const MIGRATION_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "postgres",
+  "migrations",
+  "000019_create_polis_queue.sql"
+);
+const MIGRATION_SQL = fs.readFileSync(MIGRATION_PATH, "utf8");
+
+const BASE_DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://postgres:postgres@localhost:5432/polis-dev";
+
+const SKIP_PROVISIONING =
+  String(process.env.POLIS_QUEUE_TEST_SKIP_ROLE_PROVISIONING || "")
+    .toLowerCase()
+    .trim() === "true";
+
+const PROVISIONING_SKIP_REASON =
+  "skipped: POLIS_QUEUE_TEST_SKIP_ROLE_PROVISIONING=true, so this test DB " +
+  "login is not assumed to hold CREATE ROLE / CREATE DATABASE / SET ROLE";
+
+const RUN_ID = randomUUID().replace(/-/g, "").slice(0, 10);
+const ENV_PREFIX = `test-p024-${RUN_ID}-`;
+const SCRATCH_DB = `pq_s1_${RUN_ID}`;
+const ROLE_MIGRATOR = `pq_t_mig_${RUN_ID}`;
+const ROLE_REPLAYER = `pq_t_rep_${RUN_ID}`;
+const ROLE_STRANGER = `pq_t_str_${RUN_ID}`;
+// Local, throwaway, never leaves this file or this run's cluster.
+const ROLE_PASSWORD = `pq-local-test-${RUN_ID}`;
+
+const H = "1".repeat(64);
+const URI = "synthetic-input";
+const OWNER = randomUUID();
+
+const describeProvisioned = SKIP_PROVISIONING ? describe.skip : describe;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type QueueResult = any;
+
+function urlFor(database: string, user?: string, password?: string): string {
+  const url = new URL(BASE_DATABASE_URL);
+  url.pathname = `/${database}`;
+  if (user !== undefined) {
+    url.username = user;
+    url.password = password ?? "";
+  }
+  return url.toString();
+}
+
+function databaseNameOf(url: string): string {
+  return new URL(url).pathname.replace(/^\//, "");
+}
+
+let mainPool: Pool;
+let scratchPool: Pool;
+/** Real conversations.zid used by every protocol check. */
+let zid = 0;
+/** Synthetic parent zid inside the scratch database. */
+const SCRATCH_ZID = 1;
+
+// ---------------------------------------------------------------- primitives
+
+async function runMigration(pool: Pool): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query(MIGRATION_SQL);
+  } finally {
+    client.release();
+  }
+}
+
+/** One-statement helper on a fresh pooled connection, as the owning login. */
+async function sql(
+  pool: Pool,
+  text: string,
+  values: unknown[] = []
+): Promise<any> {
+  const result = await pool.query(text, values);
+  return result.rows[0] ? Object.values(result.rows[0])[0] : undefined;
+}
+
+async function rows(
+  pool: Pool,
+  text: string,
+  values: unknown[] = []
+): Promise<any[]> {
+  const result = await pool.query(text, values);
+  return result.rows;
+}
+
+interface CallOptions {
+  timezone?: string;
+  lockTimeout?: string;
+}
+
+/** Apply the /1 session policy the design document declares. */
+async function applySessionPolicy(
+  client: PoolClient,
+  options: CallOptions = {}
+): Promise<void> {
+  await client.query("SET LOCAL ROLE polis_queue_executor");
+  await client.query("SELECT set_config('TimeZone',$1,true)", [
+    options.timezone ?? "UTC",
+  ]);
+  await client.query("SELECT set_config('lock_timeout',$1,true)", [
+    options.lockTimeout ?? "500ms",
+  ]);
+  await client.query("SELECT set_config('statement_timeout','5s',true)");
+  await client.query("SELECT set_config('transaction_timeout','10s',true)");
+}
+
+/**
+ * Call one granted RPC in its own transaction as polis_queue_executor, with
+ * every argument bound and explicitly cast. Nothing is interpolated.
+ */
+async function call(
+  pool: Pool,
+  name: string,
+  casts: string[],
+  args: unknown[],
+  options: CallOptions = {}
+): Promise<QueueResult> {
+  const placeholders = casts.map((cast, i) => `$${i + 1}::${cast}`).join(",");
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await applySessionPolicy(client, options);
+    const result = await client.query(
+      `SELECT public.${name}(${placeholders}) AS r`,
+      args
+    );
+    const value = result.rows[0].r;
+    wire(value);
+    await client.query("COMMIT");
+    return value;
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Assert the closed wire contract on every reply. Ordinary results are checked
+ * by the Node adapter itself (src/queue/enqueue.ts), so the adapter's pinning
+ * and the migration's output are verified against each other rather than
+ * against a second copy of the field list.
+ */
+function wire(x: QueueResult): void {
+  expect(x.schema_version).toBe("polis-queue/1");
+  if (x.outcome === "reap_page") {
+    expect(Object.keys(x).sort()).toEqual([
+      "next_after_job_id",
+      "outcome",
+      "schema_version",
+      "transitions",
+    ]);
+    for (const transition of x.transitions) wire(transition);
+    return;
+  }
+  if (x.outcome === "head_status") {
+    expect(Object.keys(x).sort()).toEqual([
+      "desired_run_id",
+      "desired_state",
+      "env",
+      "found",
+      "outcome",
+      "product_key",
+      "published_generation",
+      "published_run_id",
+      "published_sha256",
+      "schema_version",
+    ]);
+    expect(typeof x.found).toBe("boolean");
+    return;
+  }
+  protocol.assertOrdinaryResult(x);
+  for (const field of ["lease_epoch", "version", "mgmt_version"]) {
+    expect(x[field] === null || /^\d+$/.test(x[field])).toBe(true);
+  }
+  for (const field of [
+    "attempt_count",
+    "max_attempts",
+    "parked_attempt_count",
+  ]) {
+    expect(x[field] === null || Number.isInteger(x[field])).toBe(true);
+  }
+  for (const field of ["locked_until", "eligible_at", "first_parked_at"]) {
+    expect(x[field] === null || String(x[field]).endsWith("+00:00")).toBe(true);
+  }
+  for (const field of [
+    "env",
+    "job_id",
+    "run_id",
+    "attempt_id",
+    "owner_id",
+    "state",
+    "output_sha256",
+    "stage",
+    "stage_instance",
+    "last_error_code",
+  ]) {
+    expect(x[field] === null || typeof x[field] === "string").toBe(true);
+  }
+}
+
+interface EnqueueOptions {
+  key?: string;
+  product?: string;
+  maxAttempts?: number;
+  requestSha?: string;
+  zid?: number;
+}
+
+function enqueue(
+  pool: Pool,
+  env: string,
+  options: EnqueueOptions = {}
+): Promise<QueueResult> {
+  return call(
+    pool,
+    "pq_enqueue",
+    [
+      "text",
+      "integer",
+      "text",
+      "text",
+      "text",
+      "text",
+      "uuid",
+      "uuid",
+      "text",
+      "text",
+      "text",
+      "text",
+      "smallint",
+      "integer",
+    ],
+    [
+      env,
+      options.zid ?? (pool === scratchPool ? SCRATCH_ZID : zid),
+      options.product ?? "product",
+      "synthetic-actor",
+      options.key ?? "request",
+      options.requestSha ?? H,
+      randomUUID(),
+      randomUUID(),
+      URI,
+      H,
+      H,
+      "synthetic-image",
+      1,
+      options.maxAttempts ?? 3,
+    ]
+  );
+}
+
+function claim(pool: Pool, env: string): Promise<QueueResult> {
+  return call(
+    pool,
+    "pq_claim",
+    ["text", "smallint", "uuid", "uuid", "integer"],
+    [env, 1, OWNER, randomUUID(), 60]
+  );
+}
+
+function token(j: QueueResult): unknown[] {
+  return [j.env, j.job_id, OWNER, j.attempt_id, j.lease_epoch];
+}
+
+const TOKEN_CASTS = ["text", "uuid", "uuid", "uuid", "bigint"];
+
+function finalize(
+  pool: Pool,
+  j: QueueResult,
+  uri = URI,
+  sha = H
+): Promise<QueueResult> {
+  return call(
+    pool,
+    "pq_finalize",
+    [...TOKEN_CASTS, "text", "text"],
+    [...token(j), uri, sha]
+  );
+}
+
+async function due(
+  pool: Pool,
+  env: string,
+  after: string | null = null,
+  limit = 100
+): Promise<string[]> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("SET LOCAL ROLE polis_queue_executor");
+    const result = await client.query(
+      "SELECT job_id FROM public.pq_due($1::text,$2::uuid,$3::integer)",
+      [env, after, limit]
+    );
+    await client.query("COMMIT");
+    return result.rows.map((row) => row.job_id);
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * The normative reaper loop: discovery commits, then every mutation gets its
+ * own transaction, including the ones that return SQL NULL.
+ */
+async function reap(pool: Pool, env: string): Promise<QueueResult[]> {
+  const transitions: QueueResult[] = [];
+  for (const job of await due(pool, env)) {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await applySessionPolicy(client);
+      const result = await client.query(
+        "SELECT public.pq_reap_one($1::text,$2::uuid) AS r",
+        [env, job]
+      );
+      await client.query("COMMIT");
+      const value = result.rows[0].r;
+      if (value !== null) {
+        wire(value);
+        transitions.push(value);
+      }
+    } finally {
+      client.release();
+    }
+  }
+  return transitions;
+}
+
+/** Run `body` while another session holds `lockSql` in an open transaction. */
+async function whileHolding(
+  pool: Pool,
+  lockSql: string,
+  lockArgs: unknown[],
+  body: () => Promise<void>
+): Promise<void> {
+  const holder = await pool.connect();
+  try {
+    await holder.query("BEGIN");
+    await holder.query(lockSql, lockArgs);
+    await body();
+    await holder.query("COMMIT");
+  } catch (err) {
+    await holder.query("ROLLBACK").catch(() => undefined);
+    throw err;
+  } finally {
+    holder.release();
+  }
+}
+
+function nodes(plan: any): any[] {
+  const out = [plan];
+  for (const child of plan.Plans ?? []) out.push(...nodes(child));
+  return out;
+}
+
+async function expectSqlState(
+  promise: Promise<unknown>,
+  code: string
+): Promise<void> {
+  await expect(promise).rejects.toMatchObject({ code });
+}
+
+// -------------------------------------------------------------------- setup
+
+beforeAll(async () => {
+  process.env.POLIS_QUEUE_SUBSTRATE_ENABLED = "true";
+  protocol = await import("../../src/queue/protocol");
+  queue = await import("../../src/queue/enqueue");
+
+  mainPool = new Pool({ connectionString: BASE_DATABASE_URL, max: 12 });
+  await runMigration(mainPool);
+  zid = await sql(
+    mainPool,
+    "INSERT INTO conversations (topic, description) VALUES ($1, NULL) RETURNING zid",
+    [`p024 queue substrate ${RUN_ID}`]
+  );
+
+  if (SKIP_PROVISIONING) return;
+
+  await mainPool.query(
+    `CREATE ROLE ${ROLE_MIGRATOR} LOGIN NOSUPERUSER NOCREATEROLE PASSWORD '${ROLE_PASSWORD}'`
+  );
+  await mainPool.query(
+    `CREATE ROLE ${ROLE_REPLAYER} LOGIN NOSUPERUSER NOCREATEROLE PASSWORD '${ROLE_PASSWORD}'`
+  );
+  await mainPool.query(
+    `CREATE ROLE ${ROLE_STRANGER} LOGIN NOSUPERUSER NOCREATEROLE PASSWORD '${ROLE_PASSWORD}'`
+  );
+  // ADMIN without SET reproduces the PostgreSQL 17 shape that broke revision 3:
+  // the migration must grant itself WITH SET TRUE before it can SET LOCAL ROLE.
+  await mainPool.query(
+    `GRANT polis_queue_owner TO ${ROLE_MIGRATOR} WITH ADMIN TRUE, SET FALSE`
+  );
+  await mainPool.query(`GRANT polis_queue_owner TO ${ROLE_REPLAYER}`);
+  // The scale checks call granted RPCs in the scratch database, so the migrator
+  // login also needs to be able to SET ROLE to the executor there.
+  await mainPool.query(`GRANT polis_queue_executor TO ${ROLE_MIGRATOR}`);
+  await mainPool.query(
+    `GRANT USAGE, CREATE ON SCHEMA public TO ${ROLE_REPLAYER} WITH GRANT OPTION`
+  );
+  await mainPool.query(
+    `GRANT SELECT, REFERENCES(zid), UPDATE(topic) ON public.conversations ` +
+      `TO ${ROLE_REPLAYER} WITH GRANT OPTION`
+  );
+  await mainPool.query(`CREATE DATABASE ${SCRATCH_DB}`);
+  await mainPool.query(
+    `GRANT USAGE, CREATE ON SCHEMA public TO ${ROLE_MIGRATOR} WITH GRANT OPTION`
+  );
+
+  const bootstrap = new Pool({ connectionString: urlFor(SCRATCH_DB), max: 2 });
+  try {
+    await bootstrap.query(
+      `GRANT USAGE, CREATE ON SCHEMA public TO ${ROLE_MIGRATOR} WITH GRANT OPTION`
+    );
+  } finally {
+    await bootstrap.end();
+  }
+
+  scratchPool = new Pool({
+    connectionString: urlFor(SCRATCH_DB, ROLE_MIGRATOR, ROLE_PASSWORD),
+    max: 8,
+  });
+  await scratchPool.query(
+    "CREATE TABLE public.conversations(zid SERIAL, topic VARCHAR(1000), " +
+      "description VARCHAR(50000), UNIQUE(zid))"
+  );
+  await scratchPool.query(
+    "INSERT INTO public.conversations VALUES (1,'synthetic',NULL),(2,'synthetic',NULL)"
+  );
+}, 180000);
+
+afterAll(async () => {
+  if (mainPool) {
+    for (const table of [
+      "polis_queue_requests",
+      "polis_queue_attempts",
+      "polis_queue_jobs",
+      "polis_queue_heads",
+      "polis_queue_runs",
+    ]) {
+      await mainPool
+        .query(`DELETE FROM public.${table} WHERE env LIKE $1`, [
+          `${ENV_PREFIX}%`,
+        ])
+        .catch(() => undefined);
+    }
+    if (zid) {
+      await mainPool
+        .query("DELETE FROM conversations WHERE zid = $1", [zid])
+        .catch(() => undefined);
+    }
+  }
+  if (scratchPool) await scratchPool.end().catch(() => undefined);
+  if (mainPool && !SKIP_PROVISIONING) {
+    await mainPool
+      .query(`DROP DATABASE IF EXISTS ${SCRATCH_DB}`)
+      .catch(() => undefined);
+    for (const role of [ROLE_MIGRATOR, ROLE_REPLAYER, ROLE_STRANGER]) {
+      await mainPool.query(`DROP OWNED BY ${role}`).catch(() => undefined);
+      await mainPool
+        .query(`DROP ROLE IF EXISTS ${role}`)
+        .catch(() => undefined);
+    }
+  }
+  if (mainPool) await mainPool.end().catch(() => undefined);
+}, 120000);
+
+// ------------------------------------------------- 1-5 apply, replay, refuse
+
+describeProvisioned(
+  SKIP_PROVISIONING
+    ? `P-024 migration apply and replay (${PROVISIONING_SKIP_REASON})`
+    : "P-024 migration apply and replay",
+  () => {
+    it("applies fresh over a representative parent fixture as a non-superuser migrator", async () => {
+      // The NOLOGIN roles already exist cluster-wide, so this exercises fresh
+      // object creation, the ADMIN-without-SET self-grant and the parent grants,
+      // not first-time role creation.
+      expect(
+        await sql(
+          scratchPool,
+          "SELECT rolsuper FROM pg_roles WHERE rolname = current_user"
+        )
+      ).toBe(false);
+      await runMigration(scratchPool);
+      expect(
+        await sql(scratchPool, "SELECT to_regclass('public.polis_queue_jobs')")
+      ).toBe("polis_queue_jobs");
+    }, 60000);
+
+    it("replays for the same non-superuser migrator against a matching schema", async () => {
+      await runMigration(scratchPool);
+      expect(
+        await sql(
+          scratchPool,
+          "SELECT count(*)::int FROM pg_proc p JOIN pg_namespace n " +
+            "ON n.oid = p.pronamespace WHERE n.nspname='public' AND p.proname LIKE 'pq\\_%'"
+        )
+      ).toBe(21);
+    }, 60000);
+
+    it("replays for a superuser against the real conversations schema", async () => {
+      await runMigration(mainPool);
+      expect(
+        await sql(mainPool, "SELECT to_regclass('public.polis_queue_runs')")
+      ).toBe("polis_queue_runs");
+    }, 60000);
+
+    it("replays for a non-owner login through explicitly provisioned owner membership", async () => {
+      const pool = new Pool({
+        connectionString: urlFor(
+          databaseNameOf(BASE_DATABASE_URL),
+          ROLE_REPLAYER,
+          ROLE_PASSWORD
+        ),
+        max: 1,
+      });
+      try {
+        expect(
+          await sql(
+            pool,
+            "SELECT rolsuper FROM pg_roles WHERE rolname = current_user"
+          )
+        ).toBe(false);
+        await runMigration(pool);
+      } finally {
+        await pool.end();
+      }
+    }, 60000);
+
+    it("refuses an unprovisioned login with a readable precondition", async () => {
+      const pool = new Pool({
+        connectionString: urlFor(
+          databaseNameOf(BASE_DATABASE_URL),
+          ROLE_STRANGER,
+          ROLE_PASSWORD
+        ),
+        max: 1,
+      });
+      try {
+        await expect(runMigration(pool)).rejects.toThrow(
+          /requires membership in polis_queue_owner/
+        );
+      } finally {
+        await pool.end();
+      }
+    }, 60000);
+  }
+);
+
+// ------------------------------------- 6-29, 31-37, 39-40 protocol behaviour
+
+describe("P-024 queue substrate protocol", () => {
+  it("runs on PostgreSQL 17", async () => {
+    expect(
+      String(await sql(mainPool, "SHOW server_version_num")).slice(0, 2)
+    ).toBe("17");
+  });
+
+  it("6. enqueues idempotently and conflicts on a changed digest", async () => {
+    const env = `${ENV_PREFIX}idem`;
+    const a = await enqueue(mainPool, env);
+    const b = await enqueue(mainPool, env);
+    expect(a.input.sha256).toBe(H);
+    expect(a.input.uri).toBe(URI);
+    expect(b.run_id).toBe(a.run_id);
+    expect(b.outcome).toBe("existing");
+    expect(
+      (await enqueue(mainPool, env, { requestSha: "2".repeat(64) })).outcome
+    ).toBe("conflict");
+  }, 30000);
+
+  it("7. grants 8 concurrent claims distinct jobs and then reports none", async () => {
+    const env = `${ENV_PREFIX}concurrent`;
+    for (let i = 0; i < 8; i += 1) {
+      await enqueue(mainPool, env, { key: String(i) });
+    }
+    const claims = await Promise.all(
+      Array.from({ length: 8 }, () => claim(mainPool, env))
+    );
+    expect(claims.every((j) => j.outcome === "owned")).toBe(true);
+    expect(new Set(claims.map((j) => j.job_id)).size).toBe(8);
+    expect((await claim(mainPool, env)).outcome).toBe("none");
+  }, 60000);
+
+  describe("a single claimed job", () => {
+    const env = `${ENV_PREFIX}final`;
+    let j: QueueResult;
+
+    beforeAll(async () => {
+      await enqueue(mainPool, env);
+      j = await claim(mainPool, env);
+    }, 30000);
+
+    it("8. renews version on heartbeat without changing epoch", async () => {
+      const h = await call(
+        mainPool,
+        "pq_heartbeat",
+        [...TOKEN_CASTS, "integer"],
+        [...token(j), 60]
+      );
+      expect(h.outcome).toBe("owned");
+      expect(h.lease_epoch).toBe(j.lease_epoch);
+      expect(Number(h.version)).toBeGreaterThan(Number(j.version));
+    });
+
+    it("9. fences a heartbeat with the wrong epoch", async () => {
+      const wrong = token(j);
+      wrong[4] = String(Number(j.lease_epoch) + 1);
+      const r = await call(
+        mainPool,
+        "pq_heartbeat",
+        [...TOKEN_CASTS, "integer"],
+        [...wrong, 60]
+      );
+      expect(r.outcome).toBe("fenced");
+    });
+
+    it("10. admits only the captured output digest", async () => {
+      expect((await finalize(mainPool, j, URI, "2".repeat(64))).outcome).toBe(
+        "invalid_output"
+      );
+    });
+
+    it("11. replays a successful finalization (no transport fault injected)", async () => {
+      expect((await finalize(mainPool, j)).outcome).toBe("succeeded");
+      expect((await finalize(mainPool, j)).outcome).toBe("already_succeeded");
+    });
+  });
+
+  it("12. transfers an expired lease and fences every old-token write", async () => {
+    const env = `${ENV_PREFIX}expire`;
+    await enqueue(mainPool, env);
+    const old = await claim(mainPool, env);
+    await mainPool.query(
+      "UPDATE public.polis_queue_jobs SET locked_until = clock_timestamp() - interval '1 second' WHERE env = $1",
+      [env]
+    );
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_heartbeat",
+          [...TOKEN_CASTS, "integer"],
+          [...token(old), 60]
+        )
+      ).outcome
+    ).toBe("fenced");
+    expect((await finalize(mainPool, old)).outcome).toBe("fenced");
+    const reaped = await reap(mainPool, env);
+    expect(reaped[0].outcome).toBe("retry_wait");
+    await mainPool.query(
+      "UPDATE public.polis_queue_jobs SET eligible_at = clock_timestamp() - interval '1 second' WHERE env = $1",
+      [env]
+    );
+    const fresh = await claim(mainPool, env);
+    expect(Number(fresh.lease_epoch)).toBeGreaterThan(Number(old.lease_epoch));
+    expect(
+      (await call(mainPool, "pq_release", TOKEN_CASTS, token(old))).outcome
+    ).toBe("fenced");
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_fail",
+          [...TOKEN_CASTS, "boolean", "text"],
+          [...token(old), false, "synthetic"]
+        )
+      ).outcome
+    ).toBe("fenced");
+    expect((await finalize(mainPool, old)).outcome).toBe("fenced");
+    expect((await finalize(mainPool, fresh)).outcome).toBe("succeeded");
+  }, 60000);
+
+  it("13. refuses to move a newer product pointer with an older completed run", async () => {
+    const env = `${ENV_PREFIX}order`;
+    await enqueue(mainPool, env, { key: "old" });
+    const old = await claim(mainPool, env);
+    await enqueue(mainPool, env, { key: "new" });
+    const fresh = await claim(mainPool, env);
+    expect((await finalize(mainPool, fresh)).published).toBe(true);
+    expect((await finalize(mainPool, old)).published).toBe(false);
+    expect(
+      await sql(
+        mainPool,
+        "SELECT published_run_id::text FROM public.polis_queue_heads WHERE env = $1",
+        [env]
+      )
+    ).toBe(fresh.run_id);
+  }, 60000);
+
+  it("14. rejects a pointer regression at the schema level", async () => {
+    const env = `${ENV_PREFIX}order`;
+    await expectSqlState(
+      mainPool.query(
+        "UPDATE public.polis_queue_heads SET published_generation = 0 WHERE env = $1",
+        [env]
+      ),
+      "23514"
+    );
+  }, 30000);
+
+  it("15. terminalizes immediately on attempt exhaustion", async () => {
+    const env = `${ENV_PREFIX}budget`;
+    await enqueue(mainPool, env, { maxAttempts: 1 });
+    const j = await claim(mainPool, env);
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_fail",
+          [...TOKEN_CASTS, "boolean", "text"],
+          [...token(j), false, "synthetic"]
+        )
+      ).outcome
+    ).toBe("dead");
+    expect((await claim(mainPool, env)).outcome).toBe("none");
+  }, 30000);
+
+  it("16. resumes a park through the reaper without a new enqueue", async () => {
+    const env = `${ENV_PREFIX}park`;
+    await enqueue(mainPool, env);
+    const j = await claim(mainPool, env);
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_park",
+          [...TOKEN_CASTS, "text"],
+          [...token(j), "synthetic"]
+        )
+      ).outcome
+    ).toBe("parked");
+    await mainPool.query(
+      "UPDATE public.polis_queue_jobs SET eligible_at = clock_timestamp() - interval '1 second' WHERE env = $1",
+      [env]
+    );
+    expect((await reap(mainPool, env))[0].outcome).toBe("queued");
+    expect((await claim(mainPool, env)).outcome).toBe("owned");
+  }, 60000);
+
+  it("17. revokes ownership through a management cancellation CAS", async () => {
+    const env = `${ENV_PREFIX}cancel`;
+    await enqueue(mainPool, env);
+    const j = await claim(mainPool, env);
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_cancel",
+          ["text", "uuid", "bigint"],
+          [env, j.job_id, String(Number(j.mgmt_version) + 1)]
+        )
+      ).outcome
+    ).toBe("conflict");
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_cancel",
+          ["text", "uuid", "bigint"],
+          [env, j.job_id, j.mgmt_version]
+        )
+      ).outcome
+    ).toBe("cancelled");
+    expect(
+      (await call(mainPool, "pq_release", TOKEN_CASTS, token(j))).outcome
+    ).toBe("fenced");
+  }, 30000);
+
+  it("18. denies the executor any direct table write", async () => {
+    const client = await mainPool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query("SET LOCAL ROLE polis_queue_executor");
+      await expectSqlState(
+        client.query("UPDATE public.polis_queue_jobs SET state = 'queued'"),
+        "42501"
+      );
+    } finally {
+      await client.query("ROLLBACK").catch(() => undefined);
+      client.release();
+    }
+  }, 30000);
+
+  describe("held product head", () => {
+    const env = `${ENV_PREFIX}heartbeat`;
+    let j: QueueResult;
+
+    beforeAll(async () => {
+      await enqueue(mainPool, env);
+      j = await claim(mainPool, env);
+    }, 30000);
+
+    it("19. renews a heartbeat while another transaction holds the head", async () => {
+      await whileHolding(
+        mainPool,
+        "SELECT 1 FROM public.polis_queue_heads WHERE env = $1 FOR UPDATE",
+        [env],
+        async () => {
+          const r = await call(
+            mainPool,
+            "pq_heartbeat",
+            [...TOKEN_CASTS, "integer"],
+            [...token(j), 60]
+          );
+          expect(r.outcome).toBe("owned");
+        }
+      );
+    }, 30000);
+
+    it("20. serializes the wire in UTC for a non-UTC caller", async () => {
+      const r = await call(
+        mainPool,
+        "pq_heartbeat",
+        [...TOKEN_CASTS, "integer"],
+        [...token(j), 60],
+        { timezone: "America/Los_Angeles" }
+      );
+      expect(String(r.locked_until).endsWith("+00:00")).toBe(true);
+    });
+
+    it("21. accepts the claim-era management version after two heartbeats", async () => {
+      const r = await call(
+        mainPool,
+        "pq_cancel",
+        ["text", "uuid", "bigint"],
+        [env, j.job_id, j.mgmt_version]
+      );
+      expect(r.outcome).toBe("cancelled");
+    });
+  });
+
+  it("22. reports a suppressed success as boolean false and separates content from identity", async () => {
+    const env = `${ENV_PREFIX}suppressed`;
+    await enqueue(mainPool, env, { key: "old" });
+    const j = await claim(mainPool, env);
+    await enqueue(mainPool, env, { key: "new" });
+    expect((await finalize(mainPool, j)).published).toBe(false);
+    const replay = await finalize(mainPool, j);
+    expect(replay.outcome).toBe("already_succeeded");
+    expect(replay.published).toBe(false);
+    expect((await finalize(mainPool, j, URI, "2".repeat(64))).outcome).toBe(
+      "invalid_output"
+    );
+    const wrong = token(j);
+    wrong[3] = randomUUID();
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_finalize",
+          [...TOKEN_CASTS, "text", "text"],
+          [...wrong, URI, H]
+        )
+      ).outcome
+    ).toBe("fenced");
+  }, 60000);
+
+  it("23. retains and resumes a run parked on its last budgeted attempt", async () => {
+    const env = `${ENV_PREFIX}park-budget`;
+    await enqueue(mainPool, env, { maxAttempts: 1 });
+    const j = await claim(mainPool, env);
+    const parked = await call(
+      mainPool,
+      "pq_park",
+      [...TOKEN_CASTS, "text"],
+      [...token(j), "dependency"]
+    );
+    expect(parked.outcome).toBe("parked");
+    expect(parked.parked_attempt_count).toBe(1);
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_park",
+          [...TOKEN_CASTS, "text"],
+          [...token(j), "stale"]
+        )
+      ).outcome
+    ).toBe("fenced");
+    await mainPool.query(
+      "UPDATE public.polis_queue_jobs SET eligible_at = clock_timestamp() - interval '1 second' WHERE env = $1",
+      [env]
+    );
+    expect((await reap(mainPool, env))[0].outcome).toBe("queued");
+    const fresh = await claim(mainPool, env);
+    expect(fresh.attempt_count).toBe(2);
+    expect((await finalize(mainPool, fresh)).outcome).toBe("succeeded");
+  }, 60000);
+
+  it("24. lets the owner row-lock the parent through topic but never update zid", async () => {
+    expect(
+      await sql(
+        mainPool,
+        "SELECT has_column_privilege('polis_queue_owner','public.conversations','topic','UPDATE')"
+      )
+    ).toBe(true);
+    expect(
+      await sql(
+        mainPool,
+        "SELECT has_column_privilege('polis_queue_owner','public.conversations','zid','UPDATE')"
+      )
+    ).toBe(false);
+  }, 30000);
+
+  it("25. records expiry through the shared terminalization primitive", async () => {
+    expect(
+      await sql(
+        mainPool,
+        "SELECT outcome FROM public.polis_queue_attempts WHERE env = $1 ORDER BY lease_epoch LIMIT 1",
+        [`${ENV_PREFIX}expire`]
+      )
+    ).toBe("expired");
+  }, 30000);
+
+  it("26. admits a captured expected output through the same finalize code", async () => {
+    const env = `${ENV_PREFIX}descriptor`;
+    await enqueue(mainPool, env);
+    const j = await claim(mainPool, env);
+    // Owner-only control standing in for a Q21 enqueuer change, not an
+    // executor mutation: the executor has no table write at all.
+    await mainPool.query(
+      "UPDATE public.polis_queue_runs SET expected_output_uri = 'synthetic-output', " +
+        "expected_output_sha256 = $2 WHERE env = $1",
+      [env, "3".repeat(64)]
+    );
+    expect((await finalize(mainPool, j)).outcome).toBe("invalid_output");
+    expect(
+      (await finalize(mainPool, j, "synthetic-output", "3".repeat(64))).outcome
+    ).toBe("succeeded");
+    expect(
+      (await finalize(mainPool, j, "synthetic-output", "3".repeat(64))).outcome
+    ).toBe("already_succeeded");
+  }, 60000);
+
+  it("27. exposes a desired failure and the retained published pointer", async () => {
+    const env = `${ENV_PREFIX}status`;
+    await enqueue(mainPool, env, { key: "old" });
+    const j = await claim(mainPool, env);
+    expect((await finalize(mainPool, j)).published).toBe(true);
+    await enqueue(mainPool, env, { key: "new", maxAttempts: 1 });
+    const fresh = await claim(mainPool, env);
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_fail",
+          [...TOKEN_CASTS, "boolean", "text"],
+          [...token(fresh), true, "synthetic_failure"]
+        )
+      ).outcome
+    ).toBe("dead");
+    const status = await call(
+      mainPool,
+      "pq_head_status",
+      ["text", "text"],
+      [env, "product"]
+    );
+    expect(status.desired_state).toBe("dead");
+    expect(status.published_run_id).toBe(j.run_id);
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_head_status",
+          ["text", "text"],
+          [`${ENV_PREFIX}missing`, "product"]
+        )
+      ).found
+    ).toBe(false);
+  }, 60000);
+
+  it("28. replays an enqueue without contending for the product head", async () => {
+    const env = `${ENV_PREFIX}replay`;
+    await enqueue(mainPool, env);
+    await whileHolding(
+      mainPool,
+      "SELECT 1 FROM public.polis_queue_heads WHERE env = $1 FOR UPDATE",
+      [env],
+      async () => {
+        expect((await enqueue(mainPool, env)).outcome).toBe("existing");
+      }
+    );
+  }, 30000);
+
+  it("29. leaves no running row without a lease across every reply checked", async () => {
+    expect(
+      await sql(
+        mainPool,
+        "SELECT count(*)::int FROM public.polis_queue_jobs " +
+          "WHERE state = 'running' AND locked_until IS NULL"
+      )
+    ).toBe(0);
+  }, 30000);
+
+  it.each([
+    ["pq_release", [] as unknown[], ["retry_wait"]],
+    ["pq_fail", [false, "synthetic"], ["retry_wait"]],
+    ["pq_park", ["dependency"], ["parked"]],
+  ])(
+    "31-33. %s succeeds under a held head while the full-prefix finalize control blocks",
+    async (action, extra, expected) => {
+      const env = `${ENV_PREFIX}head-${action}`;
+      const casts: Record<string, string[]> = {
+        pq_release: TOKEN_CASTS,
+        pq_fail: [...TOKEN_CASTS, "boolean", "text"],
+        pq_park: [...TOKEN_CASTS, "text"],
+      };
+      await enqueue(mainPool, env);
+      const j = await claim(mainPool, env);
+      await whileHolding(
+        mainPool,
+        "SELECT 1 FROM public.polis_queue_heads WHERE env = $1 FOR UPDATE",
+        [env],
+        async () => {
+          // Establishes the held-lock oracle: a transition that does write the
+          // head must still contend for it.
+          await expectSqlState(finalize(mainPool, j), "55P03");
+          const result = await call(mainPool, action, casts[action], [
+            ...token(j),
+            ...extra,
+          ]);
+          expect(result.outcome).toBe(expected[0]);
+          if (action === "pq_release") {
+            expect(result.last_error_code).toBeNull();
+            expect((await claim(mainPool, env)).outcome).toBe("owned");
+          }
+        }
+      );
+    },
+    60000
+  );
+
+  it("34. supplies the management CAS token without mutating, and types a missing job", async () => {
+    const env = `${ENV_PREFIX}job-status`;
+    const a = await enqueue(mainPool, env);
+    const before = await sql(
+      mainPool,
+      "SELECT row_to_json(j) FROM public.polis_queue_jobs j WHERE env = $1",
+      [env]
+    );
+    const r = await call(
+      mainPool,
+      "pq_job_status",
+      ["text", "uuid"],
+      [env, a.job_id]
+    );
+    expect(r.state).toBe("queued");
+    expect(r.mgmt_version).toBe("0");
+    expect(
+      await sql(
+        mainPool,
+        "SELECT row_to_json(j) FROM public.polis_queue_jobs j WHERE env = $1",
+        [env]
+      )
+    ).toEqual(before);
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_job_status",
+          ["text", "uuid"],
+          [env, randomUUID()]
+        )
+      ).job_id
+    ).toBeNull();
+    expect(
+      (
+        await call(
+          mainPool,
+          "pq_cancel",
+          ["text", "uuid", "bigint"],
+          [env, a.job_id, r.mgmt_version]
+        )
+      ).outcome
+    ).toBe("cancelled");
+  }, 60000);
+
+  it("35. keeps the first park age across 12 parks and does not inflate the first real retry", async () => {
+    const env = `${ENV_PREFIX}parks`;
+    await enqueue(mainPool, env, { maxAttempts: 2 });
+    let first: string | null = null;
+    for (let i = 0; i < 12; i += 1) {
+      const j = await claim(mainPool, env);
+      const r = await call(
+        mainPool,
+        "pq_park",
+        [...TOKEN_CASTS, "text"],
+        [...token(j), "dependency"]
+      );
+      expect(r.outcome).toBe("parked");
+      expect(r.parked_attempt_count).toBe(i + 1);
+      if (first === null) first = r.first_parked_at;
+      expect(r.first_parked_at).toBe(first);
+      await mainPool.query(
+        "UPDATE public.polis_queue_jobs SET eligible_at = clock_timestamp() - interval '1 second' WHERE env = $1",
+        [env]
+      );
+      expect((await reap(mainPool, env))[0].outcome).toBe("queued");
+    }
+    const j = await claim(mainPool, env);
+    const failed = await call(
+      mainPool,
+      "pq_fail",
+      [...TOKEN_CASTS, "boolean", "text"],
+      [...token(j), false, "synthetic"]
+    );
+    expect(failed.outcome).toBe("retry_wait");
+    expect(
+      Number(
+        await sql(
+          mainPool,
+          "SELECT extract(epoch FROM eligible_at - updated_at) FROM public.polis_queue_jobs WHERE env = $1",
+          [env]
+        )
+      )
+    ).toBeLessThan(10);
+    expect(
+      (await call(mainPool, "pq_job_status", ["text", "uuid"], [env, j.job_id]))
+        .first_parked_at
+    ).toBe(first);
+  }, 180000);
+
+  it("36. reaps 30 products one committed transaction per job, holding no earlier run or head", async () => {
+    const env = `${ENV_PREFIX}reap`;
+    for (let i = 0; i < 30; i += 1) {
+      await enqueue(mainPool, env, { key: String(i), product: `product-${i}` });
+      await claim(mainPool, env);
+    }
+    await mainPool.query(
+      "UPDATE public.polis_queue_jobs SET locked_until = clock_timestamp() - interval '1 second' WHERE env = $1",
+      [env]
+    );
+    const ids = await due(mainPool, env);
+    expect(ids).toHaveLength(30);
+
+    const first = await mainPool.connect();
+    try {
+      await first.query("BEGIN");
+      await applySessionPolicy(first);
+      wire(
+        (
+          await first.query(
+            "SELECT public.pq_reap_one($1::text,$2::uuid) AS r",
+            [env, ids[0]]
+          )
+        ).rows[0].r
+      );
+      await first.query("COMMIT");
+    } finally {
+      first.release();
+    }
+
+    const held = await mainPool.connect();
+    try {
+      await held.query("BEGIN");
+      await applySessionPolicy(held);
+      wire(
+        (
+          await held.query(
+            "SELECT public.pq_reap_one($1::text,$2::uuid) AS r",
+            [env, ids[1]]
+          )
+        ).rows[0].r
+      );
+      // The previous job's run lock is gone: NOWAIT would raise if it were not.
+      const observer = await mainPool.connect();
+      try {
+        await observer.query("BEGIN");
+        await observer.query(
+          "SELECT 1 FROM public.polis_queue_runs WHERE env = $1 AND run_id = " +
+            "(SELECT run_id FROM public.polis_queue_jobs WHERE env = $1 AND job_id = $2) " +
+            "FOR UPDATE NOWAIT",
+          [env, ids[0]]
+        );
+        await observer.query("COMMIT");
+      } finally {
+        observer.release();
+      }
+      // No product head is held either.
+      for (const product of ["product-0", "product-29"]) {
+        expect(
+          (await enqueue(mainPool, env, { key: `new-${product}`, product }))
+            .outcome
+        ).toBe("enqueued");
+      }
+      await held.query("COMMIT");
+    } finally {
+      held.release();
+    }
+
+    expect(await reap(mainPool, env)).toHaveLength(28);
+  }, 180000);
+
+  it("37. skips a busy reaper row and recovers it on the next pass", async () => {
+    const env = `${ENV_PREFIX}skip`;
+    for (let i = 0; i < 2; i += 1) {
+      await enqueue(mainPool, env, { key: String(i) });
+      await claim(mainPool, env);
+    }
+    await mainPool.query(
+      "UPDATE public.polis_queue_jobs SET locked_until = clock_timestamp() - interval '1 second' WHERE env = $1",
+      [env]
+    );
+    const ids = await due(mainPool, env);
+    expect(ids).toHaveLength(2);
+    await whileHolding(
+      mainPool,
+      "SELECT 1 FROM public.polis_queue_jobs WHERE env = $1 AND job_id = $2 FOR UPDATE",
+      [env, ids[0]],
+      async () => {
+        expect((await reap(mainPool, env)).map((r) => r.job_id)).toEqual([
+          ids[1],
+        ]);
+      }
+    );
+    expect((await reap(mainPool, env)).map((r) => r.job_id)).toEqual([ids[0]]);
+  }, 120000);
+
+  it("39. pins search_path and UTC on every function, updates no conversation, and withholds CREATE grant option", async () => {
+    const functions = await rows(
+      mainPool,
+      "SELECT proname, proconfig, prosrc FROM pg_proc " +
+        "WHERE pronamespace = 'public'::regnamespace AND proname LIKE 'pq\\_%'"
+    );
+    expect(functions).toHaveLength(21);
+    for (const fn of functions) {
+      expect(fn.proconfig).toContain("search_path=pg_catalog, pg_temp");
+      expect(fn.proconfig).toContain("TimeZone=UTC");
+      expect(fn.prosrc).not.toMatch(/UPDATE\s+(?:public\.)?conversations\b/i);
+    }
+    expect(
+      await sql(
+        mainPool,
+        "SELECT has_schema_privilege('polis_queue_owner','public','CREATE WITH GRANT OPTION')"
+      )
+    ).toBe(false);
+  }, 30000);
+
+  it("40. grants EXECUTE to the executor on exactly the twelve RPCs", async () => {
+    const acl = await rows(
+      mainPool,
+      "SELECT p.proname, has_function_privilege('polis_queue_executor', p.oid, 'EXECUTE') AS granted " +
+        "FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace " +
+        "WHERE n.nspname = 'public' AND p.proname LIKE 'pq\\_%'"
+    );
+    const granted = acl
+      .filter((row) => row.granted)
+      .map((row) => row.proname)
+      .sort();
+    expect(granted).toEqual([
+      "pq_cancel",
+      "pq_claim",
+      "pq_due",
+      "pq_enqueue",
+      "pq_fail",
+      "pq_finalize",
+      "pq_head_status",
+      "pq_heartbeat",
+      "pq_job_status",
+      "pq_park",
+      "pq_reap_one",
+      "pq_release",
+    ]);
+    expect(acl.length).toBeGreaterThan(granted.length);
+  }, 30000);
+
+  it("pins the migration SHA-256 that both adapters were written against", () => {
+    expect(protocol.migrationSha256()).toBe(protocol.QUEUE_SQL_SHA256);
+  });
+
+  it("enqueues through the Node adapter inside one withTransaction", async () => {
+    const env = `${ENV_PREFIX}node-adapter`;
+    const request = {
+      env,
+      zid,
+      productKey: "product",
+      actorScope: "synthetic-actor",
+      requestKey: "adapter",
+      priority: 1,
+      maxAttempts: 3,
+    };
+    const first = await queue.enqueueNoopJob(request);
+    expect(first.outcome).toBe("enqueued");
+    expect(first.result.stage).toBe("noop");
+    expect(first.result.input).toEqual({
+      uri: queue.NOOP_INPUT_URI,
+      sha256: queue.NOOP_INPUT_SHA256,
+      config_sha256: queue.NOOP_INPUT_SHA256,
+      code_image_digest: queue.NOOP_IMAGE_DIGEST,
+    });
+    const replay = await queue.enqueueNoopJob(request);
+    expect(replay.outcome).toBe("existing");
+    expect(replay.result.run_id).toBe(first.result.run_id);
+    // The digest covers every semantic input, so the same key with a changed
+    // retry policy is a conflict rather than a silent second job.
+    const changed = await queue.enqueueNoopJob({ ...request, maxAttempts: 4 });
+    expect(changed.outcome).toBe("conflict");
+    expect(changed.requestSha256).not.toBe(first.requestSha256);
+  }, 60000);
+
+  it("refuses an env outside the dev/test namespace and refuses when disabled", async () => {
+    await expect(
+      queue.enqueueNoopJob({
+        env: "prod",
+        zid,
+        productKey: "product",
+        actorScope: "synthetic-actor",
+        requestKey: "rejected",
+      })
+    ).rejects.toThrow(/env must be/);
+  }, 30000);
+});
+
+// ---------------------------------------------- 30, 38 plans at 20,000 rows
+
+describeProvisioned(
+  SKIP_PROVISIONING
+    ? `P-024 queue substrate plans at scale (${PROVISIONING_SKIP_REASON})`
+    : "P-024 queue substrate plans at scale",
+  () => {
+    it("30. uses the ready index with 20,000 terminal and other-lane rows", async () => {
+      const a = await enqueue(scratchPool, "r3-plan");
+      await scratchPool.query(
+        "INSERT INTO public.polis_queue_jobs(env,job_id,run_id,stage,stage_instance,state,priority,max_attempts) " +
+          "SELECT 'r3-plan',gen_random_uuid(),$1,'noop',g::text," +
+          "CASE WHEN g<=10000 THEN 'succeeded' ELSE 'queued' END,2,3 FROM generate_series(1,20000) g",
+        [a.run_id]
+      );
+      await scratchPool.query("ANALYZE public.polis_queue_jobs");
+      const plan = await sql(
+        scratchPool,
+        "EXPLAIN (ANALYZE,BUFFERS,FORMAT JSON) SELECT q.env,q.job_id FROM public.polis_queue_jobs q " +
+          "WHERE q.env='r3-plan' AND q.priority=1 AND q.state IN ('queued','retry_wait') " +
+          "AND q.eligible_at<=statement_timestamp() AND q.attempt_count-q.parked_attempt_count<q.max_attempts " +
+          "ORDER BY q.eligible_at,q.created_at,q.job_id FOR UPDATE SKIP LOCKED LIMIT 1"
+      );
+      expect(
+        nodes(plan[0].Plan).some(
+          (n) =>
+            n["Node Type"] === "Index Scan" &&
+            n["Index Name"] === "polis_queue_ready"
+        )
+      ).toBe(true);
+      expect((await claim(scratchPool, "r3-plan")).job_id).toBe(a.job_id);
+    }, 180000);
+
+    it("38. uses a zid index for both parent lookups at 20,000 rows and restricts parent deletion", async () => {
+      await scratchPool.query(
+        "INSERT INTO public.conversations(zid,topic) SELECT g,'synthetic' FROM generate_series(3,20002) g"
+      );
+      await scratchPool.query(
+        "INSERT INTO public.polis_queue_heads(env,product_key,zid) " +
+          "SELECT 'r4-fk',g::text,g FROM generate_series(3,20002) g"
+      );
+      await scratchPool.query(
+        "INSERT INTO public.polis_queue_runs(env,run_id,zid,product_key,requested_generation," +
+          "input_uri,input_sha256,expected_output_uri,expected_output_sha256,config_sha256," +
+          "code_image_digest,contract_version) " +
+          "SELECT 'r4-fk',gen_random_uuid(),g,g::text,1,'synthetic',$1,'synthetic',$1,$1," +
+          "'synthetic','polis-queue/1' FROM generate_series(3,20002) g",
+        [H]
+      );
+      for (const table of ["heads", "runs"]) {
+        await scratchPool.query(`ANALYZE public.polis_queue_${table}`);
+        const plan = await sql(
+          scratchPool,
+          `EXPLAIN (ANALYZE,BUFFERS,FORMAT JSON) SELECT 1 FROM ONLY public.polis_queue_${table} x ` +
+            "WHERE x.zid=20002 FOR KEY SHARE OF x"
+        );
+        // Index-backed either way; at few distinct zids the planner may pick a
+        // bitmap, so the assertion is on the index used, not the node type.
+        expect(
+          nodes(plan[0].Plan).some(
+            (n) => n["Index Name"] === `polis_queue_${table}_zid`
+          )
+        ).toBe(true);
+      }
+      await expectSqlState(
+        scratchPool.query("DELETE FROM public.conversations WHERE zid=20002"),
+        "23503"
+      );
+      await scratchPool.query(
+        "INSERT INTO public.conversations(zid,topic) VALUES (20003,'synthetic')"
+      );
+      const deleted = await scratchPool.query(
+        "DELETE FROM public.conversations WHERE zid=20003"
+      );
+      expect(deleted.rowCount).toBe(1);
+    }, 180000);
+  }
+);

--- a/server/__tests__/integration/queue-substrate.test.ts
+++ b/server/__tests__/integration/queue-substrate.test.ts
@@ -45,8 +45,10 @@ dotenv.config({ override: false });
 // against a second copy of the field list.
 type EnqueueModule = typeof import("../../src/queue/enqueue");
 type ProtocolModule = typeof import("../../src/queue/protocol");
+type PgQueryModule = typeof import("../../src/db/pg-query");
 let queue: EnqueueModule;
 let protocol: ProtocolModule;
+let pgQuery: PgQueryModule;
 
 const MIGRATION_PATH = path.join(
   __dirname,
@@ -426,6 +428,7 @@ beforeAll(async () => {
   process.env.POLIS_QUEUE_SUBSTRATE_ENABLED = "true";
   protocol = await import("../../src/queue/protocol");
   queue = await import("../../src/queue/enqueue");
+  pgQuery = await import("../../src/db/pg-query");
 
   mainPool = new Pool({ connectionString: BASE_DATABASE_URL, max: 12 });
   await runMigration(mainPool);
@@ -1359,6 +1362,56 @@ describe("P-024 queue substrate protocol", () => {
     expect(changed.outcome).toBe("conflict");
     expect(changed.requestSha256).not.toBe(first.requestSha256);
   }, 60000);
+
+  it("puts the declared session bounds in effect on a real connection", async () => {
+    const settings = await pgQuery.default.withTransaction(async (client) => {
+      const reply = await client.query(
+        "SELECT current_setting('TimeZone') AS tz, current_setting('lock_timeout') AS lt, " +
+          "current_setting('statement_timeout') AS st, current_setting('transaction_timeout') AS tt"
+      );
+      return reply.rows[0];
+    });
+    expect(settings).toEqual({
+      tz: "UTC",
+      lt: "500ms",
+      st: "5s",
+      tt: "10s",
+    });
+  }, 30000);
+
+  it("refuses to report success when a swallowed statement error aborted the transaction", async () => {
+    await expect(
+      pgQuery.default.withTransaction(async (client) => {
+        try {
+          await client.query("SELECT 1/0");
+        } catch {
+          // A caller that swallows this leaves the transaction aborted, and
+          // PostgreSQL then answers COMMIT with a ROLLBACK command tag.
+        }
+        return 42;
+      })
+    ).rejects.toThrow("transaction_was_aborted");
+  }, 30000);
+
+  it("survives its backend being terminated between queries, and the pool recovers", async () => {
+    await expect(
+      pgQuery.default.withTransaction(async (client) => {
+        const reply = await client.query("SELECT pg_backend_pid() AS pid");
+        await mainPool.query("SELECT pg_terminate_backend($1)", [
+          reply.rows[0].pid,
+        ]);
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return 42;
+      })
+    ).rejects.toBeDefined();
+    // The discarded client did not poison the pool.
+    expect(
+      await pgQuery.default.withTransaction(async (client) => {
+        const reply = await client.query("SELECT 42 AS n");
+        return reply.rows[0].n;
+      })
+    ).toBe(42);
+  }, 30000);
 
   it("refuses an env outside the dev/test namespace and refuses when disabled", async () => {
     await expect(

--- a/server/__tests__/unit/queue-transaction.test.ts
+++ b/server/__tests__/unit/queue-transaction.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Committed regressions for the failure seams of pg-query's withTransaction.
+ *
+ * Each of these can otherwise be mistaken for success, and each was found or
+ * confirmed by an out-of-tree probe rather than by reasoning. They live here so
+ * a later edit to the shared helper cannot remove the behaviour unnoticed.
+ *
+ * The pool is mocked: these are about what the helper does with a client, not
+ * about PostgreSQL. The real-server counterparts - the session bounds actually
+ * in effect, a swallowed statement error producing a ROLLBACK command tag, and
+ * a genuinely terminated backend - are covered against a live database in
+ * __tests__/integration/queue-substrate.test.ts.
+ */
+import { EventEmitter } from "node:events";
+
+type Responder = (text: string, client: FakeClient) => unknown;
+
+class FakeClient extends EventEmitter {
+  statements: string[] = [];
+  releases: unknown[] = [];
+  responder?: Responder;
+
+  constructor(responder?: Responder) {
+    super();
+    this.responder = responder;
+  }
+
+  async query(text: string): Promise<unknown> {
+    this.statements.push(text);
+    const answer = this.responder
+      ? await this.responder(text, this)
+      : undefined;
+    if (answer !== undefined) return answer;
+    return { command: text === "COMMIT" ? "COMMIT" : "", rows: [] };
+  }
+
+  release(err?: unknown): void {
+    this.releases.push(err);
+  }
+}
+
+// jest.mock factories may only reference names beginning with "mock".
+const mockConnectQueue: unknown[] = [];
+
+jest.mock("pg", () => {
+  const actual = jest.requireActual("pg");
+  class MockPool {
+    connect(): Promise<unknown> {
+      const next = mockConnectQueue.shift();
+      if (next instanceof Error) return Promise.reject(next);
+      if (!next) return Promise.reject(new Error("no scripted client"));
+      return Promise.resolve(next);
+    }
+    query(): Promise<unknown> {
+      return Promise.resolve({ rows: [] });
+    }
+    on(): void {
+      /* pools are not exercised here */
+    }
+    end(): Promise<void> {
+      return Promise.resolve();
+    }
+  }
+  return { ...actual, Pool: MockPool };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import pgQuery, { CommitOutcomeUnknownError } from "../../src/db/pg-query";
+
+function scripted(responder?: Responder): FakeClient {
+  const client = new FakeClient(responder);
+  mockConnectQueue.push(client);
+  return client;
+}
+
+afterEach(() => {
+  mockConnectQueue.length = 0;
+});
+
+describe("withTransaction", () => {
+  it("commits and returns the callback's value, releasing a healthy client", async () => {
+    const client = scripted();
+    await expect(pgQuery.withTransaction(async () => 42)).resolves.toBe(42);
+    expect(client.statements[0]).toBe("BEGIN ISOLATION LEVEL READ COMMITTED");
+    expect(client.statements[client.statements.length - 1]).toBe("COMMIT");
+    expect(client.releases).toEqual([false]);
+    // A pooled client is handed back without this helper's error listener.
+    expect(client.listenerCount("error")).toBe(0);
+  });
+
+  it("applies the declared /1 session policy immediately after BEGIN", async () => {
+    const client = scripted();
+    await pgQuery.withTransaction(async () => 42);
+    const policy = client.statements[1];
+    expect(policy).toContain("SET LOCAL TIME ZONE 'UTC'");
+    expect(policy).toContain("lock_timeout = '500ms'");
+    expect(policy).toContain("statement_timeout = '5s'");
+    expect(policy).toContain("idle_in_transaction_session_timeout = '5s'");
+    // PostgreSQL 17 only, so it is guarded rather than issued unconditionally.
+    expect(policy).toContain("transaction_timeout");
+    expect(policy).toContain("server_version_num");
+  });
+
+  it.each(["BEGIN", "SET LOCAL"])(
+    "rolls back and never runs the callback when %s fails",
+    async (seam) => {
+      const boom = new Error("synthetic");
+      const client = scripted((text) => {
+        if (text.startsWith(seam)) throw boom;
+        return undefined;
+      });
+      let ran = false;
+      await expect(
+        pgQuery.withTransaction(async () => {
+          ran = true;
+          return 42;
+        })
+      ).rejects.toBe(boom);
+      expect(ran).toBe(false);
+      expect(client.statements).toContain("ROLLBACK");
+      expect(client.releases).toEqual([false]);
+    }
+  );
+
+  it("preserves the callback's error and rolls back", async () => {
+    const boom = new Error("work");
+    const client = scripted();
+    await expect(
+      pgQuery.withTransaction(async () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+    expect(client.statements).toContain("ROLLBACK");
+    expect(client.releases).toEqual([false]);
+  });
+
+  it("destroys the client when the rollback itself fails", async () => {
+    const boom = new Error("work");
+    const client = scripted((text) => {
+      if (text === "ROLLBACK") throw new Error("rollback");
+      return undefined;
+    });
+    await expect(
+      pgQuery.withTransaction(async () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+    // A client whose transaction state is unknown must not be pooled.
+    expect(client.releases).toEqual([true]);
+  });
+
+  it("reports a failed COMMIT as an unknown outcome, not a rollback", async () => {
+    const client = scripted((text) => {
+      if (text === "COMMIT") throw new Error("socket");
+      return undefined;
+    });
+    await expect(
+      pgQuery.withTransaction(async () => 42)
+    ).rejects.toBeInstanceOf(CommitOutcomeUnknownError);
+    expect(client.releases).toEqual([true]);
+  });
+
+  it("refuses to report success when COMMIT answers with a ROLLBACK tag", async () => {
+    // A callback that swallows a statement error leaves the transaction
+    // aborted; returning normally here would report a write that never landed.
+    const client = scripted((text) =>
+      text === "COMMIT" ? { command: "ROLLBACK", rows: [] } : undefined
+    );
+    await expect(pgQuery.withTransaction(async () => 42)).rejects.toThrow(
+      "transaction_was_aborted"
+    );
+    expect(client.releases).toEqual([false]);
+  });
+
+  it("fails and destroys the client when the backend dies between queries", async () => {
+    const boom = new Error("terminating connection");
+    const client = scripted();
+    await expect(
+      pgQuery.withTransaction(async () => {
+        // With no listener attached this escapes as an unhandled EventEmitter
+        // error rather than failing the transaction.
+        client.emit("error", boom);
+        return 42;
+      })
+    ).rejects.toBe(boom);
+    expect(client.releases).toEqual([true]);
+    // A discarded client keeps the listener: it may emit again asynchronously.
+    expect(client.listenerCount("error")).toBe(1);
+  });
+
+  it("propagates a failure to acquire a connection", async () => {
+    const boom = new Error("pool exhausted");
+    mockConnectQueue.push(boom);
+    await expect(pgQuery.withTransaction(async () => 42)).rejects.toBe(boom);
+  });
+});

--- a/server/postgres/migrations/000019_create_polis_queue.sql
+++ b/server/postgres/migrations/000019_create_polis_queue.sql
@@ -4,8 +4,9 @@
 -- Design: cost-reduction/04-plans/P-024-queue-substrate.md (revision 4).
 -- Content below is cost-reduction/04-plans/P-024-queue-substrate-v1.sql, which
 -- carries the round-4 review's H1 overload guard and the catalog fingerprint
--- guards. Two additions are made here and marked in place: the post-apply
--- signature assertion, and the explicit granted-RPC allowlist assertion.
+-- guards. Three additions are made here, each numbered and marked in place:
+-- the post-apply signature assertion, the explicit granted-RPC allowlist
+-- assertion, and the observed-state DETAIL on a drift abort.
 --
 -- HOW TO APPLY
 -- ------------

--- a/server/postgres/migrations/000019_create_polis_queue.sql
+++ b/server/postgres/migrations/000019_create_polis_queue.sql
@@ -1,0 +1,604 @@
+-- 000019_create_polis_queue.sql
+--
+-- P-024 Postgres queue substrate, contract polis-queue/1, first slice: noop only.
+-- Design: cost-reduction/04-plans/P-024-queue-substrate.md (revision 4).
+-- Content below is cost-reduction/04-plans/P-024-queue-substrate-v1.sql, which
+-- carries the round-4 review's H1 overload guard and the catalog fingerprint
+-- guards. Two additions are made here and marked in place: the post-apply
+-- signature assertion, and the explicit granted-RPC allowlist assertion.
+--
+-- HOW TO APPLY
+-- ------------
+-- Apply THIS FILE ALONE, manually, on a pinned read-write connection, exactly as
+-- docs/migrations.md describes for a post-provisioning migration:
+--
+--   docker exec -i polis-dev-postgres-1 psql -v ON_ERROR_STOP=1 -U postgres -d polis-dev \
+--     < server/postgres/migrations/000019_create_polis_queue.sql
+--
+-- Never replay the migrations directory as an upgrade mechanism:
+-- server/bin/run-migrations.sh has no version ledger and the existing files in
+-- this directory are not replay-safe. (This file is; see IDEMPOTENCE below.)
+-- On a fresh container the postgres image applies it once from
+-- /docker-entrypoint-initdb.d, in file-name order, as the superuser.
+--
+-- APPLIER REQUIREMENTS
+-- --------------------
+-- This is the first migration in this repository that creates roles and
+-- transfers object ownership, so the applying login must be able to SET ROLE to
+-- the object owner. Concretely:
+--   * On a first apply that must create the roles: CREATEROLE (or superuser).
+--   * On every apply: SET-capable membership in polis_queue_owner. PostgreSQL 17
+--     lets a role creator hold ADMIN without SET, so this file grants itself
+--     WITH SET TRUE when it is allowed to; an applier that is only a member
+--     WITHOUT SET fails with a readable precondition instead of half-applying.
+--   * public schema USAGE and CREATE, both WITH GRANT OPTION, and
+--     public.conversations SELECT, UPDATE(topic) and REFERENCES(zid), all WITH
+--     GRANT OPTION (owning conversations satisfies this).
+-- polis_queue_owner and polis_queue_executor are NOLOGIN. Provisioning a service
+-- login into polis_queue_executor is separate, separately reviewed work; this
+-- migration creates no login role and stores no password.
+--
+-- IDEMPOTENCE AND DRIFT
+-- ---------------------
+-- Re-running this file against the schema it created is safe: CREATE ... IF NOT
+-- EXISTS, CREATE OR REPLACE FUNCTION, DROP TRIGGER IF EXISTS before CREATE
+-- TRIGGER, and idempotent GRANT/ALTER OWNER. It does NOT repair or bless an
+-- incompatible pre-existing object. The guards below fingerprint the enumerated
+-- catalog metadata (columns with types/defaults/collations/ACLs, constraints,
+-- indexes, triggers, ownership, table options, RLS, and every pq_ signature,
+-- result, default, language, volatility, config, owner and ACL) before the DDL
+-- runs and again after it, and abort the transaction on any difference. The
+-- fingerprints are pinned to PostgreSQL 17 deparse output with a fixed
+-- search_path; changing the schema means regenerating them in the same reviewed
+-- change. See docs/queue-substrate.md.
+--
+-- SCOPE
+-- -----
+-- Installing this schema wires nothing. No route calls it; the Node helper that
+-- does is behind POLIS_QUEUE_SUBSTRATE_ENABLED, default off. stage is CHECK'd to
+-- 'noop' and contract_version to 'polis-queue/1'; admitting a real stage or a /2
+-- wire needs its own reviewed migration. Gates A1-A8 in the design document are
+-- open: nothing here is certified against a deployed conversations schema, no
+-- COMMIT has been severed, and there is no backup/restore rehearsal yet.
+
+BEGIN;
+DO $$ BEGIN
+ IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname=current_user AND (rolsuper OR rolcreaterole))
+    AND (NOT EXISTS (SELECT FROM pg_roles WHERE rolname='polis_queue_owner')
+      OR NOT EXISTS (SELECT FROM pg_roles WHERE rolname='polis_queue_executor')) THEN
+  RAISE EXCEPTION 'queue migration requires CREATEROLE for initial role provisioning';
+ END IF;
+ IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='polis_queue_owner') THEN
+  CREATE ROLE polis_queue_owner NOLOGIN;
+ END IF;
+ IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='polis_queue_executor') THEN
+  CREATE ROLE polis_queue_executor NOLOGIN;
+ END IF;
+ IF NOT pg_has_role(current_user,'polis_queue_owner','SET') THEN
+  BEGIN
+   GRANT polis_queue_owner TO CURRENT_USER WITH SET TRUE;
+  EXCEPTION WHEN insufficient_privilege THEN
+   RAISE EXCEPTION 'queue migration requires membership in polis_queue_owner; ask role administrator to grant it';
+  END;
+ END IF;
+ IF NOT has_schema_privilege(current_user,'public','USAGE WITH GRANT OPTION')
+    OR NOT has_schema_privilege(current_user,'public','CREATE WITH GRANT OPTION')
+    OR NOT has_table_privilege(current_user,'public.conversations','SELECT WITH GRANT OPTION')
+    OR NOT has_column_privilege(current_user,'public.conversations','topic','UPDATE WITH GRANT OPTION')
+    OR NOT has_column_privilege(current_user,'public.conversations','zid','REFERENCES WITH GRANT OPTION') THEN
+  RAISE EXCEPTION 'queue migration requires public schema CREATE and conversations SELECT/UPDATE(topic)/REFERENCES(zid) with grant option';
+ END IF;
+ IF EXISTS (SELECT FROM pg_roles WHERE rolname IN ('polis_queue_owner','polis_queue_executor')
+  AND (rolcanlogin OR rolsuper OR rolcreaterole OR rolcreatedb OR rolreplication OR rolbypassrls)) THEN
+  RAISE EXCEPTION 'queue catalog drift: owner/executor role attributes';
+ END IF;
+END $$;
+GRANT USAGE ON SCHEMA public TO polis_queue_owner WITH GRANT OPTION;
+GRANT CREATE ON SCHEMA public TO polis_queue_owner;
+GRANT SELECT, REFERENCES(zid), UPDATE(topic) ON public.conversations TO polis_queue_owner;
+-- Create AND replay as the object owner, not merely a role allowed to transfer it.
+SET LOCAL ROLE polis_queue_owner;
+SET LOCAL search_path=pg_catalog,pg_temp;
+-- H1: known unshipped signatures must not survive as ambiguous overloads.
+-- No CASCADE: unexpected dependencies fail the transaction for review.
+DROP FUNCTION IF EXISTS public.pq_lock(text,uuid,boolean);
+DO $$ BEGIN
+ IF to_regtype('public.polis_queue_jobs') IS NOT NULL THEN
+  DROP FUNCTION IF EXISTS public.pq_terminate_attempt(public.polis_queue_jobs,text,text,text);
+ END IF;
+END $$;
+
+-- Catalog fingerprints are over the explicitly enumerated metadata below, not
+-- data or object OIDs. PostgreSQL 17 and a fixed search_path make them stable.
+-- Any changed column/default, CHECK/FK, index, trigger, owner/ACL or table option
+-- requires a reviewed migration. IF NOT EXISTS must never bless schema drift.
+CREATE OR REPLACE FUNCTION pg_temp.pq_catalog(p_table oid) RETURNS jsonb
+LANGUAGE sql SET search_path=pg_catalog,pg_temp AS $catalog$
+SELECT jsonb_build_object(
+ 'columns',(SELECT jsonb_agg(jsonb_build_array(a.attname,format_type(a.atttypid,a.atttypmod),a.attnotnull,a.attidentity,a.attgenerated,co.collname,pg_get_expr(d.adbin,d.adrelid),NULLIF(a.attacl::text,'{}')) ORDER BY a.attnum)
+ FROM pg_attribute a LEFT JOIN pg_attrdef d ON d.adrelid=a.attrelid AND d.adnum=a.attnum LEFT JOIN pg_collation co ON co.oid=a.attcollation
+ WHERE a.attrelid=c.oid AND a.attnum>0 AND NOT a.attisdropped),
+ 'constraints',(SELECT jsonb_agg(jsonb_build_array(conname,pg_get_constraintdef(oid),convalidated,connoinherit) ORDER BY conname) FROM pg_constraint WHERE conrelid=c.oid),
+ 'indexes',(SELECT jsonb_agg(jsonb_build_array(ic.relname,pg_get_indexdef(i.indexrelid),i.indisvalid,i.indisready) ORDER BY ic.relname) FROM pg_index i JOIN pg_class ic ON ic.oid=i.indexrelid WHERE i.indrelid=c.oid),
+ 'triggers',(SELECT jsonb_agg(jsonb_build_array(t.tgname,pg_get_triggerdef(t.oid),t.tgenabled) ORDER BY t.tgname) FROM pg_trigger t WHERE t.tgrelid=c.oid AND NOT t.tgisinternal),
+ 'owner',pg_get_userbyid(c.relowner),'kind',c.relkind,'rls',c.relrowsecurity,'force_rls',c.relforcerowsecurity,'options',c.reloptions,
+ 'acl',(SELECT jsonb_agg(jsonb_build_array(CASE WHEN x.grantee=0 THEN 'PUBLIC' ELSE pg_get_userbyid(x.grantee) END,x.privilege_type,x.is_grantable) ORDER BY x.grantee=0,pg_get_userbyid(x.grantee),x.privilege_type,x.is_grantable) FROM aclexplode(COALESCE(c.relacl,acldefault('r',c.relowner))) x)
+ ) FROM pg_class c WHERE c.oid=p_table
+$catalog$;
+CREATE OR REPLACE FUNCTION pg_temp.pq_assert_catalog(p_fresh boolean) RETURNS void
+LANGUAGE plpgsql SET search_path=pg_catalog,pg_temp AS $guard$
+DECLARE expected jsonb='{"polis_queue_attempts": "4bf01840303c3447650ada377d535bee", "polis_queue_heads": "cf987d5673228e6ca6d6f3b86b7e77e5", "polis_queue_jobs": "d8367b8bdaa7701b9c377450d23b5db5", "polis_queue_requests": "cae8fcd4db4562b9936b7d33cf598f1e", "polis_queue_runs": "8e7fd316c23320c229387822146eebec"}'::jsonb;
+ entry record; actual text; names text[];
+BEGIN
+ SELECT array_agg(relname::text ORDER BY relname) INTO names FROM pg_class
+ WHERE relnamespace='public'::regnamespace AND starts_with(relname,'polis_queue_')
+ AND relkind IN ('r','p','v','m','f');
+ IF p_fresh AND names IS NULL THEN RETURN; END IF;
+ IF names IS DISTINCT FROM ARRAY(SELECT jsonb_object_keys(expected) ORDER BY 1) THEN
+  RAISE EXCEPTION 'queue catalog drift: table inventory';
+ END IF;
+ FOR entry IN SELECT * FROM jsonb_each_text(expected) LOOP
+  SELECT md5(pg_temp.pq_catalog(to_regclass('public.'||entry.key))::text) INTO actual;
+  IF actual IS DISTINCT FROM entry.value THEN
+   RAISE EXCEPTION 'queue catalog drift: %',entry.key
+   USING DETAIL='observed: '||pg_temp.pq_catalog(to_regclass('public.'||entry.key))::text;
+  END IF;
+ END LOOP;
+END $guard$;
+SELECT pg_temp.pq_assert_catalog(true);
+
+CREATE OR REPLACE FUNCTION pg_temp.pq_assert_signatures(p_fresh boolean) RETURNS void
+LANGUAGE plpgsql SET search_path=pg_catalog,pg_temp AS $guard$
+DECLARE expected text[]=ARRAY['pq_backoff(uuid, integer)','pq_cancel(text, uuid, bigint)','pq_claim(text, smallint, uuid, uuid, integer)','pq_due(text, uuid, integer)','pq_end_attempt(text, uuid, uuid, uuid, bigint, text, text)','pq_enqueue(text, integer, text, text, text, text, uuid, uuid, text, text, text, text, smallint, integer)','pq_fail(text, uuid, uuid, uuid, bigint, boolean, text)','pq_finalize(text, uuid, uuid, uuid, bigint, text, text)','pq_head_status(text, text)','pq_heartbeat(text, uuid, uuid, uuid, bigint, integer)','pq_job_status(text, uuid)','pq_lock(text, uuid, boolean, boolean)','pq_no_regression()','pq_owns(public.polis_queue_jobs, uuid, uuid, bigint)','pq_park(text, uuid, uuid, uuid, bigint, text)','pq_publish_allowed(public.polis_queue_heads, public.polis_queue_runs)','pq_reap(text, uuid, integer)','pq_reap_one(text, uuid)','pq_release(text, uuid, uuid, uuid, bigint)','pq_result(text, public.polis_queue_jobs, boolean)','pq_terminate_attempt(public.polis_queue_jobs, text, text, text, boolean)']; actual text[];
+BEGIN
+ SELECT array_agg(proname || '(' || oidvectortypes(proargtypes) || ')' ORDER BY proname || '(' || oidvectortypes(proargtypes) || ')')
+ INTO actual FROM pg_proc WHERE pronamespace='public'::regnamespace AND starts_with(proname,'pq_');
+ IF p_fresh AND actual IS NULL THEN RETURN; END IF;
+ IF actual IS DISTINCT FROM expected THEN
+  RAISE EXCEPTION 'queue catalog drift: unexpected function signatures (including overloads)';
+ END IF;
+END $guard$;
+SELECT pg_temp.pq_assert_signatures(true);
+CREATE OR REPLACE FUNCTION pg_temp.pq_assert_functions(p_fresh boolean) RETURNS void
+LANGUAGE plpgsql SET search_path=pg_catalog,pg_temp AS $guard$
+DECLARE actual text;
+BEGIN
+ SELECT md5((SELECT jsonb_agg(jsonb_build_object(
+ 'signature',p.proname || '(' || oidvectortypes(p.proargtypes) || ')',
+ 'result',pg_get_function_result(p.oid),'defaults',pg_get_expr(p.proargdefaults,0),
+ 'language',l.lanname,'kind',p.prokind,'security_definer',p.prosecdef,
+ 'volatility',p.provolatile,'parallel',p.proparallel,'strict',p.proisstrict,
+ 'config',p.proconfig,'owner',pg_get_userbyid(p.proowner),
+ 'acl',(SELECT jsonb_agg(jsonb_build_array(CASE WHEN a.grantee=0 THEN 'PUBLIC' ELSE pg_get_userbyid(a.grantee) END,a.privilege_type,a.is_grantable)
+ ORDER BY a.grantee=0,pg_get_userbyid(a.grantee),a.privilege_type,a.is_grantable)
+ FROM aclexplode(COALESCE(p.proacl,acldefault('f',p.proowner))) a)
+ ) ORDER BY p.proname) FROM pg_proc p JOIN pg_language l ON l.oid=p.prolang
+ WHERE p.pronamespace='public'::regnamespace AND starts_with(p.proname,'pq_'))::text) INTO actual;
+ IF p_fresh AND actual IS NULL THEN RETURN; END IF;
+ IF actual IS DISTINCT FROM 'f27901140fda2363181773810f5fbfa5' THEN
+  -- Migration addition 3: the fingerprint says only that something moved. The
+  -- likeliest drift is a hand-edited grant or owner, so name what is observed.
+  RAISE EXCEPTION 'queue catalog drift: function result/defaults/config/owner/ACL'
+   USING DETAIL='observed: '||(SELECT string_agg(format('%s owner=%s definer=%s executor_execute=%s',
+    p.proname,pg_get_userbyid(p.proowner),p.prosecdef,
+    has_function_privilege('polis_queue_executor',p.oid,'EXECUTE')),'; ' ORDER BY p.proname)
+    FROM pg_proc p WHERE p.pronamespace='public'::regnamespace AND starts_with(p.proname,'pq_'));
+ END IF;
+END $guard$;
+SELECT pg_temp.pq_assert_functions(true);
+
+
+
+CREATE TABLE IF NOT EXISTS public.polis_queue_runs (
+ env text NOT NULL CHECK (env <> ''), run_id uuid NOT NULL,
+ zid integer NOT NULL REFERENCES public.conversations(zid),
+ product_key text NOT NULL CHECK (product_key <> ''), requested_generation bigint NOT NULL CHECK (requested_generation>0),
+ input_uri text NOT NULL CHECK (length(input_uri) BETWEEN 1 AND 2048),
+ input_sha256 text NOT NULL CHECK (input_sha256 ~ '^[0-9a-f]{64}$'),
+ expected_output_uri text NOT NULL CHECK(length(expected_output_uri) BETWEEN 1 AND 2048),
+ expected_output_sha256 text NOT NULL CHECK(expected_output_sha256 ~ '^[0-9a-f]{64}$'),
+ config_sha256 text NOT NULL CHECK (config_sha256 ~ '^[0-9a-f]{64}$'),
+ code_image_digest text NOT NULL, contract_version text NOT NULL CHECK (contract_version='polis-queue/1'),
+ state text NOT NULL DEFAULT 'pending' CHECK (state IN ('pending','succeeded','dead','cancelled')),
+ output_sha256 text, created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+ PRIMARY KEY(env,run_id), UNIQUE(env,product_key,requested_generation),
+ -- Required FK target: not redundant with the primary key for product binding.
+ UNIQUE(env,product_key,run_id,requested_generation)
+);
+CREATE TABLE IF NOT EXISTS public.polis_queue_heads (
+ env text NOT NULL, product_key text NOT NULL, zid integer NOT NULL REFERENCES public.conversations(zid),
+ requested_generation bigint NOT NULL DEFAULT 0 CHECK (requested_generation>=0),
+ desired_run_id uuid, published_run_id uuid, published_generation bigint NOT NULL DEFAULT 0,
+ published_sha256 text, version bigint NOT NULL DEFAULT 0 CHECK(version>=0),
+ PRIMARY KEY(env,product_key),
+ FOREIGN KEY(env,product_key,desired_run_id,requested_generation)
+  REFERENCES public.polis_queue_runs(env,product_key,run_id,requested_generation) DEFERRABLE INITIALLY DEFERRED,
+ FOREIGN KEY(env,product_key,published_run_id,published_generation)
+  REFERENCES public.polis_queue_runs(env,product_key,run_id,requested_generation) DEFERRABLE INITIALLY DEFERRED,
+ CHECK ((published_run_id IS NULL AND published_generation=0 AND published_sha256 IS NULL)
+     OR (published_run_id IS NOT NULL AND published_generation>0 AND published_sha256 ~ '^[0-9a-f]{64}$')),
+ CHECK(published_generation<=requested_generation)
+);
+CREATE TABLE IF NOT EXISTS public.polis_queue_jobs (
+ env text NOT NULL, job_id uuid NOT NULL, run_id uuid NOT NULL,
+ stage text NOT NULL CHECK(stage='noop'), stage_instance text,
+ state text NOT NULL DEFAULT 'queued' CHECK(state IN ('queued','running','retry_wait','parked','succeeded','dead','cancelled')),
+ priority smallint NOT NULL CHECK(priority BETWEEN 0 AND 2), eligible_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+ created_at timestamptz NOT NULL DEFAULT clock_timestamp(), updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+ attempt_count integer NOT NULL DEFAULT 0 CHECK(attempt_count>=0),
+ parked_attempt_count integer NOT NULL DEFAULT 0 CHECK(parked_attempt_count>=0 AND parked_attempt_count<=attempt_count), max_attempts integer NOT NULL CHECK(max_attempts BETWEEN 1 AND 100),
+ lease_epoch bigint NOT NULL DEFAULT 0 CHECK(lease_epoch>=0), version bigint NOT NULL DEFAULT 0 CHECK(version>=0),
+ mgmt_version bigint NOT NULL DEFAULT 0 CHECK(mgmt_version>=0),
+ owner_id uuid, attempt_id uuid, locked_until timestamptz, terminal_attempt_id uuid,
+ first_parked_at timestamptz,
+ last_error_code text, output_sha256 text,
+ PRIMARY KEY(env,job_id), FOREIGN KEY(env,run_id) REFERENCES public.polis_queue_runs(env,run_id),
+ UNIQUE NULLS NOT DISTINCT(env,run_id,stage,stage_instance),
+ CHECK ((state='running' AND owner_id IS NOT NULL AND attempt_id IS NOT NULL AND locked_until IS NOT NULL)
+     OR (state<>'running' AND owner_id IS NULL AND attempt_id IS NULL AND locked_until IS NULL)),
+ CHECK(attempt_count-parked_attempt_count<=max_attempts)
+) WITH (fillfactor=80, autovacuum_vacuum_threshold=50, autovacuum_vacuum_scale_factor=0.05);
+CREATE TABLE IF NOT EXISTS public.polis_queue_attempts (
+ env text NOT NULL, attempt_id uuid NOT NULL, job_id uuid NOT NULL, owner_id uuid NOT NULL,
+ lease_epoch bigint NOT NULL CHECK(lease_epoch>0), started_at timestamptz NOT NULL DEFAULT clock_timestamp(), ended_at timestamptz,
+ outcome text NOT NULL CHECK(outcome IN ('running','succeeded','retry_wait','parked','dead','cancelled','expired')),
+ error_code text, output_sha256 text,
+ PRIMARY KEY(env,attempt_id), UNIQUE(env,job_id,lease_epoch),
+ FOREIGN KEY(env,job_id) REFERENCES public.polis_queue_jobs(env,job_id)
+);
+CREATE TABLE IF NOT EXISTS public.polis_queue_requests (
+ env text NOT NULL, actor_scope text NOT NULL, product_key text NOT NULL, request_key text NOT NULL,
+ request_sha256 text NOT NULL CHECK(request_sha256 ~ '^[0-9a-f]{64}$'),
+ run_id uuid NOT NULL, job_id uuid NOT NULL, created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+ PRIMARY KEY(env,actor_scope,product_key,request_key),
+ FOREIGN KEY(env,run_id) REFERENCES public.polis_queue_runs(env,run_id) DEFERRABLE INITIALLY DEFERRED,
+ FOREIGN KEY(env,job_id) REFERENCES public.polis_queue_jobs(env,job_id) DEFERRABLE INITIALLY DEFERRED,
+ CHECK(length(actor_scope) BETWEEN 1 AND 256 AND length(request_key) BETWEEN 1 AND 256)
+);
+CREATE INDEX IF NOT EXISTS polis_queue_ready ON public.polis_queue_jobs(env,priority,eligible_at,created_at,job_id)
+ WHERE state IN ('queued','retry_wait') AND attempt_count-parked_attempt_count<max_attempts;
+-- No heartbeat-mutated column in a key or predicate: HOT-eligible, not guaranteed HOT.
+CREATE INDEX IF NOT EXISTS polis_queue_running ON public.polis_queue_jobs(env,job_id) WHERE state='running';
+CREATE INDEX IF NOT EXISTS polis_queue_exhausted ON public.polis_queue_jobs(env,job_id) WHERE state IN ('queued','retry_wait') AND attempt_count-parked_attempt_count>=max_attempts;
+CREATE INDEX IF NOT EXISTS polis_queue_parked ON public.polis_queue_jobs(env,eligible_at,job_id) WHERE state='parked';
+CREATE INDEX IF NOT EXISTS polis_queue_heads_zid ON public.polis_queue_heads(zid);
+CREATE INDEX IF NOT EXISTS polis_queue_runs_zid ON public.polis_queue_runs(zid);
+CREATE INDEX IF NOT EXISTS polis_queue_runs_history ON public.polis_queue_runs(env,zid,created_at,run_id);
+CREATE INDEX IF NOT EXISTS polis_queue_requests_run ON public.polis_queue_requests(env,run_id);
+CREATE INDEX IF NOT EXISTS polis_queue_requests_job ON public.polis_queue_requests(env,job_id);
+
+CREATE OR REPLACE FUNCTION public.pq_no_regression() RETURNS trigger LANGUAGE plpgsql SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+BEGIN
+ IF NEW.requested_generation<OLD.requested_generation OR NEW.published_generation<OLD.published_generation THEN
+  RAISE EXCEPTION 'queue pointer generation regression' USING ERRCODE='23514';
+ END IF;
+ RETURN NEW;
+END $$;
+DROP TRIGGER IF EXISTS pq_no_regression ON public.polis_queue_heads;
+CREATE TRIGGER pq_no_regression BEFORE UPDATE ON public.polis_queue_heads FOR EACH ROW EXECUTE FUNCTION public.pq_no_regression();
+
+-- Fixed JSON wire schema: see the companion MD. No SELECT * escapes this boundary.
+CREATE OR REPLACE FUNCTION public.pq_result(p_outcome text, j public.polis_queue_jobs, p_published boolean DEFAULT false)
+RETURNS jsonb LANGUAGE sql VOLATILE SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+ SELECT jsonb_build_object('schema_version','polis-queue/1','outcome',p_outcome,
+  'env',j.env,'job_id',j.job_id,'run_id',j.run_id,
+  'attempt_id',COALESCE(j.attempt_id,j.terminal_attempt_id),'owner_id',j.owner_id,
+  'lease_epoch',j.lease_epoch::text,'version',j.version::text,'mgmt_version',j.mgmt_version::text,'locked_until',j.locked_until,
+  'state',j.state,'output_sha256',j.output_sha256,'published',COALESCE(p_published,false),
+  'stage',j.stage,'stage_instance',j.stage_instance,'attempt_count',j.attempt_count,'max_attempts',j.max_attempts,'parked_attempt_count',j.parked_attempt_count,
+  'eligible_at',j.eligible_at,'first_parked_at',j.first_parked_at,'last_error_code',j.last_error_code,
+  'input',(SELECT jsonb_build_object('uri',r.input_uri,'sha256',r.input_sha256,'config_sha256',r.config_sha256,'code_image_digest',r.code_image_digest) FROM public.polis_queue_runs r WHERE r.env=j.env AND r.run_id=j.run_id))
+$$;
+CREATE OR REPLACE FUNCTION public.pq_backoff(p_attempt uuid,p_count integer) RETURNS integer
+LANGUAGE sql IMMUTABLE SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+ SELECT LEAST(300,5*(1 << LEAST(GREATEST(p_count-1,0),6)))
+  + get_byte(decode(replace(p_attempt::text,'-',''),'hex'),15)%5
+$$;
+-- Parent locks first. Reaper may skip a busy parent/job; other callers wait to their deadline.
+CREATE OR REPLACE FUNCTION public.pq_lock(p_env text,p_job uuid,p_skip boolean DEFAULT false,p_head boolean DEFAULT true)
+RETURNS public.polis_queue_jobs LANGUAGE plpgsql SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+DECLARE j public.polis_queue_jobs; r public.polis_queue_runs;
+BEGIN
+ SELECT q.* INTO j FROM public.polis_queue_jobs q WHERE q.env=p_env AND q.job_id=p_job;
+ IF NOT FOUND THEN RETURN NULL; END IF;
+ SELECT q.* INTO r FROM public.polis_queue_runs q WHERE q.env=j.env AND q.run_id=j.run_id;
+ IF p_skip THEN
+  PERFORM 1 FROM public.conversations c WHERE c.zid=r.zid FOR KEY SHARE SKIP LOCKED;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  IF p_head THEN
+   PERFORM 1 FROM public.polis_queue_heads h WHERE h.env=r.env AND h.product_key=r.product_key FOR UPDATE SKIP LOCKED;
+   IF NOT FOUND THEN RETURN NULL; END IF;
+  END IF;
+  PERFORM 1 FROM public.polis_queue_runs q WHERE q.env=r.env AND q.run_id=r.run_id FOR UPDATE SKIP LOCKED;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT q.* INTO j FROM public.polis_queue_jobs q WHERE q.env=p_env AND q.job_id=p_job FOR UPDATE SKIP LOCKED;
+ ELSE
+  PERFORM 1 FROM public.conversations c WHERE c.zid=r.zid FOR KEY SHARE;
+  IF p_head THEN
+   PERFORM 1 FROM public.polis_queue_heads h WHERE h.env=r.env AND h.product_key=r.product_key FOR UPDATE;
+  END IF;
+  PERFORM 1 FROM public.polis_queue_runs q WHERE q.env=r.env AND q.run_id=r.run_id FOR UPDATE;
+  SELECT q.* INTO j FROM public.polis_queue_jobs q WHERE q.env=p_env AND q.job_id=p_job FOR UPDATE;
+ END IF;
+ RETURN j;
+END $$;
+CREATE OR REPLACE FUNCTION public.pq_owns(j public.polis_queue_jobs,p_owner uuid,p_attempt uuid,p_epoch bigint) RETURNS boolean
+LANGUAGE sql VOLATILE SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+ SELECT COALESCE(j.state='running' AND j.owner_id=p_owner AND j.attempt_id=p_attempt
+  AND j.lease_epoch=p_epoch AND j.locked_until>clock_timestamp(),false)
+$$;
+
+-- 1. Enqueue: all IDs/digests are application-supplied and authenticated before this call.
+CREATE OR REPLACE FUNCTION public.pq_enqueue(p_env text,p_zid integer,p_product text,p_actor text,p_key text,p_request_sha text,
+ p_run uuid,p_job uuid,p_input_uri text,p_input_sha text,p_config_sha text,p_image text,p_priority smallint,p_max_attempts integer)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+DECLARE h public.polis_queue_heads; q public.polis_queue_requests; j public.polis_queue_jobs; n integer; g bigint;
+BEGIN
+ PERFORM 1 FROM public.conversations c WHERE c.zid=p_zid FOR KEY SHARE;
+ IF NOT FOUND THEN RAISE EXCEPTION 'unknown conversation' USING ERRCODE='23503'; END IF;
+ INSERT INTO public.polis_queue_requests(env,actor_scope,product_key,request_key,request_sha256,run_id,job_id)
+ VALUES(p_env,p_actor,p_product,p_key,p_request_sha,p_run,p_job)
+ ON CONFLICT(env,actor_scope,product_key,request_key) DO NOTHING;
+ GET DIAGNOSTICS n=ROW_COUNT;
+ IF n=0 THEN
+  SELECT x.* INTO q FROM public.polis_queue_requests x WHERE x.env=p_env AND x.actor_scope=p_actor AND x.product_key=p_product AND x.request_key=p_key;
+  SELECT x.* INTO j FROM public.polis_queue_jobs x WHERE x.env=p_env AND x.job_id=q.job_id;
+  RETURN public.pq_result(CASE WHEN q.request_sha256=p_request_sha THEN 'existing' ELSE 'conflict' END,j);
+ END IF;
+ INSERT INTO public.polis_queue_heads(env,product_key,zid) VALUES(p_env,p_product,p_zid) ON CONFLICT DO NOTHING;
+ SELECT x.* INTO h FROM public.polis_queue_heads x WHERE x.env=p_env AND x.product_key=p_product FOR UPDATE;
+ IF h.product_key IS NULL THEN RAISE EXCEPTION 'missing reserved product head'; END IF;
+ IF h.zid<>p_zid THEN RAISE EXCEPTION 'product conversation mismatch' USING ERRCODE='23514'; END IF;
+ g=h.requested_generation+1;
+ INSERT INTO public.polis_queue_runs(env,run_id,zid,product_key,requested_generation,input_uri,input_sha256,expected_output_uri,expected_output_sha256,config_sha256,code_image_digest,contract_version)
+ VALUES(p_env,p_run,p_zid,p_product,g,p_input_uri,p_input_sha,p_input_uri,p_input_sha,p_config_sha,p_image,'polis-queue/1');
+ INSERT INTO public.polis_queue_jobs(env,job_id,run_id,stage,priority,max_attempts)
+ VALUES(p_env,p_job,p_run,'noop',p_priority,p_max_attempts) RETURNING * INTO j;
+ UPDATE public.polis_queue_heads SET requested_generation=g,desired_run_id=p_run,version=version+1 WHERE env=p_env AND product_key=p_product;
+ PERFORM pg_notify('polis_queue_wakeup_v1','{"schema_version":"polis-queue-wakeup/1"}');
+ RETURN public.pq_result('enqueued',j);
+END $$;
+
+-- 2. Claim: only grants ownership after the caller commits the transaction.
+CREATE OR REPLACE FUNCTION public.pq_claim(p_env text,p_priority smallint,p_owner uuid,p_attempt uuid,p_lease_seconds integer DEFAULT 60)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+DECLARE j public.polis_queue_jobs;
+BEGIN
+ IF p_lease_seconds NOT BETWEEN 10 AND 900 OR p_owner IS NULL OR p_attempt IS NULL THEN RAISE EXCEPTION 'invalid claim arguments' USING ERRCODE='22023'; END IF;
+ WITH candidate AS (
+  SELECT q.env,q.job_id FROM public.polis_queue_jobs q
+  WHERE q.env=p_env AND q.priority=p_priority AND q.state IN ('queued','retry_wait')
+   AND q.eligible_at<=statement_timestamp() AND q.attempt_count-q.parked_attempt_count<q.max_attempts
+  ORDER BY q.eligible_at,q.created_at,q.job_id FOR UPDATE SKIP LOCKED LIMIT 1
+ ) UPDATE public.polis_queue_jobs q SET state='running',owner_id=p_owner,attempt_id=p_attempt,
+  locked_until=clock_timestamp()+make_interval(secs=>p_lease_seconds),lease_epoch=q.lease_epoch+1,
+  version=q.version+1,mgmt_version=q.mgmt_version+1,attempt_count=q.attempt_count+1,updated_at=clock_timestamp()
+ FROM candidate c WHERE q.env=c.env AND q.job_id=c.job_id AND q.state IN ('queued','retry_wait')
+ RETURNING q.* INTO j;
+ IF NOT FOUND THEN RETURN public.pq_result('none',NULL); END IF;
+ INSERT INTO public.polis_queue_attempts(env,attempt_id,job_id,owner_id,lease_epoch,outcome)
+ VALUES(j.env,j.attempt_id,j.job_id,j.owner_id,j.lease_epoch,'running');
+ RETURN public.pq_result('owned',j);
+END $$;
+-- 3. Heartbeat: only current, unexpired ownership renews. Version changes; epoch does not.
+CREATE OR REPLACE FUNCTION public.pq_heartbeat(p_env text,p_job uuid,p_owner uuid,p_attempt uuid,p_epoch bigint,p_lease_seconds integer DEFAULT 60)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+DECLARE j public.polis_queue_jobs;
+BEGIN
+ IF p_lease_seconds NOT BETWEEN 10 AND 900 THEN RAISE EXCEPTION 'invalid lease interval' USING ERRCODE='22023'; END IF;
+ SELECT q.* INTO j FROM public.polis_queue_jobs q WHERE q.env=p_env AND q.job_id=p_job FOR UPDATE;
+ IF NOT public.pq_owns(j,p_owner,p_attempt,p_epoch) THEN RETURN public.pq_result('fenced',j); END IF;
+ UPDATE public.polis_queue_jobs SET locked_until=clock_timestamp()+make_interval(secs=>p_lease_seconds),version=version+1,updated_at=clock_timestamp()
+ WHERE env=p_env AND job_id=p_job RETURNING * INTO j;
+ RETURN public.pq_result('owned',j);
+END $$;
+-- Q20 policy seam, distinct from invariant trigger and ownership checks.
+CREATE OR REPLACE FUNCTION public.pq_publish_allowed(h public.polis_queue_heads,r public.polis_queue_runs)
+RETURNS boolean LANGUAGE sql IMMUTABLE SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+ SELECT COALESCE(h.desired_run_id=r.run_id AND h.requested_generation=r.requested_generation
+  AND r.requested_generation>=h.published_generation,false)
+$$;
+-- 4. Finalize and read-back: same successful attempt/digest returns already_succeeded, even after lost ack.
+CREATE OR REPLACE FUNCTION public.pq_finalize(p_env text,p_job uuid,p_owner uuid,p_attempt uuid,p_epoch bigint,p_output_uri text,p_output_sha text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+DECLARE j public.polis_queue_jobs; r public.polis_queue_runs; h public.polis_queue_heads; a public.polis_queue_attempts; moved boolean=false;
+BEGIN
+ j=public.pq_lock(p_env,p_job);
+ IF j.job_id IS NULL THEN RETURN public.pq_result('fenced',j); END IF;
+ SELECT x.* INTO r FROM public.polis_queue_runs x WHERE x.env=p_env AND x.run_id=j.run_id;
+ SELECT x.* INTO h FROM public.polis_queue_heads x WHERE x.env=p_env AND x.product_key=r.product_key;
+ SELECT x.* INTO a FROM public.polis_queue_attempts x WHERE x.env=p_env AND x.attempt_id=p_attempt;
+ IF j.state='succeeded' AND j.terminal_attempt_id=p_attempt AND a.job_id=p_job
+    AND a.owner_id=p_owner AND a.lease_epoch=p_epoch AND a.outcome='succeeded'
+ THEN
+  IF a.output_sha256 IS DISTINCT FROM p_output_sha OR r.expected_output_uri IS DISTINCT FROM p_output_uri THEN
+   RETURN public.pq_result('invalid_output',j);
+  END IF;
+  RETURN public.pq_result('already_succeeded',j,COALESCE(h.published_run_id=r.run_id,false));
+ END IF;
+ IF NOT public.pq_owns(j,p_owner,p_attempt,p_epoch) THEN RETURN public.pq_result('fenced',j); END IF;
+ -- Admission target is data. /1 enqueue fixes it to synthetic input; Q21 may change only that assignment.
+ IF p_output_sha IS DISTINCT FROM r.expected_output_sha256 OR p_output_uri IS DISTINCT FROM r.expected_output_uri THEN
+  RETURN public.pq_result('invalid_output',j);
+ END IF;
+ UPDATE public.polis_queue_attempts SET outcome='succeeded',ended_at=clock_timestamp(),output_sha256=p_output_sha
+ WHERE env=p_env AND attempt_id=p_attempt;
+ UPDATE public.polis_queue_jobs SET state='succeeded',terminal_attempt_id=p_attempt,owner_id=NULL,attempt_id=NULL,locked_until=NULL,
+  version=version+1,mgmt_version=mgmt_version+1,updated_at=clock_timestamp(),output_sha256=p_output_sha WHERE env=p_env AND job_id=p_job RETURNING * INTO j;
+ UPDATE public.polis_queue_runs SET state='succeeded',output_sha256=p_output_sha WHERE env=p_env AND run_id=r.run_id;
+ IF public.pq_publish_allowed(h,r) THEN
+  UPDATE public.polis_queue_heads SET published_run_id=r.run_id,published_generation=r.requested_generation,
+   published_sha256=p_output_sha,version=version+1 WHERE env=p_env AND product_key=r.product_key;
+  moved=true;
+ END IF;
+ RETURN public.pq_result('succeeded',j,moved);
+END $$;
+
+-- Internal single terminalization primitive. Caller holds run -> job; never grants this RPC.
+-- Policy choices (backoff, publication, reaper driver) stay behind separate helpers for Q20.
+CREATE OR REPLACE FUNCTION public.pq_terminate_attempt(j public.polis_queue_jobs,p_state text,p_outcome text,p_error text,p_immediate boolean DEFAULT false)
+RETURNS public.polis_queue_jobs LANGUAGE plpgsql SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+BEGIN
+ UPDATE public.polis_queue_attempts SET outcome=p_outcome,error_code=p_error,ended_at=clock_timestamp()
+ WHERE env=j.env AND attempt_id=j.attempt_id;
+ UPDATE public.polis_queue_jobs q SET state=p_state,terminal_attempt_id=j.attempt_id,owner_id=NULL,attempt_id=NULL,locked_until=NULL,
+  lease_epoch=q.lease_epoch+1,version=q.version+1,mgmt_version=q.mgmt_version+1,
+  parked_attempt_count=q.parked_attempt_count+CASE WHEN p_state='parked' THEN 1 ELSE 0 END,
+  first_parked_at=CASE WHEN p_state='parked' THEN COALESCE(q.first_parked_at,clock_timestamp()) ELSE q.first_parked_at END,
+  last_error_code=p_error,updated_at=clock_timestamp(),
+  eligible_at=clock_timestamp()+make_interval(secs=>CASE WHEN p_immediate THEN 0 ELSE public.pq_backoff(j.attempt_id,j.attempt_count-j.parked_attempt_count) END)
+ WHERE q.env=j.env AND q.job_id=j.job_id RETURNING q.* INTO j;
+ IF p_state='dead' THEN UPDATE public.polis_queue_runs SET state='dead' WHERE env=j.env AND run_id=j.run_id; END IF;
+ RETURN j;
+END $$;
+-- Shared ownership gate for 5 fail/retry, 6 release, 7 park. End paths can dead a run.
+CREATE OR REPLACE FUNCTION public.pq_end_attempt(p_env text,p_job uuid,p_owner uuid,p_attempt uuid,p_epoch bigint,p_action text,p_error text)
+RETURNS jsonb LANGUAGE plpgsql SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+DECLARE j public.polis_queue_jobs; s text;
+BEGIN
+ j=public.pq_lock(p_env,p_job,false,false);
+ IF NOT public.pq_owns(j,p_owner,p_attempt,p_epoch) THEN RETURN public.pq_result('fenced',j); END IF;
+ IF p_action NOT IN ('retry','permanent','release','park') THEN RAISE EXCEPTION 'invalid transition' USING ERRCODE='22023'; END IF;
+ s=CASE WHEN p_action='park' THEN 'parked' WHEN p_action='permanent' OR j.attempt_count-j.parked_attempt_count>=j.max_attempts THEN 'dead' ELSE 'retry_wait' END;
+ j=public.pq_terminate_attempt(j,s,s,p_error,p_action='release');
+ RETURN public.pq_result(s,j);
+END $$;
+CREATE OR REPLACE FUNCTION public.pq_fail(p_env text,p_job uuid,p_owner uuid,p_attempt uuid,p_epoch bigint,p_permanent boolean,p_error text)
+RETURNS jsonb LANGUAGE sql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+ SELECT public.pq_end_attempt($1,$2,$3,$4,$5,CASE WHEN $6 THEN 'permanent' ELSE 'retry' END,$7)
+$$;
+CREATE OR REPLACE FUNCTION public.pq_release(p_env text,p_job uuid,p_owner uuid,p_attempt uuid,p_epoch bigint)
+RETURNS jsonb LANGUAGE sql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+ SELECT public.pq_end_attempt($1,$2,$3,$4,$5,'release',NULL)
+$$;
+CREATE OR REPLACE FUNCTION public.pq_park(p_env text,p_job uuid,p_owner uuid,p_attempt uuid,p_epoch bigint,p_error text)
+RETURNS jsonb LANGUAGE sql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+ SELECT public.pq_end_attempt($1,$2,$3,$4,$5,'park',$6)
+$$;
+-- Q20 seams: bounded discovery, single-row primitive, optional in-DB driver.
+CREATE OR REPLACE FUNCTION public.pq_due(p_env text,p_after_job uuid,p_limit integer)
+RETURNS TABLE(job_id uuid) LANGUAGE sql STABLE SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+ SELECT q.job_id FROM public.polis_queue_jobs q WHERE q.env=p_env AND (p_after_job IS NULL OR q.job_id>p_after_job) AND
+  ((q.state='running' AND q.locked_until<=statement_timestamp()) OR
+   (q.state='parked' AND q.eligible_at<=statement_timestamp()) OR
+   (q.state IN ('queued','retry_wait') AND q.attempt_count-q.parked_attempt_count>=q.max_attempts))
+ ORDER BY q.job_id LIMIT LEAST(GREATEST(p_limit,0),100)
+$$;
+CREATE OR REPLACE FUNCTION public.pq_reap_one(p_env text,p_job uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+DECLARE j public.polis_queue_jobs; s text;
+BEGIN
+ j=public.pq_lock(p_env,p_job,true,false); IF j.job_id IS NULL THEN RETURN NULL; END IF;
+ IF j.state='running' AND j.locked_until<=clock_timestamp() THEN
+  s=CASE WHEN j.attempt_count-j.parked_attempt_count>=j.max_attempts THEN 'dead' ELSE 'retry_wait' END;
+  j=public.pq_terminate_attempt(j,s,'expired','lease_expired');
+ ELSIF j.state='parked' AND j.eligible_at<=clock_timestamp() THEN
+  s=CASE WHEN j.attempt_count-j.parked_attempt_count>=j.max_attempts THEN 'dead' ELSE 'queued' END;
+  UPDATE public.polis_queue_jobs SET state=s,version=version+1,mgmt_version=mgmt_version+1,updated_at=clock_timestamp() WHERE env=p_env AND job_id=p_job RETURNING * INTO j;
+ ELSIF j.state IN ('queued','retry_wait') AND j.attempt_count-j.parked_attempt_count>=j.max_attempts THEN
+  s='dead';
+  UPDATE public.polis_queue_jobs SET state=s,version=version+1,mgmt_version=mgmt_version+1,last_error_code='attempt_budget_exhausted',updated_at=clock_timestamp() WHERE env=p_env AND job_id=p_job RETURNING * INTO j;
+ ELSE RETURN NULL;
+ END IF;
+ IF s='dead' THEN UPDATE public.polis_queue_runs SET state='dead' WHERE env=p_env AND run_id=j.run_id; END IF;
+ RETURN public.pq_result(s,j);
+END $$;
+-- 8. Owner-only dev/compat driver; never grant to the executor.
+-- Normative coordinator calls pq_due, commits, then pq_reap_one in one tx per job.
+CREATE OR REPLACE FUNCTION public.pq_reap(p_env text,p_after_job uuid DEFAULT NULL,p_limit integer DEFAULT 1)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+DECLARE id uuid; result jsonb; last_id uuid; scanned integer=0; results jsonb='[]'::jsonb;
+BEGIN
+ IF p_limit NOT BETWEEN 1 AND 100 THEN RAISE EXCEPTION 'invalid reap bound' USING ERRCODE='22023'; END IF;
+ FOR id IN SELECT d.job_id FROM public.pq_due(p_env,p_after_job,p_limit) d LOOP
+  last_id=id; scanned=scanned+1;
+  result=public.pq_reap_one(p_env,id);
+  IF result IS NOT NULL THEN results=results || jsonb_build_array(result); END IF;
+ END LOOP;
+ RETURN jsonb_build_object('schema_version','polis-queue/1','outcome','reap_page','next_after_job_id',CASE WHEN scanned<p_limit THEN NULL ELSE last_id END,'transitions',results);
+END $$;
+-- 9. Cancel: management CAS, distinct from worker ownership. Server authorizes actor/product first.
+CREATE OR REPLACE FUNCTION public.pq_cancel(p_env text,p_job uuid,p_expected_mgmt_version bigint)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+DECLARE j public.polis_queue_jobs;
+BEGIN
+ j=public.pq_lock(p_env,p_job);
+ IF j.job_id IS NULL OR j.mgmt_version IS DISTINCT FROM p_expected_mgmt_version THEN RETURN public.pq_result('conflict',j); END IF;
+ IF j.state IN ('succeeded','dead','cancelled') THEN RETURN public.pq_result('terminal',j); END IF;
+ IF j.attempt_id IS NOT NULL THEN
+  UPDATE public.polis_queue_attempts SET outcome='cancelled',ended_at=clock_timestamp() WHERE env=p_env AND attempt_id=j.attempt_id;
+ END IF;
+ UPDATE public.polis_queue_jobs SET state='cancelled',terminal_attempt_id=COALESCE(attempt_id,terminal_attempt_id),owner_id=NULL,attempt_id=NULL,locked_until=NULL,
+  lease_epoch=lease_epoch+1,version=version+1,mgmt_version=mgmt_version+1,updated_at=clock_timestamp() WHERE env=p_env AND job_id=p_job RETURNING * INTO j;
+ UPDATE public.polis_queue_runs SET state='cancelled' WHERE env=p_env AND run_id=j.run_id;
+ RETURN public.pq_result('cancelled',j);
+END $$;
+
+-- Non-mutating management token and park-age read; authorize job before exposing.
+CREATE OR REPLACE FUNCTION public.pq_job_status(p_env text,p_job uuid)
+RETURNS jsonb LANGUAGE sql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+ SELECT public.pq_result('job_status',j)
+ FROM (SELECT 1) seed LEFT JOIN public.polis_queue_jobs j ON j.env=p_env AND j.job_id=p_job
+$$;
+
+-- Authorized internal status read. Public APIs expose only an actor-authorized subset.
+CREATE OR REPLACE FUNCTION public.pq_head_status(p_env text,p_product text)
+RETURNS jsonb LANGUAGE sql SECURITY DEFINER SET search_path=pg_catalog,pg_temp SET TimeZone='UTC' AS $$
+ SELECT jsonb_build_object('schema_version','polis-queue/1','outcome','head_status',
+  'env',p_env,'product_key',p_product,'found',h.product_key IS NOT NULL,
+  'desired_run_id',h.desired_run_id,'desired_state',r.state,
+  'published_run_id',h.published_run_id,'published_generation',h.published_generation::text,
+  'published_sha256',h.published_sha256)
+ FROM (SELECT 1) seed LEFT JOIN public.polis_queue_heads h ON h.env=p_env AND h.product_key=p_product
+ LEFT JOIN public.polis_queue_runs r ON r.env=h.env AND r.run_id=h.desired_run_id
+$$;
+
+SELECT pg_temp.pq_assert_signatures(false);
+
+-- Explicit privilege boundary: no direct writes for executor; helpers not public RPCs.
+GRANT USAGE ON SCHEMA public TO polis_queue_owner,polis_queue_executor;
+-- UPDATE(topic) above exists solely for parent FOR KEY SHARE; never grant UPDATE(zid).
+DO $$ DECLARE x record; BEGIN
+ FOR x IN SELECT c.oid::regclass AS name FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+  WHERE n.nspname='public' AND c.relkind='r' AND c.relname IN ('polis_queue_runs','polis_queue_heads','polis_queue_jobs','polis_queue_attempts','polis_queue_requests')
+ LOOP
+  EXECUTE format('ALTER TABLE %s OWNER TO polis_queue_owner',x.name);
+  EXECUTE format('REVOKE ALL ON %s FROM PUBLIC, polis_queue_executor',x.name);
+ END LOOP;
+ FOR x IN SELECT p.oid::regprocedure AS name,p.proname FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+  WHERE n.nspname='public' AND p.proname IN ('pq_no_regression','pq_publish_allowed','pq_due','pq_reap_one','pq_result','pq_backoff','pq_lock','pq_owns','pq_enqueue','pq_claim','pq_heartbeat','pq_finalize','pq_end_attempt','pq_terminate_attempt','pq_job_status','pq_head_status','pq_fail','pq_release','pq_park','pq_reap','pq_cancel')
+ LOOP
+  EXECUTE format('ALTER FUNCTION %s OWNER TO polis_queue_owner',x.name);
+  EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC, polis_queue_executor',x.name);
+  IF x.proname IN ('pq_enqueue','pq_claim','pq_heartbeat','pq_finalize','pq_fail','pq_release','pq_park','pq_due','pq_reap_one','pq_cancel','pq_job_status','pq_head_status') THEN
+   EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO polis_queue_executor',x.name);
+  END IF;
+ END LOOP;
+END $$;
+SELECT pg_temp.pq_assert_catalog(false);
+SELECT pg_temp.pq_assert_functions(false);
+-- Migration addition 1: the pre-apply signature assertion above compares the
+-- catalog this file inherited. Repeat it after the DDL so a CREATE OR REPLACE in
+-- THIS file cannot leave an overload behind either. Without it, H1's failure
+-- mode (a stale pq_lock arity making pq_finalize raise "function
+-- public.pq_lock(text, uuid) is not unique") would only be caught on the next
+-- apply.
+SELECT pg_temp.pq_assert_signatures(false);
+-- Migration addition 2: name the executor's twelve granted RPCs explicitly. The
+-- function fingerprint already covers every ACL, but it reports only that
+-- something changed; this reports which grant is missing or extra, which is the
+-- distinction an operator needs at 3am.
+DO $$
+DECLARE granted CONSTANT text[] := ARRAY[
+ 'pq_cancel','pq_claim','pq_due','pq_enqueue','pq_fail','pq_finalize','pq_head_status',
+ 'pq_heartbeat','pq_job_status','pq_park','pq_reap_one','pq_release'];
+ actual text[];
+BEGIN
+ SELECT array_agg(p.proname::text ORDER BY p.proname) INTO actual FROM pg_proc p
+ WHERE p.pronamespace='public'::regnamespace AND starts_with(p.proname,'pq_')
+ AND has_function_privilege('polis_queue_executor',p.oid,'EXECUTE');
+ IF actual IS DISTINCT FROM granted THEN
+  RAISE EXCEPTION 'queue executor grant drift: expected % got %',granted,COALESCE(actual,'{}');
+ END IF;
+END $$;
+COMMIT;

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -120,6 +120,13 @@ export default {
   polisFromAddress: process.env.POLIS_FROM_ADDRESS as string,
   polisJwtIssuer: process.env.POLIS_JWT_ISSUER || "https://pol.is/",
   polisJwtAudience: process.env.POLIS_JWT_AUDIENCE || "participants",
+  // P-024 Postgres queue substrate, first slice. Default off, and never on in
+  // production regardless of the variable: turning it on only makes
+  // src/queue/enqueue.ts callable from dev/test code, it wires no route and
+  // starts no worker. See docs/queue-substrate.md.
+  queueSubstrateEnabled:
+    process.env.NODE_ENV !== "production" &&
+    isTrue(process.env.POLIS_QUEUE_SUBSTRATE_ENABLED),
   readOnlyDatabaseURL:
     process.env.READ_ONLY_DATABASE_URL || (process.env.DATABASE_URL as string),
   runPeriodicExportTests: isTrue(process.env.RUN_PERIODIC_EXPORT_TESTS),

--- a/server/src/db/pg-query.ts
+++ b/server/src/db/pg-query.ts
@@ -1,5 +1,5 @@
 import { isFunction, isString, isUndefined } from "underscore";
-import { Pool, PoolConfig, QueryResult } from "pg";
+import { Pool, PoolClient, PoolConfig, QueryResult } from "pg";
 import { parse as parsePgConnectionString } from "pg-connection-string";
 import QueryStream from "pg-query-stream";
 
@@ -230,6 +230,110 @@ function connect() {
   return readWritePool.connect();
 }
 
+// Session policy applied immediately after BEGIN, from
+// cost-reduction/04-plans/P-024-queue-substrate.md. These are declared initial
+// bounds for the queue substrate, not a general-purpose transaction profile;
+// changing them is a pinned contract change with its own tests.
+//
+// transaction_timeout only exists on PostgreSQL 17, so it is set through
+// set_config() behind a server-version guard: on an older server the target
+// list is never evaluated and the SET is simply skipped, rather than aborting
+// the transaction with "unrecognized configuration parameter".
+const TRANSACTION_SESSION_POLICY = `SET LOCAL TIME ZONE 'UTC';
+   SET LOCAL lock_timeout = '500ms';
+   SET LOCAL statement_timeout = '5s';
+   SET LOCAL idle_in_transaction_session_timeout = '5s';
+   SELECT set_config('transaction_timeout', '10s', true)
+     WHERE current_setting('server_version_num')::int >= 170000`;
+
+/**
+ * A COMMIT that did not report success. The transaction may or may not be
+ * durable: a lost acknowledgement is unknown, never proof of rollback. Callers
+ * must resolve it by reading authoritative state back under the original
+ * request identity, not by assuming either outcome.
+ */
+export class CommitOutcomeUnknownError extends Error {
+  readonly cause: unknown;
+  constructor(cause: unknown) {
+    super("transaction_commit_outcome_unknown");
+    this.name = "CommitOutcomeUnknownError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * Run `callback` inside one transaction on one pinned readWritePool client.
+ *
+ * Every read and write that must be atomic with the callback's writes has to go
+ * through the client passed in. queryP / queryP_readOnly acquire and release
+ * their own connection per statement, so a statement issued through them is a
+ * different session and is NOT part of this transaction, idempotency and
+ * read-back checks included.
+ *
+ * No network call, upload, child-process execution or other long work belongs
+ * inside the callback: the session policy above bounds how long the transaction
+ * may hold its locks.
+ *
+ * Three failure modes are handled explicitly, because each of them can
+ * otherwise be mistaken for success:
+ *
+ *   * The backend can die, or the socket can drop, while the callback is
+ *     between queries. A borrowed pg client emits that on its own "error"
+ *     event; with no listener attached it escapes as an unhandled EventEmitter
+ *     error. It is captured here, fails the transaction, and discards the
+ *     client.
+ *   * A callback that catches a statement error and continues leaves the
+ *     transaction aborted, and PostgreSQL then answers COMMIT with a ROLLBACK
+ *     command tag. Returning normally there would report a write that did not
+ *     happen, so the command tag is checked.
+ *   * A failure raised by COMMIT itself is rethrown as
+ *     CommitOutcomeUnknownError, and that client is discarded rather than
+ *     pooled.
+ *
+ * A client whose transaction state is unknown is never handed back to the pool.
+ */
+async function withTransaction<T>(
+  callback: (client: PoolClient) => Promise<T>
+): Promise<T> {
+  const client: PoolClient = await connect();
+  let discard = false;
+  let committing = false;
+  let connectionError: Error | undefined;
+  const onClientError = (error: Error) => {
+    connectionError = error;
+    discard = true;
+  };
+  client.on("error", onClientError);
+  try {
+    await client.query("BEGIN ISOLATION LEVEL READ COMMITTED");
+    await client.query(TRANSACTION_SESSION_POLICY);
+    const result = await callback(client);
+    if (connectionError) throw connectionError;
+    committing = true;
+    const commit = await client.query("COMMIT");
+    committing = false;
+    if (commit.command !== "COMMIT") {
+      throw new Error("transaction_was_aborted");
+    }
+    return result;
+  } catch (err) {
+    discard = discard || committing;
+    try {
+      await client.query("ROLLBACK");
+    } catch (rollbackErr) {
+      logger.error("pg_transaction_rollback_failed", rollbackErr);
+      discard = true;
+    }
+    if (committing) throw new CommitOutcomeUnknownError(err);
+    throw err;
+  } finally {
+    client.release(discard);
+    // A discarded client may still emit a socket error asynchronously, so it
+    // keeps its listener. A healthy pooled client is handed back clean.
+    if (!discard) client.removeListener("error", onClientError);
+  }
+}
+
 export default {
   query,
   query_readOnly,
@@ -240,4 +344,5 @@ export default {
   queryP_readOnly_wRetryIfEmpty,
   stream_queryP_readOnly,
   connect,
+  withTransaction,
 };

--- a/server/src/queue/enqueue.ts
+++ b/server/src/queue/enqueue.ts
@@ -1,0 +1,269 @@
+/**
+ * P-024 Postgres queue substrate, first slice: dev/test-only noop enqueue.
+ *
+ * This module is the only Node code that calls the queue schema installed by
+ * server/postgres/migrations/000019_create_polis_queue.sql. It is deliberately
+ * not reachable from any route: nothing under src/routes imports it, and
+ * src/routes/delphi/jobs.ts is untouched. Wiring a real route would route real
+ * work, which this slice must not do. Its callers are the integration test and
+ * local experiments.
+ *
+ * Three guards, all required:
+ *   1. Config.queueSubstrateEnabled (POLIS_QUEUE_SUBSTRATE_ENABLED), default
+ *      off and forced off when NODE_ENV is production.
+ *   2. The env namespace must be dev or test, so a synthetic job cannot be
+ *      addressed at some other environment's product heads.
+ *   3. The migration must have been applied. It is not applied automatically to
+ *      an existing database; see docs/queue-substrate.md.
+ *
+ * What this is NOT, yet:
+ *   - It does not run under the fenced polis_queue_executor role. The server
+ *     connects with its existing broad read-write login, so the grant boundary
+ *     in the migration is real in the database but is not what constrains this
+ *     caller. A dedicated service login with executor membership is separate,
+ *     separately reviewed provisioning work. The Python executor does require
+ *     the restricted login.
+ *   - The input descriptor is fixed and synthetic, and is built here rather
+ *     than accepted from the caller. /1 enqueue pins expected_output_uri and
+ *     expected_output_sha256 to that descriptor, and the noop stage returns it
+ *     unchanged. Admitting a real captured artifact is Q21 plus a reviewed
+ *     migration widening the stage CHECK.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import { PoolClient } from "pg";
+
+import Config from "../config";
+import pgQuery, { CommitOutcomeUnknownError } from "../db/pg-query";
+import {
+  assertOrdinaryResult,
+  QUEUE_CONTRACT_VERSION,
+  QUEUE_STAGE,
+  QueueOrdinaryResult,
+  QueueProtocolError,
+} from "./protocol";
+
+export const QUEUE_SUBSTRATE_FLAG = "POLIS_QUEUE_SUBSTRATE_ENABLED";
+
+/**
+ * The fixed synthetic input descriptor of the /1 noop stage. Not caller
+ * supplied: the enqueuer pins it, and the executor refuses any job whose
+ * descriptor differs.
+ */
+export const NOOP_INPUT_URI = "synthetic:polis-queue-noop/1";
+export const NOOP_INPUT_SHA256 = createHash("sha256")
+  .update("polis-queue-noop/1\n")
+  .digest("hex");
+export const NOOP_IMAGE_DIGEST = "synthetic-noop/1";
+
+/** dev or test, optionally suffixed for per-run isolation in tests. */
+const ENV_NAMESPACE = /^(dev|test)(-[a-z0-9][a-z0-9-]{0,48})?$/;
+
+/** Transient SQLSTATEs the design document admits for a bounded retry. */
+const RETRYABLE_SQLSTATES = new Set(["40001", "40P01", "55P03", "57014"]);
+const MAX_TRANSACTION_RETRIES = 3;
+
+export type EnqueueOutcome = "enqueued" | "existing" | "conflict";
+
+export interface NoopEnqueueRequest {
+  /** Queue environment namespace: dev, test, or a suffix of either. */
+  env: string;
+  /** Existing conversations.zid. pq_enqueue takes FOR KEY SHARE on it. */
+  zid: number;
+  /** Opaque logical output slot; one conversation per product_key. */
+  productKey: string;
+  /** Authorization scope of the producer, authenticated before this call. */
+  actorScope: string;
+  /** Idempotency key within (env, actorScope, productKey). */
+  requestKey: string;
+  /** 0 is most urgent. Defaults to 1. */
+  priority?: number;
+  /** Budgeted claims including the first, 1..100. Defaults to 3. */
+  maxAttempts?: number;
+}
+
+export interface NoopEnqueueOutcome {
+  outcome: EnqueueOutcome;
+  /** Digest this call computed over the canonical request. */
+  requestSha256: string;
+  /** IDs this call minted. On existing/conflict the result names the originals. */
+  mintedRunId: string;
+  mintedJobId: string;
+  result: QueueOrdinaryResult;
+}
+
+function assertEnabled(): void {
+  if (!Config.queueSubstrateEnabled) {
+    throw new Error(
+      `polis queue substrate is disabled; set ${QUEUE_SUBSTRATE_FLAG}=true outside ` +
+        "production to use it. It is a dev/test facility: no route calls it and " +
+        "no worker runs by default."
+    );
+  }
+}
+
+/**
+ * Digest of the canonical request. The producer computes it; it never accepts a
+ * caller-supplied digest, because the digest is what separates an exact replay
+ * ("existing") from a changed request reusing a key ("conflict").
+ *
+ * Every semantic input is covered: the request identity, the captured
+ * input/config/image descriptor, the stage and the retry policy. Field order is
+ * fixed here rather than taken from object insertion order.
+ */
+export function canonicalRequestDigest(request: NoopEnqueueRequest): string {
+  const canonical = JSON.stringify([
+    QUEUE_CONTRACT_VERSION,
+    request.env,
+    request.zid,
+    request.productKey,
+    request.actorScope,
+    request.requestKey,
+    QUEUE_STAGE,
+    NOOP_INPUT_URI,
+    NOOP_INPUT_SHA256,
+    NOOP_INPUT_SHA256,
+    NOOP_IMAGE_DIGEST,
+    request.priority ?? 1,
+    request.maxAttempts ?? 3,
+  ]);
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}
+
+const ENQUEUE_SQL =
+  "SELECT public.pq_enqueue($1::text,$2::integer,$3::text,$4::text,$5::text,$6::text," +
+  "$7::uuid,$8::uuid,$9::text,$10::text,$11::text,$12::text,$13::smallint,$14::integer) AS result";
+
+function sqlState(error: unknown): string | undefined {
+  return (error as { code?: string } | undefined)?.code;
+}
+
+function isRetryable(error: unknown): boolean {
+  return (
+    error instanceof CommitOutcomeUnknownError ||
+    RETRYABLE_SQLSTATES.has(sqlState(error) ?? "")
+  );
+}
+
+/**
+ * The deterministic backoff family the design document specifies for bounded
+ * transaction retries, in milliseconds, keyed on the minted job id so two
+ * concurrent producers do not retry in lockstep.
+ */
+function retryDelayMs(attempt: number, jobId: string): number {
+  const jitter = parseInt(jobId.slice(-2), 16) % 5;
+  return (Math.min(300, 5 * 2 ** attempt) + jitter) * 1000;
+}
+
+/**
+ * Enqueue one noop job, atomically with its request reservation, run row and
+ * desired-head advance. Repeating the call with the same key and an unchanged
+ * request returns the original job ("existing"); the same key with a changed
+ * request returns "conflict" and changes nothing.
+ *
+ * The whole call is one transaction on one pinned client. Do not add a
+ * queryP/queryP_readOnly call to this flow: those run on a different session
+ * and would not be part of the transaction.
+ *
+ * A transient failure, including a COMMIT whose outcome is unknown, is retried
+ * at most three times with the SAME request key, digest and minted UUIDs, so a
+ * retry after a lost acknowledgement returns the original job rather than
+ * creating a second one. Exhaustion rethrows the typed error; an unknown COMMIT
+ * outcome is never reported as a rollback.
+ */
+export async function enqueueNoopJob(
+  request: NoopEnqueueRequest
+): Promise<NoopEnqueueOutcome> {
+  assertEnabled();
+  if (!ENV_NAMESPACE.test(request.env)) {
+    throw new Error(
+      `env must be "dev" or "test", optionally suffixed (got ${JSON.stringify(
+        request.env
+      )})`
+    );
+  }
+  if (
+    !Number.isSafeInteger(request.zid) ||
+    request.zid <= 0 ||
+    request.zid > 2147483647
+  ) {
+    throw new Error("zid must be a positive 32-bit integer");
+  }
+  for (const [name, value] of [
+    ["productKey", request.productKey],
+    ["actorScope", request.actorScope],
+    ["requestKey", request.requestKey],
+  ] as const) {
+    if (typeof value !== "string" || value.length < 1 || value.length > 256) {
+      throw new Error(`${name} must be a string of length 1..256`);
+    }
+  }
+  const priority = request.priority ?? 1;
+  const maxAttempts = request.maxAttempts ?? 3;
+  if (![0, 1, 2].includes(priority)) {
+    throw new Error("priority must be 0, 1 or 2 (0 is most urgent)");
+  }
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1 || maxAttempts > 100) {
+    throw new Error("maxAttempts must be an integer in 1..100");
+  }
+
+  const requestSha256 = canonicalRequestDigest(request);
+  const mintedRunId = randomUUID();
+  const mintedJobId = randomUUID();
+  const args = [
+    request.env,
+    request.zid,
+    request.productKey,
+    request.actorScope,
+    request.requestKey,
+    requestSha256,
+    mintedRunId,
+    mintedJobId,
+    NOOP_INPUT_URI,
+    NOOP_INPUT_SHA256,
+    NOOP_INPUT_SHA256,
+    NOOP_IMAGE_DIGEST,
+    priority,
+    maxAttempts,
+  ];
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      const result = await pgQuery.withTransaction(
+        async (client: PoolClient) => {
+          const reply = await client.query(ENQUEUE_SQL, args);
+          const value = assertOrdinaryResult(reply.rows[0]?.result);
+          if (
+            value.outcome !== "enqueued" &&
+            value.outcome !== "existing" &&
+            value.outcome !== "conflict"
+          ) {
+            throw new QueueProtocolError(
+              `unexpected pq_enqueue outcome ${value.outcome}`
+            );
+          }
+          if (
+            typeof value.job_id !== "string" ||
+            typeof value.run_id !== "string"
+          ) {
+            throw new QueueProtocolError("enqueue reply has no job identity");
+          }
+          return value;
+        }
+      );
+      return {
+        outcome: result.outcome as EnqueueOutcome,
+        requestSha256,
+        mintedRunId,
+        mintedJobId,
+        result,
+      };
+    } catch (err) {
+      if (attempt >= MAX_TRANSACTION_RETRIES || !isRetryable(err)) throw err;
+      await new Promise((resolve) =>
+        setTimeout(resolve, retryDelayMs(attempt, mintedJobId))
+      );
+    }
+  }
+}
+
+export default { enqueueNoopJob, canonicalRequestDigest };

--- a/server/src/queue/protocol.ts
+++ b/server/src/queue/protocol.ts
@@ -27,7 +27,7 @@ export const QUEUE_STAGE = "noop";
  * migration's own catalog fingerprints cover that.
  */
 export const QUEUE_SQL_SHA256 =
-  "e8ad0d3212809b1da92e9ab2f4d24930101e2de4507b095cf953746a341fcce9";
+  "c229a7fb41dbc86a5a5ae637772f70ebfbb469cfc52f8e40a61303c82b428617";
 
 export const QUEUE_MIGRATION_PATH = path.join(
   __dirname,

--- a/server/src/queue/protocol.ts
+++ b/server/src/queue/protocol.ts
@@ -1,0 +1,220 @@
+/**
+ * The closed polis-queue/1 wire boundary, shared by every Node caller of the
+ * queue schema.
+ *
+ * The field set is frozen by the migration, not by the string "polis-queue/1",
+ * so this validator rejects missing AND unknown fields. An adapter that
+ * tolerated an extra field would also tolerate a different schema, which is the
+ * exact failure the round-4 review asked both adapters to pin against.
+ */
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export const QUEUE_CONTRACT_VERSION = "polis-queue/1";
+
+/** The only stage the /1 schema admits. It is a table CHECK, not a setting. */
+export const QUEUE_STAGE = "noop";
+
+/**
+ * SHA-256 of server/postgres/migrations/000019_create_polis_queue.sql as this
+ * adapter was written against it. Round 4 requires both adapters to pin the
+ * SQL, so that no deployed adapter is silently upgraded by a schema change.
+ * The Python executor pins the same value.
+ *
+ * This pins the file in the repository. It is not runtime attestation: it says
+ * nothing about what an administrator later did to the live catalog. The
+ * migration's own catalog fingerprints cover that.
+ */
+export const QUEUE_SQL_SHA256 =
+  "e8ad0d3212809b1da92e9ab2f4d24930101e2de4507b095cf953746a341fcce9";
+
+export const QUEUE_MIGRATION_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "postgres",
+  "migrations",
+  "000019_create_polis_queue.sql"
+);
+
+/** Digest the migration file on disk, for the test that enforces the pin. */
+export function migrationSha256(): string {
+  return createHash("sha256")
+    .update(fs.readFileSync(QUEUE_MIGRATION_PATH))
+    .digest("hex");
+}
+
+/** Closed field set of an ordinary polis-queue/1 result. */
+export const ORDINARY_RESULT_FIELDS: readonly string[] = [
+  "attempt_count",
+  "attempt_id",
+  "eligible_at",
+  "env",
+  "first_parked_at",
+  "input",
+  "job_id",
+  "last_error_code",
+  "lease_epoch",
+  "locked_until",
+  "max_attempts",
+  "mgmt_version",
+  "outcome",
+  "output_sha256",
+  "owner_id",
+  "parked_attempt_count",
+  "published",
+  "run_id",
+  "schema_version",
+  "stage",
+  "stage_instance",
+  "state",
+  "version",
+];
+
+const INPUT_FIELDS: readonly string[] = [
+  "code_image_digest",
+  "config_sha256",
+  "sha256",
+  "uri",
+];
+
+/** Counters that cross the wire as decimal strings, never as JSON numbers. */
+const DECIMAL_STRING_FIELDS = ["lease_epoch", "version", "mgmt_version"];
+const BOUNDED_INTEGER_FIELDS = [
+  "attempt_count",
+  "max_attempts",
+  "parked_attempt_count",
+];
+const UTC_TIMESTAMP_FIELDS = ["locked_until", "eligible_at", "first_parked_at"];
+const NULLABLE_TEXT_FIELDS = [
+  "env",
+  "job_id",
+  "run_id",
+  "attempt_id",
+  "owner_id",
+  "state",
+  "output_sha256",
+  "stage",
+  "stage_instance",
+  "last_error_code",
+  "outcome",
+];
+
+export interface QueueOrdinaryResult {
+  schema_version: string;
+  outcome: string;
+  env: string | null;
+  job_id: string | null;
+  run_id: string | null;
+  attempt_id: string | null;
+  owner_id: string | null;
+  lease_epoch: string | null;
+  version: string | null;
+  mgmt_version: string | null;
+  locked_until: string | null;
+  state: string | null;
+  output_sha256: string | null;
+  published: boolean;
+  stage: string | null;
+  stage_instance: string | null;
+  attempt_count: number | null;
+  max_attempts: number | null;
+  parked_attempt_count: number | null;
+  eligible_at: string | null;
+  first_parked_at: string | null;
+  last_error_code: string | null;
+  input: {
+    uri: string;
+    sha256: string;
+    config_sha256: string;
+    code_image_digest: string;
+  } | null;
+}
+
+export class QueueProtocolError extends Error {
+  constructor(detail: string) {
+    super(`invalid_queue_reply: ${detail}`);
+    this.name = "QueueProtocolError";
+  }
+}
+
+/**
+ * Reject anything that is not an ordinary polis-queue/1 result: wrong version,
+ * missing field, unknown field, wrongly typed counter, non-UTC timestamp, or a
+ * published flag that is not a boolean.
+ */
+export function assertOrdinaryResult(value: unknown): QueueOrdinaryResult {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new QueueProtocolError("reply is not a JSON object");
+  }
+  const record = value as Record<string, unknown>;
+  if (record.schema_version !== QUEUE_CONTRACT_VERSION) {
+    throw new QueueProtocolError(
+      `wire version ${String(record.schema_version)}; ` +
+        `this adapter is pinned to ${QUEUE_CONTRACT_VERSION}`
+    );
+  }
+  const seen = Object.keys(record).sort();
+  const want = [...ORDINARY_RESULT_FIELDS].sort();
+  const unknown = seen.filter((field) => !want.includes(field));
+  const missing = want.filter((field) => !seen.includes(field));
+  if (unknown.length > 0 || missing.length > 0) {
+    throw new QueueProtocolError(
+      `field set mismatch; unknown=[${unknown.join(
+        ","
+      )}] missing=[${missing.join(",")}]`
+    );
+  }
+  if (typeof record.published !== "boolean") {
+    throw new QueueProtocolError("published must be a boolean");
+  }
+  for (const field of DECIMAL_STRING_FIELDS) {
+    const raw = record[field];
+    if (raw !== null && (typeof raw !== "string" || !/^\d+$/.test(raw))) {
+      throw new QueueProtocolError(`${field} must be a decimal string or null`);
+    }
+  }
+  for (const field of BOUNDED_INTEGER_FIELDS) {
+    const raw = record[field];
+    if (
+      raw !== null &&
+      (!Number.isInteger(raw) ||
+        (raw as number) < 0 ||
+        (raw as number) > 2147483647)
+    ) {
+      throw new QueueProtocolError(
+        `${field} must be a bounded integer or null`
+      );
+    }
+  }
+  for (const field of UTC_TIMESTAMP_FIELDS) {
+    const raw = record[field];
+    if (raw !== null && (typeof raw !== "string" || !raw.endsWith("+00:00"))) {
+      throw new QueueProtocolError(`${field} must be a UTC timestamp or null`);
+    }
+  }
+  for (const field of NULLABLE_TEXT_FIELDS) {
+    const raw = record[field];
+    if (raw !== null && typeof raw !== "string") {
+      throw new QueueProtocolError(`${field} must be text or null`);
+    }
+  }
+  if (record.input !== null) {
+    if (typeof record.input !== "object" || Array.isArray(record.input)) {
+      throw new QueueProtocolError("input must be an object or null");
+    }
+    const input = record.input as Record<string, unknown>;
+    if (
+      Object.keys(input).sort().join(",") !== [...INPUT_FIELDS].sort().join(",")
+    ) {
+      throw new QueueProtocolError(
+        `input field set mismatch: ${Object.keys(input).sort().join(",")}`
+      );
+    }
+    if (!Object.values(input).every((v) => typeof v === "string")) {
+      throw new QueueProtocolError("input fields must all be text");
+    }
+  }
+  return record as unknown as QueueOrdinaryResult;
+}


### PR DESCRIPTION
First strangler slice of the Postgres-native job queue (P-024). The design went through four cross-review rounds; every blocker was re-derived by independent probes; the SQL is applied here verbatim in substance. This slice touches no live route and no existing poller; it exists so the queue can be exercised end to end on `noop` jobs before anything real is routed through it.

- `server/postgres/migrations/000019_create_polis_queue.sql`: the five queue tables, twelve SECURITY DEFINER transitions with typed wire descriptors, FK indexes, a post-apply exact-signature assertion (guards against the function-overload hazard found in review), an explicit assertion of the twelve granted RPCs, and a catalog drift check with a detailed message. Applied manually per `docs/migrations.md`.
- `withTransaction` on the pool connect path; the client is destroyed, not returned, if cleanup fails.
- A dev/test-only enqueue of `noop` jobs behind `POLIS_QUEUE_SUBSTRATE_ENABLED` (default off, hard-off under `NODE_ENV=production`). No change to `routes/delphi/jobs.ts`.
- `server/__tests__/integration/queue-substrate.test.ts`: the 40 review-smoke checks ported (44 tests; 7 named skips when role provisioning is unavailable), plus test-enforced pinning of the SQL hash in both languages.
- A standalone Python executor for `noop` jobs (`delphi/polismath/queue/`) with claim, heartbeat, finalize, between-query error capture (a backend-death bug found by an independent comparison implementation), aborted-COMMIT detection, bounded same-identity retry on unknown commit outcome, and uncertain-claim reconciliation. Neither existing poller is touched.
- `docs/queue-substrate.md`.

Verification: Astra's unmodified 40-check smoke against this migration 40/40; server suite 47 suites, 394 passed, 1 skipped (baseline 46 / 350 / 1, delta exactly the new suite); executor 12/12 against a real Postgres; tsc, eslint, prettier clean; compose stack with the flag off applies the migration at initdb.

Open items stated in the notes: ACL drift is not self-healing (a hand-revoked grant needs manual repair); the Node enqueuer runs on the server's broad login while only the executor asserts the restricted role; two policy questions (how much policy lives in PL/pgSQL; the finalize shape) are held for Colin and the slice keeps both as small deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s