### PR TITLE
feat(replay): per-stage engine oracles for Clojure and Python (diagnostics)

### DIFF
--- a/delphi/polismath/replay/driver.py
+++ b/delphi/polismath/replay/driver.py
@@ -66,6 +66,7 @@ def run_replay(
     spec: ScheduleSpec,
     *,
     progress: Callable[[int, int], None] | None = None,
+    on_step: Callable[[ReplayStep, Conversation, StepRecord], None] | None = None,
 ) -> list[StepRecord]:
     """Replay ``dataset`` through the math engine on ``spec``'s schedule.
 
@@ -74,6 +75,13 @@ def run_replay(
     timestamps are data-derived — the only wall-clock field is the blob's
     ``math_tick`` (conversation.py:2226). ``progress(i, total)`` is called
     before each step if provided.
+
+    ``on_step(step, conv, record)`` is a read-only observer called after each
+    step's record is built and BEFORE the restart seam, so a caller can capture
+    intermediate engine state (``polismath.replay.stages``' stage dump) without
+    re-implementing this fold. It is purely additive: leaving it ``None`` — as
+    ``scripts/replay_driver.py`` and ``certify`` do — is byte-identical to the
+    pre-hook behavior. An observer must not mutate ``conv``.
     """
     steps = slice_schedule(dataset, spec)
     total = len(steps)
@@ -141,6 +149,8 @@ def run_replay(
             extras=_step_extras(conv),
         )
         records.append(record)
+        if on_step is not None:
+            on_step(step, conv, record)
         woven_mods.extend(step.mod_events)
 
         if spec.restart_after is not None and step.index == spec.restart_after:

--- a/delphi/polismath/replay/stagecompare.py
+++ b/delphi/polismath/replay/stagecompare.py
@@ -67,8 +67,11 @@ from typing import Any, Sequence
 
 from polismath.replay.stages import (
     COMMENT_PROJECTION_AXES,
+    PROJECTION_WIDTH,
     STAGE_DUMP_SCHEMA,
+    STAGE_KEYS,
     STAGE_ORDER,
+    STRUCTURAL_ERROR_KEY,
 )
 
 COMPARE_SCHEMA = "polis-stage-compare/1"
@@ -392,6 +395,8 @@ def _validate_named_matrix(nm: Any, label: str) -> Structural | None:
 def _nm_cells(nm: Any, label: str) -> dict[str, Any] | Structural:
     """A named matrix as ``{rowlabel|collabel: cell}`` — order-independent, with
     dimensions and label uniqueness validated first."""
+    if isinstance(nm, Structural):
+        return nm
     bad = _validate_named_matrix(nm, label)
     if bad is not None:
         return bad
@@ -404,8 +409,8 @@ def _nm_cells(nm: Any, label: str) -> dict[str, Any] | Structural:
 
 def _by_tid(values: Any, tids: Sequence[Any], label: str) -> Any:
     """Index an array by tid, requiring exact length agreement."""
-    if values is None:
-        return None
+    if values is None or isinstance(values, Structural):
+        return values
     if not isinstance(values, list):
         return Structural(f"{label}: expected a list")
     if len(values) != len(tids):
@@ -449,13 +454,30 @@ def _flip(d: Any, sign: float) -> Any:
             for k, v in d.items()}
 
 
+def _lift_emitter_errors(value: Any) -> Any:
+    """Turn an emitter's ``__structural_error__`` sentinel into a
+    :class:`Structural`, wherever it appears. An emitter that refused to guess
+    must not have its refusal graded as data."""
+    if isinstance(value, dict):
+        if STRUCTURAL_ERROR_KEY in value:
+            return Structural(f"emitter: {value[STRUCTURAL_ERROR_KEY]}")
+        return {k: _lift_emitter_errors(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_lift_emitter_errors(v) for v in value]
+    return value
+
+
 def canonicalize(doc: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Polarity-normalize, key everything by identity, and orient components.
 
     Returns ``{stage: {key: canonical value}}``. A value that could not be
     canonicalized is a :class:`Structural`, never a synthesized number.
     """
-    stages = apply_polarity(doc.get("stages") or {},
+    raw_stages = doc.get("stages")
+    if not isinstance(raw_stages, dict):
+        return {s: {"__stage__": Structural("document 'stages' is not an object")}
+                for s in STAGE_ORDER}
+    stages = apply_polarity(_lift_emitter_errors(raw_stages),
                             doc.get("vote_sign_convention", "delphi"))
     out: dict[str, dict[str, Any]] = {
         s: (dict(v) if isinstance(v, dict) else {"__stage__": Structural(
@@ -498,7 +520,8 @@ def canonicalize(doc: dict[str, Any]) -> dict[str, dict[str, Any]]:
             pca.get("comment-extremity"), tids, "pca.comment-extremity")
 
         comps = pca.get("comps")
-        if comps is None:
+        if comps is None or isinstance(comps, Structural):
+            # An emitter that refused keeps its own reason; do not overwrite it.
             comps_by_tid: list[Any] = []
         elif not isinstance(comps, list):
             pca["comps"] = Structural("pca.comps: expected a list of components")
@@ -513,7 +536,7 @@ def canonicalize(doc: dict[str, Any]) -> dict[str, dict[str, Any]]:
         # case (n_tids == n_comps).
         declared = doc.get("comment_projection_axes")
         proj_rows = pca.get("comment-projection")
-        if proj_rows is None:
+        if proj_rows is None or isinstance(proj_rows, Structural):
             cproj_by_comp: list[Any] = []
         elif declared != COMMENT_PROJECTION_AXES:
             pca["comment-projection"] = Structural(
@@ -524,20 +547,25 @@ def canonicalize(doc: dict[str, Any]) -> dict[str, dict[str, Any]]:
             pca["comment-projection"] = Structural(
                 "pca.comment-projection: expected a list of component rows")
             cproj_by_comp = []
-        elif isinstance(comps, list) and len(proj_rows) != len(comps):
+        elif isinstance(comps, list) and len(proj_rows) != max(
+                len(comps), PROJECTION_WIDTH):
+            # The projection is always at least PROJECTION_WIDTH rows wide (the
+            # rank-one Q16 case), and otherwise exactly one row per component.
             pca["comment-projection"] = Structural(
                 f"pca.comment-projection: {len(proj_rows)} component rows for "
-                f"{len(comps)} comps")
+                f"{len(comps)} comps (expected "
+                f"{max(len(comps), PROJECTION_WIDTH)})")
             cproj_by_comp = []
         else:
             cproj_by_comp = [_by_tid(row, tids, f"pca.comment-projection[{i}]")
                              for i, row in enumerate(proj_rows)]
 
         signs = _orient(comps_by_tid, tid_labels)
-        if not isinstance(pca.get("comps"), Structural):
+        if not isinstance(pca.get("comps"), Structural) and comps is not None:
             pca["comps"] = {str(i): _flip(c, s)
                             for i, (c, s) in enumerate(zip(comps_by_tid, signs))}
-        if not isinstance(pca.get("comment-projection"), Structural):
+        if not isinstance(pca.get("comment-projection"), Structural) \
+                and proj_rows is not None:
             pca["comment-projection"] = {
                 str(i): _flip(c, s)
                 for i, (c, s) in enumerate(zip(cproj_by_comp, signs))}
@@ -609,6 +637,8 @@ def canonicalize(doc: dict[str, Any]) -> dict[str, dict[str, Any]]:
 def _rows_by_pid(rows: Any, label: str) -> Any:
     """Row list -> ``{pid: row}``, retaining every field. A duplicate or missing
     pid is a structural defect, not a silent overwrite."""
+    if isinstance(rows, Structural):
+        return rows
     if not isinstance(rows, list):
         return Structural(f"{label}: expected a list of rows")
     out: dict[str, Any] = {}
@@ -825,16 +855,49 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
 
     integer_leaf = _is_integer_leaf(stage, key, field)
 
-    # Non-finite wire tokens compare as tokens, on either or both sides.
+    # Non-finite wire tokens compare as tokens, on either or both sides. This
+    # runs BEFORE the integer type check so the token evidence is always
+    # retained (R2-F5): a non-finite value is never a silent pass, whether or
+    # not the two sides agree on it.
     if _is_token(a) or _is_token(b):
         res.n_compared += 1
         res.n_nonfinite += 1
+        res.note(path, a, b, nonfinite=True)
         if a != b:
             res.n_diff += 1
-            res.note(path, a, b, nonfinite=True)
             if res.worst_path is None:
                 res.worst_path = path
             res.max_rel = max(res.max_rel, 1.0)
+        elif integer_leaf:
+            # A vote, id or count is never NaN or an infinity.
+            res.structural.append(
+                f"{path}: integer-typed field carries the non-finite token "
+                f"{a!r}")
+        return
+
+    # An integer-typed leaf is validated BEFORE any equality test, on BOTH
+    # sides, so that two equally-malformed operands (True/True, "1"/"1", two
+    # equal float-spelled ids) cannot pass as a match. Containers fall through
+    # to the recursive branches below; only leaves are typed here.
+    if integer_leaf and not isinstance(a, (dict, list)) \
+            and not isinstance(b, (dict, list)):
+        res.n_compared += 1
+        ia, ib = _as_exact_int(a), _as_exact_int(b)
+        bad = [f"[{side}] {v!r}" for side, v, iv in (("a", a, ia), ("b", b, ib))
+               if iv is None]
+        if bad:
+            res.structural.append(
+                f"{path}: integer-typed field is not an integer: {', '.join(bad)}")
+            return
+        if ia != ib:
+            res.n_diff += 1
+            res.n_over_tight += 1
+            delta = float(abs(ia - ib))
+            if delta > res.max_abs:
+                res.max_abs, res.worst_path = delta, path
+            scale = max(abs(ia), abs(ib))
+            res.max_rel = max(res.max_rel, delta / scale if scale else 1.0)
+            res.note(path, a, b, abs=delta)
         return
 
     if _is_num(a) and _is_num(b):
@@ -910,10 +973,18 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
 
 
 def _is_null_empty_pair(a: Any, b: Any) -> bool:
-    """Exactly the C1 case: one side absent, the other an empty collection."""
-    empty = ([], {}, set())
-    return ((a is None and any(b == e for e in empty))
-            or (b is None and any(a == e for e in empty)))
+    """Exactly the C1 case and nothing adjacent to it: one side is ``None`` and
+    the other is an empty JSON **list**, in either direction.
+
+    Type-checked, not equality-checked. ``{}`` and ``set()`` compare equal to
+    neither but an ``x == []`` test on a stray object can still succeed, and
+    ``null`` against an empty *object* is a shape difference this carve-out
+    never promised to cover.
+    """
+    def empty_list(x: Any) -> bool:
+        return type(x) is list and len(x) == 0
+
+    return (a is None and empty_list(b)) or (b is None and empty_list(a))
 
 
 def compare_step(doc_a: dict[str, Any], doc_b: dict[str, Any]) -> dict[str, Any]:
@@ -922,6 +993,7 @@ def compare_step(doc_a: dict[str, Any], doc_b: dict[str, Any]) -> dict[str, Any]
     stage_reports: dict[str, Any] = {}
     first_diverging: str | None = None
     problems: list[str] = []
+    nonfinite_total = 0
 
     for stage in STAGE_ORDER:
         raw_a, raw_b = can_a.get(stage), can_b.get(stage)
@@ -960,14 +1032,29 @@ def compare_step(doc_a: dict[str, Any], doc_b: dict[str, Any]) -> dict[str, Any]
             if carve is not None and not diverged and res.n_suppressed:
                 entry["carve_out"] = carve
                 entry["status"] = "CARVED"
+            elif diverged:
+                if carve is not None:
+                    entry["carve_out"] = carve
+                entry["status"] = "DIVERGENT"
+                stage_divergent = True
+            elif res.n_nonfinite:
+                # Agreeing on NaN is not a divergence, but it is not clean data
+                # either. It gets its own status so it can never be hidden
+                # behind a default "every stage within tolerance" (R2-F5).
+                if carve is not None:
+                    entry["carve_out"] = carve
+                entry["status"] = "NONFINITE"
+                nonfinite_total += res.n_nonfinite
             else:
                 if carve is not None:
                     entry["carve_out"] = carve
-                entry["status"] = "DIVERGENT" if diverged else "MATCH"
-                stage_divergent = stage_divergent or diverged
+                entry["status"] = "MATCH"
             key_reports[key] = entry
+        stage_nonfinite = any(k.get("status") == "NONFINITE"
+                              for k in key_reports.values())
         stage_reports[stage] = {
-            "status": "DIVERGENT" if stage_divergent else "MATCH",
+            "status": ("DIVERGENT" if stage_divergent
+                       else "NONFINITE" if stage_nonfinite else "MATCH"),
             "keys": key_reports,
         }
         if stage_divergent and first_diverging is None:
@@ -983,6 +1070,7 @@ def compare_step(doc_a: dict[str, Any], doc_b: dict[str, Any]) -> dict[str, Any]
 
     return {
         "step": doc_a.get("step"),
+        "n_nonfinite": nonfinite_total,
         "input_digest_match": digest_match,
         "tick_a": doc_a.get("tick"),
         "tick_b": doc_b.get("tick"),
@@ -1027,13 +1115,21 @@ def load_stage_dumps(directory: str | Path) -> list[dict[str, Any]]:
     d = Path(directory)
     docs = []
     for path in sorted(d.glob("step-*.stages.json")):
-        doc = json.loads(path.read_text())
+        try:
+            doc = json.loads(path.read_text())
+        except (ValueError, OSError) as exc:
+            raise ValueError(f"{path}: unreadable ({exc})") from exc
+        if not isinstance(doc, dict):
+            raise ValueError(f"{path}: document is not an object")
         schema = doc.get("schema")
         if schema != STAGE_DUMP_SCHEMA:
             raise ValueError(
                 f"{path}: schema {schema!r}, expected {STAGE_DUMP_SCHEMA!r}")
         docs.append(doc)
-    docs.sort(key=lambda x: int(x.get("step", 0)))
+    # Sort by a TYPE-TAGGED key: a malformed step identity must not raise here;
+    # validate_recording reports it as an input problem instead.
+    docs.sort(key=lambda x: (not isinstance(x.get("step"), int),
+                             x.get("step") if isinstance(x.get("step"), int) else 0))
     return docs
 
 
@@ -1068,25 +1164,70 @@ def validate_recording(directory: str | Path) -> tuple[list[dict[str, Any]], lis
         problems.append(f"{d}: no step-NNN.stages.json files")
 
     steps = [doc.get("step") for doc in docs]
-    if len(set(steps)) != len(steps):
+    if len(set(map(repr, steps))) != len(steps):
         problems.append(f"{d}: duplicate step identities {steps}")
     for doc in docs:
-        if not isinstance(doc.get("step"), int):
-            problems.append(f"{d}: a document has a non-integer step identity")
+        sid = doc.get("step")
+        # Mandatory identity and evidence fields, TYPED. A null tick or a null
+        # digest is missing evidence, not a value that happens to be equal to
+        # the other side's (R2-F2).
+        if not isinstance(sid, int) or isinstance(sid, bool):
+            problems.append(f"{d}: a document has a non-integer step identity "
+                            f"({sid!r})")
+        if not isinstance(doc.get("tick"), int) or isinstance(doc.get("tick"), bool):
+            problems.append(f"{d}: step {sid!r} has no integer tick "
+                            f"({doc.get('tick')!r})")
+        digest = doc.get("input_digest")
+        if not isinstance(digest, str) or not digest.startswith("sha256:") \
+                or len(digest) <= len("sha256:"):
+            problems.append(f"{d}: step {sid!r} has no sha256 input_digest "
+                            f"({digest!r})")
+        if not isinstance(doc.get("engine"), str) or not doc.get("engine"):
+            problems.append(f"{d}: step {sid!r} declares no engine")
         if doc.get("vote_sign_convention") not in SUPPORTED_CONVENTIONS:
             problems.append(
-                f"{d}: step {doc.get('step')!r} declares unsupported "
+                f"{d}: step {sid!r} declares unsupported "
                 f"vote_sign_convention {doc.get('vote_sign_convention')!r}")
         if doc.get("comment_projection_axes") != COMMENT_PROJECTION_AXES:
             problems.append(
-                f"{d}: step {doc.get('step')!r} does not declare "
+                f"{d}: step {sid!r} does not declare "
                 f"comment_projection_axes={COMMENT_PROJECTION_AXES!r}")
-        stages_present = set(doc.get("stages") or {})
-        missing = [s for s in STAGE_ORDER if s not in stages_present]
+
+        raw_stages = doc.get("stages")
+        if not isinstance(raw_stages, dict):
+            problems.append(f"{d}: step {sid!r} has no stages object")
+            continue
+        missing = [s for s in STAGE_ORDER if s not in raw_stages]
         if missing:
             problems.append(
-                f"{d}: step {doc.get('step')!r} is missing stage(s) "
-                f"{', '.join(missing)}")
+                f"{d}: step {sid!r} is missing stage(s) {', '.join(missing)}")
+        extra_stages = sorted(set(raw_stages) - set(STAGE_ORDER))
+        if extra_stages:
+            problems.append(
+                f"{d}: step {sid!r} carries unknown stage(s) "
+                f"{', '.join(extra_stages)}")
+        # A stage with no evidence is a hole in the recording, not a stage that
+        # happened to match: every declared key must be PRESENT on every side.
+        for name in STAGE_ORDER:
+            body = raw_stages.get(name)
+            if body is None:
+                continue
+            if not isinstance(body, dict):
+                problems.append(
+                    f"{d}: step {sid!r} stage {name} is not an object")
+                continue
+            inventory = STAGE_KEYS[name]
+            absent = sorted(inventory["required"] - set(body))
+            if absent:
+                problems.append(
+                    f"{d}: step {sid!r} stage {name} is missing required "
+                    f"key(s) {', '.join(absent)}")
+            unknown = sorted(
+                set(body) - inventory["required"] - inventory["optional"])
+            if unknown:
+                problems.append(
+                    f"{d}: step {sid!r} stage {name} carries unknown key(s) "
+                    f"{', '.join(unknown)}")
 
     if manifest is not None:
         if manifest.get("schema") != STAGE_DUMP_SCHEMA:
@@ -1105,10 +1246,35 @@ def validate_recording(directory: str | Path) -> tuple[list[dict[str, Any]], lis
             if declared != steps:
                 problems.append(
                     f"{d}: manifest inventory {declared} != on-disk steps {steps}")
+            by_step = {doc.get("step"): doc for doc in docs}
             for r in rows:
-                if isinstance(r, dict) and not (d / str(r.get("file"))).is_file():
+                if not isinstance(r, dict):
+                    problems.append(f"{d}: manifest row is not an object")
+                    continue
+                if not (d / str(r.get("file"))).is_file():
                     problems.append(f"{d}: manifest names a missing file "
                                     f"{r.get('file')!r}")
+                # The manifest must agree with the document it names, or it is
+                # not an inventory of this recording (R2-F2).
+                doc = by_step.get(r.get("index"))
+                if doc is None:
+                    problems.append(f"{d}: manifest row {r.get('index')!r} "
+                                    f"names no on-disk step")
+                    continue
+                for field in ("tick", "input_digest"):
+                    if r.get(field) != doc.get(field):
+                        problems.append(
+                            f"{d}: manifest step {r.get('index')!r} {field} "
+                            f"{r.get(field)!r} != document {doc.get(field)!r}")
+            engines = {doc.get("engine") for doc in docs}
+            if manifest.get("engine") not in engines and docs:
+                problems.append(
+                    f"{d}: manifest engine {manifest.get('engine')!r} is not "
+                    f"the documents' engine {sorted(map(str, engines))}")
+            if manifest.get("comment_projection_axes") != COMMENT_PROJECTION_AXES:
+                problems.append(
+                    f"{d}: manifest does not declare "
+                    f"comment_projection_axes={COMMENT_PROJECTION_AXES!r}")
     return docs, problems
 
 
@@ -1144,6 +1310,7 @@ def compare_recordings(dir_a: str | Path, dir_b: str | Path) -> dict[str, Any]:
                 first_stage, first_step = s["first_diverging_stage"], s["step"]
 
     input_valid = not problems
+    nonfinite_total = sum(s.get("n_nonfinite", 0) for s in per_step)
     return {
         "schema": COMPARE_SCHEMA,
         "grading": GRADING_NOTE,
@@ -1162,6 +1329,10 @@ def compare_recordings(dir_a: str | Path, dir_b: str | Path) -> dict[str, Any]:
         "first_diverging_stage": first_stage if input_valid else None,
         "first_diverging_step": first_step if input_valid else None,
         "headline_withheld": not input_valid,
+        "n_nonfinite": nonfinite_total,
+        # A clean "every stage within tolerance" is not available while
+        # non-finite values are present in graded leaves (R2-F5).
+        "headline_qualified": bool(nonfinite_total) if input_valid else False,
         "carve_outs": {c.id: {"mode": c.mode, "reason": c.reason}
                        for c in CARVE_OUTS.values()},
         "auto_carved": list(AUTO_CARVED),
@@ -1198,11 +1369,17 @@ def format_report(report: dict[str, Any], *, verbose: bool = False) -> str:
             lines.append(f"      ! … and {extra} more")
     else:
         fds = report["first_diverging_stage"]
-        lines.append(
-            f"  first diverging stage: {fds} (step {report['first_diverging_step']})"
-            if fds else
-            "  first diverging stage: none — every stage within tolerance"
-        )
+        if fds:
+            lines.append(f"  first diverging stage: {fds} "
+                         f"(step {report['first_diverging_step']})")
+        elif report.get("n_nonfinite"):
+            lines.append(
+                f"  first diverging stage: none, but {report['n_nonfinite']} "
+                f"NON-FINITE value(s) are present in graded leaves — the data "
+                f"is not clean; see the NONFINITE keys below")
+        else:
+            lines.append(
+                "  first diverging stage: none — every stage within tolerance")
     for step in report["per_step"]:
         lines.append(f"  step {step['step']}: first diverging stage = "
                      f"{step['first_diverging_stage'] or 'none'}"
@@ -1215,6 +1392,13 @@ def format_report(report: dict[str, Any], *, verbose: bool = False) -> str:
                 continue
             for key, k in sorted(sr["keys"].items()):
                 if k["status"] == "MATCH" and not verbose:
+                    continue
+                if k["status"] == "NONFINITE":
+                    lines.append(
+                        f"      [NONFINITE] {stage}.{key} ({k['tolerance']}): "
+                        f"{k['n_nonfinite']} non-finite value(s) present and "
+                        f"matching — reported, never a silent pass"
+                        + (f" worst={k['worst_path']}" if k["worst_path"] else ""))
                     continue
                 if k["status"] == "ENGINE_LOCAL":
                     lines.append(

--- a/delphi/polismath/replay/stagecompare.py
+++ b/delphi/polismath/replay/stagecompare.py
@@ -6,38 +6,51 @@ Reads two ``polis-stage-dump/1`` recordings (``<recording>/clj-stages`` and
 
 * the **first diverging stage** — the earliest stage, in pipeline order, that
   carries a difference outside its declared tolerance and outside the declared
-  carve-outs. A cross-engine difference at stage *N* explains every difference at
-  stages > *N*, so this is the only number worth acting on;
+  carve-outs. A difference at stage *N* is a plausible cause of differences at
+  stages > *N*; it does not prove they are all propagation, and it does not rule
+  out a second independent bug further down;
 * per key: how many values were compared, how many differed, and the **max
   absolute and max relative error** with the path that produced it.
 
-**GRADING — non-negotiable (P-030 §2.3).** This is a DIAGNOSTIC. It has no
-verdict vocabulary, is never consulted by :mod:`polismath.replay.certify`, and
-changes no gate. Clojure and Python already differ at ~1e-16 inside ``proj`` and
-at ~1e-5 in cold-tick ``comps`` (CLOJURE_QUIRKS Q12/Q13/Q18) while the final blob
-still MATCHes; a stage-level exact comparison would fail on exactly the noise the
-acceptance policy deliberately tolerates. ``certify`` on the final blob remains
-the sole PASS/FAIL authority.
+**GRADING (P-030 §2.3).** This is a DIAGNOSTIC. It emits per-key statuses
+(MATCH / DIVERGENT / CARVED / ENGINE_LOCAL / INVALID), but the accurate promise
+is that :mod:`polismath.replay.certify` never consumes any of them: the
+final-blob gate is untouched and no status here admits or rejects an engine.
+Clojure and Python already differ at ~1e-16 inside ``proj`` and at ~1e-5 in
+cold-tick ``comps`` while the final blob still MATCHes, so a stage-level exact
+comparison of continuous geometry would fail on noise the acceptance policy
+deliberately tolerates.
+
+Two rules the comparer holds to, both learned the hard way:
+
+1. **A carve-out must never suppress a real difference.** Each carve-out has a
+   narrow, mechanical scope (an exact value pair, or numeric leaves only).
+   Anything outside that scope — a non-empty set changing, a missing key, a
+   changed identity — is reported.
+2. **Missing or misaligned input is a divergence, not a pass.** The report
+   withholds its numeric headline whenever the two recordings are not a complete,
+   step-identity-aligned, same-input pair.
 
 Canonicalization (applied to each side before diffing, so that only real
 differences survive):
 
 1. **Polarity.** A dump declaring ``vote_sign_convention == "raw-db"`` has its
-   vote-valued and geometry nodes negated into Delphi convention (AGREE=+1).
-   ``comps`` are NOT negated (``XᵀX == (-X)ᵀ(-X)``, so power iteration from the
-   same start vector returns the identical vector) and neither is
-   ``comment-extremity`` (a norm) or ``bucket-dists`` (distances). P-030 §2.5.
-2. **Identity keying.** Named matrices become ``{rowname|colname: cell}`` and
-   every tid/pid/bid-indexed array becomes a dict keyed by that id, so the two
-   engines' arbitrary and DIFFERENT array orders (Clojure emits hash/insertion
-   order, Python sorted — ``crosslang.canonicalize_blob``'s note) cannot
-   masquerade as a numeric difference.
-3. **Component sign.** Each principal component is oriented so its largest-|v|
-   entry is positive (first tid on ties), and the coupled arrays — that
-   component's ``comment-projection`` row, the matching ``proj`` column, and
-   coordinate *k* of every base- and group-cluster center — are flipped with it.
-   ``pca.center`` is a data mean and is never flipped
-   (``crosslang.canonicalize_blob:150-163``).
+   vote-valued and geometry nodes negated into Delphi convention (AGREE=+1),
+   including the non-finite wire tokens (``"Infinity"`` <-> ``"-Infinity"``,
+   ``"NaN"`` unchanged). ``comps`` are NOT negated (``XᵀX == (−X)ᵀ(−X)``, so
+   power iteration from the same start vector returns the identical vector) and
+   neither is ``comment-extremity`` (a norm) or ``bucket-dists`` (distances).
+2. **Identity keying.** Named matrices become ``{rowlabel|collabel: cell}`` with
+   TYPE-TAGGED labels, and every tid/pid/bid-indexed array becomes a dict keyed
+   by that id, so the two engines' arbitrary and DIFFERENT array orders cannot
+   masquerade as numeric differences. Dimensions, rectangularity and label
+   uniqueness are VALIDATED first; a violation is carried as a structural error,
+   never as a synthesized number that a tolerance could absorb.
+3. **Coupled component sign.** Each principal component is oriented so its
+   largest-magnitude entry is positive (first tid in canonical order on ties),
+   and the arrays coupled to it are flipped with it. ``pca.center`` is a data
+   mean and is never flipped. Axis orientation is READ from the dump's declared
+   ``comment_projection_axes``; it is never inferred from array lengths.
 
 Run it::
 
@@ -48,18 +61,48 @@ from __future__ import annotations
 
 import argparse
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dc_field
 from pathlib import Path
 from typing import Any, Sequence
 
-from polismath.replay.stages import STAGE_DUMP_SCHEMA, STAGE_ORDER
+from polismath.replay.stages import (
+    COMMENT_PROJECTION_AXES,
+    STAGE_DUMP_SCHEMA,
+    STAGE_ORDER,
+)
 
 COMPARE_SCHEMA = "polis-stage-compare/1"
 
 GRADING_NOTE = (
-    "DIAGNOSTICS ONLY — certify on the final blob is the sole PASS/FAIL "
-    "authority (P-030 §2.3). Nothing here is a gate."
+    "DIAGNOSTICS ONLY — certify never consumes these statuses; the final-blob "
+    "gate is untouched (P-030 §2.3)."
 )
+
+SUPPORTED_CONVENTIONS = ("raw-db", "delphi")
+
+#: The three non-finite values the dump encodes as JSON strings, because JSON has
+#: no literal for them. They must survive every normalization step.
+NAN_TOKEN = "NaN"
+POS_INF_TOKEN = "Infinity"
+NEG_INF_TOKEN = "-Infinity"
+NONFINITE_TOKENS = frozenset({NAN_TOKEN, POS_INF_TOKEN, NEG_INF_TOKEN})
+
+
+class Structural:
+    """A canonicalization failure carried in place of a value.
+
+    Kept as an object rather than a synthesized number so that ``_walk`` reports
+    it as a structural defect: a sentinel like ``{"__length_mismatch__": [3, 4]}``
+    would be walked as numeric leaves and could be absorbed by a tolerance.
+    """
+
+    __slots__ = ("reason",)
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"Structural({self.reason!r})"
 
 
 # ---------------------------------------------------------------------------
@@ -80,85 +123,135 @@ class Tolerance:
         return abs(a - b) <= self.abs_tol + self.rel_tol * scale
 
 
-#: Typed ids, counts, membership, eligibility, vote meaning and cursors — the
-#: families P-022-G-engine-contract.md:433-441 requires exact.
+#: Not a tolerance at all — the marker for leaves compared as exact integers.
+#: Typed IDs, counts, memberships, selections, watermarks and vote meanings are
+#: compared without ever being converted to float (see :func:`_is_integer_leaf`).
 EXACT = Tolerance(0.0, 0.0, "exact")
 
-#: The bound P-022-G-engine-contract.md:434-436 proposes for finite numeric
-#: statistics, with zero outlier allowance.
+#: The bound P-022-G-engine-contract.md proposes for finite numeric statistics,
+#: with zero outlier allowance. A *proposed* diagnostic reference: it has not
+#: been admitted against the full battery.
 TIGHT = Tolerance(1e-6, 1e-4, "tight")
 
-#: Geometry. Deliberately looser than TIGHT because the two engines' cold-tick
-#: ``comps`` are documented to differ at ~1e-5 (CLOJURE_QUIRKS Q12/Q18) while the
-#: final blob still MATCHes; this is the same 1e-2 relative bound
-#: ``stepcompare.StepComparer`` already defaults to for PCA-family paths.
-GEOM = Tolerance(1e-6, 1e-2, "geom")
+#: A LEGACY-COMPARER diagnostic setting, not the proposed contract. It is the
+#: 1e-2 relative bound `stepcompare.StepComparer` already defaults to for
+#: PCA-family paths, kept so this tool's geometry verdicts line up with the
+#: comparer already in use. The documented ~1e-5 cross-engine noise does NOT
+#: establish that 1e-2 is necessary — it is two orders below this ceiling and
+#: already inside TIGHT's relative coefficient at most scales. G permits a higher
+#: ceiling only under scoped, independently measured reference jitter, so every
+#: GEOM key ALSO reports its exceedances of the stricter TIGHT reference
+#: (`n_over_tight`), and this bound is never tuned from candidate output.
+GEOM = Tolerance(1e-6, 1e-2, "geom-legacy")
 
 
 @dataclass(frozen=True)
 class CarveOut:
-    """A difference the port plan says is expected and must NOT be chased."""
+    """A difference the port plan says is expected and must NOT be chased.
+
+    ``mode`` is the mechanical scope, and it is deliberately narrow:
+
+    * ``null-empty`` — suppress ONLY the exact ``None`` <-> ``[]`` value pair at
+      the top of the key. A non-empty set changing, or a null becoming
+      non-empty, is a real difference and is reported.
+    * ``numeric-only`` — suppress numeric leaf differences only. Missing keys,
+      changed candidate inventories, changed types and structural defects are
+      reported.
+    * ``documented`` — declared for the reader, with NO comparison rule. Nothing
+      is suppressed.
+    """
 
     id: str
+    mode: str
     reason: str
 
 
 CARVE_OUTS: dict[str, CarveOut] = {
     "C1": CarveOut(
-        "C1",
+        "C1", "null-empty",
         "mod-in/mod-out/meta-tids: Clojure emits nil until a mod-update has "
-        "written the set; this engine emits an empty set. null-vs-[] on those "
-        "three keys only — a genuinely absent value elsewhere still reports.",
+        "written the set; this engine emits an empty set. ONLY the null-vs-[] "
+        "value pair is suppressed. [1] -> [2], null -> [2], a missing key or a "
+        "wrong type all report normally.",
     ),
     "C2": CarveOut(
-        "C2",
+        "C2", "documented",
         "Q13 — warm-chain split-loop extraction order is knife-edge chaotic on "
         "tie-dense geometry (within-engine gaps ~2.5e-16 vs cross-engine "
         "projection noise ~1e-5). Cluster ids/membership can permute with no "
-        "arithmetic cause. Not carved automatically: reported, and flagged so a "
-        "reader recognises the fingerprint (P-030 §5/R7).",
+        "arithmetic cause. NOTHING is suppressed: identity and lineage drift "
+        "stays visible, because a path rule that hid it would also hide real "
+        "breakage in the lineage code (P-030 §5/R7).",
     ),
     "C3": CarveOut(
-        "C3",
-        "group-clusterings-silhouettes: Clojure scores with clusters/silhouette "
-        "over bucket-dists; this engine scores with calculate_silhouette_sklearn "
-        "over the base-cluster centers. Different estimators, so the VALUES are "
-        "expected to differ. What must agree is the argmax they feed — visible "
-        "in group-k-smoother and the group count, both compared exactly.",
+        "C3", "numeric-only",
+        "group-clusterings-silhouettes VALUES: Clojure scores with "
+        "clusters/silhouette over bucket-dists, this engine with "
+        "calculate_silhouette_sklearn over the base-cluster centers. Different "
+        "estimators, so the numbers are expected to differ. The candidate "
+        "inventory (which k were scored), the argmax they feed, the smoother "
+        "state and group membership are all OUTSIDE the exception and compared "
+        "normally. This is not an approved final-output difference.",
     ),
     "C4": CarveOut(
-        "C4",
-        "ptpt-stats: the engines compute DIFFERENT statistics under this name. "
-        "Clojure emits coreness/centricness/extremeness (geometry over the "
-        "participant projection, repness.clj:372-381); this engine emits "
-        "n_agree/n_disagree/n_pass/group_correlations. Even the two "
-        "same-named fields disagree by construction: Clojure's n-votes is "
-        "user-vote-counts over the RAW rating matrix, this engine's n_votes "
-        "counts non-zero cells of the moderation-applied matrix, and this "
-        "engine omits participants with no votes entirely. math_ptptstats has "
-        "no reader in Node or the clients (P-030 §5/R13), so it is "
-        "verification surface only and the whole key is carved.",
+        "C4", "documented",
+        "participant-info-legacy is this engine's vote-correlation report "
+        "statistic (n_agree/n_disagree/n_pass/group_correlations). It is NOT "
+        "engine-contract surface and has no Clojure counterpart, so it is "
+        "carried as an engine-local diagnostic and never graded against one. "
+        "The contract's geometric ptpt-stats (pid/gid/n-votes/centricness/"
+        "coreness/extremeness) is a fully compared stage with NO waiver.",
     ),
     "C5": CarveOut(
-        "C5",
+        "C5", "documented",
         "mat, all-NaN column: this engine substitutes a 0.0 column mean where "
         "Clojure would divide by zero. Unreachable on a real conversation "
-        "(every column carries at least one vote).",
+        "(every column carries at least one vote), so there is no comparison "
+        "rule and nothing is suppressed — if it were ever observed it would be "
+        "reported as an ordinary divergence.",
     ),
     "C6": CarveOut(
-        "C6",
+        "C6", "documented",
         "Q18 — uniqify's exact-center-equality predicate is value-dependent ulp "
-        "luck, so whether a merge chain over coincident singletons continues "
-        "(and which id survives) depends on the 17th digit. Ledgered as the root "
-        "cause of all 11 carved-out entries in delphi/docs/divergences.json. "
-        "Reported, not auto-suppressed (P-030 §5/R7).",
+        "luck, so whether a merge chain over coincident singletons continues — "
+        "and which id survives — depends on the 17th digit. Root cause of all "
+        "11 carved-out entries in delphi/docs/divergences.json. NOTHING is "
+        "suppressed, for the same reason as C2.",
     ),
 }
 
-#: Carve-outs applied automatically by the comparer. C2/C6 are documentation for
-#: the reader — they are chaotic, not addressable by a path rule, so suppressing
-#: them by path would hide real structural breakage.
-AUTO_CARVED = ("C1", "C3", "C4", "C5")
+#: Carve-outs with an actual comparison rule. Everything else in CARVE_OUTS is
+#: documentation for the reader and suppresses nothing.
+AUTO_CARVED = tuple(cid for cid, c in CARVE_OUTS.items() if c.mode != "documented")
+
+#: (stage, key) -> carve-out id, for the carve-outs that have a rule.
+KEY_CARVE_OUT: dict[tuple[str, str], str] = {
+    ("R02_moderation", "meta-tids"): "C1",
+    ("R02_moderation", "mod-in"): "C1",
+    ("R02_moderation", "mod-out"): "C1",
+    ("R09_group_clusters", "group-clusterings-silhouettes"): "C3",
+}
+
+#: Keys one engine emits that have no counterpart on the other. Reported, never
+#: graded, never a divergence — and never silently dropped either.
+ENGINE_LOCAL_KEYS: frozenset[tuple[str, str]] = frozenset({
+    ("R13_ptpt_stats", "participant-info-legacy"),
+})
+
+
+# ---------------------------------------------------------------------------
+# Non-finite tokens.
+# ---------------------------------------------------------------------------
+def _is_token(x: Any) -> bool:
+    return isinstance(x, str) and x in NONFINITE_TOKENS
+
+
+def _negate_token(tok: str) -> str:
+    if tok == POS_INF_TOKEN:
+        return NEG_INF_TOKEN
+    if tok == NEG_INF_TOKEN:
+        return POS_INF_TOKEN
+    return NAN_TOKEN
 
 
 # ---------------------------------------------------------------------------
@@ -167,7 +260,7 @@ AUTO_CARVED = ("C1", "C3", "C4", "C5")
 #: Stage -> the keys whose values are negated when converting a raw-DB dump into
 #: Delphi convention. Everything not listed is polarity-invariant: counts are
 #: relabelled not rescaled, distances and extremities are norms, and comps are
-#: invariant because XᵀX == (-X)ᵀ(-X).
+#: invariant because XᵀX == (−X)ᵀ(−X).
 NEGATE: dict[str, tuple[str, ...]] = {
     "R01_ingest": ("rating-mat", "raw-rating-mat"),
     "R04_pca": ("mat", "pca.center", "pca.comment-projection"),
@@ -178,7 +271,12 @@ NEGATE: dict[str, tuple[str, ...]] = {
 
 
 def _negate(x: Any) -> Any:
-    if x is None or isinstance(x, (str, bool)):
+    """Negate a value, carrying the non-finite wire tokens correctly."""
+    if x is None or isinstance(x, bool) or isinstance(x, Structural):
+        return x
+    if _is_token(x):
+        return _negate_token(x)
+    if isinstance(x, str):
         return x
     if isinstance(x, (int, float)):
         return -x
@@ -191,27 +289,36 @@ def _negate(x: Any) -> Any:
 
 def _negate_clusters(clusters: Any) -> Any:
     """Only a cluster's ``center`` is geometry; its id and members are not."""
-    if clusters is None:
-        return None
+    if clusters is None or isinstance(clusters, Structural):
+        return clusters
     if isinstance(clusters, dict):  # {k: [clusters]}
         return {k: _negate_clusters(v) for k, v in clusters.items()}
-    return [dict(c, center=_negate(c.get("center"))) for c in clusters]
+    if not isinstance(clusters, list):
+        return Structural("clusters must be a list")
+    out = []
+    for c in clusters:
+        if not isinstance(c, dict):
+            return Structural("cluster entry must be an object")
+        out.append(dict(c, center=_negate(c.get("center"))))
+    return out
 
 
 def _negate_named_matrix(nm: Any) -> Any:
     if not isinstance(nm, dict) or "matrix" not in nm:
         return _negate(nm)
-    return dict(nm, matrix=[[None if v is None else -v for v in row]
-                            for row in nm["matrix"]])
+    rows = nm["matrix"]
+    if not isinstance(rows, list):
+        return Structural("named matrix 'matrix' must be a list")
+    return dict(nm, matrix=[_negate(row) for row in rows])
 
 
 def apply_polarity(stages: dict[str, Any], convention: str) -> dict[str, Any]:
     """Bring a stage tree into Delphi convention (AGREE=+1)."""
     if convention != "raw-db":
         return stages
-    out = {k: dict(v) for k, v in stages.items()}
+    out = {k: (dict(v) if isinstance(v, dict) else v) for k, v in stages.items()}
     for stage, keys in NEGATE.items():
-        if stage not in out:
+        if not isinstance(out.get(stage), dict):
             continue
         for key in keys:
             if "." in key:
@@ -237,39 +344,92 @@ def apply_polarity(stages: dict[str, Any], convention: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Identity keying + component sign orientation.
 # ---------------------------------------------------------------------------
-def _nm_cells(nm: Any) -> dict[str, Any] | None:
-    """A named matrix as ``{"rowname|colname": cell}`` — order-independent."""
-    if not isinstance(nm, dict) or "matrix" not in nm:
-        return None
-    rows, cols = nm.get("rownames") or [], nm.get("colnames") or []
+def _typed_label(x: Any) -> str:
+    """A label that keeps the identity's TYPE, so integer 1 and string "1" are
+    different rows/columns rather than colliding into one."""
+    if isinstance(x, bool):
+        return f"b:{x}"
+    if isinstance(x, int):
+        return f"i:{x}"
+    if isinstance(x, float):
+        return f"f:{x!r}"
+    if isinstance(x, str):
+        return f"s:{x}"
+    if x is None:
+        return "n:"
+    return f"o:{x!r}"
+
+
+def _sort_labels(values: Sequence[Any]) -> list[Any]:
+    """Canonical order for identities: by type tag, then value. Used so both
+    engines' tie-breaks land on the same element."""
+    return sorted(values, key=lambda v: (type(v).__name__, _typed_label(v)))
+
+
+def _validate_named_matrix(nm: Any, label: str) -> Structural | None:
+    if not isinstance(nm, dict):
+        return Structural(f"{label}: not an object")
+    for k in ("rownames", "colnames", "matrix"):
+        if not isinstance(nm.get(k), list):
+            return Structural(f"{label}: '{k}' missing or not a list")
+    rows, cols, mat = nm["rownames"], nm["colnames"], nm["matrix"]
+    if len(mat) != len(rows):
+        return Structural(
+            f"{label}: {len(mat)} matrix rows for {len(rows)} rownames")
+    for i, row in enumerate(mat):
+        if not isinstance(row, list):
+            return Structural(f"{label}: row {i} is not a list")
+        if len(row) != len(cols):
+            return Structural(
+                f"{label}: row {i} has {len(row)} cells for {len(cols)} colnames")
+    for name, labels in (("rownames", rows), ("colnames", cols)):
+        seen = [_typed_label(x) for x in labels]
+        if len(set(seen)) != len(seen):
+            return Structural(f"{label}: duplicate {name}")
+    return None
+
+
+def _nm_cells(nm: Any, label: str) -> dict[str, Any] | Structural:
+    """A named matrix as ``{rowlabel|collabel: cell}`` — order-independent, with
+    dimensions and label uniqueness validated first."""
+    bad = _validate_named_matrix(nm, label)
+    if bad is not None:
+        return bad
     cells: dict[str, Any] = {}
-    for i, r in enumerate(rows):
-        if i >= len(nm["matrix"]):
-            break
-        row = nm["matrix"][i]
-        for j, c in enumerate(cols):
-            if j < len(row):
-                cells[f"{r}|{c}"] = row[j]
+    for i, r in enumerate(nm["rownames"]):
+        for j, c in enumerate(nm["colnames"]):
+            cells[f"{_typed_label(r)}|{_typed_label(c)}"] = nm["matrix"][i][j]
     return cells
 
 
-def _by_tid(values: Sequence[Any] | None, tids: Sequence[Any]) -> dict[str, Any] | None:
+def _by_tid(values: Any, tids: Sequence[Any], label: str) -> Any:
+    """Index an array by tid, requiring exact length agreement."""
     if values is None:
         return None
+    if not isinstance(values, list):
+        return Structural(f"{label}: expected a list")
     if len(values) != len(tids):
-        return {"__length_mismatch__": [len(values), len(tids)]}
-    return {str(t): v for t, v in zip(tids, values)}
+        return Structural(f"{label}: {len(values)} values for {len(tids)} tids")
+    return {_typed_label(t): v for t, v in zip(tids, values)}
 
 
-def _orient(comps_by_tid: list[dict[str, Any]]) -> list[float]:
-    """Flip sign per component so its max-|value| entry is positive; ties go to
-    the first tid in sorted-tid order (crosslang.canonicalize_blob:162-163)."""
+def _orient(comps_by_tid: list[Any], tid_labels: Sequence[str]) -> list[float]:
+    """Flip sign per component so its largest-magnitude entry is positive; ties
+    go to the first tid in canonical order (crosslang.canonicalize_blob:162-163).
+
+    A non-finite token is not comparable by magnitude, so a component containing
+    one is left un-oriented (sign +1) — the difference then shows up honestly
+    rather than being flipped into agreement.
+    """
     signs = []
     for comp in comps_by_tid:
+        if not isinstance(comp, dict):
+            signs.append(1.0)
+            continue
         best_key, best_abs = None, -1.0
-        for key in sorted(comp, key=lambda k: (len(k), k)):
-            v = comp[key]
-            if not isinstance(v, (int, float)):
+        for key in tid_labels:
+            v = comp.get(key)
+            if not isinstance(v, (int, float)) or isinstance(v, bool):
                 continue
             if abs(v) > best_abs:
                 best_key, best_abs = key, abs(v)
@@ -277,162 +437,293 @@ def _orient(comps_by_tid: list[dict[str, Any]]) -> list[float]:
     return signs
 
 
-def _flip(d: dict[str, Any] | None, sign: float) -> dict[str, Any] | None:
-    if d is None or sign == 1.0:
+def _flip(d: Any, sign: float) -> Any:
+    if d is None or isinstance(d, Structural) or sign == 1.0:
         return d
-    return {k: (-v if isinstance(v, (int, float)) and not isinstance(v, bool) else v)
+    if not isinstance(d, dict):
+        return d
+    return {k: _negate(v) if (_is_token(v)
+                              or (isinstance(v, (int, float))
+                                  and not isinstance(v, bool)))
+            else v
             for k, v in d.items()}
 
 
 def canonicalize(doc: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Polarity-normalize, key everything by identity, and orient components.
 
-    Returns ``{stage: {key: canonical value}}``. Values are plain JSON data whose
-    ORDER is meaningful only where it is meaningful on both engines (repness
-    selection order, votes-base bucket arrays, bid-to-pid).
+    Returns ``{stage: {key: canonical value}}``. A value that could not be
+    canonicalized is a :class:`Structural`, never a synthesized number.
     """
     stages = apply_polarity(doc.get("stages") or {},
                             doc.get("vote_sign_convention", "delphi"))
-    out: dict[str, dict[str, Any]] = {s: dict(v) for s, v in stages.items()}
+    out: dict[str, dict[str, Any]] = {
+        s: (dict(v) if isinstance(v, dict) else {"__stage__": Structural(
+            "stage is not an object")})
+        for s, v in stages.items()
+    }
 
     r01 = out.get("R01_ingest", {})
-    tids = list(r01.get("tids") or [])
+    raw_tids = r01.get("tids")
+    tids = list(raw_tids) if isinstance(raw_tids, list) else []
+    if tids and len({_typed_label(t) for t in tids}) != len(tids):
+        r01["tids"] = Structural("tids: duplicate identity")
+        tids = []
+    tid_labels = [_typed_label(t) for t in _sort_labels(tids)]
 
-    # R01: order-free views of the two vote matrices; tids as a sorted set.
     for key in ("rating-mat", "raw-rating-mat"):
-        cells = _nm_cells(r01.get(key))
-        if cells is not None:
-            r01[key] = cells
-    if tids:
-        r01["tids"] = sorted(tids, key=lambda t: (str(type(t)), t))
+        if key in r01 and r01[key] is not None:
+            r01[key] = _nm_cells(r01[key], key)
+    if isinstance(r01.get("tids"), list):
+        r01["tids"] = _sort_labels(r01["tids"])
 
     # R04: mat keyed by (pid, tid); pca arrays keyed by tid.
     r04 = out.get("R04_pca", {})
     mat = r04.get("mat")
     rating_nm = (stages.get("R01_ingest") or {}).get("rating-mat")
-    if isinstance(mat, list) and isinstance(rating_nm, dict):
-        r04["mat"] = _nm_cells({"rownames": rating_nm.get("rownames"),
-                                "colnames": rating_nm.get("colnames"),
-                                "matrix": mat})
-    comps_by_tid: list[dict[str, Any]] = []
+    if mat is not None:
+        if isinstance(mat, list) and isinstance(rating_nm, dict):
+            r04["mat"] = _nm_cells({"rownames": rating_nm.get("rownames"),
+                                    "colnames": rating_nm.get("colnames"),
+                                    "matrix": mat}, "mat")
+        else:
+            r04["mat"] = Structural("mat: not a matrix, or rating-mat missing")
+
+    signs: list[float] = []
     pca = r04.get("pca")
     if isinstance(pca, dict):
         pca = dict(pca)
-        pca["center"] = _by_tid(pca.get("center"), tids)
-        pca["comment-extremity"] = _by_tid(pca.get("comment-extremity"), tids)
-        comps = pca.get("comps") or []
-        comps_by_tid = [_by_tid(row, tids) or {} for row in comps]
+        pca["center"] = _by_tid(pca.get("center"), tids, "pca.center")
+        pca["comment-extremity"] = _by_tid(
+            pca.get("comment-extremity"), tids, "pca.comment-extremity")
+
+        comps = pca.get("comps")
+        if comps is None:
+            comps_by_tid: list[Any] = []
+        elif not isinstance(comps, list):
+            pca["comps"] = Structural("pca.comps: expected a list of components")
+            comps_by_tid = []
+        else:
+            comps_by_tid = [_by_tid(row, tids, f"pca.comps[{i}]")
+                            for i, row in enumerate(comps)]
+
+        # AXES ARE DECLARED, NOT INFERRED. Both emitters write
+        # comment-projection as n_comps rows of n_tids values and say so in
+        # `comment_projection_axes`; guessing from lengths misreads every square
+        # case (n_tids == n_comps).
+        declared = doc.get("comment_projection_axes")
         proj_rows = pca.get("comment-projection")
-        cproj_by_comp: list[dict[str, Any]] = []
-        if isinstance(proj_rows, list) and proj_rows:
-            # Clojure emits n_comps x n_tids; this engine n_tids x n_comps.
-            if len(proj_rows) == len(tids) and len(tids) != len(comps):
-                proj_rows = [list(col) for col in zip(*proj_rows)]
-            cproj_by_comp = [_by_tid(row, tids) or {} for row in proj_rows]
-        signs = _orient(comps_by_tid)
-        pca["comps"] = {str(i): _flip(c, s)
-                        for i, (c, s) in enumerate(zip(comps_by_tid, signs))}
-        pca["comment-projection"] = {str(i): _flip(c, s)
-                                     for i, (c, s) in enumerate(zip(cproj_by_comp, signs))}
+        if proj_rows is None:
+            cproj_by_comp: list[Any] = []
+        elif declared != COMMENT_PROJECTION_AXES:
+            pca["comment-projection"] = Structural(
+                f"pca.comment-projection: undeclared or unsupported axes "
+                f"{declared!r}, expected {COMMENT_PROJECTION_AXES!r}")
+            cproj_by_comp = []
+        elif not isinstance(proj_rows, list):
+            pca["comment-projection"] = Structural(
+                "pca.comment-projection: expected a list of component rows")
+            cproj_by_comp = []
+        elif isinstance(comps, list) and len(proj_rows) != len(comps):
+            pca["comment-projection"] = Structural(
+                f"pca.comment-projection: {len(proj_rows)} component rows for "
+                f"{len(comps)} comps")
+            cproj_by_comp = []
+        else:
+            cproj_by_comp = [_by_tid(row, tids, f"pca.comment-projection[{i}]")
+                             for i, row in enumerate(proj_rows)]
+
+        signs = _orient(comps_by_tid, tid_labels)
+        if not isinstance(pca.get("comps"), Structural):
+            pca["comps"] = {str(i): _flip(c, s)
+                            for i, (c, s) in enumerate(zip(comps_by_tid, signs))}
+        if not isinstance(pca.get("comment-projection"), Structural):
+            pca["comment-projection"] = {
+                str(i): _flip(c, s)
+                for i, (c, s) in enumerate(zip(cproj_by_comp, signs))}
         r04["pca"] = pca
-    else:
-        signs = []
+    elif pca is not None:
+        r04["pca"] = Structural("pca: not an object")
 
     # R05: proj columns keyed by pid, flipped with their component.
     r05 = out.get("R05_projections", {})
     proj_nm = r05.get("proj")
-    if isinstance(proj_nm, dict) and "matrix" in proj_nm:
-        rows = proj_nm.get("rownames") or []
-        cols: dict[str, dict[str, Any]] = {}
-        for k in range(len(proj_nm.get("colnames") or [])):
-            col = {str(r): (proj_nm["matrix"][i][k]
-                            if i < len(proj_nm["matrix"]) and k < len(proj_nm["matrix"][i])
-                            else None)
-                   for i, r in enumerate(rows)}
-            cols[str(k)] = _flip(col, signs[k] if k < len(signs) else 1.0)
-        r05["proj"] = cols
+    if proj_nm is not None:
+        cells = _nm_cells(proj_nm, "proj")
+        if isinstance(cells, Structural):
+            r05["proj"] = cells
+        else:
+            cols = proj_nm["colnames"]
+            if signs and len(cols) != len(signs):
+                r05["proj"] = Structural(
+                    f"proj: {len(cols)} columns for {len(signs)} components")
+            else:
+                out_cols: dict[str, Any] = {}
+                for k, cname in enumerate(cols):
+                    suffix = f"|{_typed_label(cname)}"
+                    col = {key[: -len(suffix)]: v for key, v in cells.items()
+                           if key.endswith(suffix)}
+                    out_cols[str(k)] = _flip(
+                        col, signs[k] if k < len(signs) else 1.0)
+                r05["proj"] = out_cols
 
     # R06: cluster centers flip with their component; the rest is identity data.
     r06 = out.get("R06_base_clusters", {})
-    r06["base-clusters"] = _canon_clusters(r06.get("base-clusters"), signs)
-    bcp = _nm_cells(r06.get("base-clusters-proj"))
-    if bcp is not None:
-        r06["base-clusters-proj"] = _flip_nm_cells(bcp, signs,
-                                                   r06.get("base-clusters-proj"))
-    bd = _nm_cells(r06.get("bucket-dists"))
-    if bd is not None:
-        r06["bucket-dists"] = bd  # distances are sign-invariant
-    if isinstance(r06.get("bid-to-pid"), list):
-        r06["bid-to-pid"] = [sorted(m, key=lambda x: (str(type(x)), x))
-                             for m in r06["bid-to-pid"]]
+    if "base-clusters" in r06:
+        r06["base-clusters"] = _canon_clusters(r06.get("base-clusters"), signs)
+    if r06.get("base-clusters-proj") is not None:
+        r06["base-clusters-proj"] = _flip_nm_cells(
+            r06["base-clusters-proj"], signs, "base-clusters-proj")
+    if r06.get("bucket-dists") is not None:
+        # distances are sign-invariant
+        r06["bucket-dists"] = _nm_cells(r06["bucket-dists"], "bucket-dists")
+    btp = r06.get("bid-to-pid")
+    if btp is not None:
+        if isinstance(btp, list) and all(isinstance(m, list) for m in btp):
+            r06["bid-to-pid"] = [_sort_labels(m) for m in btp]
+        else:
+            r06["bid-to-pid"] = Structural("bid-to-pid: expected a list of lists")
 
     r09 = out.get("R09_group_clusters", {})
-    r09["group-clusters"] = _canon_clusters(r09.get("group-clusters"), signs)
+    if "group-clusters" in r09:
+        r09["group-clusters"] = _canon_clusters(r09.get("group-clusters"), signs)
     gcs = r09.get("group-clusterings")
     if isinstance(gcs, dict):
-        r09["group-clusterings"] = {k: _canon_clusters(v, signs) for k, v in gcs.items()}
+        r09["group-clusterings"] = {k: _canon_clusters(v, signs)
+                                    for k, v in gcs.items()}
+    elif gcs is not None:
+        r09["group-clusterings"] = Structural("group-clusterings: not an object")
 
-    # R13: key by pid; only pid/gid/n-votes are the same quantity (carve-out C4).
+    # R13: the CONTRACT geometry, keyed by pid with EVERY field retained.
     r13 = out.get("R13_ptpt_stats", {})
     stats = r13.get("ptpt-stats")
-    if isinstance(stats, list):
-        r13["ptpt-stats"] = {
-            str(row.get("pid")): {"gid": row.get("gid"), "n-votes": row.get("n-votes")}
-            for row in stats
-        }
+    if stats is not None:
+        r13["ptpt-stats"] = _rows_by_pid(stats, "ptpt-stats")
+    legacy = r13.get("participant-info-legacy")
+    if legacy is not None:
+        r13["participant-info-legacy"] = _rows_by_pid(
+            legacy, "participant-info-legacy")
     return out
 
 
-def _flip_nm_cells(cells: dict[str, Any], signs: Sequence[float],
-                   nm: Any) -> dict[str, Any]:
-    """Flip an ``x``/``y`` named matrix's columns with their components."""
-    cols = list((nm or {}).get("colnames") or [])
+def _rows_by_pid(rows: Any, label: str) -> Any:
+    """Row list -> ``{pid: row}``, retaining every field. A duplicate or missing
+    pid is a structural defect, not a silent overwrite."""
+    if not isinstance(rows, list):
+        return Structural(f"{label}: expected a list of rows")
+    out: dict[str, Any] = {}
+    for i, row in enumerate(rows):
+        if not isinstance(row, dict):
+            return Structural(f"{label}[{i}]: not an object")
+        if "pid" not in row:
+            return Structural(f"{label}[{i}]: no pid")
+        key = _typed_label(row["pid"])
+        if key in out:
+            return Structural(f"{label}: duplicate pid {row['pid']!r}")
+        out[key] = {k: v for k, v in row.items() if k != "pid"}
+    return out
+
+
+def _flip_nm_cells(nm: Any, signs: Sequence[float], label: str) -> Any:
+    """Flip an x/y named matrix's columns with their components."""
+    cells = _nm_cells(nm, label)
+    if isinstance(cells, Structural):
+        return cells
+    cols = list(nm["colnames"])
+    if signs and len(cols) != len(signs):
+        return Structural(f"{label}: {len(cols)} columns for {len(signs)} components")
     out = {}
     for key, v in cells.items():
-        col = key.rsplit("|", 1)[-1]
-        k = cols.index(col) if col in cols else -1
+        col_label = key.rsplit("|", 1)[-1]
+        k = next((i for i, c in enumerate(cols)
+                  if _typed_label(c) == col_label), -1)
         s = signs[k] if 0 <= k < len(signs) else 1.0
-        out[key] = -v if (s == -1.0 and isinstance(v, (int, float))
-                          and not isinstance(v, bool)) else v
+        out[key] = _negate(v) if (s == -1.0 and (_is_token(v) or (
+            isinstance(v, (int, float)) and not isinstance(v, bool)))) else v
     return out
 
 
 def _canon_clusters(clusters: Any, signs: Sequence[float]) -> Any:
-    if not isinstance(clusters, list):
+    if isinstance(clusters, Structural) or clusters is None:
         return clusters
+    if not isinstance(clusters, list):
+        return Structural("clusters: expected a list")
     out = []
+    seen: set[str] = set()
     for c in clusters:
-        center = list(c.get("center") or [])
-        center = [(-v if (k < len(signs) and signs[k] == -1.0
-                          and isinstance(v, (int, float))) else v)
+        if not isinstance(c, dict):
+            return Structural("cluster entry: not an object")
+        if "id" not in c:
+            return Structural("cluster entry: no id")
+        label = _typed_label(c["id"])
+        if label in seen:
+            return Structural(f"clusters: duplicate id {c['id']!r}")
+        seen.add(label)
+        center = c.get("center")
+        if center is not None and not isinstance(center, list):
+            return Structural("cluster center: expected a list")
+        center = list(center or [])
+        center = [(_negate(v) if (k < len(signs) and signs[k] == -1.0
+                                  and (_is_token(v) or (
+                                      isinstance(v, (int, float))
+                                      and not isinstance(v, bool))))
+                   else v)
                   for k, v in enumerate(center)]
+        members = c.get("members")
+        if members is not None and not isinstance(members, list):
+            return Structural("cluster members: expected a list")
         out.append({"center": center,
-                    "id": c.get("id"),
-                    "members": sorted(c.get("members") or [],
-                                      key=lambda x: (str(type(x)), x))})
-    out.sort(key=lambda c: (str(type(c["id"])), c["id"]))
+                    "id": c["id"],
+                    "members": _sort_labels(members or [])})
+    out.sort(key=lambda c: (type(c["id"]).__name__, _typed_label(c["id"])))
     return out
 
 
 # ---------------------------------------------------------------------------
-# Per-key tolerance policy.
+# Per-leaf semantics: integer identities vs continuous statistics.
 # ---------------------------------------------------------------------------
-#: (stage, key) -> Tolerance for that key's NUMERIC leaves. Non-numeric leaves
-#: (ids, booleans, strings, membership) are always compared exactly, whatever a
-#: key's numeric class is.
+#: Whole keys whose every numeric leaf is integer-typed by contract.
+INTEGER_KEYS: frozenset[tuple[str, str]] = frozenset({
+    ("R01_ingest", "last-vote-timestamp"),
+    ("R01_ingest", "n"),
+    ("R01_ingest", "n-cmts"),
+    ("R01_ingest", "rating-mat"),
+    ("R01_ingest", "raw-rating-mat"),
+    ("R01_ingest", "tids"),
+    ("R02_moderation", "last-mod-timestamp"),
+    ("R02_moderation", "meta-tids"),
+    ("R02_moderation", "mod-in"),
+    ("R02_moderation", "mod-out"),
+    ("R03_eligibility", "in-conv"),
+    ("R03_eligibility", "user-vote-counts"),
+    ("R06_base_clusters", "base-clusters-weights"),
+    ("R06_base_clusters", "bid-to-pid"),
+    ("R09_group_clusters", "group-k-smoother"),
+    ("R10_tallies", "votes-base"),
+    ("R10_tallies", "group-votes"),
+})
+
+#: Field names that are integer-typed wherever they appear. Matched against the
+#: nearest enclosing object key, so `base-clusters[3].id` and
+#: `repness.0[2].n-trials` both resolve.
+INTEGER_FIELDS: frozenset[str] = frozenset({
+    "A", "D", "S",
+    "bid", "count", "gid", "id", "members", "n-agree", "n-cmts", "n-members",
+    "n-success", "n-trials", "n-votes", "pid", "tid",
+    "last-k", "last-k-count", "smoothed-k",
+    "last-mod-timestamp", "last-vote-timestamp",
+})
+
+
+def _is_integer_leaf(stage: str, key: str, field: str | None) -> bool:
+    if (stage, key) in INTEGER_KEYS:
+        return True
+    return field in INTEGER_FIELDS
+
+
+#: (stage, key) -> Tolerance for that key's CONTINUOUS numeric leaves. Integer
+#: leaves (see above) never use a tolerance, whatever this table says.
 KEY_TOLERANCE: dict[tuple[str, str], Tolerance] = {
-    ("R01_ingest", "last-vote-timestamp"): EXACT,
-    ("R01_ingest", "n"): EXACT,
-    ("R01_ingest", "n-cmts"): EXACT,
-    ("R01_ingest", "raw-rating-mat"): EXACT,
-    ("R01_ingest", "rating-mat"): EXACT,
-    ("R01_ingest", "tids"): EXACT,
-    ("R02_moderation", "last-mod-timestamp"): EXACT,
-    ("R02_moderation", "meta-tids"): EXACT,
-    ("R02_moderation", "mod-in"): EXACT,
-    ("R02_moderation", "mod-out"): EXACT,
-    ("R03_eligibility", "in-conv"): EXACT,
-    ("R03_eligibility", "user-vote-counts"): EXACT,
     # `mat` is a deterministic function of integers and one division per column
     # (P-030 §5/R4) — TIGHT, not GEOM.
     ("R04_pca", "mat"): TIGHT,
@@ -440,33 +731,22 @@ KEY_TOLERANCE: dict[tuple[str, str], Tolerance] = {
     ("R05_projections", "proj"): GEOM,
     ("R06_base_clusters", "base-clusters"): GEOM,
     ("R06_base_clusters", "base-clusters-proj"): GEOM,
-    ("R06_base_clusters", "base-clusters-weights"): EXACT,
-    ("R06_base_clusters", "bid-to-pid"): EXACT,
     ("R06_base_clusters", "bucket-dists"): GEOM,
     ("R09_group_clusters", "group-clusterings"): GEOM,
     ("R09_group_clusters", "group-clusterings-silhouettes"): GEOM,
     ("R09_group_clusters", "group-clusters"): GEOM,
-    ("R09_group_clusters", "group-k-smoother"): EXACT,
     ("R10_tallies", "group-aware-consensus"): TIGHT,
-    ("R10_tallies", "group-votes"): EXACT,
-    ("R10_tallies", "votes-base"): EXACT,
     ("R11_repness", "consensus"): TIGHT,
     ("R11_repness", "repness"): TIGHT,
     ("R12_priorities", "comment-priorities"): TIGHT,
-    ("R13_ptpt_stats", "ptpt-stats"): EXACT,
-}
-
-#: Keys whose divergences are automatically attributed to a carve-out.
-KEY_CARVE_OUT: dict[tuple[str, str], str] = {
-    ("R02_moderation", "meta-tids"): "C1",
-    ("R02_moderation", "mod-in"): "C1",
-    ("R02_moderation", "mod-out"): "C1",
-    ("R09_group_clusters", "group-clusterings-silhouettes"): "C3",
-    ("R13_ptpt_stats", "ptpt-stats"): "C4",
+    ("R13_ptpt_stats", "ptpt-stats"): TIGHT,
+    ("R13_ptpt_stats", "participant-info-legacy"): TIGHT,
 }
 
 
 def _tolerance(stage: str, key: str) -> Tolerance:
+    if (stage, key) in INTEGER_KEYS:
+        return EXACT
     return KEY_TOLERANCE.get((stage, key), TIGHT)
 
 
@@ -477,28 +757,43 @@ def _is_num(x: Any) -> bool:
     return isinstance(x, (int, float)) and not isinstance(x, bool)
 
 
+def _as_exact_int(x: Any) -> int | None:
+    """The exact integer value of an integer-typed leaf, WITHOUT float coercion.
+
+    A Python ``int`` passes through with full precision (so 2**53 and 2**53+1
+    stay distinct). A float is accepted only when it is exactly integral — the
+    two engines legitimately spell the same vote as ``-1`` and ``-1.0``.
+    Booleans are rejected: a bool is not a count.
+    """
+    if isinstance(x, bool):
+        return None
+    if isinstance(x, int):
+        return x
+    if isinstance(x, float) and x.is_integer():
+        return int(x)
+    return None
+
+
 @dataclass
 class KeyResult:
     n_compared: int = 0
     n_diff: int = 0
+    n_over_tight: int = 0
     max_abs: float = 0.0
     max_rel: float = 0.0
     n_suppressed: int = 0
+    n_nonfinite: int = 0
     worst_path: str | None = None
-    structural: list[str] = None  # type: ignore[assignment]
-    examples: list[dict[str, Any]] = None  # type: ignore[assignment]
-
-    def __post_init__(self) -> None:
-        if self.structural is None:
-            self.structural = []
-        if self.examples is None:
-            self.examples = []
+    structural: list[str] = dc_field(default_factory=list)
+    examples: list[dict[str, Any]] = dc_field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "n_compared": self.n_compared,
             "n_diff": self.n_diff,
+            "n_over_tight": self.n_over_tight,
             "n_suppressed": self.n_suppressed,
+            "n_nonfinite": self.n_nonfinite,
             "max_abs": self.max_abs,
             "max_rel": self.max_rel,
             "worst_path": self.worst_path,
@@ -507,64 +802,118 @@ class KeyResult:
             "examples": self.examples[:5],
         }
 
+    def note(self, path: str, a: Any, b: Any, **extra: Any) -> None:
+        if len(self.examples) < 5:
+            self.examples.append({"path": path, "a": a, "b": b, **extra})
 
-def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult,
-          *, carved: bool) -> None:
-    """Recursively diff two canonical values, accumulating into ``res``."""
+
+def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
+          stage: str, key: str, field: str | None, carve_numeric: bool) -> None:
+    """Recursively diff two canonical values, accumulating into ``res``.
+
+    ``carve_numeric`` attributes NUMERIC differences to a numeric-only carve-out
+    (C3). Structural defects, type changes and non-numeric differences are always
+    counted, whatever the carve-out says.
+    """
+    if isinstance(a, Structural) or isinstance(b, Structural):
+        for side, v in (("a", a), ("b", b)):
+            if isinstance(v, Structural):
+                res.structural.append(f"{path}: [{side}] {v.reason}")
+        return
     if a is None and b is None:
         return
+
+    integer_leaf = _is_integer_leaf(stage, key, field)
+
+    # Non-finite wire tokens compare as tokens, on either or both sides.
+    if _is_token(a) or _is_token(b):
+        res.n_compared += 1
+        res.n_nonfinite += 1
+        if a != b:
+            res.n_diff += 1
+            res.note(path, a, b, nonfinite=True)
+            if res.worst_path is None:
+                res.worst_path = path
+            res.max_rel = max(res.max_rel, 1.0)
+        return
+
     if _is_num(a) and _is_num(b):
         res.n_compared += 1
+        if integer_leaf:
+            ia, ib = _as_exact_int(a), _as_exact_int(b)
+            if ia is None or ib is None:
+                res.structural.append(
+                    f"{path}: integer-typed field carries a non-integral value "
+                    f"({a!r} vs {b!r})")
+                return
+            if ia != ib:
+                res.n_diff += 1
+                res.n_over_tight += 1
+                delta = float(abs(ia - ib))
+                if delta > res.max_abs:
+                    res.max_abs, res.worst_path = delta, path
+                scale = max(abs(ia), abs(ib))
+                res.max_rel = max(res.max_rel, delta / scale if scale else 1.0)
+                res.note(path, a, b, abs=delta)
+            return
         abs_err = abs(float(a) - float(b))
         scale = max(abs(float(a)), abs(float(b)))
         rel_err = abs_err / scale if scale > 0 else 0.0
         # max_abs/max_rel are over EVERY compared pair, not only the failing
-        # ones: on a key that is fully within tolerance they are the headroom
-        # measurement the port plan wants, and on a failing key the worst pair
-        # is by construction also the largest error.
+        # ones: on a key within tolerance they are the headroom measurement.
         if abs_err > res.max_abs:
             res.max_abs, res.worst_path = abs_err, path
         res.max_rel = max(res.max_rel, rel_err)
+        if not TIGHT.ok(float(a), float(b)):
+            res.n_over_tight += 1
         if not tol.ok(float(a), float(b)):
-            res.n_diff += 1
-            if len(res.examples) < 5:
-                res.examples.append({"path": path, "a": a, "b": b,
-                                     "abs": abs_err, "rel": rel_err})
+            if carve_numeric:
+                res.n_suppressed += 1
+            else:
+                res.n_diff += 1
+                res.note(path, a, b, abs=abs_err, rel=rel_err)
         return
+
+    if integer_leaf and (_is_num(a) or _is_num(b)) and a is not None and b is not None:
+        res.structural.append(
+            f"{path}: integer-typed field type mismatch ({a!r} vs {b!r})")
+        return
+
     if isinstance(a, dict) and isinstance(b, dict):
         for k in sorted(set(a) | set(b)):
             if k not in a or k not in b:
-                if carved and (a.get(k) in (None, [], {}) or b.get(k) in (None, [], {})):
-                    res.n_suppressed += 1
-                    continue
                 res.structural.append(f"{path}.{k}: present on only one side")
                 continue
-            _walk(a[k], b[k], f"{path}.{k}", tol, res, carved=carved)
+            _walk(a[k], b[k], f"{path}.{k}", tol, res,
+                  stage=stage, key=key, field=k, carve_numeric=carve_numeric)
         return
+
     if isinstance(a, list) and isinstance(b, list):
         if len(a) != len(b):
             res.structural.append(f"{path}: length {len(a)} vs {len(b)}")
         for i, (x, y) in enumerate(zip(a, b)):
-            _walk(x, y, f"{path}[{i}]", tol, res, carved=carved)
+            _walk(x, y, f"{path}[{i}]", tol, res,
+                  stage=stage, key=key, field=field, carve_numeric=carve_numeric)
         return
+
     if a is None or b is None:
-        # C1: an empty collection and an absent one are the same emptiness for
-        # the moderation sets only; anywhere else it is a real shape difference.
-        # Exactly one side is None here (both-None returned at the top), so this
-        # is the null-vs-empty case C1 covers.
-        if carved and a in (None, [], {}) and b in (None, [], {}):
-            res.n_suppressed += 1
-            return
         res.structural.append(f"{path}: {a!r} vs {b!r}")
         return
+
     res.n_compared += 1
     if a != b:
         res.n_diff += 1
-        if len(res.examples) < 5:
-            res.examples.append({"path": path, "a": a, "b": b})
+        res.note(path, a, b)
         if res.worst_path is None:
             res.worst_path = path
         res.max_rel = max(res.max_rel, 1.0)
+
+
+def _is_null_empty_pair(a: Any, b: Any) -> bool:
+    """Exactly the C1 case: one side absent, the other an empty collection."""
+    empty = ([], {}, set())
+    return ((a is None and any(b == e for e in empty))
+            or (b is None and any(a == e for e in empty)))
 
 
 def compare_step(doc_a: dict[str, Any], doc_b: dict[str, Any]) -> dict[str, Any]:
@@ -572,33 +921,48 @@ def compare_step(doc_a: dict[str, Any], doc_b: dict[str, Any]) -> dict[str, Any]
     can_a, can_b = canonicalize(doc_a), canonicalize(doc_b)
     stage_reports: dict[str, Any] = {}
     first_diverging: str | None = None
+    problems: list[str] = []
 
     for stage in STAGE_ORDER:
-        sa, sb = can_a.get(stage) or {}, can_b.get(stage) or {}
+        raw_a, raw_b = can_a.get(stage), can_b.get(stage)
+        if raw_a is None or raw_b is None:
+            missing = [s for s, v in (("a", raw_a), ("b", raw_b)) if v is None]
+            problems.append(f"{stage}: absent on side(s) {','.join(missing)}")
+        sa, sb = raw_a or {}, raw_b or {}
         keys = sorted(set(sa) | set(sb))
         key_reports: dict[str, Any] = {}
         stage_divergent = False
         for key in keys:
+            if (stage, key) in ENGINE_LOCAL_KEYS:
+                key_reports[key] = _engine_local_report(stage, key, sa, sb)
+                continue
             carve = KEY_CARVE_OUT.get((stage, key))
+            mode = CARVE_OUTS[carve].mode if carve else None
             tol = _tolerance(stage, key)
             res = KeyResult()
+
             if key not in sa or key not in sb:
                 res.structural.append(f"{key}: present on only one side")
+            elif mode == "null-empty" and _is_null_empty_pair(sa[key], sb[key]):
+                # The ONLY thing C1 suppresses. Anything else on this key —
+                # [1] vs [2], null vs [2], a wrong type — falls through to the
+                # ordinary comparison below.
+                res.n_suppressed += 1
             else:
-                _walk(sa[key], sb[key], key, tol, res, carved=carve is not None)
+                _walk(sa[key], sb[key], key, tol, res, stage=stage, key=key,
+                      field=None, carve_numeric=(mode == "numeric-only"))
+
             entry = res.to_dict()
             entry["tolerance"] = tol.name
             entry["abs_tol"] = tol.abs_tol
             entry["rel_tol"] = tol.rel_tol
             diverged = bool(res.n_diff or res.structural)
-            if carve is not None and carve in AUTO_CARVED:
+            if carve is not None and not diverged and res.n_suppressed:
                 entry["carve_out"] = carve
-                # CARVED, not MATCH, whenever the carve-out actually did
-                # something: the reader must see that a difference was
-                # suppressed, not be told the key was clean.
-                entry["status"] = ("CARVED" if (diverged or res.n_suppressed)
-                                   else "MATCH")
+                entry["status"] = "CARVED"
             else:
+                if carve is not None:
+                    entry["carve_out"] = carve
                 entry["status"] = "DIVERGENT" if diverged else "MATCH"
                 stage_divergent = stage_divergent or diverged
             key_reports[key] = entry
@@ -609,22 +973,56 @@ def compare_step(doc_a: dict[str, Any], doc_b: dict[str, Any]) -> dict[str, Any]
         if stage_divergent and first_diverging is None:
             first_diverging = stage
 
+    digest_match = doc_a.get("input_digest") == doc_b.get("input_digest")
+    tick_match = doc_a.get("tick") == doc_b.get("tick")
+    if not digest_match:
+        problems.append("input digests differ — the engines were not fed the "
+                        "same batch")
+    if not tick_match:
+        problems.append(f"tick {doc_a.get('tick')!r} vs {doc_b.get('tick')!r}")
+
     return {
         "step": doc_a.get("step"),
-        "input_digest_match": doc_a.get("input_digest") == doc_b.get("input_digest"),
+        "input_digest_match": digest_match,
         "tick_a": doc_a.get("tick"),
         "tick_b": doc_b.get("tick"),
-        "tick_match": doc_a.get("tick") == doc_b.get("tick"),
+        "tick_match": tick_match,
+        "comparable": not problems,
+        "problems": problems,
         "first_diverging_stage": first_diverging,
         "stages": stage_reports,
     }
 
 
+def _engine_local_report(stage: str, key: str, sa: dict, sb: dict) -> dict[str, Any]:
+    """An engine-local diagnostic key: reported, never graded against the other
+    engine, and never counted as a divergence — but never silently dropped."""
+    present = [side for side, s in (("a", sa), ("b", sb)) if key in s]
+    entry = KeyResult().to_dict()
+    entry.update({
+        "status": "ENGINE_LOCAL",
+        "tolerance": "not-compared",
+        "abs_tol": None,
+        "rel_tol": None,
+        "present_on": present,
+        "note": ("engine-local diagnostic with no counterpart in the engine "
+                 "contract; not graded"),
+    })
+    if len(present) == 2:
+        res = KeyResult()
+        _walk(sa[key], sb[key], key, _tolerance(stage, key), res,
+              stage=stage, key=key, field=None, carve_numeric=False)
+        entry.update(res.to_dict())
+        entry["status"] = "ENGINE_LOCAL"
+        entry["tolerance"] = "informational"
+    return entry
+
+
 # ---------------------------------------------------------------------------
-# Loading + the whole-recording compare.
+# Loading + input validation.
 # ---------------------------------------------------------------------------
 def load_stage_dumps(directory: str | Path) -> list[dict[str, Any]]:
-    """Load ``step-NNN.stages.json`` from a stage-recording directory, in index
+    """Load ``step-NNN.stages.json`` from a stage-recording directory, in step
     order. Rejects a document whose ``schema`` is not the one we understand."""
     d = Path(directory)
     docs = []
@@ -639,15 +1037,104 @@ def load_stage_dumps(directory: str | Path) -> list[dict[str, Any]]:
     return docs
 
 
-def compare_recordings(dir_a: str | Path, dir_b: str | Path) -> dict[str, Any]:
-    """Diff two stage recordings step by step.
+def validate_recording(directory: str | Path) -> tuple[list[dict[str, Any]], list[str]]:
+    """Load a stage recording and check that it is complete and self-consistent.
 
-    A step-count mismatch is reported, never silently truncated: only the
-    overlapping prefix is diffed.
+    Returns ``(documents, problems)``. Anything on the problems list makes the
+    recording incomparable; the caller must withhold its numeric headline rather
+    than reporting the empty comparison as agreement.
     """
-    docs_a, docs_b = load_stage_dumps(dir_a), load_stage_dumps(dir_b)
-    aligned = min(len(docs_a), len(docs_b))
-    per_step = [compare_step(docs_a[i], docs_b[i]) for i in range(aligned)]
+    d = Path(directory)
+    problems: list[str] = []
+    if not d.is_dir():
+        return [], [f"{d}: not a directory"]
+
+    manifest_path = d / "stages-manifest.json"
+    manifest: dict[str, Any] | None = None
+    if not manifest_path.is_file():
+        problems.append(f"{d}: no stages-manifest.json")
+    else:
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (ValueError, OSError) as exc:
+            problems.append(f"{d}: unreadable manifest ({exc})")
+            manifest = None
+
+    try:
+        docs = load_stage_dumps(d)
+    except ValueError as exc:
+        return [], problems + [str(exc)]
+    if not docs:
+        problems.append(f"{d}: no step-NNN.stages.json files")
+
+    steps = [doc.get("step") for doc in docs]
+    if len(set(steps)) != len(steps):
+        problems.append(f"{d}: duplicate step identities {steps}")
+    for doc in docs:
+        if not isinstance(doc.get("step"), int):
+            problems.append(f"{d}: a document has a non-integer step identity")
+        if doc.get("vote_sign_convention") not in SUPPORTED_CONVENTIONS:
+            problems.append(
+                f"{d}: step {doc.get('step')!r} declares unsupported "
+                f"vote_sign_convention {doc.get('vote_sign_convention')!r}")
+        if doc.get("comment_projection_axes") != COMMENT_PROJECTION_AXES:
+            problems.append(
+                f"{d}: step {doc.get('step')!r} does not declare "
+                f"comment_projection_axes={COMMENT_PROJECTION_AXES!r}")
+        stages_present = set(doc.get("stages") or {})
+        missing = [s for s in STAGE_ORDER if s not in stages_present]
+        if missing:
+            problems.append(
+                f"{d}: step {doc.get('step')!r} is missing stage(s) "
+                f"{', '.join(missing)}")
+
+    if manifest is not None:
+        if manifest.get("schema") != STAGE_DUMP_SCHEMA:
+            problems.append(f"{d}: manifest schema {manifest.get('schema')!r}")
+        if manifest.get("stage_order") != list(STAGE_ORDER):
+            problems.append(f"{d}: manifest stage_order does not match this "
+                            f"comparer's pipeline")
+        rows = manifest.get("steps")
+        if not isinstance(rows, list):
+            problems.append(f"{d}: manifest has no steps list")
+        else:
+            if manifest.get("n_steps") != len(rows):
+                problems.append(f"{d}: manifest n_steps "
+                                f"{manifest.get('n_steps')!r} != {len(rows)} rows")
+            declared = [r.get("index") for r in rows if isinstance(r, dict)]
+            if declared != steps:
+                problems.append(
+                    f"{d}: manifest inventory {declared} != on-disk steps {steps}")
+            for r in rows:
+                if isinstance(r, dict) and not (d / str(r.get("file"))).is_file():
+                    problems.append(f"{d}: manifest names a missing file "
+                                    f"{r.get('file')!r}")
+    return docs, problems
+
+
+def compare_recordings(dir_a: str | Path, dir_b: str | Path) -> dict[str, Any]:
+    """Diff two stage recordings, aligned by STEP IDENTITY.
+
+    Missing directories, incomplete manifests, mismatched inventories and
+    unpaired steps are input problems: they are reported and the numeric headline
+    is withheld. An empty or absent comparison is never reported as agreement.
+    """
+    docs_a, problems_a = validate_recording(dir_a)
+    docs_b, problems_b = validate_recording(dir_b)
+    problems = [f"A: {p}" for p in problems_a] + [f"B: {p}" for p in problems_b]
+
+    by_step_a = {doc.get("step"): doc for doc in docs_a}
+    by_step_b = {doc.get("step"): doc for doc in docs_b}
+    only_a = sorted(k for k in by_step_a if k not in by_step_b)
+    only_b = sorted(k for k in by_step_b if k not in by_step_a)
+    if only_a:
+        problems.append(f"steps present only in A: {only_a}")
+    if only_b:
+        problems.append(f"steps present only in B: {only_b}")
+
+    shared = sorted(k for k in by_step_a if k in by_step_b)
+    per_step = [compare_step(by_step_a[k], by_step_b[k]) for k in shared]
+    problems += [f"step {s['step']}: {p}" for s in per_step for p in s["problems"]]
 
     first_stage, first_step = None, None
     for s in per_step:
@@ -655,6 +1142,8 @@ def compare_recordings(dir_a: str | Path, dir_b: str | Path) -> dict[str, Any]:
             idx = STAGE_ORDER.index(s["first_diverging_stage"])
             if first_stage is None or idx < STAGE_ORDER.index(first_stage):
                 first_stage, first_step = s["first_diverging_stage"], s["step"]
+
+    input_valid = not problems
     return {
         "schema": COMPARE_SCHEMA,
         "grading": GRADING_NOTE,
@@ -664,19 +1153,28 @@ def compare_recordings(dir_a: str | Path, dir_b: str | Path) -> dict[str, Any]:
         "engine_b": docs_b[0].get("engine") if docs_b else None,
         "n_steps_a": len(docs_a),
         "n_steps_b": len(docs_b),
-        "aligned_steps": aligned,
+        "aligned_steps": len(shared),
         "step_count_mismatch": len(docs_a) != len(docs_b),
-        "first_diverging_stage": first_stage,
-        "first_diverging_step": first_step,
-        "carve_outs": {c.id: c.reason for c in CARVE_OUTS.values()},
+        "input_valid": input_valid,
+        "input_problems": problems,
+        # Withheld unless the two recordings are a complete, aligned, same-input
+        # pair: "no diverging stage" over incomparable input is not agreement.
+        "first_diverging_stage": first_stage if input_valid else None,
+        "first_diverging_step": first_step if input_valid else None,
+        "headline_withheld": not input_valid,
+        "carve_outs": {c.id: {"mode": c.mode, "reason": c.reason}
+                       for c in CARVE_OUTS.values()},
         "auto_carved": list(AUTO_CARVED),
+        "engine_local_keys": [f"{s}.{k}" for s, k in sorted(ENGINE_LOCAL_KEYS)],
         "stage_order": list(STAGE_ORDER),
         "per_step": per_step,
     }
 
 
 def format_report(report: dict[str, Any], *, verbose: bool = False) -> str:
-    """A compact human summary. The first diverging stage is the headline.
+    """A compact human summary. The first diverging stage is the headline —
+    unless the input is incomplete or misaligned, in which case there is no
+    headline to give.
 
     ``verbose`` also prints the max abs/rel error of every MATCHing key — the
     headroom measurement, i.e. how far a stage is from its tolerance.
@@ -688,22 +1186,29 @@ def format_report(report: dict[str, Any], *, verbose: bool = False) -> str:
         f"  B: {report['recording_b']}  ({report['n_steps_b']} steps)",
     ]
     if report["step_count_mismatch"]:
-        lines.append(f"  ! step-count mismatch — comparing first "
-                     f"{report['aligned_steps']}")
-    fds = report["first_diverging_stage"]
-    lines.append(
-        f"  first diverging stage: {fds} (step {report['first_diverging_step']})"
-        if fds else "  first diverging stage: none — every stage within tolerance"
-    )
+        lines.append(f"  ! step-count mismatch — {report['aligned_steps']} steps "
+                     f"share an identity")
+    if report.get("headline_withheld"):
+        lines.append("  INCOMPLETE OR MISALIGNED INPUT — no comparison headline. "
+                     "Fix the input and re-run:")
+        for p in report["input_problems"][:20]:
+            lines.append(f"      ! {p}")
+        extra = len(report["input_problems"]) - 20
+        if extra > 0:
+            lines.append(f"      ! … and {extra} more")
+    else:
+        fds = report["first_diverging_stage"]
+        lines.append(
+            f"  first diverging stage: {fds} (step {report['first_diverging_step']})"
+            if fds else
+            "  first diverging stage: none — every stage within tolerance"
+        )
     for step in report["per_step"]:
-        if not step["input_digest_match"]:
-            lines.append(f"  step {step['step']}: ! input digests differ — the two "
-                         f"engines were NOT fed the same batch")
-        if not step["tick_match"]:
-            lines.append(f"  step {step['step']}: ! tick {step['tick_a']} vs "
-                         f"{step['tick_b']}")
         lines.append(f"  step {step['step']}: first diverging stage = "
-                     f"{step['first_diverging_stage'] or 'none'}")
+                     f"{step['first_diverging_stage'] or 'none'}"
+                     + ("" if step["comparable"] else "  [INCOMPARABLE]"))
+        for p in step["problems"]:
+            lines.append(f"      ! {p}")
         for stage in report["stage_order"]:
             sr = step["stages"].get(stage)
             if not sr:
@@ -711,16 +1216,28 @@ def format_report(report: dict[str, Any], *, verbose: bool = False) -> str:
             for key, k in sorted(sr["keys"].items()):
                 if k["status"] == "MATCH" and not verbose:
                     continue
+                if k["status"] == "ENGINE_LOCAL":
+                    lines.append(
+                        f"      [ENGINE_LOCAL] {stage}.{key}: not graded "
+                        f"(present on {','.join(k.get('present_on') or [])})")
+                    continue
                 tag = ("MATCH" if k["status"] == "MATCH"
                        else f"CARVED {k['carve_out']}" if k["status"] == "CARVED"
                        else "DIVERGENT")
-                lines.append(
-                    f"      [{tag}] {stage}.{key} ({k['tolerance']}): "
-                    f"{k['n_diff']}/{k['n_compared']} out of tolerance, "
-                    f"max_abs={k['max_abs']:.3e} max_rel={k['max_rel']:.3e}"
-                    + (f" struct={k['n_structural']}" if k["n_structural"] else "")
-                    + (f" worst={k['worst_path']}" if k["worst_path"] else "")
-                )
+                line = (f"      [{tag}] {stage}.{key} ({k['tolerance']}): "
+                        f"{k['n_diff']}/{k['n_compared']} out of tolerance, "
+                        f"max_abs={k['max_abs']:.3e} max_rel={k['max_rel']:.3e}")
+                if k["tolerance"] == GEOM.name and k.get("n_over_tight"):
+                    line += f" over_tight={k['n_over_tight']}"
+                if k["n_structural"]:
+                    line += f" struct={k['n_structural']}"
+                if k.get("n_suppressed"):
+                    line += f" suppressed={k['n_suppressed']}"
+                if k.get("n_nonfinite"):
+                    line += f" nonfinite={k['n_nonfinite']}"
+                if k["worst_path"]:
+                    line += f" worst={k['worst_path']}"
+                lines.append(line)
     return "\n".join(lines)
 
 

--- a/delphi/polismath/replay/stagecompare.py
+++ b/delphi/polismath/replay/stagecompare.py
@@ -896,7 +896,7 @@ def _tolerance(stage: str, key: str) -> Tolerance:
 # ---------------------------------------------------------------------------
 # The diff.
 # ---------------------------------------------------------------------------
-#: Sentinel meaning "derive the shape from (stage, key)" — the top-level call.
+#: Sentinel meaning "derive the rank from (stage, key)" — the top-level call.
 _UNSET = "\x00unset"
 
 
@@ -970,11 +970,12 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
         return
     integer_leaf = _is_integer_leaf(stage, key, field)
 
-    # Field-level SHAPE, validated before any recursion (R3-F4). A count is a
-    # typed integer, not an arbitrary tree that happens to contain none. The
-    # declaration applies at the DECLARED position only: once an "array" has
-    # been validated, its elements carry no container declaration of their own,
-    # so an array of arrays (bid-to-pid) still recurses.
+    # Field-level RANK, validated before any recursion (R3-F4, R4-F2). A count
+    # is a typed integer, not an arbitrary tree that happens to contain none.
+    # `shape` is this level's obligation and `rank[1:]` is what the levels below
+    # inherit, so a declared integer array constrains its ELEMENTS too — which
+    # is how ("array","array","scalar") distinguishes bid-to-pid from a list of
+    # ids rather than leaving either an unconstrained tree.
     if rank is _UNSET:
         rank = _integer_rank(stage, key, None)
     shape = rank[0] if rank else None

--- a/delphi/polismath/replay/stagecompare.py
+++ b/delphi/polismath/replay/stagecompare.py
@@ -1,0 +1,756 @@
+"""Stage-wise Clojure-vs-Python diff — R-ORACLE (P-030 §2.3).
+
+Reads two ``polis-stage-dump/1`` recordings (``<recording>/clj-stages`` and
+``<recording>/py-stages``, produced by ``math/dev/replay.clj --stage-json`` and
+:mod:`polismath.replay.stages`) and reports, per step:
+
+* the **first diverging stage** — the earliest stage, in pipeline order, that
+  carries a difference outside its declared tolerance and outside the declared
+  carve-outs. A cross-engine difference at stage *N* explains every difference at
+  stages > *N*, so this is the only number worth acting on;
+* per key: how many values were compared, how many differed, and the **max
+  absolute and max relative error** with the path that produced it.
+
+**GRADING — non-negotiable (P-030 §2.3).** This is a DIAGNOSTIC. It has no
+verdict vocabulary, is never consulted by :mod:`polismath.replay.certify`, and
+changes no gate. Clojure and Python already differ at ~1e-16 inside ``proj`` and
+at ~1e-5 in cold-tick ``comps`` (CLOJURE_QUIRKS Q12/Q13/Q18) while the final blob
+still MATCHes; a stage-level exact comparison would fail on exactly the noise the
+acceptance policy deliberately tolerates. ``certify`` on the final blob remains
+the sole PASS/FAIL authority.
+
+Canonicalization (applied to each side before diffing, so that only real
+differences survive):
+
+1. **Polarity.** A dump declaring ``vote_sign_convention == "raw-db"`` has its
+   vote-valued and geometry nodes negated into Delphi convention (AGREE=+1).
+   ``comps`` are NOT negated (``XᵀX == (-X)ᵀ(-X)``, so power iteration from the
+   same start vector returns the identical vector) and neither is
+   ``comment-extremity`` (a norm) or ``bucket-dists`` (distances). P-030 §2.5.
+2. **Identity keying.** Named matrices become ``{rowname|colname: cell}`` and
+   every tid/pid/bid-indexed array becomes a dict keyed by that id, so the two
+   engines' arbitrary and DIFFERENT array orders (Clojure emits hash/insertion
+   order, Python sorted — ``crosslang.canonicalize_blob``'s note) cannot
+   masquerade as a numeric difference.
+3. **Component sign.** Each principal component is oriented so its largest-|v|
+   entry is positive (first tid on ties), and the coupled arrays — that
+   component's ``comment-projection`` row, the matching ``proj`` column, and
+   coordinate *k* of every base- and group-cluster center — are flipped with it.
+   ``pca.center`` is a data mean and is never flipped
+   (``crosslang.canonicalize_blob:150-163``).
+
+Run it::
+
+    python -m polismath.replay.stagecompare --recording <recording-dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from polismath.replay.stages import STAGE_DUMP_SCHEMA, STAGE_ORDER
+
+COMPARE_SCHEMA = "polis-stage-compare/1"
+
+GRADING_NOTE = (
+    "DIAGNOSTICS ONLY — certify on the final blob is the sole PASS/FAIL "
+    "authority (P-030 §2.3). Nothing here is a gate."
+)
+
+
+# ---------------------------------------------------------------------------
+# Tolerance classes.
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class Tolerance:
+    """``abs(a-b) <= abs_tol + rel_tol * max(abs(a), abs(b))``."""
+
+    abs_tol: float
+    rel_tol: float
+    name: str
+
+    def ok(self, a: float, b: float) -> bool:
+        if a == b:
+            return True
+        scale = max(abs(a), abs(b))
+        return abs(a - b) <= self.abs_tol + self.rel_tol * scale
+
+
+#: Typed ids, counts, membership, eligibility, vote meaning and cursors — the
+#: families P-022-G-engine-contract.md:433-441 requires exact.
+EXACT = Tolerance(0.0, 0.0, "exact")
+
+#: The bound P-022-G-engine-contract.md:434-436 proposes for finite numeric
+#: statistics, with zero outlier allowance.
+TIGHT = Tolerance(1e-6, 1e-4, "tight")
+
+#: Geometry. Deliberately looser than TIGHT because the two engines' cold-tick
+#: ``comps`` are documented to differ at ~1e-5 (CLOJURE_QUIRKS Q12/Q18) while the
+#: final blob still MATCHes; this is the same 1e-2 relative bound
+#: ``stepcompare.StepComparer`` already defaults to for PCA-family paths.
+GEOM = Tolerance(1e-6, 1e-2, "geom")
+
+
+@dataclass(frozen=True)
+class CarveOut:
+    """A difference the port plan says is expected and must NOT be chased."""
+
+    id: str
+    reason: str
+
+
+CARVE_OUTS: dict[str, CarveOut] = {
+    "C1": CarveOut(
+        "C1",
+        "mod-in/mod-out/meta-tids: Clojure emits nil until a mod-update has "
+        "written the set; this engine emits an empty set. null-vs-[] on those "
+        "three keys only — a genuinely absent value elsewhere still reports.",
+    ),
+    "C2": CarveOut(
+        "C2",
+        "Q13 — warm-chain split-loop extraction order is knife-edge chaotic on "
+        "tie-dense geometry (within-engine gaps ~2.5e-16 vs cross-engine "
+        "projection noise ~1e-5). Cluster ids/membership can permute with no "
+        "arithmetic cause. Not carved automatically: reported, and flagged so a "
+        "reader recognises the fingerprint (P-030 §5/R7).",
+    ),
+    "C3": CarveOut(
+        "C3",
+        "group-clusterings-silhouettes: Clojure scores with clusters/silhouette "
+        "over bucket-dists; this engine scores with calculate_silhouette_sklearn "
+        "over the base-cluster centers. Different estimators, so the VALUES are "
+        "expected to differ. What must agree is the argmax they feed — visible "
+        "in group-k-smoother and the group count, both compared exactly.",
+    ),
+    "C4": CarveOut(
+        "C4",
+        "ptpt-stats: the engines compute DIFFERENT statistics under this name. "
+        "Clojure emits coreness/centricness/extremeness (geometry over the "
+        "participant projection, repness.clj:372-381); this engine emits "
+        "n_agree/n_disagree/n_pass/group_correlations. Even the two "
+        "same-named fields disagree by construction: Clojure's n-votes is "
+        "user-vote-counts over the RAW rating matrix, this engine's n_votes "
+        "counts non-zero cells of the moderation-applied matrix, and this "
+        "engine omits participants with no votes entirely. math_ptptstats has "
+        "no reader in Node or the clients (P-030 §5/R13), so it is "
+        "verification surface only and the whole key is carved.",
+    ),
+    "C5": CarveOut(
+        "C5",
+        "mat, all-NaN column: this engine substitutes a 0.0 column mean where "
+        "Clojure would divide by zero. Unreachable on a real conversation "
+        "(every column carries at least one vote).",
+    ),
+    "C6": CarveOut(
+        "C6",
+        "Q18 — uniqify's exact-center-equality predicate is value-dependent ulp "
+        "luck, so whether a merge chain over coincident singletons continues "
+        "(and which id survives) depends on the 17th digit. Ledgered as the root "
+        "cause of all 11 carved-out entries in delphi/docs/divergences.json. "
+        "Reported, not auto-suppressed (P-030 §5/R7).",
+    ),
+}
+
+#: Carve-outs applied automatically by the comparer. C2/C6 are documentation for
+#: the reader — they are chaotic, not addressable by a path rule, so suppressing
+#: them by path would hide real structural breakage.
+AUTO_CARVED = ("C1", "C3", "C4", "C5")
+
+
+# ---------------------------------------------------------------------------
+# Polarity: the negation set (P-030 §2.5).
+# ---------------------------------------------------------------------------
+#: Stage -> the keys whose values are negated when converting a raw-DB dump into
+#: Delphi convention. Everything not listed is polarity-invariant: counts are
+#: relabelled not rescaled, distances and extremities are norms, and comps are
+#: invariant because XᵀX == (-X)ᵀ(-X).
+NEGATE: dict[str, tuple[str, ...]] = {
+    "R01_ingest": ("rating-mat", "raw-rating-mat"),
+    "R04_pca": ("mat", "pca.center", "pca.comment-projection"),
+    "R05_projections": ("proj",),
+    "R06_base_clusters": ("base-clusters", "base-clusters-proj"),
+    "R09_group_clusters": ("group-clusters", "group-clusterings"),
+}
+
+
+def _negate(x: Any) -> Any:
+    if x is None or isinstance(x, (str, bool)):
+        return x
+    if isinstance(x, (int, float)):
+        return -x
+    if isinstance(x, list):
+        return [_negate(v) for v in x]
+    if isinstance(x, dict):
+        return {k: _negate(v) for k, v in x.items()}
+    return x
+
+
+def _negate_clusters(clusters: Any) -> Any:
+    """Only a cluster's ``center`` is geometry; its id and members are not."""
+    if clusters is None:
+        return None
+    if isinstance(clusters, dict):  # {k: [clusters]}
+        return {k: _negate_clusters(v) for k, v in clusters.items()}
+    return [dict(c, center=_negate(c.get("center"))) for c in clusters]
+
+
+def _negate_named_matrix(nm: Any) -> Any:
+    if not isinstance(nm, dict) or "matrix" not in nm:
+        return _negate(nm)
+    return dict(nm, matrix=[[None if v is None else -v for v in row]
+                            for row in nm["matrix"]])
+
+
+def apply_polarity(stages: dict[str, Any], convention: str) -> dict[str, Any]:
+    """Bring a stage tree into Delphi convention (AGREE=+1)."""
+    if convention != "raw-db":
+        return stages
+    out = {k: dict(v) for k, v in stages.items()}
+    for stage, keys in NEGATE.items():
+        if stage not in out:
+            continue
+        for key in keys:
+            if "." in key:
+                outer, inner = key.split(".", 1)
+                container = out[stage].get(outer)
+                if isinstance(container, dict) and container.get(inner) is not None:
+                    container = dict(container)
+                    container[inner] = _negate(container[inner])
+                    out[stage][outer] = container
+                continue
+            val = out[stage].get(key)
+            if val is None:
+                continue
+            if key in ("base-clusters", "group-clusters", "group-clusterings"):
+                out[stage][key] = _negate_clusters(val)
+            elif isinstance(val, dict) and "matrix" in val:
+                out[stage][key] = _negate_named_matrix(val)
+            else:
+                out[stage][key] = _negate(val)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Identity keying + component sign orientation.
+# ---------------------------------------------------------------------------
+def _nm_cells(nm: Any) -> dict[str, Any] | None:
+    """A named matrix as ``{"rowname|colname": cell}`` — order-independent."""
+    if not isinstance(nm, dict) or "matrix" not in nm:
+        return None
+    rows, cols = nm.get("rownames") or [], nm.get("colnames") or []
+    cells: dict[str, Any] = {}
+    for i, r in enumerate(rows):
+        if i >= len(nm["matrix"]):
+            break
+        row = nm["matrix"][i]
+        for j, c in enumerate(cols):
+            if j < len(row):
+                cells[f"{r}|{c}"] = row[j]
+    return cells
+
+
+def _by_tid(values: Sequence[Any] | None, tids: Sequence[Any]) -> dict[str, Any] | None:
+    if values is None:
+        return None
+    if len(values) != len(tids):
+        return {"__length_mismatch__": [len(values), len(tids)]}
+    return {str(t): v for t, v in zip(tids, values)}
+
+
+def _orient(comps_by_tid: list[dict[str, Any]]) -> list[float]:
+    """Flip sign per component so its max-|value| entry is positive; ties go to
+    the first tid in sorted-tid order (crosslang.canonicalize_blob:162-163)."""
+    signs = []
+    for comp in comps_by_tid:
+        best_key, best_abs = None, -1.0
+        for key in sorted(comp, key=lambda k: (len(k), k)):
+            v = comp[key]
+            if not isinstance(v, (int, float)):
+                continue
+            if abs(v) > best_abs:
+                best_key, best_abs = key, abs(v)
+        signs.append(-1.0 if best_key is not None and comp[best_key] < 0 else 1.0)
+    return signs
+
+
+def _flip(d: dict[str, Any] | None, sign: float) -> dict[str, Any] | None:
+    if d is None or sign == 1.0:
+        return d
+    return {k: (-v if isinstance(v, (int, float)) and not isinstance(v, bool) else v)
+            for k, v in d.items()}
+
+
+def canonicalize(doc: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Polarity-normalize, key everything by identity, and orient components.
+
+    Returns ``{stage: {key: canonical value}}``. Values are plain JSON data whose
+    ORDER is meaningful only where it is meaningful on both engines (repness
+    selection order, votes-base bucket arrays, bid-to-pid).
+    """
+    stages = apply_polarity(doc.get("stages") or {},
+                            doc.get("vote_sign_convention", "delphi"))
+    out: dict[str, dict[str, Any]] = {s: dict(v) for s, v in stages.items()}
+
+    r01 = out.get("R01_ingest", {})
+    tids = list(r01.get("tids") or [])
+
+    # R01: order-free views of the two vote matrices; tids as a sorted set.
+    for key in ("rating-mat", "raw-rating-mat"):
+        cells = _nm_cells(r01.get(key))
+        if cells is not None:
+            r01[key] = cells
+    if tids:
+        r01["tids"] = sorted(tids, key=lambda t: (str(type(t)), t))
+
+    # R04: mat keyed by (pid, tid); pca arrays keyed by tid.
+    r04 = out.get("R04_pca", {})
+    mat = r04.get("mat")
+    rating_nm = (stages.get("R01_ingest") or {}).get("rating-mat")
+    if isinstance(mat, list) and isinstance(rating_nm, dict):
+        r04["mat"] = _nm_cells({"rownames": rating_nm.get("rownames"),
+                                "colnames": rating_nm.get("colnames"),
+                                "matrix": mat})
+    comps_by_tid: list[dict[str, Any]] = []
+    pca = r04.get("pca")
+    if isinstance(pca, dict):
+        pca = dict(pca)
+        pca["center"] = _by_tid(pca.get("center"), tids)
+        pca["comment-extremity"] = _by_tid(pca.get("comment-extremity"), tids)
+        comps = pca.get("comps") or []
+        comps_by_tid = [_by_tid(row, tids) or {} for row in comps]
+        proj_rows = pca.get("comment-projection")
+        cproj_by_comp: list[dict[str, Any]] = []
+        if isinstance(proj_rows, list) and proj_rows:
+            # Clojure emits n_comps x n_tids; this engine n_tids x n_comps.
+            if len(proj_rows) == len(tids) and len(tids) != len(comps):
+                proj_rows = [list(col) for col in zip(*proj_rows)]
+            cproj_by_comp = [_by_tid(row, tids) or {} for row in proj_rows]
+        signs = _orient(comps_by_tid)
+        pca["comps"] = {str(i): _flip(c, s)
+                        for i, (c, s) in enumerate(zip(comps_by_tid, signs))}
+        pca["comment-projection"] = {str(i): _flip(c, s)
+                                     for i, (c, s) in enumerate(zip(cproj_by_comp, signs))}
+        r04["pca"] = pca
+    else:
+        signs = []
+
+    # R05: proj columns keyed by pid, flipped with their component.
+    r05 = out.get("R05_projections", {})
+    proj_nm = r05.get("proj")
+    if isinstance(proj_nm, dict) and "matrix" in proj_nm:
+        rows = proj_nm.get("rownames") or []
+        cols: dict[str, dict[str, Any]] = {}
+        for k in range(len(proj_nm.get("colnames") or [])):
+            col = {str(r): (proj_nm["matrix"][i][k]
+                            if i < len(proj_nm["matrix"]) and k < len(proj_nm["matrix"][i])
+                            else None)
+                   for i, r in enumerate(rows)}
+            cols[str(k)] = _flip(col, signs[k] if k < len(signs) else 1.0)
+        r05["proj"] = cols
+
+    # R06: cluster centers flip with their component; the rest is identity data.
+    r06 = out.get("R06_base_clusters", {})
+    r06["base-clusters"] = _canon_clusters(r06.get("base-clusters"), signs)
+    bcp = _nm_cells(r06.get("base-clusters-proj"))
+    if bcp is not None:
+        r06["base-clusters-proj"] = _flip_nm_cells(bcp, signs,
+                                                   r06.get("base-clusters-proj"))
+    bd = _nm_cells(r06.get("bucket-dists"))
+    if bd is not None:
+        r06["bucket-dists"] = bd  # distances are sign-invariant
+    if isinstance(r06.get("bid-to-pid"), list):
+        r06["bid-to-pid"] = [sorted(m, key=lambda x: (str(type(x)), x))
+                             for m in r06["bid-to-pid"]]
+
+    r09 = out.get("R09_group_clusters", {})
+    r09["group-clusters"] = _canon_clusters(r09.get("group-clusters"), signs)
+    gcs = r09.get("group-clusterings")
+    if isinstance(gcs, dict):
+        r09["group-clusterings"] = {k: _canon_clusters(v, signs) for k, v in gcs.items()}
+
+    # R13: key by pid; only pid/gid/n-votes are the same quantity (carve-out C4).
+    r13 = out.get("R13_ptpt_stats", {})
+    stats = r13.get("ptpt-stats")
+    if isinstance(stats, list):
+        r13["ptpt-stats"] = {
+            str(row.get("pid")): {"gid": row.get("gid"), "n-votes": row.get("n-votes")}
+            for row in stats
+        }
+    return out
+
+
+def _flip_nm_cells(cells: dict[str, Any], signs: Sequence[float],
+                   nm: Any) -> dict[str, Any]:
+    """Flip an ``x``/``y`` named matrix's columns with their components."""
+    cols = list((nm or {}).get("colnames") or [])
+    out = {}
+    for key, v in cells.items():
+        col = key.rsplit("|", 1)[-1]
+        k = cols.index(col) if col in cols else -1
+        s = signs[k] if 0 <= k < len(signs) else 1.0
+        out[key] = -v if (s == -1.0 and isinstance(v, (int, float))
+                          and not isinstance(v, bool)) else v
+    return out
+
+
+def _canon_clusters(clusters: Any, signs: Sequence[float]) -> Any:
+    if not isinstance(clusters, list):
+        return clusters
+    out = []
+    for c in clusters:
+        center = list(c.get("center") or [])
+        center = [(-v if (k < len(signs) and signs[k] == -1.0
+                          and isinstance(v, (int, float))) else v)
+                  for k, v in enumerate(center)]
+        out.append({"center": center,
+                    "id": c.get("id"),
+                    "members": sorted(c.get("members") or [],
+                                      key=lambda x: (str(type(x)), x))})
+    out.sort(key=lambda c: (str(type(c["id"])), c["id"]))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-key tolerance policy.
+# ---------------------------------------------------------------------------
+#: (stage, key) -> Tolerance for that key's NUMERIC leaves. Non-numeric leaves
+#: (ids, booleans, strings, membership) are always compared exactly, whatever a
+#: key's numeric class is.
+KEY_TOLERANCE: dict[tuple[str, str], Tolerance] = {
+    ("R01_ingest", "last-vote-timestamp"): EXACT,
+    ("R01_ingest", "n"): EXACT,
+    ("R01_ingest", "n-cmts"): EXACT,
+    ("R01_ingest", "raw-rating-mat"): EXACT,
+    ("R01_ingest", "rating-mat"): EXACT,
+    ("R01_ingest", "tids"): EXACT,
+    ("R02_moderation", "last-mod-timestamp"): EXACT,
+    ("R02_moderation", "meta-tids"): EXACT,
+    ("R02_moderation", "mod-in"): EXACT,
+    ("R02_moderation", "mod-out"): EXACT,
+    ("R03_eligibility", "in-conv"): EXACT,
+    ("R03_eligibility", "user-vote-counts"): EXACT,
+    # `mat` is a deterministic function of integers and one division per column
+    # (P-030 §5/R4) — TIGHT, not GEOM.
+    ("R04_pca", "mat"): TIGHT,
+    ("R04_pca", "pca"): GEOM,
+    ("R05_projections", "proj"): GEOM,
+    ("R06_base_clusters", "base-clusters"): GEOM,
+    ("R06_base_clusters", "base-clusters-proj"): GEOM,
+    ("R06_base_clusters", "base-clusters-weights"): EXACT,
+    ("R06_base_clusters", "bid-to-pid"): EXACT,
+    ("R06_base_clusters", "bucket-dists"): GEOM,
+    ("R09_group_clusters", "group-clusterings"): GEOM,
+    ("R09_group_clusters", "group-clusterings-silhouettes"): GEOM,
+    ("R09_group_clusters", "group-clusters"): GEOM,
+    ("R09_group_clusters", "group-k-smoother"): EXACT,
+    ("R10_tallies", "group-aware-consensus"): TIGHT,
+    ("R10_tallies", "group-votes"): EXACT,
+    ("R10_tallies", "votes-base"): EXACT,
+    ("R11_repness", "consensus"): TIGHT,
+    ("R11_repness", "repness"): TIGHT,
+    ("R12_priorities", "comment-priorities"): TIGHT,
+    ("R13_ptpt_stats", "ptpt-stats"): EXACT,
+}
+
+#: Keys whose divergences are automatically attributed to a carve-out.
+KEY_CARVE_OUT: dict[tuple[str, str], str] = {
+    ("R02_moderation", "meta-tids"): "C1",
+    ("R02_moderation", "mod-in"): "C1",
+    ("R02_moderation", "mod-out"): "C1",
+    ("R09_group_clusters", "group-clusterings-silhouettes"): "C3",
+    ("R13_ptpt_stats", "ptpt-stats"): "C4",
+}
+
+
+def _tolerance(stage: str, key: str) -> Tolerance:
+    return KEY_TOLERANCE.get((stage, key), TIGHT)
+
+
+# ---------------------------------------------------------------------------
+# The diff.
+# ---------------------------------------------------------------------------
+def _is_num(x: Any) -> bool:
+    return isinstance(x, (int, float)) and not isinstance(x, bool)
+
+
+@dataclass
+class KeyResult:
+    n_compared: int = 0
+    n_diff: int = 0
+    max_abs: float = 0.0
+    max_rel: float = 0.0
+    worst_path: str | None = None
+    structural: list[str] = None  # type: ignore[assignment]
+    examples: list[dict[str, Any]] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.structural is None:
+            self.structural = []
+        if self.examples is None:
+            self.examples = []
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "n_compared": self.n_compared,
+            "n_diff": self.n_diff,
+            "max_abs": self.max_abs,
+            "max_rel": self.max_rel,
+            "worst_path": self.worst_path,
+            "structural": self.structural[:10],
+            "n_structural": len(self.structural),
+            "examples": self.examples[:5],
+        }
+
+
+def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult,
+          *, carved: bool) -> None:
+    """Recursively diff two canonical values, accumulating into ``res``."""
+    if a is None and b is None:
+        return
+    if _is_num(a) and _is_num(b):
+        res.n_compared += 1
+        abs_err = abs(float(a) - float(b))
+        scale = max(abs(float(a)), abs(float(b)))
+        rel_err = abs_err / scale if scale > 0 else 0.0
+        # max_abs/max_rel are over EVERY compared pair, not only the failing
+        # ones: on a key that is fully within tolerance they are the headroom
+        # measurement the port plan wants, and on a failing key the worst pair
+        # is by construction also the largest error.
+        if abs_err > res.max_abs:
+            res.max_abs, res.worst_path = abs_err, path
+        res.max_rel = max(res.max_rel, rel_err)
+        if not tol.ok(float(a), float(b)):
+            res.n_diff += 1
+            if len(res.examples) < 5:
+                res.examples.append({"path": path, "a": a, "b": b,
+                                     "abs": abs_err, "rel": rel_err})
+        return
+    if isinstance(a, dict) and isinstance(b, dict):
+        for k in sorted(set(a) | set(b)):
+            if k not in a or k not in b:
+                if carved and (a.get(k) in (None, [], {}) or b.get(k) in (None, [], {})):
+                    continue
+                res.structural.append(f"{path}.{k}: present on only one side")
+                continue
+            _walk(a[k], b[k], f"{path}.{k}", tol, res, carved=carved)
+        return
+    if isinstance(a, list) and isinstance(b, list):
+        if len(a) != len(b):
+            res.structural.append(f"{path}: length {len(a)} vs {len(b)}")
+        for i, (x, y) in enumerate(zip(a, b)):
+            _walk(x, y, f"{path}[{i}]", tol, res, carved=carved)
+        return
+    if a is None or b is None:
+        # C1: an empty collection and an absent one are the same emptiness for
+        # the moderation sets only; anywhere else it is a real shape difference.
+        if carved and (a in (None, [], {}) and b in (None, [], {})):
+            return
+        if carved and ((a is None and b in ([], {})) or (b is None and a in ([], {}))):
+            return
+        res.structural.append(f"{path}: {a!r} vs {b!r}")
+        return
+    res.n_compared += 1
+    if a != b:
+        res.n_diff += 1
+        if len(res.examples) < 5:
+            res.examples.append({"path": path, "a": a, "b": b})
+        if res.worst_path is None:
+            res.worst_path = path
+        res.max_rel = max(res.max_rel, 1.0)
+
+
+def compare_step(doc_a: dict[str, Any], doc_b: dict[str, Any]) -> dict[str, Any]:
+    """Diff one step's pair of stage dumps."""
+    can_a, can_b = canonicalize(doc_a), canonicalize(doc_b)
+    stage_reports: dict[str, Any] = {}
+    first_diverging: str | None = None
+
+    for stage in STAGE_ORDER:
+        sa, sb = can_a.get(stage) or {}, can_b.get(stage) or {}
+        keys = sorted(set(sa) | set(sb))
+        key_reports: dict[str, Any] = {}
+        stage_divergent = False
+        for key in keys:
+            carve = KEY_CARVE_OUT.get((stage, key))
+            tol = _tolerance(stage, key)
+            res = KeyResult()
+            if key not in sa or key not in sb:
+                res.structural.append(f"{key}: present on only one side")
+            else:
+                _walk(sa[key], sb[key], key, tol, res, carved=carve is not None)
+            entry = res.to_dict()
+            entry["tolerance"] = tol.name
+            entry["abs_tol"] = tol.abs_tol
+            entry["rel_tol"] = tol.rel_tol
+            diverged = bool(res.n_diff or res.structural)
+            if carve is not None and carve in AUTO_CARVED:
+                entry["carve_out"] = carve
+                entry["status"] = "CARVED" if diverged else "MATCH"
+            else:
+                entry["status"] = "DIVERGENT" if diverged else "MATCH"
+                stage_divergent = stage_divergent or diverged
+            key_reports[key] = entry
+        stage_reports[stage] = {
+            "status": "DIVERGENT" if stage_divergent else "MATCH",
+            "keys": key_reports,
+        }
+        if stage_divergent and first_diverging is None:
+            first_diverging = stage
+
+    return {
+        "step": doc_a.get("step"),
+        "input_digest_match": doc_a.get("input_digest") == doc_b.get("input_digest"),
+        "tick_a": doc_a.get("tick"),
+        "tick_b": doc_b.get("tick"),
+        "tick_match": doc_a.get("tick") == doc_b.get("tick"),
+        "first_diverging_stage": first_diverging,
+        "stages": stage_reports,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Loading + the whole-recording compare.
+# ---------------------------------------------------------------------------
+def load_stage_dumps(directory: str | Path) -> list[dict[str, Any]]:
+    """Load ``step-NNN.stages.json`` from a stage-recording directory, in index
+    order. Rejects a document whose ``schema`` is not the one we understand."""
+    d = Path(directory)
+    docs = []
+    for path in sorted(d.glob("step-*.stages.json")):
+        doc = json.loads(path.read_text())
+        schema = doc.get("schema")
+        if schema != STAGE_DUMP_SCHEMA:
+            raise ValueError(
+                f"{path}: schema {schema!r}, expected {STAGE_DUMP_SCHEMA!r}")
+        docs.append(doc)
+    docs.sort(key=lambda x: int(x.get("step", 0)))
+    return docs
+
+
+def compare_recordings(dir_a: str | Path, dir_b: str | Path) -> dict[str, Any]:
+    """Diff two stage recordings step by step.
+
+    A step-count mismatch is reported, never silently truncated: only the
+    overlapping prefix is diffed.
+    """
+    docs_a, docs_b = load_stage_dumps(dir_a), load_stage_dumps(dir_b)
+    aligned = min(len(docs_a), len(docs_b))
+    per_step = [compare_step(docs_a[i], docs_b[i]) for i in range(aligned)]
+
+    first_stage, first_step = None, None
+    for s in per_step:
+        if s["first_diverging_stage"] is not None:
+            idx = STAGE_ORDER.index(s["first_diverging_stage"])
+            if first_stage is None or idx < STAGE_ORDER.index(first_stage):
+                first_stage, first_step = s["first_diverging_stage"], s["step"]
+    return {
+        "schema": COMPARE_SCHEMA,
+        "grading": GRADING_NOTE,
+        "recording_a": str(dir_a),
+        "recording_b": str(dir_b),
+        "engine_a": docs_a[0].get("engine") if docs_a else None,
+        "engine_b": docs_b[0].get("engine") if docs_b else None,
+        "n_steps_a": len(docs_a),
+        "n_steps_b": len(docs_b),
+        "aligned_steps": aligned,
+        "step_count_mismatch": len(docs_a) != len(docs_b),
+        "first_diverging_stage": first_stage,
+        "first_diverging_step": first_step,
+        "carve_outs": {c.id: c.reason for c in CARVE_OUTS.values()},
+        "auto_carved": list(AUTO_CARVED),
+        "stage_order": list(STAGE_ORDER),
+        "per_step": per_step,
+    }
+
+
+def format_report(report: dict[str, Any], *, verbose: bool = False) -> str:
+    """A compact human summary. The first diverging stage is the headline.
+
+    ``verbose`` also prints the max abs/rel error of every MATCHing key — the
+    headroom measurement, i.e. how far a stage is from its tolerance.
+    """
+    lines = [
+        f"Stage comparison ({report['engine_a']} vs {report['engine_b']})",
+        f"  {report['grading']}",
+        f"  A: {report['recording_a']}  ({report['n_steps_a']} steps)",
+        f"  B: {report['recording_b']}  ({report['n_steps_b']} steps)",
+    ]
+    if report["step_count_mismatch"]:
+        lines.append(f"  ! step-count mismatch — comparing first "
+                     f"{report['aligned_steps']}")
+    fds = report["first_diverging_stage"]
+    lines.append(
+        f"  first diverging stage: {fds} (step {report['first_diverging_step']})"
+        if fds else "  first diverging stage: none — every stage within tolerance"
+    )
+    for step in report["per_step"]:
+        if not step["input_digest_match"]:
+            lines.append(f"  step {step['step']}: ! input digests differ — the two "
+                         f"engines were NOT fed the same batch")
+        if not step["tick_match"]:
+            lines.append(f"  step {step['step']}: ! tick {step['tick_a']} vs "
+                         f"{step['tick_b']}")
+        lines.append(f"  step {step['step']}: first diverging stage = "
+                     f"{step['first_diverging_stage'] or 'none'}")
+        for stage in report["stage_order"]:
+            sr = step["stages"].get(stage)
+            if not sr:
+                continue
+            for key, k in sorted(sr["keys"].items()):
+                if k["status"] == "MATCH" and not verbose:
+                    continue
+                tag = ("MATCH" if k["status"] == "MATCH"
+                       else f"CARVED {k['carve_out']}" if k["status"] == "CARVED"
+                       else "DIVERGENT")
+                lines.append(
+                    f"      [{tag}] {stage}.{key} ({k['tolerance']}): "
+                    f"{k['n_diff']}/{k['n_compared']} out of tolerance, "
+                    f"max_abs={k['max_abs']:.3e} max_rel={k['max_rel']:.3e}"
+                    + (f" struct={k['n_structural']}" if k["n_structural"] else "")
+                    + (f" worst={k['worst_path']}" if k["worst_path"] else "")
+                )
+    return "\n".join(lines)
+
+
+def write_report(report: dict[str, Any], path: str | Path) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(report, indent=2, default=str))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Diff Clojure vs Python stage dumps. " + GRADING_NOTE)
+    ap.add_argument("--recording",
+                    help="Recording dir holding clj-stages/ and py-stages/.")
+    ap.add_argument("--a", help="Stage dir A (defaults to <recording>/clj-stages).")
+    ap.add_argument("--b", help="Stage dir B (defaults to <recording>/py-stages).")
+    ap.add_argument("--out", help="Write the full JSON report here.")
+    ap.add_argument("--verbose", action="store_true",
+                    help="Also print the max abs/rel error of matching keys.")
+    args = ap.parse_args(argv)
+
+    if args.recording:
+        dir_a = args.a or str(Path(args.recording) / "clj-stages")
+        dir_b = args.b or str(Path(args.recording) / "py-stages")
+    elif args.a and args.b:
+        dir_a, dir_b = args.a, args.b
+    else:
+        ap.error("pass --recording, or both --a and --b")
+        return 2
+
+    report = compare_recordings(dir_a, dir_b)
+    if args.out:
+        write_report(report, args.out)
+    print(format_report(report, verbose=args.verbose))
+    # Always 0: this is a diagnostic, never a gate (P-030 §2.3).
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/delphi/polismath/replay/stagecompare.py
+++ b/delphi/polismath/replay/stagecompare.py
@@ -522,7 +522,10 @@ def canonicalize(doc: dict[str, Any]) -> dict[str, dict[str, Any]]:
     # R04: mat keyed by (pid, tid); pca arrays keyed by tid.
     r04 = out.get("R04_pca", {})
     mat = r04.get("mat")
-    rating_nm = (stages.get("R01_ingest") or {}).get("rating-mat")
+    raw_r01 = stages.get("R01_ingest")
+    # A non-empty ARRAY here is truthy, so `(x or {}).get(...)` raised
+    # AttributeError on it (R4-F1). Type-check, never truthiness.
+    rating_nm = raw_r01.get("rating-mat") if isinstance(raw_r01, dict) else None
     if mat is not None:
         if isinstance(mat, list) and isinstance(rating_nm, dict):
             r04["mat"] = _nm_cells({"rownames": rating_nm.get("rownames"),
@@ -781,48 +784,59 @@ INTEGER_FIELDS: frozenset[str] = frozenset({
 })
 
 
-#: Integer positions that must hold a SCALAR — never a container. Without this
-#: an `n` of `{}` on both sides recurses into two empty trees and reports MATCH:
-#: "no integer leaf disagreed" is not the same as "this is a count".
-SCALAR_INTEGER_KEYS: frozenset[tuple[str, str]] = frozenset({
-    ("R01_ingest", "last-vote-timestamp"),
-    ("R01_ingest", "n"),
-    ("R01_ingest", "n-cmts"),
-    ("R02_moderation", "last-mod-timestamp"),
-})
-SCALAR_INTEGER_FIELDS: frozenset[str] = frozenset({
-    "bid", "count", "gid", "id", "last-k", "last-k-count",
-    "last-mod-timestamp", "last-vote-timestamp", "n", "n-agree", "n-cmts",
-    "n-members", "n-success", "n-trials", "n-votes", "pid", "smoothed-k", "tid",
-})
+#: The RANK of an integer position: the shape at this level and at every level
+#: below it. ``("array", "scalar")`` is a list of integers; ``("array", "array",
+#: "scalar")`` is a list of lists of integers. Carrying the whole rank through
+#: recursion is what stops a declared integer array from admitting arbitrary
+#: nested containers: an element of `in-conv` is an integer, not "whatever
+#: happens to contain no disagreeing leaves".
+SCALAR: tuple[str, ...] = ("scalar",)
+INT_ARRAY: tuple[str, ...] = ("array", "scalar")
+INT_ARRAY_2D: tuple[str, ...] = ("array", "array", "scalar")
 
-#: Integer positions that must hold a LIST of integers.
-ARRAY_INTEGER_KEYS: frozenset[tuple[str, str]] = frozenset({
-    ("R01_ingest", "tids"),
-    ("R02_moderation", "meta-tids"),
-    ("R02_moderation", "mod-in"),
-    ("R02_moderation", "mod-out"),
-    ("R03_eligibility", "in-conv"),
-    ("R06_base_clusters", "bid-to-pid"),
-})
-ARRAY_INTEGER_FIELDS: frozenset[str] = frozenset({"members"})
+#: Rank by (stage, key), for whole keys.
+INTEGER_KEY_RANK: dict[tuple[str, str], tuple[str, ...]] = {
+    ("R01_ingest", "last-vote-timestamp"): SCALAR,
+    ("R01_ingest", "n"): SCALAR,
+    ("R01_ingest", "n-cmts"): SCALAR,
+    ("R02_moderation", "last-mod-timestamp"): SCALAR,
+    ("R01_ingest", "tids"): INT_ARRAY,
+    ("R02_moderation", "meta-tids"): INT_ARRAY,
+    ("R02_moderation", "mod-in"): INT_ARRAY,
+    ("R02_moderation", "mod-out"): INT_ARRAY,
+    ("R03_eligibility", "in-conv"): INT_ARRAY,
+    # bid-to-pid is the one legitimately two-dimensional integer key: a list of
+    # per-base-cluster member lists (conversation.clj:593-594).
+    ("R06_base_clusters", "bid-to-pid"): INT_ARRAY_2D,
+}
 
-#: Shapes that depend on WHICH key the field sits under. The A/D/S vote tallies
+#: Rank by field name, wherever that field appears.
+INTEGER_FIELD_RANK: dict[str, tuple[str, ...]] = {
+    "bid": SCALAR, "count": SCALAR, "gid": SCALAR, "id": SCALAR,
+    "last-k": SCALAR, "last-k-count": SCALAR, "last-mod-timestamp": SCALAR,
+    "last-vote-timestamp": SCALAR, "n": SCALAR, "n-agree": SCALAR,
+    "n-cmts": SCALAR, "n-members": SCALAR, "n-success": SCALAR,
+    "n-trials": SCALAR, "n-votes": SCALAR, "pid": SCALAR,
+    "smoothed-k": SCALAR, "tid": SCALAR,
+    "members": INT_ARRAY,
+}
+
+#: Rank that depends on WHICH key the field sits under. The A/D/S vote tallies
 #: are the reason this exists: in `votes-base` they are per-base-cluster bucket
 #: ARRAYS, and in `group-votes` they are per-group SCALAR totals
 #: (conversation.clj:600-624). A field-name-only rule gets one of them wrong.
-KEY_SCOPED_INTEGER_SHAPE: dict[tuple[str, str, str], str] = {
-    ("R10_tallies", "votes-base", "A"): "array",
-    ("R10_tallies", "votes-base", "D"): "array",
-    ("R10_tallies", "votes-base", "S"): "array",
-    ("R10_tallies", "group-votes", "A"): "scalar",
-    ("R10_tallies", "group-votes", "D"): "scalar",
-    ("R10_tallies", "group-votes", "S"): "scalar",
+KEY_SCOPED_INTEGER_RANK: dict[tuple[str, str, str], tuple[str, ...]] = {
+    ("R10_tallies", "votes-base", "A"): INT_ARRAY,
+    ("R10_tallies", "votes-base", "D"): INT_ARRAY,
+    ("R10_tallies", "votes-base", "S"): INT_ARRAY,
+    ("R10_tallies", "group-votes", "A"): SCALAR,
+    ("R10_tallies", "group-votes", "D"): SCALAR,
+    ("R10_tallies", "group-votes", "S"): SCALAR,
 }
 
 #: Integer keys whose canonical form is a MAPPING whose every value is a scalar
 #: integer (a cell, a per-participant count, a per-cluster weight). Declared so
-#: the scalar rule reaches one level below the key too.
+#: the rank rule reaches one level below the key too.
 MAPPING_SCALAR_INTEGER_KEYS: frozenset[tuple[str, str]] = frozenset({
     ("R01_ingest", "rating-mat"),
     ("R01_ingest", "raw-rating-mat"),
@@ -831,24 +845,17 @@ MAPPING_SCALAR_INTEGER_KEYS: frozenset[tuple[str, str]] = frozenset({
 })
 
 
-def _integer_shape(stage: str, key: str, field: str | None) -> str | None:
-    """``"scalar"``, ``"array"`` or ``None`` (unconstrained container) for an
-    integer-typed position. A field declaration wins over the key's, because it
-    is the more specific statement about that position."""
+def _integer_rank(stage: str, key: str,
+                  field: str | None) -> tuple[str, ...] | None:
+    """The declared rank for an integer position, or ``None`` when the position
+    is an unconstrained container (a mapping keyed by id, say). A field
+    declaration wins over the key's: it is the more specific statement."""
     if field is not None:
-        scoped = KEY_SCOPED_INTEGER_SHAPE.get((stage, key, field))
+        scoped = KEY_SCOPED_INTEGER_RANK.get((stage, key, field))
         if scoped is not None:
             return scoped
-        if field in SCALAR_INTEGER_FIELDS:
-            return "scalar"
-        if field in ARRAY_INTEGER_FIELDS:
-            return "array"
-        return None
-    if (stage, key) in SCALAR_INTEGER_KEYS:
-        return "scalar"
-    if (stage, key) in ARRAY_INTEGER_KEYS:
-        return "array"
-    return None
+        return INTEGER_FIELD_RANK.get(field)
+    return INTEGER_KEY_RANK.get((stage, key))
 
 
 def _is_integer_leaf(stage: str, key: str, field: str | None) -> bool:
@@ -949,7 +956,7 @@ class KeyResult:
 
 def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
           stage: str, key: str, field: str | None, carve_numeric: bool,
-          shape: str | None = _UNSET) -> None:
+          rank: tuple[str, ...] | None = _UNSET, in_array: bool = False) -> None:
     """Recursively diff two canonical values, accumulating into ``res``.
 
     ``carve_numeric`` attributes NUMERIC differences to a numeric-only carve-out
@@ -961,9 +968,6 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
             if isinstance(v, Structural):
                 res.structural.append(f"{path}: [{side}] {v.reason}")
         return
-    if a is None and b is None:
-        return
-
     integer_leaf = _is_integer_leaf(stage, key, field)
 
     # Field-level SHAPE, validated before any recursion (R3-F4). A count is a
@@ -971,8 +975,20 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
     # declaration applies at the DECLARED position only: once an "array" has
     # been validated, its elements carry no container declaration of their own,
     # so an array of arrays (bid-to-pid) still recurses.
-    if shape is _UNSET:
-        shape = _integer_shape(stage, key, None)
+    if rank is _UNSET:
+        rank = _integer_rank(stage, key, None)
+    shape = rank[0] if rank else None
+
+    if a is None and b is None:
+        # A top-level integer field may legitimately be null: a nullable
+        # n-votes, a watermark on a votes tick, a moderation set before any
+        # mod-update (the C1 case). An ELEMENT of a declared integer array
+        # never may — the array holds integers (R4-F2).
+        if in_array and integer_leaf and shape == "scalar":
+            res.structural.append(
+                f"{path}: element of an integer array must not be null")
+        return
+
     if integer_leaf and shape is not None:
         wrong = [f"[{side}] {type(v).__name__}"
                  for side, v in (("a", a), ("b", b))
@@ -983,7 +999,7 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
                 f"{path}: integer field must be a {shape}, got "
                 f"{', '.join(wrong)}")
             return
-    root = shape is not None or field is None
+    root = rank is not None or field is None
 
     # Non-finite wire tokens compare as tokens, on either or both sides. This
     # runs BEFORE the integer type check so the token evidence is always
@@ -1077,22 +1093,26 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
             if k not in a or k not in b:
                 res.structural.append(f"{path}.{k}: present on only one side")
                 continue
-            child = _integer_shape(stage, key, k)
+            child = _integer_rank(stage, key, k)
             if child is None and root \
                     and (stage, key) in MAPPING_SCALAR_INTEGER_KEYS:
-                child = "scalar"
+                child = SCALAR
             _walk(a[k], b[k], f"{path}.{k}", tol, res,
                   stage=stage, key=key, field=k, carve_numeric=carve_numeric,
-                  shape=child)
+                  rank=child)
         return
 
     if isinstance(a, list) and isinstance(b, list):
         if len(a) != len(b):
             res.structural.append(f"{path}: length {len(a)} vs {len(b)}")
         for i, (x, y) in enumerate(zip(a, b)):
+            # The rank descends WITH the recursion: an element of a declared
+            # integer array carries the rest of that declaration, so
+            # `in-conv = [{}]` is a malformed element rather than an
+            # unconstrained subtree (R4-F2).
             _walk(x, y, f"{path}[{i}]", tol, res,
                   stage=stage, key=key, field=field, carve_numeric=carve_numeric,
-                  shape=None)
+                  rank=(rank[1:] if rank else None), in_array=True)
         return
 
     if a is None or b is None:
@@ -1269,6 +1289,40 @@ def load_stage_dumps(directory: str | Path) -> list[dict[str, Any]]:
     return docs
 
 
+def document_is_comparable(doc: Any) -> str | None:
+    """``None`` when a document is structurally safe to canonicalize and diff,
+    else the reason it is not.
+
+    A document that :func:`validate_recording` has already rejected must not be
+    sent onward merely because its step identity is usable: canonicalization
+    assumes typed containers, and an invalid one produced an exception from the
+    PUBLIC compare path rather than a named input problem (R4-F1).
+    """
+    if not isinstance(doc, dict):
+        return "document is not an object"
+    if not _valid_engine(doc.get("engine")):
+        return f"unusable engine {doc.get('engine')!r}"
+    if not _valid_convention(doc.get("vote_sign_convention")):
+        return f"unsupported vote_sign_convention {doc.get('vote_sign_convention')!r}"
+    stages_map = doc.get("stages")
+    if not isinstance(stages_map, dict):
+        return f"stages is {type(stages_map).__name__}, not an object"
+    for name, body in stages_map.items():
+        if not isinstance(body, dict):
+            return f"stage {name} is {type(body).__name__}, not an object"
+    return None
+
+
+def _valid_engine(value: Any) -> bool:
+    """An engine tag must be a non-empty string. No whitelist — a third engine
+    is anticipated — but it must be usable as a set member and a label."""
+    return isinstance(value, str) and bool(value)
+
+
+def _valid_convention(value: Any) -> bool:
+    return isinstance(value, str) and value in SUPPORTED_CONVENTIONS
+
+
 _STEP_FILE_RE = re.compile(r"^step-(\d{3,})\.stages\.json$")
 _SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
@@ -1349,9 +1403,10 @@ def validate_recording(directory: str | Path) -> tuple[list[dict[str, Any]], lis
             # 64 lower-case hex digits, not merely a "sha256:" prefix.
             problems.append(f"{d}: step {sid!r} has no well-formed sha256 "
                             f"input_digest ({digest!r})")
-        if not isinstance(doc.get("engine"), str) or not doc.get("engine"):
-            problems.append(f"{d}: step {sid!r} declares no engine")
-        if doc.get("vote_sign_convention") not in SUPPORTED_CONVENTIONS:
+        if not _valid_engine(doc.get("engine")):
+            problems.append(f"{d}: step {sid!r} declares no usable engine "
+                            f"({doc.get('engine')!r})")
+        if not _valid_convention(doc.get("vote_sign_convention")):
             problems.append(
                 f"{d}: step {sid!r} declares unsupported "
                 f"vote_sign_convention {doc.get('vote_sign_convention')!r}")
@@ -1459,29 +1514,38 @@ def validate_recording(directory: str | Path) -> tuple[list[dict[str, Any]], lis
                     f"{d}: step file(s) {', '.join(unlisted)} are not in the "
                     f"manifest")
 
-            engines = {doc.get("engine") for doc in docs}
+            # Only VALIDATED values enter a set or a membership test: an
+            # engine of [] or a convention of {} is unhashable, and building
+                # the set first raised TypeError before the report was written.
+            engines = {doc["engine"] for doc in docs
+                       if _valid_engine(doc.get("engine"))}
             if len(engines) > 1:
                 problems.append(
                     f"{d}: documents declare more than one engine "
-                    f"{sorted(map(str, engines))}")
-            if docs and manifest.get("engine") not in engines:
+                    f"{sorted(engines)}")
+            man_engine = manifest.get("engine")
+            if not _valid_engine(man_engine):
+                problems.append(f"{d}: manifest declares no usable engine "
+                                f"({man_engine!r})")
+            elif engines and man_engine not in engines:
                 problems.append(
-                    f"{d}: manifest engine {manifest.get('engine')!r} is not "
-                    f"the documents' engine {sorted(map(str, engines))}")
-            conventions = {doc.get("vote_sign_convention") for doc in docs}
-            if manifest.get("vote_sign_convention") not in SUPPORTED_CONVENTIONS:
+                    f"{d}: manifest engine {man_engine!r} is not "
+                    f"the documents' engine {sorted(engines)}")
+            conventions = {doc["vote_sign_convention"] for doc in docs
+                           if _valid_convention(doc.get("vote_sign_convention"))}
+            man_conv = manifest.get("vote_sign_convention")
+            if not _valid_convention(man_conv):
                 problems.append(
                     f"{d}: manifest declares unsupported vote_sign_convention "
-                    f"{manifest.get('vote_sign_convention')!r}")
-            elif docs and manifest.get("vote_sign_convention") not in conventions:
+                    f"{man_conv!r}")
+            elif conventions and man_conv not in conventions:
                 problems.append(
-                    f"{d}: manifest vote_sign_convention "
-                    f"{manifest.get('vote_sign_convention')!r} contradicts the "
-                    f"documents' {sorted(map(str, conventions))}")
+                    f"{d}: manifest vote_sign_convention {man_conv!r} "
+                    f"contradicts the documents' {sorted(conventions)}")
             if len(conventions) > 1:
                 problems.append(
                     f"{d}: documents declare more than one "
-                    f"vote_sign_convention {sorted(map(str, conventions))}")
+                    f"vote_sign_convention {sorted(conventions)}")
             if manifest.get("comment_projection_axes") != COMMENT_PROJECTION_AXES:
                 problems.append(
                     f"{d}: manifest does not declare "
@@ -1514,6 +1578,15 @@ def compare_recordings(dir_a: str | Path, dir_b: str | Path) -> dict[str, Any]:
     if unusable:
         problems.append(f"{len(unusable)} document(s) have an unusable step "
                         f"identity and cannot be aligned")
+
+    # Drop documents that are not safe to canonicalize, with a named reason.
+    for side, table in (("A", by_step_a), ("B", by_step_b)):
+        for step_id in sorted(table):
+            reason = document_is_comparable(table[step_id])
+            if reason is not None:
+                problems.append(f"{side}: step {step_id} is not comparable "
+                                f"({reason})")
+                del table[step_id]
     only_a = sorted(k for k in by_step_a if k not in by_step_b)
     only_b = sorted(k for k in by_step_b if k not in by_step_a)
     if only_a:

--- a/delphi/polismath/replay/stagecompare.py
+++ b/delphi/polismath/replay/stagecompare.py
@@ -48,10 +48,9 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any, Sequence
 
 from polismath.replay.stages import STAGE_DUMP_SCHEMA, STAGE_ORDER
 
@@ -484,6 +483,7 @@ class KeyResult:
     n_diff: int = 0
     max_abs: float = 0.0
     max_rel: float = 0.0
+    n_suppressed: int = 0
     worst_path: str | None = None
     structural: list[str] = None  # type: ignore[assignment]
     examples: list[dict[str, Any]] = None  # type: ignore[assignment]
@@ -498,6 +498,7 @@ class KeyResult:
         return {
             "n_compared": self.n_compared,
             "n_diff": self.n_diff,
+            "n_suppressed": self.n_suppressed,
             "max_abs": self.max_abs,
             "max_rel": self.max_rel,
             "worst_path": self.worst_path,
@@ -534,6 +535,7 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult,
         for k in sorted(set(a) | set(b)):
             if k not in a or k not in b:
                 if carved and (a.get(k) in (None, [], {}) or b.get(k) in (None, [], {})):
+                    res.n_suppressed += 1
                     continue
                 res.structural.append(f"{path}.{k}: present on only one side")
                 continue
@@ -548,9 +550,10 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult,
     if a is None or b is None:
         # C1: an empty collection and an absent one are the same emptiness for
         # the moderation sets only; anywhere else it is a real shape difference.
-        if carved and (a in (None, [], {}) and b in (None, [], {})):
-            return
-        if carved and ((a is None and b in ([], {})) or (b is None and a in ([], {}))):
+        # Exactly one side is None here (both-None returned at the top), so this
+        # is the null-vs-empty case C1 covers.
+        if carved and a in (None, [], {}) and b in (None, [], {}):
+            res.n_suppressed += 1
             return
         res.structural.append(f"{path}: {a!r} vs {b!r}")
         return
@@ -590,7 +593,11 @@ def compare_step(doc_a: dict[str, Any], doc_b: dict[str, Any]) -> dict[str, Any]
             diverged = bool(res.n_diff or res.structural)
             if carve is not None and carve in AUTO_CARVED:
                 entry["carve_out"] = carve
-                entry["status"] = "CARVED" if diverged else "MATCH"
+                # CARVED, not MATCH, whenever the carve-out actually did
+                # something: the reader must see that a difference was
+                # suppressed, not be told the key was clean.
+                entry["status"] = ("CARVED" if (diverged or res.n_suppressed)
+                                   else "MATCH")
             else:
                 entry["status"] = "DIVERGENT" if diverged else "MATCH"
                 stage_divergent = stage_divergent or diverged

--- a/delphi/polismath/replay/stagecompare.py
+++ b/delphi/polismath/replay/stagecompare.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from dataclasses import dataclass, field as dc_field
 from pathlib import Path
 from typing import Any, Sequence
@@ -418,6 +419,25 @@ def _by_tid(values: Any, tids: Sequence[Any], label: str) -> Any:
     return {_typed_label(t): v for t, v in zip(tids, values)}
 
 
+#: Sign applied to a projection row that has no component to couple with — the
+#: rank-one Q16 pad. It is all-zero by construction, so the choice is inert; it
+#: is declared rather than left implicit, and the construction is validated.
+PADDED_COMPONENT_SIGN = 1.0
+
+
+def _non_zero_labels(row: Any) -> list[str]:
+    """Labels in a padded projection row whose value is not exactly zero. A
+    non-finite token counts as non-zero: the Q16 pad is real zeros."""
+    if not isinstance(row, dict):
+        return ["<not a row>"]
+    out = []
+    for label, v in sorted(row.items()):
+        if _is_token(v) or not (isinstance(v, (int, float))
+                                and not isinstance(v, bool) and v == 0):
+            out.append(f"{label}={v!r}")
+    return out
+
+
 def _orient(comps_by_tid: list[Any], tid_labels: Sequence[str]) -> list[float]:
     """Flip sign per component so its largest-magnitude entry is positive; ties
     go to the first tid in canonical order (crosslang.canonicalize_blob:162-163).
@@ -562,13 +582,29 @@ def canonicalize(doc: dict[str, Any]) -> dict[str, dict[str, Any]]:
 
         signs = _orient(comps_by_tid, tid_labels)
         if not isinstance(pca.get("comps"), Structural) and comps is not None:
-            pca["comps"] = {str(i): _flip(c, s)
-                            for i, (c, s) in enumerate(zip(comps_by_tid, signs))}
+            pca["comps"] = {str(i): _flip(comps_by_tid[i], signs[i])
+                            for i in range(len(comps_by_tid))}
         if not isinstance(pca.get("comment-projection"), Structural) \
                 and proj_rows is not None:
-            pca["comment-projection"] = {
-                str(i): _flip(c, s)
-                for i, (c, s) in enumerate(zip(cproj_by_comp, signs))}
+            # NO ZIP. The projection can be WIDER than `comps` — the rank-one
+            # Q16 pad — and a zip over unequal lengths would silently drop the
+            # padded row, so a garbage value there would never be compared.
+            # Padded rows keep sign +1 (they are all-zero by construction) and
+            # that construction is VALIDATED rather than assumed.
+            out_proj: dict[str, Any] = {}
+            for i, row in enumerate(cproj_by_comp):
+                if i < len(signs):
+                    out_proj[str(i)] = _flip(row, signs[i])
+                    continue
+                bad = _non_zero_labels(row)
+                if bad:
+                    out_proj[str(i)] = Structural(
+                        f"pca.comment-projection[{i}]: padded component beyond "
+                        f"{len(signs)} comps must be all-zero (Q16), but "
+                        f"{', '.join(bad)} are not")
+                else:
+                    out_proj[str(i)] = _flip(row, PADDED_COMPONENT_SIGN)
+            pca["comment-projection"] = out_proj
         r04["pca"] = pca
     elif pca is not None:
         r04["pca"] = Structural("pca: not an object")
@@ -745,6 +781,76 @@ INTEGER_FIELDS: frozenset[str] = frozenset({
 })
 
 
+#: Integer positions that must hold a SCALAR — never a container. Without this
+#: an `n` of `{}` on both sides recurses into two empty trees and reports MATCH:
+#: "no integer leaf disagreed" is not the same as "this is a count".
+SCALAR_INTEGER_KEYS: frozenset[tuple[str, str]] = frozenset({
+    ("R01_ingest", "last-vote-timestamp"),
+    ("R01_ingest", "n"),
+    ("R01_ingest", "n-cmts"),
+    ("R02_moderation", "last-mod-timestamp"),
+})
+SCALAR_INTEGER_FIELDS: frozenset[str] = frozenset({
+    "bid", "count", "gid", "id", "last-k", "last-k-count",
+    "last-mod-timestamp", "last-vote-timestamp", "n", "n-agree", "n-cmts",
+    "n-members", "n-success", "n-trials", "n-votes", "pid", "smoothed-k", "tid",
+})
+
+#: Integer positions that must hold a LIST of integers.
+ARRAY_INTEGER_KEYS: frozenset[tuple[str, str]] = frozenset({
+    ("R01_ingest", "tids"),
+    ("R02_moderation", "meta-tids"),
+    ("R02_moderation", "mod-in"),
+    ("R02_moderation", "mod-out"),
+    ("R03_eligibility", "in-conv"),
+    ("R06_base_clusters", "bid-to-pid"),
+})
+ARRAY_INTEGER_FIELDS: frozenset[str] = frozenset({"members"})
+
+#: Shapes that depend on WHICH key the field sits under. The A/D/S vote tallies
+#: are the reason this exists: in `votes-base` they are per-base-cluster bucket
+#: ARRAYS, and in `group-votes` they are per-group SCALAR totals
+#: (conversation.clj:600-624). A field-name-only rule gets one of them wrong.
+KEY_SCOPED_INTEGER_SHAPE: dict[tuple[str, str, str], str] = {
+    ("R10_tallies", "votes-base", "A"): "array",
+    ("R10_tallies", "votes-base", "D"): "array",
+    ("R10_tallies", "votes-base", "S"): "array",
+    ("R10_tallies", "group-votes", "A"): "scalar",
+    ("R10_tallies", "group-votes", "D"): "scalar",
+    ("R10_tallies", "group-votes", "S"): "scalar",
+}
+
+#: Integer keys whose canonical form is a MAPPING whose every value is a scalar
+#: integer (a cell, a per-participant count, a per-cluster weight). Declared so
+#: the scalar rule reaches one level below the key too.
+MAPPING_SCALAR_INTEGER_KEYS: frozenset[tuple[str, str]] = frozenset({
+    ("R01_ingest", "rating-mat"),
+    ("R01_ingest", "raw-rating-mat"),
+    ("R03_eligibility", "user-vote-counts"),
+    ("R06_base_clusters", "base-clusters-weights"),
+})
+
+
+def _integer_shape(stage: str, key: str, field: str | None) -> str | None:
+    """``"scalar"``, ``"array"`` or ``None`` (unconstrained container) for an
+    integer-typed position. A field declaration wins over the key's, because it
+    is the more specific statement about that position."""
+    if field is not None:
+        scoped = KEY_SCOPED_INTEGER_SHAPE.get((stage, key, field))
+        if scoped is not None:
+            return scoped
+        if field in SCALAR_INTEGER_FIELDS:
+            return "scalar"
+        if field in ARRAY_INTEGER_FIELDS:
+            return "array"
+        return None
+    if (stage, key) in SCALAR_INTEGER_KEYS:
+        return "scalar"
+    if (stage, key) in ARRAY_INTEGER_KEYS:
+        return "array"
+    return None
+
+
 def _is_integer_leaf(stage: str, key: str, field: str | None) -> bool:
     if (stage, key) in INTEGER_KEYS:
         return True
@@ -783,6 +889,10 @@ def _tolerance(stage: str, key: str) -> Tolerance:
 # ---------------------------------------------------------------------------
 # The diff.
 # ---------------------------------------------------------------------------
+#: Sentinel meaning "derive the shape from (stage, key)" — the top-level call.
+_UNSET = "\x00unset"
+
+
 def _is_num(x: Any) -> bool:
     return isinstance(x, (int, float)) and not isinstance(x, bool)
 
@@ -838,7 +948,8 @@ class KeyResult:
 
 
 def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
-          stage: str, key: str, field: str | None, carve_numeric: bool) -> None:
+          stage: str, key: str, field: str | None, carve_numeric: bool,
+          shape: str | None = _UNSET) -> None:
     """Recursively diff two canonical values, accumulating into ``res``.
 
     ``carve_numeric`` attributes NUMERIC differences to a numeric-only carve-out
@@ -854,6 +965,25 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
         return
 
     integer_leaf = _is_integer_leaf(stage, key, field)
+
+    # Field-level SHAPE, validated before any recursion (R3-F4). A count is a
+    # typed integer, not an arbitrary tree that happens to contain none. The
+    # declaration applies at the DECLARED position only: once an "array" has
+    # been validated, its elements carry no container declaration of their own,
+    # so an array of arrays (bid-to-pid) still recurses.
+    if shape is _UNSET:
+        shape = _integer_shape(stage, key, None)
+    if integer_leaf and shape is not None:
+        wrong = [f"[{side}] {type(v).__name__}"
+                 for side, v in (("a", a), ("b", b))
+                 if (shape == "scalar" and isinstance(v, (dict, list)))
+                 or (shape == "array" and not isinstance(v, list))]
+        if wrong:
+            res.structural.append(
+                f"{path}: integer field must be a {shape}, got "
+                f"{', '.join(wrong)}")
+            return
+    root = shape is not None or field is None
 
     # Non-finite wire tokens compare as tokens, on either or both sides. This
     # runs BEFORE the integer type check so the token evidence is always
@@ -947,8 +1077,13 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
             if k not in a or k not in b:
                 res.structural.append(f"{path}.{k}: present on only one side")
                 continue
+            child = _integer_shape(stage, key, k)
+            if child is None and root \
+                    and (stage, key) in MAPPING_SCALAR_INTEGER_KEYS:
+                child = "scalar"
             _walk(a[k], b[k], f"{path}.{k}", tol, res,
-                  stage=stage, key=key, field=k, carve_numeric=carve_numeric)
+                  stage=stage, key=key, field=k, carve_numeric=carve_numeric,
+                  shape=child)
         return
 
     if isinstance(a, list) and isinstance(b, list):
@@ -956,7 +1091,8 @@ def _walk(a: Any, b: Any, path: str, tol: Tolerance, res: KeyResult, *,
             res.structural.append(f"{path}: length {len(a)} vs {len(b)}")
         for i, (x, y) in enumerate(zip(a, b)):
             _walk(x, y, f"{path}[{i}]", tol, res,
-                  stage=stage, key=key, field=field, carve_numeric=carve_numeric)
+                  stage=stage, key=key, field=field, carve_numeric=carve_numeric,
+                  shape=None)
         return
 
     if a is None or b is None:
@@ -1133,6 +1269,35 @@ def load_stage_dumps(directory: str | Path) -> list[dict[str, Any]]:
     return docs
 
 
+_STEP_FILE_RE = re.compile(r"^step-(\d{3,})\.stages\.json$")
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _load_with_paths(d: Path) -> list[tuple[Path, dict[str, Any]]]:
+    """Every step document paired with the file it came from, so a manifest can
+    be checked against the actual file rather than against an index lookup."""
+    out = []
+    for path in sorted(d.glob("step-*.stages.json")):
+        try:
+            doc = json.loads(path.read_text())
+        except (ValueError, OSError) as exc:
+            raise ValueError(f"{path}: unreadable ({exc})") from exc
+        if not isinstance(doc, dict):
+            raise ValueError(f"{path}: document is not an object")
+        if doc.get("schema") != STAGE_DUMP_SCHEMA:
+            raise ValueError(
+                f"{path}: schema {doc.get('schema')!r}, expected "
+                f"{STAGE_DUMP_SCHEMA!r}")
+        out.append((path, doc))
+    return out
+
+
+def _step_sort_key(doc: dict[str, Any]) -> tuple[int, int]:
+    step = doc.get("step")
+    ok = isinstance(step, int) and not isinstance(step, bool)
+    return (0 if ok else 1, step if ok else 0)
+
+
 def validate_recording(directory: str | Path) -> tuple[list[dict[str, Any]], list[str]]:
     """Load a stage recording and check that it is complete and self-consistent.
 
@@ -1157,9 +1322,11 @@ def validate_recording(directory: str | Path) -> tuple[list[dict[str, Any]], lis
             manifest = None
 
     try:
-        docs = load_stage_dumps(d)
+        pairs = _load_with_paths(d)
     except ValueError as exc:
         return [], problems + [str(exc)]
+    pairs.sort(key=lambda pd: _step_sort_key(pd[1]))
+    docs = [doc for _, doc in pairs]
     if not docs:
         problems.append(f"{d}: no step-NNN.stages.json files")
 
@@ -1178,10 +1345,10 @@ def validate_recording(directory: str | Path) -> tuple[list[dict[str, Any]], lis
             problems.append(f"{d}: step {sid!r} has no integer tick "
                             f"({doc.get('tick')!r})")
         digest = doc.get("input_digest")
-        if not isinstance(digest, str) or not digest.startswith("sha256:") \
-                or len(digest) <= len("sha256:"):
-            problems.append(f"{d}: step {sid!r} has no sha256 input_digest "
-                            f"({digest!r})")
+        if not isinstance(digest, str) or not _SHA256_RE.match(digest):
+            # 64 lower-case hex digits, not merely a "sha256:" prefix.
+            problems.append(f"{d}: step {sid!r} has no well-formed sha256 "
+                            f"input_digest ({digest!r})")
         if not isinstance(doc.get("engine"), str) or not doc.get("engine"):
             problems.append(f"{d}: step {sid!r} declares no engine")
         if doc.get("vote_sign_convention") not in SUPPORTED_CONVENTIONS:
@@ -1209,12 +1376,15 @@ def validate_recording(directory: str | Path) -> tuple[list[dict[str, Any]], lis
         # A stage with no evidence is a hole in the recording, not a stage that
         # happened to match: every declared key must be PRESENT on every side.
         for name in STAGE_ORDER:
-            body = raw_stages.get(name)
-            if body is None:
-                continue
+            if name not in raw_stages:
+                continue  # already reported as a missing stage above
+            body = raw_stages[name]
             if not isinstance(body, dict):
+                # A null or array stage is a MISSING stage, not one to skip:
+                # skipping it bypassed every required-key check below.
                 problems.append(
-                    f"{d}: step {sid!r} stage {name} is not an object")
+                    f"{d}: step {sid!r} stage {name} is not an object "
+                    f"({type(body).__name__}) — no evidence for it")
                 continue
             inventory = STAGE_KEYS[name]
             absent = sorted(inventory["required"] - set(body))
@@ -1229,6 +1399,10 @@ def validate_recording(directory: str | Path) -> tuple[list[dict[str, Any]], lis
                     f"{d}: step {sid!r} stage {name} carries unknown key(s) "
                     f"{', '.join(unknown)}")
 
+    if manifest is not None and not isinstance(manifest, dict):
+        problems.append(f"{d}: manifest is not an object "
+                        f"({type(manifest).__name__})")
+        manifest = None
     if manifest is not None:
         if manifest.get("schema") != STAGE_DUMP_SCHEMA:
             problems.append(f"{d}: manifest schema {manifest.get('schema')!r}")
@@ -1246,31 +1420,68 @@ def validate_recording(directory: str | Path) -> tuple[list[dict[str, Any]], lis
             if declared != steps:
                 problems.append(
                     f"{d}: manifest inventory {declared} != on-disk steps {steps}")
-            by_step = {doc.get("step"): doc for doc in docs}
+            # Each row is bound to the ACTUAL parsed file, not merely to a
+            # path that happens to exist and an index that happens to resolve
+            # (R3-F3): a row naming stages-manifest.json used to pass.
+            by_file = {path.name: doc for path, doc in pairs}
+            seen_files: set[str] = set()
             for r in rows:
                 if not isinstance(r, dict):
-                    problems.append(f"{d}: manifest row is not an object")
+                    problems.append(f"{d}: manifest row is not an object "
+                                    f"({type(r).__name__})")
                     continue
-                if not (d / str(r.get("file"))).is_file():
-                    problems.append(f"{d}: manifest names a missing file "
-                                    f"{r.get('file')!r}")
-                # The manifest must agree with the document it names, or it is
-                # not an inventory of this recording (R2-F2).
-                doc = by_step.get(r.get("index"))
+                name = r.get("file")
+                if not isinstance(name, str) or not _STEP_FILE_RE.match(name):
+                    problems.append(f"{d}: manifest row names {name!r}, which "
+                                    f"is not a step-NNN.stages.json filename")
+                    continue
+                if name in seen_files:
+                    problems.append(f"{d}: manifest names {name!r} twice")
+                    continue
+                seen_files.add(name)
+                doc = by_file.get(name)
                 if doc is None:
-                    problems.append(f"{d}: manifest row {r.get('index')!r} "
-                                    f"names no on-disk step")
+                    problems.append(f"{d}: manifest names {name!r}, which is "
+                                    f"not a step file in this recording")
                     continue
-                for field in ("tick", "input_digest"):
-                    if r.get(field) != doc.get(field):
+                # Every identity field must agree with THAT document.
+                for field in ("step", "tick", "input_digest", "engine",
+                              "vote_sign_convention"):
+                    row_field = "index" if field == "step" else field
+                    if r.get(row_field) != doc.get(field):
                         problems.append(
-                            f"{d}: manifest step {r.get('index')!r} {field} "
-                            f"{r.get(field)!r} != document {doc.get(field)!r}")
+                            f"{d}: manifest row {name} {row_field} "
+                            f"{r.get(row_field)!r} != document {field} "
+                            f"{doc.get(field)!r}")
+            unlisted = sorted({path.name for path, _ in pairs} - seen_files)
+            if unlisted:
+                problems.append(
+                    f"{d}: step file(s) {', '.join(unlisted)} are not in the "
+                    f"manifest")
+
             engines = {doc.get("engine") for doc in docs}
-            if manifest.get("engine") not in engines and docs:
+            if len(engines) > 1:
+                problems.append(
+                    f"{d}: documents declare more than one engine "
+                    f"{sorted(map(str, engines))}")
+            if docs and manifest.get("engine") not in engines:
                 problems.append(
                     f"{d}: manifest engine {manifest.get('engine')!r} is not "
                     f"the documents' engine {sorted(map(str, engines))}")
+            conventions = {doc.get("vote_sign_convention") for doc in docs}
+            if manifest.get("vote_sign_convention") not in SUPPORTED_CONVENTIONS:
+                problems.append(
+                    f"{d}: manifest declares unsupported vote_sign_convention "
+                    f"{manifest.get('vote_sign_convention')!r}")
+            elif docs and manifest.get("vote_sign_convention") not in conventions:
+                problems.append(
+                    f"{d}: manifest vote_sign_convention "
+                    f"{manifest.get('vote_sign_convention')!r} contradicts the "
+                    f"documents' {sorted(map(str, conventions))}")
+            if len(conventions) > 1:
+                problems.append(
+                    f"{d}: documents declare more than one "
+                    f"vote_sign_convention {sorted(map(str, conventions))}")
             if manifest.get("comment_projection_axes") != COMMENT_PROJECTION_AXES:
                 problems.append(
                     f"{d}: manifest does not declare "
@@ -1289,8 +1500,20 @@ def compare_recordings(dir_a: str | Path, dir_b: str | Path) -> dict[str, Any]:
     docs_b, problems_b = validate_recording(dir_b)
     problems = [f"A: {p}" for p in problems_a] + [f"B: {p}" for p in problems_b]
 
-    by_step_a = {doc.get("step"): doc for doc in docs_a}
-    by_step_b = {doc.get("step"): doc for doc in docs_b}
+    # Only documents with a usable identity take part in the alignment. An
+    # invalid one is already an input problem (the headline is withheld); it
+    # must not be used as a dict key or a sort key on the way there.
+    def _by_step(docs: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+        return {doc["step"]: doc for doc in docs
+                if isinstance(doc.get("step"), int)
+                and not isinstance(doc.get("step"), bool)}
+
+    by_step_a, by_step_b = _by_step(docs_a), _by_step(docs_b)
+    unusable = ([d for d in docs_a if _by_step([d]) == {}]
+                + [d for d in docs_b if _by_step([d]) == {}])
+    if unusable:
+        problems.append(f"{len(unusable)} document(s) have an unusable step "
+                        f"identity and cannot be aligned")
     only_a = sorted(k for k in by_step_a if k not in by_step_b)
     only_b = sorted(k for k in by_step_b if k not in by_step_a)
     if only_a:

--- a/delphi/polismath/replay/stages.py
+++ b/delphi/polismath/replay/stages.py
@@ -120,6 +120,24 @@ STAGE_DIR_NAME = {"py": "py-stages", "clj": "clj-stages"}
 #: never guess from lengths — a square case (n_tids == n_comps) is ambiguous.
 COMMENT_PROJECTION_AXES = "comps-by-tids"
 
+#: Marker key for a value the EMITTER could not produce faithfully. It travels
+#: on the wire so the comparer reports a structural failure instead of grading a
+#: guess. An emitter must never fall back to inferring a shape it cannot verify.
+STRUCTURAL_ERROR_KEY = "__structural_error__"
+
+#: Width of the comment projection, on BOTH engines. `pca_project_cmnts` returns
+#: (n_cmnts, n_components) and is ALWAYS 2-wide even in the rank-one Q16 case,
+#: where Clojure's `[pc1 pc2]` destructure truncates every comment to 0.0 on both
+#: components (pca.py:470-478, pca.clj:134-157). So the emitted comps-by-tids
+#: array has max(len(comps), 2) rows — never fewer, and never inferred.
+PROJECTION_WIDTH = 2
+
+
+def structural_error(reason: str) -> dict[str, str]:
+    """A wire-visible emitter failure. Never a guess, never a silent drop."""
+    return {STRUCTURAL_ERROR_KEY: reason}
+
+
 #: Zero-padded so that lexicographic key order IS pipeline order.
 STAGE_ORDER = [
     "R01_ingest",
@@ -134,6 +152,51 @@ STAGE_ORDER = [
     "R12_priorities",
     "R13_ptpt_stats",
 ]
+
+
+#: The exact key inventory each stage must carry. `required` keys must be
+#: present in EVERY document from EVERY engine — a stage mapped to `{}` is
+#: missing evidence, not a stage that happened to match. `optional` keys are
+#: engine-local diagnostics with no counterpart in the engine contract.
+STAGE_KEYS: dict[str, dict[str, frozenset[str]]] = {
+    "R01_ingest": {
+        "required": frozenset({"last-vote-timestamp", "n", "n-cmts",
+                               "raw-rating-mat", "rating-mat", "tids"}),
+        "optional": frozenset()},
+    "R02_moderation": {
+        "required": frozenset({"last-mod-timestamp", "meta-tids", "mod-in",
+                               "mod-out"}),
+        "optional": frozenset()},
+    "R03_eligibility": {
+        "required": frozenset({"in-conv", "user-vote-counts"}),
+        "optional": frozenset()},
+    "R04_pca": {
+        "required": frozenset({"mat", "pca"}), "optional": frozenset()},
+    "R05_projections": {
+        "required": frozenset({"proj"}), "optional": frozenset()},
+    "R06_base_clusters": {
+        "required": frozenset({"base-clusters", "base-clusters-proj",
+                               "base-clusters-weights", "bid-to-pid",
+                               "bucket-dists"}),
+        "optional": frozenset()},
+    "R09_group_clusters": {
+        "required": frozenset({"group-clusterings",
+                               "group-clusterings-silhouettes",
+                               "group-clusters", "group-k-smoother"}),
+        "optional": frozenset()},
+    "R10_tallies": {
+        "required": frozenset({"group-aware-consensus", "group-votes",
+                               "votes-base"}),
+        "optional": frozenset()},
+    "R11_repness": {
+        "required": frozenset({"consensus", "repness"}),
+        "optional": frozenset()},
+    "R12_priorities": {
+        "required": frozenset({"comment-priorities"}), "optional": frozenset()},
+    "R13_ptpt_stats": {
+        "required": frozenset({"ptpt-stats"}),
+        "optional": frozenset({"participant-info-legacy"})},
+}
 
 
 # ---------------------------------------------------------------------------
@@ -375,18 +438,33 @@ def stage_r04_pca(conv: Conversation) -> dict[str, Any]:
         pca["center"] = plain(center)
         pca["comps"] = plain(comps)
         if center.size and comps.size:
-            cmnt_proj = np.asarray(pca_project_cmnts(center, comps))
-            # AXES ARE NORMALIZED HERE, NOT INFERRED DOWNSTREAM. Clojure's
-            # with-proj-and-extremtiy emits comment-projection as
-            # n_comps x n_tids; pca_project_cmnts returns n_tids x n_comps.
-            # A comparer that guessed the orientation from lengths would read a
-            # square case (n_tids == n_comps) wrong, so the transpose happens
-            # once, here, and COMMENT_PROJECTION_AXES declares the result.
-            if cmnt_proj.ndim == 2 and cmnt_proj.shape[0] != comps.shape[0]:
-                cmnt_proj = cmnt_proj.T
-            pca["comment-projection"] = plain(cmnt_proj)
-            pca["comment-extremity"] = plain(
-                compute_comment_extremity(np.asarray(pca_project_cmnts(center, comps))))
+            raw_proj = np.asarray(pca_project_cmnts(center, comps))
+            # AXES ARE NORMALIZED BY THE PRODUCER'S DOCUMENTED ORIENTATION,
+            # UNCONDITIONALLY. pca_project_cmnts always returns
+            # (n_cmnts, n_components) — comments-by-components, and always
+            # 2-wide even in the rank-one Q16 case (pca.py:470-478). Clojure's
+            # with-proj-and-extremtiy emits comps-by-tids, so the transpose is
+            # ALWAYS applied. It is deliberately NOT conditional on a shape
+            # comparison: when n_tids == n_components the two orientations are
+            # indistinguishable by shape, so any such test silently emits the
+            # wrong array while declaring the right axes.
+            pca["comment-extremity"] = plain(compute_comment_extremity(raw_proj))
+            if raw_proj.ndim != 2:
+                pca["comment-projection"] = structural_error(
+                    f"pca_project_cmnts returned a {raw_proj.ndim}-d array; "
+                    f"expected 2-d (n_cmnts, n_components)")
+            else:
+                cmnt_proj = raw_proj.T
+                expected_rows = max(int(comps.shape[0]), PROJECTION_WIDTH)
+                if cmnt_proj.shape != (expected_rows, int(center.size)):
+                    # Refuse rather than reshape: the declaration would be a
+                    # lie about data we cannot verify.
+                    pca["comment-projection"] = structural_error(
+                        f"comment-projection is {cmnt_proj.shape} but "
+                        f"{COMMENT_PROJECTION_AXES} requires "
+                        f"({expected_rows}, {int(center.size)})")
+                else:
+                    pca["comment-projection"] = plain(cmnt_proj)
         else:
             pca["comment-projection"] = None
             pca["comment-extremity"] = None

--- a/delphi/polismath/replay/stages.py
+++ b/delphi/polismath/replay/stages.py
@@ -1,0 +1,651 @@
+"""Stage-wise oracle for the Python engine — R-ORACLE (P-030 §2.3).
+
+The Clojure driver's ``--stage-json`` sink (``math/dev/replay.clj``) writes one
+``polis-stage-dump/1`` document per replay step carrying the plumbing-graph node
+outputs, grouped by the port plan's R-stage. This module is its Python twin: one
+function per stage that reads the Python engine's state after the same step on
+the same inputs and emits the SAME JSON shape, so
+:mod:`polismath.replay.stagecompare` can localise a cross-engine difference to
+its FIRST DIVERGING STAGE instead of only reporting that the final blob differs.
+
+**Grading — non-negotiable (P-030 §2.3).** Stage dumps are DIAGNOSTICS, not a
+gate. Clojure and Python already differ at ~1e-16 inside ``proj`` and at ~1e-5
+in cold-tick ``comps`` (CLOJURE_QUIRKS Q12/Q13/Q18) while the final blob still
+MATCHes; a stage-level exact comparison would fail on noise the acceptance
+policy deliberately tolerates. The only PASS/FAIL authority remains
+:mod:`polismath.replay.certify` on the final blob. Nothing here is imported by
+``certify``.
+
+**Where the files go.** ``<recording>/py-stages/step-NNN.stages.json`` plus
+``stages-manifest.json`` — a SIBLING of ``py/``, never inside it: ``certify``
+globs ``step-*`` / ``step-*.json`` inside the engine dir for its inventory and
+digest sets (certify.py:868,873,1283), ``store.write_recording`` deletes
+``step-*.json`` there before each write, and ``store.load_step_blobs`` globs
+``step-*.json`` as step payloads.
+
+**Vote-sign convention.** Each engine dumps its NATIVE numbers. Clojure computes
+in raw-DB convention (AGREE=-1, utils.clj:40-49); this engine computes in Delphi
+convention (AGREE=+1) and negates only at its blob-emission boundary
+(conversation.py:1767-1788). So the vote-valued and geometry stage nodes differ
+by sign BEFORE that boundary. The dump records ``vote_sign_convention`` and
+``stagecompare`` applies the negation set; the emitters deliberately do not, so
+each file is a faithful record of what that engine actually computed.
+
+**Encoding contract**, mirrored byte-for-byte by ``replay.clj``:
+
+* every JSON object's keys are sorted ascending as strings (integer/keyword map
+  keys are stringified FIRST, then sorted, so ``"10" < "2"`` on both engines);
+* integers are JSON integers; doubles use the shortest decimal that round-trips
+  (``repr(float)`` here, ``Double/toString`` there) — NO rounding, ever;
+* non-finite doubles become the JSON strings ``"NaN"`` / ``"Infinity"`` /
+  ``"-Infinity"`` (JSON has no literal for them);
+* a named matrix is ``{"rownames": […], "colnames": […], "matrix": [[…]]}`` with
+  missing cells as ``null``, so the diff keys cells by (rowname, colname) rather
+  than by cross-engine-arbitrary position;
+* sets become sorted arrays.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import warnings
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+import numpy as np
+import pandas as pd
+
+from polismath.conversation.conversation import (
+    Conversation,
+    _labels_from_id_clusters,
+)
+from polismath.pca_kmeans_rep.clusters import (
+    calculate_silhouette_sklearn,
+    distance_matrix,
+)
+from polismath.pca_kmeans_rep.pca import (
+    compute_comment_extremity,
+    pca_project_cmnts,
+)
+from polismath.replay import driver as _driver
+from polismath.replay import real_data, schedule as _schedule
+from polismath.replay.schedule import ReplayStep, ScheduleSpec
+from polismath.replay.types import ReplayDataset
+
+STAGE_DUMP_SCHEMA = "polis-stage-dump/1"
+
+#: This engine's internal vote convention (AGREE=+1); see the module docstring.
+VOTE_SIGN_CONVENTION = "delphi"
+
+PY_STAGE_ENGINE = "py"
+
+#: Directory name for a stage recording, per engine. Sibling of the blob dir.
+STAGE_DIR_NAME = {"py": "py-stages", "clj": "clj-stages"}
+
+#: Zero-padded so that lexicographic key order IS pipeline order.
+STAGE_ORDER = [
+    "R01_ingest",
+    "R02_moderation",
+    "R03_eligibility",
+    "R04_pca",
+    "R05_projections",
+    "R06_base_clusters",
+    "R09_group_clusters",
+    "R10_tallies",
+    "R11_repness",
+    "R12_priorities",
+    "R13_ptpt_stats",
+]
+
+
+# ---------------------------------------------------------------------------
+# Encoding: plain-data coercion + canonical JSON.
+# ---------------------------------------------------------------------------
+def _key(k: Any) -> str:
+    """Stringify a mapping key. Integers become their decimal form (NOT
+    ``12.0``) so tid/pid/gid keys agree with Clojure's ``(str (bigint k))``."""
+    if isinstance(k, str):
+        return k
+    if isinstance(k, bool):
+        return "true" if k else "false"
+    if isinstance(k, (int, np.integer)):
+        return str(int(k))
+    if k is None:
+        return "null"
+    if isinstance(k, (float, np.floating)):
+        return _float_repr(float(k))
+    return str(k)
+
+
+def _float_repr(x: float) -> Any:
+    """A finite float passes through (``json`` writes ``repr``, the shortest
+    round-tripping decimal); a non-finite one becomes its JSON string."""
+    if math.isnan(x):
+        return "NaN"
+    if x == math.inf:
+        return "Infinity"
+    if x == -math.inf:
+        return "-Infinity"
+    return x
+
+
+def _sorted_elems(coll: Iterable[Any]) -> list:
+    """Deterministic ascending order for a set's elements: naturally when they
+    are mutually comparable, else by their printed form."""
+    items = list(coll)
+    try:
+        return sorted(items)
+    except TypeError:
+        return sorted(items, key=repr)
+
+
+def plain(x: Any) -> Any:
+    """Coerce an engine value into plain JSON-ready data.
+
+    Raises on anything unrecognised rather than silently emitting ``str(x)``.
+    """
+    if x is None:
+        return None
+    if isinstance(x, bool):  # before int — bool is an int subclass
+        return x
+    if isinstance(x, (int, np.integer)):
+        return int(x)
+    if isinstance(x, (float, np.floating)):
+        return _float_repr(float(x))
+    if isinstance(x, str):
+        return x
+    if x is pd.NA or (isinstance(x, float) and x != x):  # pragma: no cover
+        return None
+    if isinstance(x, pd.DataFrame):
+        return dataframe_to_named_matrix(x)
+    if isinstance(x, np.ndarray):
+        return [plain(v) for v in x.tolist()]
+    if isinstance(x, (set, frozenset)):
+        return [plain(v) for v in _sorted_elems(x)]
+    if isinstance(x, dict):
+        return {k: v for k, v in sorted((_key(k), plain(v)) for k, v in x.items())}
+    if isinstance(x, (list, tuple)):
+        return [plain(v) for v in x]
+    if pd.isna(x) is True:
+        return None
+    raise TypeError(f"stage-json: unsupported value type {type(x).__name__}")
+
+
+def canonical_json(obj: Any) -> str:
+    """Serialize already-plain data (see :func:`plain`) as canonical stage-dump
+    JSON: sorted keys, no whitespace, shortest round-tripping floats. Non-finite
+    floats must already have been turned into their JSON strings — ``json``
+    would otherwise emit the non-standard ``NaN`` literal, so we forbid it."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def named_matrix(rownames: Sequence[Any], colnames: Sequence[Any],
+                 rows: Iterable[Iterable[Any]]) -> dict[str, Any]:
+    """The ``{"rownames","colnames","matrix"}`` shape both engines emit."""
+    return {
+        "colnames": [plain(c) for c in colnames],
+        "matrix": [[plain(v) for v in row] for row in rows],
+        "rownames": [plain(r) for r in rownames],
+    }
+
+
+def dataframe_to_named_matrix(df: pd.DataFrame) -> dict[str, Any]:
+    """A vote matrix as a named matrix, with missing cells as ``null`` (the
+    Clojure named-matrix's ``nil``). Integral floats stay floats here; the
+    comparer is numeric, not type-sensitive."""
+    values = df.to_numpy(copy=True)
+    rows = []
+    for row in values:
+        out = []
+        for cell in row:
+            if cell is None or cell is pd.NA:
+                out.append(None)
+            elif isinstance(cell, (float, np.floating)) and math.isnan(float(cell)):
+                out.append(None)
+            else:
+                out.append(plain(cell))
+        rows.append(out)
+    return {
+        "colnames": [plain(c) for c in df.columns],
+        "matrix": rows,
+        "rownames": [plain(r) for r in df.index],
+    }
+
+
+def input_digest(vote_rows: Sequence[Sequence[int]],
+                 mod_rows: Sequence[Sequence[int]]) -> str:
+    """sha256 over one step's fed inputs, in a form BOTH engines reproduce.
+
+    Votes are digested in EXPORT/Delphi sign convention (AGREE=+1) — the sign
+    the CSV carries — not in the raw-DB convention Clojure's ``conv-update``
+    consumes, so the clj and py digests agree for the same batch. Rows keep fed
+    order; booleans are 0/1.
+    """
+    payload = canonical_json({
+        "mods": [[int(v) for v in row] for row in mod_rows],
+        "votes": [[int(v) for v in row] for row in vote_rows],
+    })
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def step_input_digest(step: ReplayStep) -> str:
+    """:func:`input_digest` for a sliced replay step."""
+    votes = [(v.pid, v.tid, v.sign, v.t_ms) for v in step.vote_events]
+    mods = [(m.tid, 1 if m.is_meta else 0, m.mod, m.t_ms) for m in step.mod_events]
+    return input_digest(votes, mods)
+
+
+# ---------------------------------------------------------------------------
+# Per-stage extractors. Each returns the stage's node map, keyed with the
+# CLOJURE node names so the two dumps line up key-for-key.
+# ---------------------------------------------------------------------------
+def stage_r01_ingest(conv: Conversation) -> dict[str, Any]:
+    """R1 — ingest / named matrix / tids arrival order / caps / timestamps.
+
+    Clojure nodes ``:raw-rating-mat``, ``:rating-mat``, ``:tids``, ``:n``,
+    ``:n-cmts``, ``:last-vote-timestamp`` (conversation.clj:196-220). ``n`` /
+    ``n-cmts`` come from the rating matrix's own shape on BOTH engines, not from
+    the cached counters.
+    """
+    rating = conv.rating_mat
+    return {
+        "last-vote-timestamp": plain(conv.last_updated),
+        "n": int(rating.shape[0]),
+        "n-cmts": int(rating.shape[1]),
+        "raw-rating-mat": dataframe_to_named_matrix(conv.raw_rating_mat),
+        "rating-mat": dataframe_to_named_matrix(rating),
+        "tids": [plain(c) for c in rating.columns],
+    }
+
+
+def stage_r02_moderation(conv: Conversation) -> dict[str, Any]:
+    """R2 — the moderation reducer's sets and watermark (conversation.clj:846-884).
+
+    Clojure emits ``nil`` for ``:mod-in``/``:mod-out`` until a ``mod-update``
+    has written them. This engine reproduces that at its blob boundary by
+    keying off ``moderation_applied`` (``_apply_legacy_blob_shape``,
+    conversation.py:1795-1797), and the same rule is applied here so the stage
+    dump carries the engine's own emission, not its raw in-memory sets. Any
+    residual ``null`` vs ``[]`` is carve-out ``C1`` in stagecompare.
+    """
+    applied = bool(getattr(conv, "moderation_applied", False))
+    return {
+        "last-mod-timestamp": plain(conv.last_mod_timestamp),
+        "meta-tids": plain(set(conv.meta_tids)),
+        "mod-in": plain(set(conv.mod_in_tids)) if applied else None,
+        "mod-out": plain(set(conv.mod_out_tids)) if applied else None,
+    }
+
+
+def stage_r03_eligibility(conv: Conversation) -> dict[str, Any]:
+    """R3 — ``user-vote-counts`` and the carried ``in-conv`` set
+    (conversation.clj:222-268). Both are exact-family."""
+    return {
+        "in-conv": plain(set(conv._get_in_conv_participants())),
+        "user-vote-counts": plain(conv._compute_user_vote_counts()),
+    }
+
+
+def imputed_matrix(conv: Conversation) -> np.ndarray:
+    """The Clojure ``:mat`` node: the rating matrix with missing cells replaced
+    by their column average (conversation.clj:358-380).
+
+    Replicates ``pca.pca_project_dataframe``'s imputation verbatim (pca.py, the
+    ``col_means`` block) — including the all-NaN-column rule, where this engine
+    substitutes 0.0 and Clojure would divide by zero. That rule is unreachable
+    on a real conversation (every column carries at least one vote) and is
+    recorded as carve-out ``C5``.
+    """
+    matrix_data = conv._get_clean_matrix().to_numpy(copy=True)
+    if not np.issubdtype(matrix_data.dtype, np.floating):
+        matrix_data = matrix_data.astype(float)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)  # "Mean of empty slice"
+        col_means = np.nanmean(matrix_data, axis=0)
+    col_means = np.where(np.isnan(col_means), 0.0, col_means)
+    nan_indices = np.where(np.isnan(matrix_data))
+    out = matrix_data.copy()
+    out[nan_indices] = col_means[nan_indices[1]]
+    return out
+
+
+def stage_r04_pca(conv: Conversation) -> dict[str, Any]:
+    """R4 — imputation (``:mat``) and PCA (``:pca``).
+
+    ``:pca`` carries the four fields Clojure's ``with-proj-and-extremtiy``
+    attaches (conversation.clj:341-352): ``center``, ``comps``,
+    ``comment-projection``, ``comment-extremity``. This engine stores only the
+    first two; the other two are the same pure functions of them that
+    ``_compute_comment_priorities`` calls (conversation.py:1410-1411).
+    """
+    pca: dict[str, Any] = {}
+    if conv.pca:
+        center = np.asarray(conv.pca.get("center"))
+        comps = np.asarray(conv.pca.get("comps"))
+        pca["center"] = plain(center)
+        pca["comps"] = plain(comps)
+        if center.size and comps.size:
+            cmnt_proj = pca_project_cmnts(center, comps)
+            pca["comment-projection"] = plain(cmnt_proj)
+            pca["comment-extremity"] = plain(compute_comment_extremity(cmnt_proj))
+        else:
+            pca["comment-projection"] = None
+            pca["comment-extremity"] = None
+    return {
+        "mat": plain(imputed_matrix(conv)),
+        "pca": pca or None,
+    }
+
+
+def stage_r05_projections(conv: Conversation) -> dict[str, Any]:
+    """R5 — the sparsity-aware participant projection (``:proj-nmat``).
+
+    Emitted as a named matrix on both engines (Clojure's ``:proj`` is a bare
+    positional seq; its ``:proj-nmat`` is the same values with the rating
+    matrix's rownames, conversation.clj:392-397), so the diff can key rows by
+    participant id rather than by row position.
+    """
+    rownames = list(conv.rating_mat.index)
+    proj = conv.proj or {}
+    rows = []
+    for pid in rownames:
+        vec = proj.get(pid)
+        rows.append([] if vec is None else list(np.asarray(vec).tolist()))
+    return {"proj": named_matrix(rownames, ["x", "y"], rows)}
+
+
+def _clusters_plain(clusters: Iterable[dict[str, Any]] | None) -> list | None:
+    """``[{id, center, members}]`` — only the three fields Clojure's clusters
+    carry, so an engine-private extra key cannot masquerade as a divergence."""
+    if clusters is None:
+        return None
+    return [
+        {
+            "center": plain(np.asarray(c["center"], dtype=float)),
+            "id": plain(c["id"]),
+            "members": [plain(m) for m in c["members"]],
+        }
+        for c in clusters
+    ]
+
+
+def stage_r06_base_clusters(conv: Conversation) -> dict[str, Any]:
+    """R6/R8 — base clusters and everything derived positionally from them:
+    ``:base-clusters``, ``:base-clusters-proj``, ``:base-clusters-weights``,
+    ``:bid-to-pid`` and ``:bucket-dists`` (conversation.clj:402-431, 590-594).
+
+    This engine keeps only ``base_clusters``; the other four are the same pure
+    functions of it that Clojure's fnks are, computed here so the stage compares.
+    """
+    base = list(conv.base_clusters or [])
+    ordered = sorted(base, key=lambda c: c["id"])
+    ids = [c["id"] for c in ordered]
+    centers = (np.asarray([c["center"] for c in ordered], dtype=float)
+               if ordered else np.zeros((0, 2)))
+    dists = distance_matrix(centers) if len(ordered) else np.zeros((0, 0))
+    return {
+        "base-clusters": _clusters_plain(ordered),
+        "base-clusters-proj": named_matrix(ids, ["x", "y"], centers.tolist()),
+        "base-clusters-weights": plain({c["id"]: len(c["members"]) for c in ordered}),
+        "bid-to-pid": [[plain(m) for m in c["members"]] for c in ordered],
+        "bucket-dists": named_matrix(ids, ids, dists.tolist()),
+    }
+
+
+def stage_r09_group_clusters(conv: Conversation) -> dict[str, Any]:
+    """R9 — per-k group clusterings, their silhouettes, the k-smoother state and
+    the selected clustering (conversation.clj:433-484).
+
+    The silhouettes are recomputed from the stored ``group_clusterings`` with
+    exactly the call ``_compute_clusters`` made
+    (``calculate_silhouette_sklearn`` on the base-cluster centers,
+    conversation.py:1003-1006). That scorer is NOT Clojure's
+    ``clusters/silhouette`` over ``bucket-dists``, so the silhouette values
+    themselves are expected to differ — carve-out ``C3``. What must agree is the
+    ARGMAX they feed, visible in ``group-k-smoother`` and the group count.
+    """
+    base = sorted(list(conv.base_clusters or []), key=lambda c: c["id"])
+    base_ids = [c["id"] for c in base]
+    centers = (np.asarray([c["center"] for c in base], dtype=float)
+               if base else np.zeros((0, 2)))
+
+    clusterings = getattr(conv, "group_clusterings", None) or {}
+    silhouettes: dict[Any, Any] = {}
+    out_clusterings: dict[Any, Any] = {}
+    for k, gc in clusterings.items():
+        ordered = sorted(gc, key=lambda c: c["id"])
+        out_clusterings[k] = _clusters_plain(ordered)
+        if len(base):
+            labels = _labels_from_id_clusters(base_ids, ordered)
+            silhouettes[k] = plain(calculate_silhouette_sklearn(centers, labels))
+        else:  # pragma: no cover - degenerate
+            silhouettes[k] = None
+
+    smoother = getattr(conv, "group_k_smoother", None) or {}
+    smoother_out = {
+        "last-k": plain(smoother.get("last_k")),
+        "last-k-count": plain(smoother.get("last_k_count")),
+        "smoothed-k": plain(smoother.get("smoothed_k")),
+    } if smoother else None
+
+    return {
+        "group-clusterings": plain(out_clusterings) if out_clusterings else None,
+        "group-clusterings-silhouettes": plain(silhouettes) if silhouettes else None,
+        "group-clusters": _clusters_plain(
+            sorted(list(conv.group_clusters or []), key=lambda c: c["id"])),
+        "group-k-smoother": smoother_out,
+    }
+
+
+def stage_r10_tallies(conv: Conversation, blob: dict[str, Any] | None = None
+                      ) -> dict[str, Any]:
+    """R10 — ``votes-base``, ``group-votes`` and ``group-aware-consensus``
+    (conversation.clj:600-654).
+
+    Taken from ``to_dict()`` — the place this engine computes them — so that
+    this stage's diff is exactly the diff certify sees on those three blob keys.
+    """
+    b = blob if blob is not None else conv.to_dict()
+    return {
+        "group-aware-consensus": plain(b.get("group-aware-consensus")),
+        "group-votes": plain(b.get("group-votes")),
+        "votes-base": plain(b.get("votes-base")),
+    }
+
+
+def stage_r11_repness(conv: Conversation) -> dict[str, Any]:
+    """R11 — repness selection and consensus selection (conversation.clj:688-716).
+
+    This engine nests both under ``conv.repness`` and keeps its rows in an
+    internal spelling (``comment_id``/``na``/``pat``/``rat``/``repful``); the
+    Clojure ``finalize-cmt-stats`` spelling is produced by the engine's own
+    ``_legacy_repness_entry`` projection (conversation.py:1680-1704), which is
+    exactly what its blob emits. That projection is applied here, and the two
+    nodes are split back out, so the stage matches Clojure key-for-key.
+    """
+    rep = conv.repness or {}
+    group_repness = rep.get("group_repness")
+    projected = None
+    if group_repness is not None:
+        projected = {
+            gid: [Conversation._legacy_repness_entry(e) for e in entries]
+            for gid, entries in group_repness.items()
+        }
+    return {
+        "consensus": plain(rep.get("consensus_comments")),
+        "repness": plain(projected),
+    }
+
+
+def stage_r12_priorities(conv: Conversation) -> dict[str, Any]:
+    """R12 — ``comment-priorities``, including the Q2 previous-tick group-votes
+    shadow (conversation.clj:656-687)."""
+    return {"comment-priorities": plain(getattr(conv, "comment_priorities", None) or {})}
+
+
+def stage_r13_ptpt_stats(conv: Conversation) -> dict[str, Any]:
+    """R13 — participant stats (``:ptpt-stats``, repness.clj:372-381).
+
+    KNOWN STRUCTURAL DIVERGENCE (carve-out ``C4``): the two engines compute
+    DIFFERENT statistics under this name. Clojure emits
+    ``{pid, gid, n-votes, coreness, centricness, extremeness}`` — geometry over
+    the participant projection. This engine emits
+    ``{n_agree, n_disagree, n_pass, n_votes, group, group_correlations}``.
+    Only ``pid``, ``gid`` and ``n-votes`` are the same quantity, so those three
+    are re-keyed here and the rest is carried under its native names. The blob
+    key has no reader anywhere in Node or the clients (P-030 §5/R13), so this is
+    verification surface only.
+    """
+    info = getattr(conv, "participant_info", None) or {}
+    out = []
+    for pid, stats in info.items():
+        row = {"pid": plain(pid),
+               "gid": plain(stats.get("group")),
+               "n-votes": plain(stats.get("n_votes"))}
+        for k, v in stats.items():
+            if k in ("group", "n_votes"):
+                continue
+            row[k] = plain(v)
+        out.append(row)
+    out.sort(key=lambda r: (r["pid"] is None, str(r["pid"])))
+    return {"ptpt-stats": out}
+
+
+#: Stage name -> extractor. ``R10_tallies`` additionally accepts the cached blob.
+STAGE_FUNCS: dict[str, Callable[..., dict[str, Any]]] = {
+    "R01_ingest": stage_r01_ingest,
+    "R02_moderation": stage_r02_moderation,
+    "R03_eligibility": stage_r03_eligibility,
+    "R04_pca": stage_r04_pca,
+    "R05_projections": stage_r05_projections,
+    "R06_base_clusters": stage_r06_base_clusters,
+    "R09_group_clusters": stage_r09_group_clusters,
+    "R10_tallies": stage_r10_tallies,
+    "R11_repness": stage_r11_repness,
+    "R12_priorities": stage_r12_priorities,
+    "R13_ptpt_stats": stage_r13_ptpt_stats,
+}
+
+
+# ---------------------------------------------------------------------------
+# Documents, manifests, and the fold that produces them.
+# ---------------------------------------------------------------------------
+def stage_document(conv: Conversation, *, step_index: int, digest: str,
+                   tick: Any = None, blob: dict[str, Any] | None = None,
+                   engine: str = PY_STAGE_ENGINE) -> dict[str, Any]:
+    """The ``polis-stage-dump/1`` document for one step of this engine."""
+    stages: dict[str, Any] = {}
+    for name in STAGE_ORDER:
+        fn = STAGE_FUNCS[name]
+        stages[name] = fn(conv, blob) if name == "R10_tallies" else fn(conv)
+    return {
+        "engine": engine,
+        "input_digest": digest,
+        "schema": STAGE_DUMP_SCHEMA,
+        "stages": stages,
+        "step": int(step_index),
+        "tick": plain(conv.last_updated if tick is None else tick),
+        "vote_sign_convention": VOTE_SIGN_CONVENTION,
+    }
+
+
+def write_stage_documents(out_dir: str | Path, documents: Sequence[dict[str, Any]],
+                          *, engine: str = PY_STAGE_ENGINE) -> Path:
+    """Write per-step dumps and ``stages-manifest.json`` into ``out_dir``.
+
+    Stale ``step-*.stages.json`` from a longer prior run are removed first, so
+    each write is the authoritative step set (the discipline
+    ``store.write_recording`` uses for blobs).
+    """
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    for stale in out.glob("step-*.stages.json"):
+        stale.unlink()
+
+    rows = []
+    for doc in documents:
+        name = f"step-{int(doc['step']):03d}.stages.json"
+        (out / name).write_text(canonical_json(doc))
+        rows.append({
+            "file": name,
+            "index": int(doc["step"]),
+            "input_digest": doc["input_digest"],
+            "tick": doc["tick"],
+        })
+    (out / "stages-manifest.json").write_text(canonical_json({
+        "engine": engine,
+        "n_steps": len(rows),
+        "schema": STAGE_DUMP_SCHEMA,
+        "stage_order": list(STAGE_ORDER),
+        "steps": rows,
+        "vote_sign_convention": VOTE_SIGN_CONVENTION,
+    }))
+    return out
+
+
+def run_stage_dump(dataset: ReplayDataset, spec: ScheduleSpec, *,
+                   out_dir: str | Path) -> Path:
+    """Replay ``dataset`` on ``spec`` and write this engine's stage recording.
+
+    The fold is :func:`polismath.replay.driver.run_replay` itself, via its
+    ``on_step`` hook, so the stage dump can never drift from the recording the
+    Python driver produces for ``certify``.
+    """
+    documents: list[dict[str, Any]] = []
+
+    def collect(step: ReplayStep, conv: Conversation, record) -> None:
+        documents.append(stage_document(
+            conv,
+            step_index=step.index,
+            digest=step_input_digest(step),
+            blob=record.blob,
+        ))
+
+    _driver.run_replay(dataset, spec, on_step=collect)
+    return write_stage_documents(out_dir, documents)
+
+
+# ---------------------------------------------------------------------------
+# CLI: python -m polismath.replay.stages --dataset vw --preset single-cut --out DIR
+# ---------------------------------------------------------------------------
+def _spec_for(dataset: str, ds: ReplayDataset, preset: str, n_cuts: int | None,
+              schedule_path: str | None) -> ScheduleSpec:
+    if schedule_path:
+        return ScheduleSpec.from_json_file(Path(schedule_path))
+    if preset == "single-cut":
+        return _schedule.preset_single_cut(dataset, ds.n)
+    if preset == "uniform":
+        return _schedule.preset_uniform(dataset, ds.n, n_cuts=n_cuts or 8)
+    if preset == "front-loaded":
+        return _schedule.preset_front_loaded(dataset, ds.n, n_cuts=n_cuts or 6)
+    if preset == "every-vote":
+        return _schedule.preset_every_vote(dataset, ds.n)
+    raise SystemExit(f"unknown preset {preset!r}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Write this engine's polis-stage-dump/1 recording "
+                    "(DIAGNOSTICS ONLY — certify remains the gate).")
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--preset", default="single-cut")
+    ap.add_argument("--n-cuts", type=int, default=None)
+    ap.add_argument("--schedule", default=None,
+                    help="Schedule JSON to use verbatim instead of a preset.")
+    ap.add_argument("--out", required=True,
+                    help="Recording dir; py-stages/ is written under it.")
+    args = ap.parse_args(argv)
+
+    ds = real_data.load_export_votes(args.dataset)
+    spec = _spec_for(args.dataset, ds, args.preset, args.n_cuts, args.schedule)
+    out = run_stage_dump(ds, spec,
+                         out_dir=Path(args.out) / STAGE_DIR_NAME[PY_STAGE_ENGINE])
+    print(f"wrote stage dumps → {out}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/delphi/polismath/replay/stages.py
+++ b/delphi/polismath/replay/stages.py
@@ -16,6 +16,15 @@ policy deliberately tolerates. The only PASS/FAIL authority remains
 :mod:`polismath.replay.certify` on the final blob. Nothing here is imported by
 ``certify``.
 
+**Captures vs reconstructions.** Where this engine persists a node, the stage
+function CAPTURES it. Where it does not, the stage function RECONSTRUCTS the node
+by calling the engine's own code on stored state — `mat` (the imputation block of
+``pca_project_dataframe``), ``pca.comment-projection`` / ``comment-extremity``
+(``pca_project_cmnts`` / ``compute_comment_extremity``), the base-cluster derived
+matrices, the per-k silhouettes, ``user-vote-counts``, and the R13 geometry
+(``math_writer.derive_ptptstats``). A reconstruction is faithful to the engine's
+code but is not evidence that the engine executed it during the tick.
+
 **Where the files go.** ``<recording>/py-stages/step-NNN.stages.json`` plus
 ``stages-manifest.json`` — a SIBLING of ``py/``, never inside it: ``certify``
 globs ``step-*`` / ``step-*.json`` inside the engine dir for its inventory and
@@ -42,7 +51,26 @@ each file is a faithful record of what that engine actually computed.
 * a named matrix is ``{"rownames": […], "colnames": […], "matrix": [[…]]}`` with
   missing cells as ``null``, so the diff keys cells by (rowname, colname) rather
   than by cross-engine-arbitrary position;
-* sets become sorted arrays.
+* sets become sorted arrays;
+* ``pca.comment-projection`` is ``n_comps`` rows of ``n_tids`` values on BOTH
+  engines, declared by ``comment_projection_axes`` in each document — an axis
+  orientation must never be inferred from array lengths.
+
+**Admitted value domain.** The encoding is lossless for finite binary64, JSON
+integers in the signed-64-bit range, strings, booleans, null, and the three
+non-finite tokens. It is NOT a general object serializer, and these limits are
+deliberate rather than incidental:
+
+* map keys are stringified, so integer ``1`` and string ``"1"`` collapse into one
+  key on both engines;
+* the JSON string ``"NaN"`` and the non-finite token for NaN are indistinguishable
+  on the wire;
+* Clojure ``Ratio`` (e.g. ``1/3``) is projected to the nearest double, and
+  keyword/set/type identity is projected away;
+* a pandas ``NaN`` cell in a vote matrix is a MISSING VOTE and becomes ``null``,
+  not a non-finite token — that is a field-level rule, not a number rule.
+
+A stage value outside that domain must be rejected by :func:`plain`, not coerced.
 """
 
 from __future__ import annotations
@@ -70,6 +98,7 @@ from polismath.pca_kmeans_rep.pca import (
     compute_comment_extremity,
     pca_project_cmnts,
 )
+from polismath.poller.math_writer import derive_ptptstats
 from polismath.replay import driver as _driver
 from polismath.replay import real_data, schedule as _schedule
 from polismath.replay.schedule import ReplayStep, ScheduleSpec
@@ -84,6 +113,12 @@ PY_STAGE_ENGINE = "py"
 
 #: Directory name for a stage recording, per engine. Sibling of the blob dir.
 STAGE_DIR_NAME = {"py": "py-stages", "clj": "clj-stages"}
+
+#: Axis orientation of ``pca.comment-projection``, declared rather than inferred
+#: (Astra F4): both engines emit ``n_comps`` rows of ``n_tids`` values, matching
+#: Clojure's ``with-proj-and-extremtiy``. A comparer must VALIDATE against this,
+#: never guess from lengths — a square case (n_tids == n_comps) is ambiguous.
+COMMENT_PROJECTION_AXES = "comps-by-tids"
 
 #: Zero-padded so that lexicographic key order IS pipeline order.
 STAGE_ORDER = [
@@ -282,9 +317,21 @@ def stage_r02_moderation(conv: Conversation) -> dict[str, Any]:
 
 def stage_r03_eligibility(conv: Conversation) -> dict[str, Any]:
     """R3 — ``user-vote-counts`` and the carried ``in-conv`` set
-    (conversation.clj:222-268). Both are exact-family."""
+    (conversation.clj:222-268). Both are exact-family.
+
+    Reads the CARRIED ``conv.in_conv`` that the tick already persisted rather
+    than calling ``_get_in_conv_participants()``, which assigns ``self.in_conv``
+    (conversation.py:2035) — an observer documented as read-only must not invoke
+    a state-changing computation. On a degenerate tick where ``_compute_clusters``
+    returned before reaching that call, ``conv.in_conv`` still holds the prior
+    tick's carried set, which is exactly what Clojure's carried ``:in-conv`` is.
+
+    ``user-vote-counts`` is a RECONSTRUCTION, not a capture: this engine has no
+    stored node for it, so the same ``_compute_user_vote_counts()`` its blob
+    calls is re-run here (it is pure over ``raw_rating_mat``).
+    """
     return {
-        "in-conv": plain(set(conv._get_in_conv_participants())),
+        "in-conv": plain(set(getattr(conv, "in_conv", None) or set())),
         "user-vote-counts": plain(conv._compute_user_vote_counts()),
     }
 
@@ -328,9 +375,18 @@ def stage_r04_pca(conv: Conversation) -> dict[str, Any]:
         pca["center"] = plain(center)
         pca["comps"] = plain(comps)
         if center.size and comps.size:
-            cmnt_proj = pca_project_cmnts(center, comps)
+            cmnt_proj = np.asarray(pca_project_cmnts(center, comps))
+            # AXES ARE NORMALIZED HERE, NOT INFERRED DOWNSTREAM. Clojure's
+            # with-proj-and-extremtiy emits comment-projection as
+            # n_comps x n_tids; pca_project_cmnts returns n_tids x n_comps.
+            # A comparer that guessed the orientation from lengths would read a
+            # square case (n_tids == n_comps) wrong, so the transpose happens
+            # once, here, and COMMENT_PROJECTION_AXES declares the result.
+            if cmnt_proj.ndim == 2 and cmnt_proj.shape[0] != comps.shape[0]:
+                cmnt_proj = cmnt_proj.T
             pca["comment-projection"] = plain(cmnt_proj)
-            pca["comment-extremity"] = plain(compute_comment_extremity(cmnt_proj))
+            pca["comment-extremity"] = plain(
+                compute_comment_extremity(np.asarray(pca_project_cmnts(center, comps))))
         else:
             pca["comment-projection"] = None
             pca["comment-extremity"] = None
@@ -487,31 +543,56 @@ def stage_r12_priorities(conv: Conversation) -> dict[str, Any]:
 
 
 def stage_r13_ptpt_stats(conv: Conversation) -> dict[str, Any]:
-    """R13 — participant stats (``:ptpt-stats``, repness.clj:372-381).
+    """R13 — participant stats (``:ptpt-stats``, repness.clj:383-413).
 
-    KNOWN STRUCTURAL DIVERGENCE (carve-out ``C4``): the two engines compute
-    DIFFERENT statistics under this name. Clojure emits
-    ``{pid, gid, n-votes, coreness, centricness, extremeness}`` — geometry over
-    the participant projection. This engine emits
-    ``{n_agree, n_disagree, n_pass, n_votes, group, group_correlations}``.
-    Only ``pid``, ``gid`` and ``n-votes`` are the same quantity, so those three
-    are re-keyed here and the rest is carried under its native names. The blob
-    key has no reader anywhere in Node or the clients (P-030 §5/R13), so this is
-    verification surface only.
+    Clojure's node is a LIST of per-participant row maps
+    ``{pid, gid, n-votes, centricness, coreness, extremeness}``; ``prep-ptpt-stats``
+    columnizes them afterwards (conv_man.clj:90-94). This engine's geometric
+    implementation is :func:`polismath.poller.math_writer.derive_ptptstats` — the
+    production output adapter, a verbatim port of ``repness/participant-stats``,
+    pinned against a live Clojure reference row. It is called here with the
+    already-computed RAW ``user-vote-counts`` (Clojure's ``n-votes`` is the raw
+    count, and the adapter takes it as an argument for exactly that reason), and
+    its columnar result is transposed back into the stage's row shape.
+
+    This is the statistic the engine contract names
+    (``P-022-G-engine-contract.md``: columnar pid / gid / n-votes / centricness /
+    coreness / extremeness, aligned lengths, nullable n-votes, finite numeric
+    stats) and it is compared as such — pid/gid/n-votes exact, the three
+    geometric floats tolerant, row coverage exact. There is no waiver here.
+
+    ``conv.participant_info`` is a DIFFERENT, Python-only statistic
+    (n_agree / n_disagree / n_pass / group_correlations, vote-correlation based).
+    ``math_writer`` has distinguished the two since 2026-07-24 and ``crosslang``
+    excludes ``participant_info`` from the parity surface. It is carried here
+    under the separate, engine-local key ``participant-info-legacy`` so the
+    report can still show it, explicitly NOT as engine-contract surface: it has
+    no Clojure counterpart, and the comparer refuses to grade it against one.
     """
-    info = getattr(conv, "participant_info", None) or {}
-    out = []
-    for pid, stats in info.items():
-        row = {"pid": plain(pid),
-               "gid": plain(stats.get("group")),
-               "n-votes": plain(stats.get("n_votes"))}
-        for k, v in stats.items():
-            if k in ("group", "n_votes"):
-                continue
-            row[k] = plain(v)
-        out.append(row)
-    out.sort(key=lambda r: (r["pid"] is None, str(r["pid"])))
-    return {"ptpt-stats": out}
+    columns = derive_ptptstats(
+        conv,
+        getattr(conv, "conversation_id", None),
+        conv._compute_user_vote_counts(),
+    )["ptptstats"]
+    rows: list[dict[str, Any]] = []
+    if columns:
+        names = list(columns)
+        length = len(columns[names[0]])
+        for i in range(length):
+            rows.append({name: plain(columns[name][i]) for name in names})
+
+    legacy = getattr(conv, "participant_info", None) or {}
+    legacy_rows = []
+    for pid, stats in legacy.items():
+        row = {"pid": plain(pid)}
+        row.update({k: plain(v) for k, v in stats.items()})
+        legacy_rows.append(row)
+    legacy_rows.sort(key=lambda r: (r["pid"] is None, str(r["pid"])))
+
+    return {
+        "ptpt-stats": rows,
+        "participant-info-legacy": legacy_rows,
+    }
 
 
 #: Stage name -> extractor. ``R10_tallies`` additionally accepts the cached blob.
@@ -542,6 +623,7 @@ def stage_document(conv: Conversation, *, step_index: int, digest: str,
         fn = STAGE_FUNCS[name]
         stages[name] = fn(conv, blob) if name == "R10_tallies" else fn(conv)
     return {
+        "comment_projection_axes": COMMENT_PROJECTION_AXES,
         "engine": engine,
         "input_digest": digest,
         "schema": STAGE_DUMP_SCHEMA,
@@ -576,6 +658,7 @@ def write_stage_documents(out_dir: str | Path, documents: Sequence[dict[str, Any
             "tick": doc["tick"],
         })
     (out / "stages-manifest.json").write_text(canonical_json({
+        "comment_projection_axes": COMMENT_PROJECTION_AXES,
         "engine": engine,
         "n_steps": len(rows),
         "schema": STAGE_DUMP_SCHEMA,

--- a/delphi/polismath/replay/stages.py
+++ b/delphi/polismath/replay/stages.py
@@ -729,11 +729,17 @@ def write_stage_documents(out_dir: str | Path, documents: Sequence[dict[str, Any
     for doc in documents:
         name = f"step-{int(doc['step']):03d}.stages.json"
         (out / name).write_text(canonical_json(doc))
+        # Each row is self-describing: a manifest must be checkable against
+        # the document it names on all four identity fields (file/index, tick,
+        # digest, engine) plus the polarity the numbers were emitted in.
         rows.append({
+            "engine": doc.get("engine", engine),
             "file": name,
             "index": int(doc["step"]),
             "input_digest": doc["input_digest"],
             "tick": doc["tick"],
+            "vote_sign_convention": doc.get("vote_sign_convention",
+                                            VOTE_SIGN_CONVENTION),
         })
     (out / "stages-manifest.json").write_text(canonical_json({
         "comment_projection_axes": COMMENT_PROJECTION_AXES,

--- a/delphi/tests/replay_harness/test_stage_oracle_e2e.py
+++ b/delphi/tests/replay_harness/test_stage_oracle_e2e.py
@@ -191,15 +191,29 @@ def test_both_engines_dump_stages_and_the_comparison_report_is_produced(tmp_path
 
     assert report["aligned_steps"] == 1
     assert report["step_count_mismatch"] is False
+    # Two complete, step-identity-aligned, same-input recordings: the report is
+    # entitled to a headline (Astra F5 — an invalid input must withhold one).
+    assert report["input_valid"] is True, report["input_problems"]
+    assert report["headline_withheld"] is False
     step = report["per_step"][0]
     assert step["input_digest_match"] is True
     assert step["tick_match"] is True
+    assert step["comparable"] is True
     assert list(step["stages"]) == stages.STAGE_ORDER
     for name, stage in step["stages"].items():
         assert stage["keys"], f"{name} produced no compared keys"
         for key in stage["keys"].values():
-            assert key["status"] in ("MATCH", "CARVED", "DIVERGENT")
+            assert key["status"] in ("MATCH", "CARVED", "DIVERGENT",
+                                     "ENGINE_LOCAL")
             assert "max_abs" in key and "max_rel" in key
+
+    # The corrected R13 stage carries the engine contract's six geometric
+    # columns and is compared with no waiver (Astra F1). Its Python-only
+    # correlation view rides along, explicitly ungraded.
+    r13 = step["stages"]["R13_ptpt_stats"]["keys"]
+    assert r13["ptpt-stats"]["n_compared"] > 0
+    assert "carve_out" not in r13["ptpt-stats"]
+    assert r13["participant-info-legacy"]["status"] == "ENGINE_LOCAL"
 
     # The human rendering must name the first diverging stage either way.
     text = sc.format_report(report)

--- a/delphi/tests/replay_harness/test_stage_oracle_e2e.py
+++ b/delphi/tests/replay_harness/test_stage_oracle_e2e.py
@@ -1,0 +1,206 @@
+"""End-to-end stage-oracle run on the smallest public battery case (R-ORACLE).
+
+``vw:single-cut`` — "single cold-start recompute over all votes",
+``scripts/certify_battery.json`` entry 3, over the public export
+``real_data/r6vbnhffkxbd7ifmfbdrd-vw`` (4 683 votes, 69 participants,
+125 comments). It is the smallest entry over a dataset that is actually in the
+checkout: the other public entries are 6-8-step warm chains or the 56-step
+every-vote schedule, and every other battery dataset is prodclone-derived and
+absent here.
+
+The run produces BOTH stage recordings and a comparison report:
+
+  1. ``clojure -M:replay --schedule … --stage-json`` -> ``clj-stages/``
+  2. ``stages.run_stage_dump`` -> ``py-stages/``
+  3. ``stagecompare.compare_recordings`` -> the report
+
+Everything is generated into ``tmp_path``. Nothing is checked in: a single
+step's dump for this case is ~350 KB per engine, well over the 200 KB fixture
+ceiling, and it would be a derived artifact of two engines at a given commit —
+exactly the thing that goes stale silently.
+
+Step 1 needs a JVM and the Clojure toolchain, so the full test is opt-in via
+``RUN_CLJ_INTEGRATION=1`` (the gate ``test_certify.py`` already uses). The
+Python half and the comparer run unconditionally in
+``test_stage_dump_runs_on_the_battery_case``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from polismath.replay import certify, real_data
+from polismath.replay import stagecompare as sc
+from polismath.replay import stages
+
+_DELPHI_ROOT = Path(__file__).resolve().parents[2]
+_MATH_ROOT = _DELPHI_ROOT.parent / "math"
+
+#: The smallest public battery entry (scripts/certify_battery.json).
+BATTERY_DATASET = "vw"
+BATTERY_PRESET = "single-cut"
+BATTERY_SCHEDULE_ID = "single-cut-clojure-legacy"  # derive_schedule_id adds the profile suffix
+
+_HAVE_DATASET = real_data.dataset_dir(BATTERY_DATASET) is not None
+_HAVE_CLJ = (
+    shutil.which("clojure") is not None
+    and (_MATH_ROOT / "dev" / "replay.clj").exists()
+    and os.environ.get("RUN_CLJ_INTEGRATION") == "1"
+)
+
+requires_dataset = pytest.mark.skipif(
+    not _HAVE_DATASET,
+    reason=f"public dataset {BATTERY_DATASET!r} not present in this checkout")
+requires_clojure = pytest.mark.skipif(
+    not _HAVE_CLJ,
+    reason="needs the Clojure toolchain and RUN_CLJ_INTEGRATION=1")
+
+
+def _battery_entry():
+    """The battery's own entry, so this test tracks the file rather than a copy."""
+    battery = certify.load_battery()
+    for e in battery:
+        if e.dataset == BATTERY_DATASET and getattr(e, "preset", None) == BATTERY_PRESET:
+            return e
+    pytest.fail(f"{BATTERY_DATASET}:{BATTERY_PRESET} is no longer in the battery")
+
+
+def _spec(dataset):
+    entry = _battery_entry()
+    return certify.build_effective_spec(entry, dataset)
+
+
+@requires_dataset
+def test_the_battery_still_carries_the_case_this_test_pins():
+    entry = _battery_entry()
+    assert entry.schedule_id == BATTERY_SCHEDULE_ID
+    assert "single cold-start recompute" in entry.notes
+
+
+@requires_dataset
+def test_stage_dump_runs_on_the_battery_case(tmp_path):
+    """The Python half end-to-end: a real replay of the battery entry produces a
+    well-formed stage recording with every stage populated."""
+    ds = real_data.load_export_votes(BATTERY_DATASET)
+    out = stages.run_stage_dump(ds, _spec(ds),
+                                out_dir=tmp_path / "py-stages")
+
+    manifest = json.loads((out / "stages-manifest.json").read_text())
+    assert manifest["schema"] == stages.STAGE_DUMP_SCHEMA
+    assert manifest["engine"] == "py"
+    assert manifest["vote_sign_convention"] == "delphi"
+    assert manifest["n_steps"] == 1
+    row = manifest["steps"][0]
+    assert row["index"] == 0
+    assert row["file"] == "step-000.stages.json"
+    assert row["input_digest"].startswith("sha256:")
+    assert isinstance(row["tick"], int) and row["tick"] > 0
+
+    doc = json.loads((out / row["file"]).read_text())
+    assert list(doc["stages"]) == stages.STAGE_ORDER
+    r01 = doc["stages"]["R01_ingest"]
+    assert r01["n"] == 69 and r01["n-cmts"] == 125
+    assert len(r01["tids"]) == 125
+    assert doc["stages"]["R04_pca"]["pca"]["center"] is not None
+    assert doc["stages"]["R06_base_clusters"]["base-clusters"]
+    assert doc["stages"]["R09_group_clusters"]["group-clusters"]
+    assert doc["stages"]["R11_repness"]["repness"]
+
+    # The file must be re-readable by the comparer's own loader.
+    assert len(sc.load_stage_dumps(out)) == 1
+
+
+@requires_dataset
+def test_a_recording_compared_against_itself_has_no_diverging_stage(tmp_path):
+    """A self-comparison is the comparer's negative control: identical inputs
+    must produce no diverging stage and zero error everywhere."""
+    ds = real_data.load_export_votes(BATTERY_DATASET)
+    a = stages.run_stage_dump(ds, _spec(ds), out_dir=tmp_path / "a")
+    shutil.copytree(a, tmp_path / "b")
+
+    report = sc.compare_recordings(a, tmp_path / "b")
+    assert report["first_diverging_stage"] is None
+    assert report["aligned_steps"] == 1
+    for stage in report["per_step"][0]["stages"].values():
+        for key in stage["keys"].values():
+            assert key["n_diff"] == 0
+            assert key["max_abs"] == 0.0
+
+
+@requires_dataset
+@requires_clojure
+@pytest.mark.clojure_comparison
+def test_both_engines_dump_stages_and_the_comparison_report_is_produced(tmp_path):
+    """The full R-ORACLE loop on the smallest public battery case.
+
+    Asserts what the harness OWES: both dumps exist, they were fed the same
+    batch (equal input digests), and every stage is present on both sides with
+    an error report. It does NOT assert a verdict — stage dumps are diagnostics
+    (P-030 §2.3), and a numeric threshold here would quietly become the gate the
+    plan forbids. The measured first-diverging-stage result is recorded in
+    cost-reduction/04-plans/P-030-R-ORACLE-implementation-notes.md.
+    """
+    ds = real_data.load_export_votes(BATTERY_DATASET)
+    spec = _spec(ds)
+
+    schedule_path = tmp_path / "schedule.json"
+    spec.write_json(schedule_path)
+    votes_csv = certify.votes_csv_path(BATTERY_DATASET)
+    assert votes_csv is not None
+
+    proc = subprocess.run(
+        ["clojure", "-M:replay",
+         "--schedule", str(schedule_path),
+         "--votes", str(votes_csv),
+         "--out", str(tmp_path),
+         "--stage-json"],
+        cwd=_MATH_ROOT, capture_output=True, text=True, timeout=1800,
+    )
+    assert proc.returncode == 0, proc.stderr[-4000:]
+
+    clj_stages = tmp_path / "clj-stages"
+    assert (clj_stages / "stages-manifest.json").exists()
+    # The sink must not have written into the blob dir: certify globs step-*
+    # there for its inventory and digest sets.
+    assert not list((tmp_path / "clj").glob("*.stages.json"))
+
+    py_stages = stages.run_stage_dump(ds, spec, out_dir=tmp_path / "py-stages")
+
+    clj_manifest = json.loads((clj_stages / "stages-manifest.json").read_text())
+    py_manifest = json.loads((py_stages / "stages-manifest.json").read_text())
+    assert clj_manifest["schema"] == py_manifest["schema"] == stages.STAGE_DUMP_SCHEMA
+    assert clj_manifest["stage_order"] == py_manifest["stage_order"]
+    assert clj_manifest["vote_sign_convention"] == "raw-db"
+    assert py_manifest["vote_sign_convention"] == "delphi"
+
+    # Same batch on both sides — the digest is taken in export sign convention
+    # precisely so the raw-DB flip does not disturb it.
+    assert [r["input_digest"] for r in clj_manifest["steps"]] == \
+        [r["input_digest"] for r in py_manifest["steps"]]
+
+    report = sc.compare_recordings(clj_stages, py_stages)
+    report_path = tmp_path / "stagecompare.json"
+    sc.write_report(report, report_path)
+    assert report_path.exists()
+
+    assert report["aligned_steps"] == 1
+    assert report["step_count_mismatch"] is False
+    step = report["per_step"][0]
+    assert step["input_digest_match"] is True
+    assert step["tick_match"] is True
+    assert list(step["stages"]) == stages.STAGE_ORDER
+    for name, stage in step["stages"].items():
+        assert stage["keys"], f"{name} produced no compared keys"
+        for key in stage["keys"].values():
+            assert key["status"] in ("MATCH", "CARVED", "DIVERGENT")
+            assert "max_abs" in key and "max_rel" in key
+
+    # The human rendering must name the first diverging stage either way.
+    text = sc.format_report(report)
+    assert "first diverging stage" in text

--- a/delphi/tests/replay_harness/test_stages.py
+++ b/delphi/tests/replay_harness/test_stages.py
@@ -157,6 +157,7 @@ def _doc(engine: str, convention: str, stage_map: dict) -> dict:
     for k, v in stage_map.items():
         full[k] = v
     return {
+        "comment_projection_axes": stages.COMMENT_PROJECTION_AXES,
         "engine": engine,
         "input_digest": "sha256:deadbeef",
         "schema": stages.STAGE_DUMP_SCHEMA,
@@ -180,14 +181,17 @@ def test_polarity_negates_votes_and_geometry_but_not_comps():
         },
     })
     can = sc.canonicalize(raw)
-    assert can["R01_ingest"]["rating-mat"]["1|7"] == 1
-    assert can["R04_pca"]["mat"]["1|7"] == 1.0
-    assert can["R04_pca"]["pca"]["center"]["7"] == 0.5
-    assert can["R04_pca"]["pca"]["comment-projection"]["0"]["7"] == 0.25
+    # Labels are TYPE-TAGGED so integer 1 and string "1" cannot collide.
+    cell = f"{sc._typed_label(1)}|{sc._typed_label(7)}"
+    tid7 = sc._typed_label(7)
+    assert can["R01_ingest"]["rating-mat"][cell] == 1
+    assert can["R04_pca"]["mat"][cell] == 1.0
+    assert can["R04_pca"]["pca"]["center"][tid7] == 0.5
+    assert can["R04_pca"]["pca"]["comment-projection"]["0"][tid7] == 0.25
     # comps are invariant: X^T X == (-X)^T (-X).
-    assert can["R04_pca"]["pca"]["comps"]["0"]["7"] == 1.0
+    assert can["R04_pca"]["pca"]["comps"]["0"][tid7] == 1.0
     # extremity is a norm.
-    assert can["R04_pca"]["pca"]["comment-extremity"]["7"] == 0.25
+    assert can["R04_pca"]["pca"]["comment-extremity"][tid7] == 0.25
 
 
 def test_identity_keying_defeats_a_column_permutation():
@@ -317,13 +321,21 @@ def test_a_carved_key_does_not_hide_a_real_shape_difference_elsewhere():
     assert rep["stages"]["R03_eligibility"]["status"] == "DIVERGENT"
 
 
-def test_silhouette_and_ptpt_stats_are_carved_with_their_reason_recorded():
+def test_only_carve_outs_with_a_rule_are_auto_applied():
+    """AUTO_CARVED must be derived from the rules that exist, so the docs can
+    never claim a suppression the comparer does not implement (Astra F6/C5)."""
     assert sc.KEY_CARVE_OUT[("R09_group_clusters",
                              "group-clusterings-silhouettes")] == "C3"
-    assert sc.KEY_CARVE_OUT[("R13_ptpt_stats", "ptpt-stats")] == "C4"
+    # The contract geometry has NO waiver any more (Astra F1).
+    assert ("R13_ptpt_stats", "ptpt-stats") not in sc.KEY_CARVE_OUT
+    assert set(sc.AUTO_CARVED) == {"C1", "C3"}
     for cid in sc.AUTO_CARVED:
         assert cid in sc.CARVE_OUTS
+        assert sc.CARVE_OUTS[cid].mode != "documented"
         assert sc.CARVE_OUTS[cid].reason
+    for cid in ("C2", "C4", "C5", "C6"):
+        assert sc.CARVE_OUTS[cid].mode == "documented"
+        assert cid not in sc.AUTO_CARVED
 
 
 def test_q13_and_q18_are_documented_but_never_auto_suppressed():
@@ -388,3 +400,313 @@ def test_certify_does_not_import_the_stage_oracle():
     src = inspect.getsource(certify)
     assert "stagecompare" not in src
     assert "replay.stages" not in src and "import stages" not in src
+
+
+# ---------------------------------------------------------------------------
+# Round 2 — regressions for the six findings in P-030-R-ORACLE-astra-review.md.
+# Each name says which finding it pins.
+# ---------------------------------------------------------------------------
+def test_f1_r13_emits_the_contract_geometry_from_the_production_adapter():
+    """The engine contract's ptptstats is pid/gid/n-votes/centricness/coreness/
+    extremeness, and this engine already implements it in
+    ``math_writer.derive_ptptstats``. The stage must read THAT, with the RAW
+    user-vote-counts, not the vote-correlation report statistic."""
+    from types import SimpleNamespace
+
+    from polismath.poller.math_writer import derive_ptptstats
+
+    conv = SimpleNamespace(
+        base_clusters=[{"id": 0, "members": [1], "center": [0.0, 0.0]}],
+        group_clusters=[{"id": 2, "members": [0], "center": [0.0, 0.0]}],
+        proj={1: [0.0, 0.0]}, last_updated=1000, conversation_id=1,
+        participant_info={1: {"n_votes": 1, "group": 2, "n_pass": 4}})
+    conv._compute_user_vote_counts = lambda: {1: 5}
+
+    published = derive_ptptstats(conv, 1, {1: 5})["ptptstats"]
+    dumped = stages.stage_r13_ptpt_stats(conv)
+    row = dumped["ptpt-stats"][0]
+    assert set(row) == {"pid", "gid", "n-votes", "centricness", "coreness",
+                        "extremeness"}
+    # Same statistic, same raw vote count, as the production output adapter.
+    assert row["n-votes"] == published["n-votes"][0] == 5
+    assert row["coreness"] == published["coreness"][0] == 1.0
+    # The correlation view survives only under its own, clearly separate key.
+    assert dumped["participant-info-legacy"][0]["n_pass"] == 4
+
+
+def test_f1_r13_geometry_is_compared_with_no_waiver():
+    a = _doc("clj", "delphi", {"R13_ptpt_stats": {"ptpt-stats": [
+        {"pid": 1, "gid": 2, "n-votes": 3, "coreness": 0.2}]}})
+    b = _doc("py", "delphi", {"R13_ptpt_stats": {"ptpt-stats": [
+        {"pid": 1, "gid": 2, "n-votes": 3, "coreness": 0.9}]}})
+    rep = sc.compare_step(a, b)
+    assert rep["stages"]["R13_ptpt_stats"]["keys"]["ptpt-stats"]["status"] == \
+        "DIVERGENT"
+    assert rep["first_diverging_stage"] == "R13_ptpt_stats"
+
+
+def test_f1_the_legacy_correlation_view_is_engine_local_never_graded():
+    a = _doc("clj", "delphi", {"R13_ptpt_stats": {
+        "participant-info-legacy": [{"pid": 1, "n_pass": 4}]}})
+    b = _doc("py", "delphi", {"R13_ptpt_stats": {
+        "participant-info-legacy": [{"pid": 1, "n_pass": 9}]}})
+    rep = sc.compare_step(a, b)
+    k = rep["stages"]["R13_ptpt_stats"]["keys"]["participant-info-legacy"]
+    assert k["status"] == "ENGINE_LOCAL"
+    assert rep["first_diverging_stage"] is None
+
+
+def test_f1_duplicate_or_missing_pid_in_ptpt_stats_is_structural():
+    a = _doc("clj", "delphi", {"R13_ptpt_stats": {"ptpt-stats": [
+        {"pid": 1, "gid": 0}, {"pid": 1, "gid": 1}]}})
+    b = _doc("py", "delphi", {"R13_ptpt_stats": {"ptpt-stats": [
+        {"pid": 1, "gid": 0}]}})
+    k = sc.compare_step(a, b)["stages"]["R13_ptpt_stats"]["keys"]["ptpt-stats"]
+    assert k["status"] == "DIVERGENT" and k["n_structural"] >= 1
+
+
+@pytest.mark.parametrize("a,b", [([1], [2]), (None, [2]), ([1, 2], [1])])
+def test_f2_c1_never_suppresses_a_real_moderation_change(a, b):
+    """C1 promises only null<->[]. Anything else on those keys is a real diff."""
+    rep = sc.compare_step(_doc("clj", "delphi", {"R02_moderation": {"mod-out": a}}),
+                          _doc("py", "delphi", {"R02_moderation": {"mod-out": b}}))
+    assert rep["stages"]["R02_moderation"]["keys"]["mod-out"]["status"] == "DIVERGENT"
+    assert rep["first_diverging_stage"] == "R02_moderation"
+
+
+def test_f2_c3_covers_silhouette_values_only_not_the_candidate_inventory():
+    """A different estimator explains different NUMBERS. It does not explain a
+    missing k, so coverage stays outside the exception."""
+    key = "group-clusterings-silhouettes"
+    same_keys = sc.compare_step(
+        _doc("clj", "delphi", {"R09_group_clusters": {key: {"2": 0.1, "3": 0.2}}}),
+        _doc("py", "delphi", {"R09_group_clusters": {key: {"2": 0.9, "3": 0.8}}}))
+    assert same_keys["stages"]["R09_group_clusters"]["keys"][key]["status"] == "CARVED"
+    assert same_keys["first_diverging_stage"] is None
+
+    missing_k = sc.compare_step(
+        _doc("clj", "delphi", {"R09_group_clusters": {key: {"2": 0.1, "3": 0.2}}}),
+        _doc("py", "delphi", {"R09_group_clusters": {key: {"2": 0.1}}}))
+    k = missing_k["stages"]["R09_group_clusters"]["keys"][key]
+    assert k["status"] == "DIVERGENT" and k["n_structural"] >= 1
+
+
+@pytest.mark.parametrize("stage,key,a,b", [
+    ("R06_base_clusters", "base-clusters",
+     [{"id": 200, "members": [1000], "center": [1.0, 2.0]}],
+     [{"id": 201, "members": [1000], "center": [1.0, 2.0]}]),
+    ("R06_base_clusters", "base-clusters",
+     [{"id": 200, "members": [1000], "center": [1.0, 2.0]}],
+     [{"id": 200, "members": [1001], "center": [1.0, 2.0]}]),
+    ("R11_repness", "repness",
+     {"0": [{"tid": 100000, "n-agree": 100000}]},
+     {"0": [{"tid": 100001, "n-agree": 100001}]}),
+])
+def test_f3_no_tolerance_ever_applies_to_an_integer_identity_or_count(
+        stage, key, a, b):
+    """Cluster ids, memberships, tids and counts are structural invariants. A
+    GEOM or TIGHT class on the containing key must not leak onto them."""
+    rep = sc.compare_step(_doc("clj", "delphi", {stage: {key: a}}),
+                          _doc("py", "delphi", {stage: {key: b}}))
+    assert rep["stages"][stage]["keys"][key]["status"] == "DIVERGENT"
+
+
+def test_f3_large_integers_are_compared_without_float_coercion():
+    """2**53 and 2**53+1 are the same float. They are not the same integer."""
+    a, b = 2 ** 53, 2 ** 53 + 1
+    assert float(a) == float(b)  # the coercion that used to hide this
+    rep = sc.compare_step(_doc("clj", "delphi", {"R01_ingest":
+                                                 {"last-vote-timestamp": a}}),
+                          _doc("py", "delphi", {"R01_ingest":
+                                                {"last-vote-timestamp": b}}))
+    k = rep["stages"]["R01_ingest"]["keys"]["last-vote-timestamp"]
+    assert k["status"] == "DIVERGENT" and k["max_abs"] == 1.0
+
+
+def test_f3_the_two_engines_integral_spellings_still_agree():
+    """Clojure writes a vote as -1, this engine as -1.0. Same integer."""
+    nm = {"rownames": [1], "colnames": [2], "matrix": [[-1]]}
+    rep = sc.compare_step(
+        _doc("clj", "delphi", {"R01_ingest": {"rating-mat": nm}}),
+        _doc("py", "delphi", {"R01_ingest": {"rating-mat":
+                                             dict(nm, matrix=[[-1.0]])}}))
+    assert rep["stages"]["R01_ingest"]["keys"]["rating-mat"]["status"] == "MATCH"
+
+
+def test_f3_a_non_integral_value_in_an_integer_field_is_structural():
+    rep = sc.compare_step(_doc("clj", "delphi", {"R01_ingest": {"n": 3}}),
+                          _doc("py", "delphi", {"R01_ingest": {"n": 3.5}}))
+    k = rep["stages"]["R01_ingest"]["keys"]["n"]
+    assert k["status"] == "DIVERGENT" and k["n_structural"] >= 1
+
+
+def test_f3_a_boolean_is_not_a_count():
+    rep = sc.compare_step(_doc("clj", "delphi", {"R01_ingest": {"n": 1}}),
+                          _doc("py", "delphi", {"R01_ingest": {"n": True}}))
+    assert rep["stages"]["R01_ingest"]["keys"]["n"]["status"] == "DIVERGENT"
+
+
+@pytest.mark.parametrize("label,broken", [
+    ("extra row", {"rownames": [1], "colnames": [2], "matrix": [[1], [99]]}),
+    ("extra column", {"rownames": [1], "colnames": [2], "matrix": [[1, 99]]}),
+    ("duplicate row identity",
+     {"rownames": [1, 1], "colnames": [2], "matrix": [[99], [1]]}),
+])
+def test_f4_a_malformed_named_matrix_is_a_structural_defect(label, broken):
+    """Dropping the extra cells, or letting a duplicate identity overwrite a
+    different value, would hide a real difference behind a clean MATCH."""
+    good = {"rownames": [1], "colnames": [2], "matrix": [[1]]}
+    rep = sc.compare_step(_doc("clj", "delphi", {"R01_ingest": {"rating-mat": good}}),
+                          _doc("py", "delphi", {"R01_ingest": {"rating-mat": broken}}))
+    k = rep["stages"]["R01_ingest"]["keys"]["rating-mat"]
+    assert k["status"] == "DIVERGENT" and k["n_structural"] >= 1, label
+
+
+def _square_pca_doc(engine, projection):
+    doc = _doc(engine, "delphi", {
+        "R01_ingest": {"tids": [1, 2]},
+        "R04_pca": {"pca": {
+            "center": [0.0, 0.0], "comps": [[1.0, 0.0], [0.0, 1.0]],
+            "comment-projection": projection, "comment-extremity": [1.0, 2.0]}}})
+    return doc
+
+
+def test_f4_square_projection_axes_are_declared_not_guessed():
+    """When n_tids == n_comps the orientation is ambiguous from lengths alone.
+    Both emitters declare comps-by-tids, so a transposed array is a real
+    difference and an identical one matches."""
+    p = [[1.0, 2.0], [3.0, 4.0]]
+    same = sc.compare_step(_square_pca_doc("clj", p), _square_pca_doc("py", p))
+    assert same["first_diverging_stage"] is None
+
+    transposed = sc.compare_step(_square_pca_doc("clj", p),
+                                 _square_pca_doc("py", [[1.0, 3.0], [2.0, 4.0]]))
+    assert transposed["first_diverging_stage"] == "R04_pca"
+
+
+def test_f4_an_undeclared_axis_orientation_is_refused():
+    a = _square_pca_doc("clj", [[1.0, 2.0], [3.0, 4.0]])
+    b = _square_pca_doc("py", [[1.0, 2.0], [3.0, 4.0]])
+    del b["comment_projection_axes"]
+    k = sc.compare_step(a, b)["stages"]["R04_pca"]["keys"]["pca"]
+    assert k["status"] == "DIVERGENT" and k["n_structural"] >= 1
+
+
+def test_f4_an_extra_component_row_is_not_silently_zipped_away():
+    a = _square_pca_doc("clj", [[1.0, 2.0], [3.0, 4.0]])
+    b = _square_pca_doc("py", [[1.0, 2.0], [3.0, 4.0], [99.0, 99.0]])
+    rep = sc.compare_step(a, b)
+    k = rep["stages"]["R04_pca"]["keys"]["pca"]
+    assert rep["first_diverging_stage"] == "R04_pca"
+    assert k["n_structural"] >= 1
+
+
+def test_f5_missing_directories_withhold_the_headline(tmp_path):
+    report = sc.compare_recordings(tmp_path / "absent-a", tmp_path / "absent-b")
+    assert report["headline_withheld"] is True
+    assert report["input_valid"] is False
+    text = sc.format_report(report)
+    assert "INCOMPLETE OR MISALIGNED INPUT" in text
+    assert "every stage within tolerance" not in text
+
+
+def test_f5_steps_are_aligned_by_identity_not_position(tmp_path):
+    a = _doc("clj", "delphi", {"R01_ingest": {"n": 1}})
+    b = dict(_doc("py", "delphi", {"R01_ingest": {"n": 1}}), step=7)
+    stages.write_stage_documents(tmp_path / "a", [a], engine="clj")
+    stages.write_stage_documents(tmp_path / "b", [b], engine="py")
+    report = sc.compare_recordings(tmp_path / "a", tmp_path / "b")
+    assert report["aligned_steps"] == 0
+    assert report["headline_withheld"] is True
+    assert any("only in A" in p for p in report["input_problems"])
+
+
+def test_f5_a_manifest_that_disagrees_with_the_files_is_an_input_problem(tmp_path):
+    stages.write_stage_documents(
+        tmp_path, [_doc("py", "delphi", {"R01_ingest": {"n": 1}})])
+    manifest = json.loads((tmp_path / "stages-manifest.json").read_text())
+    manifest["steps"].append({"file": "step-009.stages.json", "index": 9,
+                              "input_digest": "sha256:x", "tick": 1})
+    manifest["n_steps"] = 2
+    (tmp_path / "stages-manifest.json").write_text(json.dumps(manifest))
+    _, problems = sc.validate_recording(tmp_path)
+    assert any("inventory" in p for p in problems)
+    assert any("missing file" in p for p in problems)
+
+
+def test_f5_a_missing_stage_is_reported_not_ignored(tmp_path):
+    doc = _doc("py", "delphi", {"R01_ingest": {"n": 1}})
+    del doc["stages"]["R09_group_clusters"]
+    stages.write_stage_documents(tmp_path, [doc])
+    _, problems = sc.validate_recording(tmp_path)
+    assert any("missing stage" in p for p in problems)
+
+
+def test_f5_a_digest_mismatch_makes_the_step_incomparable():
+    a = _doc("clj", "delphi", {"R01_ingest": {"n": 1}})
+    b = dict(_doc("py", "delphi", {"R01_ingest": {"n": 1}}),
+             input_digest="sha256:other")
+    step = sc.compare_step(a, b)
+    assert step["comparable"] is False
+    assert any("input digests differ" in p for p in step["problems"])
+
+
+def test_f6_non_finite_tokens_survive_raw_db_polarity_conversion():
+    nm = {"rownames": [1], "colnames": [2], "matrix": [[sc.POS_INF_TOKEN]]}
+    can = sc.canonicalize(_doc("clj", "raw-db", {"R01_ingest": {"rating-mat": nm}}))
+    cell = f"{sc._typed_label(1)}|{sc._typed_label(2)}"
+    assert can["R01_ingest"]["rating-mat"][cell] == sc.NEG_INF_TOKEN
+
+
+def test_f6_matching_non_finite_geometry_compares_equal_across_polarity():
+    nm = {"rownames": [1], "colnames": [2], "matrix": [[sc.POS_INF_TOKEN]]}
+    flipped = {"rownames": [1], "colnames": [2], "matrix": [[sc.NEG_INF_TOKEN]]}
+    rep = sc.compare_step(
+        _doc("clj", "raw-db", {"R01_ingest": {"rating-mat": nm}}),
+        _doc("py", "delphi", {"R01_ingest": {"rating-mat": flipped}}))
+    k = rep["stages"]["R01_ingest"]["keys"]["rating-mat"]
+    assert k["status"] == "MATCH" and k["n_nonfinite"] == 1
+
+
+@pytest.mark.parametrize("a,b", [
+    (sc.NAN_TOKEN, sc.POS_INF_TOKEN),
+    (sc.POS_INF_TOKEN, sc.NEG_INF_TOKEN),
+    (sc.NAN_TOKEN, 1.0),
+])
+def test_f6_differing_non_finite_values_are_a_divergence(a, b):
+    rep = sc.compare_step(_doc("clj", "delphi", {"R04_pca": {"mat": [[a]]},
+                                                 "R01_ingest": {"tids": [1]}}),
+                          _doc("py", "delphi", {"R04_pca": {"mat": [[b]]},
+                                                "R01_ingest": {"tids": [1]}}))
+    k = rep["stages"]["R04_pca"]["keys"]["mat"]
+    assert k["status"] == "DIVERGENT"
+
+
+def test_geom_reports_its_exceedances_of_the_stricter_tight_reference():
+    """GEOM is a legacy-comparer setting, not the proposed contract bound, so a
+    GEOM key must always show how many values a TIGHT reference would reject."""
+    a = _doc("clj", "delphi", {"R01_ingest": {"tids": [1]},
+                               "R05_projections": {"proj": {
+                                   "rownames": [9], "colnames": ["x"],
+                                   "matrix": [[1.0]]}}})
+    b = _doc("py", "delphi", {"R01_ingest": {"tids": [1]},
+                              "R05_projections": {"proj": {
+                                  "rownames": [9], "colnames": ["x"],
+                                  "matrix": [[1.0 + 1e-3]]}}})
+    k = sc.compare_step(a, b)["stages"]["R05_projections"]["keys"]["proj"]
+    assert k["status"] == "MATCH"          # inside the legacy GEOM bound
+    assert k["n_over_tight"] == 1          # but outside the stricter reference
+    assert sc.GEOM.name == "geom-legacy"
+
+
+def test_r03_reads_the_carried_in_conv_without_invoking_the_setter():
+    """A documented read-only observer must not call a state-changing
+    computation (``_get_in_conv_participants`` assigns ``self.in_conv``)."""
+    from types import SimpleNamespace
+
+    called = []
+    conv = SimpleNamespace(in_conv={3, 1, 2})
+    conv._compute_user_vote_counts = lambda: {1: 5}
+    conv._get_in_conv_participants = lambda: called.append(1) or set()
+    assert stages.stage_r03_eligibility(conv)["in-conv"] == [1, 2, 3]
+    assert called == []

--- a/delphi/tests/replay_harness/test_stages.py
+++ b/delphi/tests/replay_harness/test_stages.py
@@ -159,7 +159,7 @@ def _doc(engine: str, convention: str, stage_map: dict) -> dict:
     return {
         "comment_projection_axes": stages.COMMENT_PROJECTION_AXES,
         "engine": engine,
-        "input_digest": "sha256:deadbeef",
+        "input_digest": "sha256:" + "de" * 32,   # 64 hex digits, as required
         "schema": stages.STAGE_DUMP_SCHEMA,
         "stages": full,
         "step": 0,
@@ -645,7 +645,7 @@ def test_f5_a_manifest_that_disagrees_with_the_files_is_an_input_problem(tmp_pat
     (tmp_path / "stages-manifest.json").write_text(json.dumps(manifest))
     _, problems = sc.validate_recording(tmp_path)
     assert any("inventory" in p for p in problems)
-    assert any("missing file" in p for p in problems)
+    assert any("not a step file in this recording" in p for p in problems)
 
 
 def test_f5_a_missing_stage_is_reported_not_ignored(tmp_path):
@@ -957,3 +957,223 @@ def test_r2f4_both_sides_null_in_a_nullable_integer_field_still_matches():
         _doc("py", "delphi", {"R02_moderation": {"last-mod-timestamp": None}}))
     assert rep["stages"]["R02_moderation"]["keys"]["last-mod-timestamp"][
         "status"] == "MATCH"
+
+
+# ---------------------------------------------------------------------------
+# Round 4 — regressions for the four residual findings in the round-3 review
+# (R3-F1 … R3-F4).
+# ---------------------------------------------------------------------------
+def _rank_one_doc(engine, second_row):
+    """A valid rank-one document: one component, a 2-wide projection (Q16)."""
+    return _doc(engine, "delphi", {
+        "R01_ingest": {"tids": [1, 2]},
+        "R04_pca": {"pca": {"center": [0.2, 0.4], "comps": [[1.0, 0.0]],
+                            "comment-projection": [[0.0, 0.0], second_row],
+                            "comment-extremity": [0.0, 0.0]}}})
+
+
+def test_r3f1_the_padded_rank_one_projection_row_is_compared_not_zipped_away():
+    """The projection can be WIDER than `comps`. Zipping it against the
+    component signs dropped the padded row, so anything at all could hide
+    there."""
+    tampered = sc.compare_step(_rank_one_doc("clj", [0.0, 0.0]),
+                               _rank_one_doc("py", [999.0, 999.0]))
+    assert tampered["stages"]["R04_pca"]["keys"]["pca"]["status"] == "DIVERGENT"
+    assert tampered["first_diverging_stage"] == "R04_pca"
+
+    clean = sc.compare_step(_rank_one_doc("clj", [0.0, 0.0]),
+                            _rank_one_doc("py", [0.0, 0.0]))
+    assert clean["first_diverging_stage"] is None
+
+
+def test_r3f1_the_padded_row_must_satisfy_its_producer_invariant():
+    """Q16 says the padded component is all-zero. A non-zero value there is a
+    structural defect even when both engines agree on it — the row is preserved
+    AND its construction is checked."""
+    doc = _rank_one_doc("py", [1.0, 0.0])
+    k = sc.compare_step(doc, doc)["stages"]["R04_pca"]["keys"]["pca"]
+    assert k["status"] == "DIVERGENT"
+    assert any("all-zero (Q16)" in m for m in k["structural"])
+
+
+def test_r3f1_a_padded_sign_is_declared_not_incidental():
+    assert sc.PADDED_COMPONENT_SIGN == 1.0
+
+
+@pytest.mark.parametrize("mutate,expect", [
+    (lambda d: d["stages"].__setitem__("R01_ingest", None), "not an object"),
+    (lambda d: d["stages"].__setitem__("R01_ingest", []), "not an object"),
+    (lambda d: d.__setitem__("step", []), "non-integer step identity"),
+    (lambda d: d.__setitem__("stages", []), "no stages object"),
+])
+def test_r3f2_a_malformed_document_container_is_an_input_problem(
+        tmp_path, mutate, expect):
+    """Every container is type-validated before it is dereferenced or used as a
+    key. A null stage in particular must count as a MISSING stage, not be
+    skipped past every required-key check."""
+    # Written as a valid recording first, then corrupted on disk: the writer
+    # legitimately refuses some of these, and the point is that the READER
+    # survives them.
+    stages.write_stage_documents(
+        tmp_path, [_complete(_doc("py", "delphi", {}))], engine="py")
+    doc = json.loads((tmp_path / "step-000.stages.json").read_text())
+    mutate(doc)
+    (tmp_path / "step-000.stages.json").write_text(json.dumps(doc))
+    _, problems = sc.validate_recording(tmp_path)   # must not raise
+    assert any(expect in p for p in problems), problems
+
+
+def test_r3f2_a_null_stage_does_not_bypass_the_key_inventory(tmp_path):
+    doc = _complete(_doc("py", "delphi", {}))
+    doc["stages"]["R01_ingest"] = None
+    stages.write_stage_documents(tmp_path, [doc], engine="py")
+    _, problems = sc.validate_recording(tmp_path)
+    assert any("R01_ingest" in p and "no evidence" in p for p in problems)
+
+
+def test_r3f2_a_manifest_that_is_not_an_object_is_an_input_problem(tmp_path):
+    stages.write_stage_documents(
+        tmp_path, [_complete(_doc("py", "delphi", {}))], engine="py")
+    (tmp_path / "stages-manifest.json").write_text("[]")
+    _, problems = sc.validate_recording(tmp_path)   # must not raise
+    assert any("manifest is not an object" in p for p in problems)
+
+
+def test_r3f2_an_unhashable_step_identity_does_not_crash_the_comparer(tmp_path):
+    a, b = tmp_path / "a", tmp_path / "b"
+    good = _complete(_doc("py", "delphi", {}))
+    bad = _complete(_doc("py", "delphi", {}))
+    bad["step"] = []
+    stages.write_stage_documents(a, [good], engine="py")
+    stages.write_stage_documents(b, [good], engine="py")
+    (b / "step-000.stages.json").write_text(json.dumps(bad))
+    report = sc.compare_recordings(a, b)            # must not raise
+    assert report["headline_withheld"] is True
+
+
+def test_r3f3_a_manifest_row_naming_a_non_step_file_is_rejected(tmp_path):
+    stages.write_stage_documents(
+        tmp_path, [_complete(_doc("py", "delphi", {}))], engine="py")
+    manifest = json.loads((tmp_path / "stages-manifest.json").read_text())
+    manifest["steps"][0]["file"] = "stages-manifest.json"
+    (tmp_path / "stages-manifest.json").write_text(json.dumps(manifest))
+    _, problems = sc.validate_recording(tmp_path)
+    assert any("not a step-NNN.stages.json filename" in p for p in problems)
+
+
+def test_r3f3_a_step_file_missing_from_the_manifest_is_rejected(tmp_path):
+    stages.write_stage_documents(
+        tmp_path, [_complete(_doc("py", "delphi", {}))], engine="py")
+    manifest = json.loads((tmp_path / "stages-manifest.json").read_text())
+    manifest["steps"] = []
+    manifest["n_steps"] = 0
+    (tmp_path / "stages-manifest.json").write_text(json.dumps(manifest))
+    _, problems = sc.validate_recording(tmp_path)
+    assert any("not in the manifest" in p for p in problems)
+
+
+def test_r3f3_a_mixed_engine_recording_is_rejected(tmp_path):
+    a = _complete(_doc("py", "delphi", {}))
+    b = dict(_complete(_doc("py", "delphi", {})), step=1, engine="other")
+    stages.write_stage_documents(tmp_path, [a, b], engine="py")
+    _, problems = sc.validate_recording(tmp_path)
+    assert any("more than one engine" in p for p in problems)
+
+
+def test_r3f3_a_contradictory_manifest_polarity_is_rejected(tmp_path):
+    stages.write_stage_documents(
+        tmp_path, [_complete(_doc("py", "delphi", {}))], engine="py")
+    manifest = json.loads((tmp_path / "stages-manifest.json").read_text())
+    manifest["vote_sign_convention"] = "raw-db"
+    (tmp_path / "stages-manifest.json").write_text(json.dumps(manifest))
+    _, problems = sc.validate_recording(tmp_path)
+    assert any("contradicts" in p for p in problems)
+
+
+@pytest.mark.parametrize("digest", [
+    "sha256:x", "sha256:", "deadbeef", "sha256:" + "A" * 64, "sha256:" + "a" * 63,
+])
+def test_r3f3_a_malformed_digest_is_rejected(tmp_path, digest):
+    """64 lower-case hex digits, not merely a prefix."""
+    doc = _complete(_doc("py", "delphi", {}))
+    doc["input_digest"] = digest
+    stages.write_stage_documents(tmp_path, [doc], engine="py")
+    _, problems = sc.validate_recording(tmp_path)
+    assert any("well-formed sha256" in p for p in problems)
+
+
+def test_r3f3_the_manifest_rows_carry_every_identity_field(tmp_path):
+    out = stages.write_stage_documents(
+        tmp_path, [_complete(_doc("py", "delphi", {}))], engine="py")
+    row = json.loads((out / "stages-manifest.json").read_text())["steps"][0]
+    assert set(row) >= {"engine", "file", "index", "input_digest", "tick",
+                        "vote_sign_convention"}
+    assert not sc.validate_recording(out)[1]
+
+
+@pytest.mark.parametrize("value", [{}, [], {"a": 1}, [1, 2]])
+def test_r3f4_a_container_in_a_scalar_count_position_is_structural(value):
+    """`n` is a typed integer, not a tree that happens to contain no
+    disagreeing leaves."""
+    rep = sc.compare_step(_doc("clj", "delphi", {"R01_ingest": {"n": value}}),
+                          _doc("py", "delphi", {"R01_ingest": {"n": value}}))
+    k = rep["stages"]["R01_ingest"]["keys"]["n"]
+    assert k["status"] == "DIVERGENT"
+    assert any("must be a scalar" in m for m in k["structural"])
+
+
+def test_r3f4_a_scalar_in_an_array_position_is_structural():
+    rep = sc.compare_step(_doc("clj", "delphi", {"R03_eligibility":
+                                                 {"in-conv": 5}}),
+                          _doc("py", "delphi", {"R03_eligibility":
+                                                {"in-conv": 5}}))
+    k = rep["stages"]["R03_eligibility"]["keys"]["in-conv"]
+    assert k["status"] == "DIVERGENT"
+    assert any("must be a array" in m for m in k["structural"])
+
+
+def test_r3f4_a_container_in_a_nested_scalar_id_position_is_structural():
+    clusters = [{"id": {}, "members": [1], "center": [0.0, 0.0]}]
+    rep = sc.compare_step(_doc("clj", "delphi", {"R06_base_clusters":
+                                                 {"base-clusters": clusters}}),
+                          _doc("py", "delphi", {"R06_base_clusters":
+                                                {"base-clusters": clusters}}))
+    assert rep["stages"]["R06_base_clusters"]["keys"]["base-clusters"][
+        "status"] == "DIVERGENT"
+
+
+def test_r3f4_declared_containers_still_compare_normally():
+    """The shape rule applies at the declared position only, so an array of
+    arrays and an array of integers both still recurse."""
+    a = _doc("clj", "delphi", {
+        "R03_eligibility": {"in-conv": [1, 2, 3]},
+        "R06_base_clusters": {"bid-to-pid": [[1, 2], [3]]},
+        "R10_tallies": {"votes-base": {"7": {"A": [1, 0], "D": [0, 1],
+                                             "S": [1, 1]}}}})
+    assert sc.compare_step(a, a)["first_diverging_stage"] is None
+
+
+def test_r3f4_the_ads_tally_shape_is_key_scoped_not_field_scoped():
+    """A/D/S are per-base-cluster bucket ARRAYS in `votes-base` and per-group
+    SCALAR totals in `group-votes` (conversation.clj:600-624). A field-name-only
+    shape rule gets one of them wrong — this was caught by the battery run, not
+    by a synthetic control."""
+    tallies = {
+        "votes-base": {"7": {"A": [1, 0], "D": [0, 1], "S": [1, 1]}},
+        "group-votes": {"0": {"n-members": 2,
+                              "votes": {"7": {"A": 1, "D": 1, "S": 2}}}},
+    }
+    doc = _doc("py", "delphi", {"R10_tallies": tallies})
+    assert sc.compare_step(doc, doc)["first_diverging_stage"] is None
+
+    # And each is still rejected in the other's shape.
+    swapped = _doc("py", "delphi", {"R10_tallies": {
+        "votes-base": {"7": {"A": 1, "D": 1, "S": 2}},
+        "group-votes": {"0": {"n-members": 2,
+                              "votes": {"7": {"A": [1], "D": [1], "S": [2]}}}},
+    }})
+    rep = sc.compare_step(swapped, swapped)
+    assert rep["stages"]["R10_tallies"]["keys"]["votes-base"]["status"] == \
+        "DIVERGENT"
+    assert rep["stages"]["R10_tallies"]["keys"]["group-votes"]["status"] == \
+        "DIVERGENT"

--- a/delphi/tests/replay_harness/test_stages.py
+++ b/delphi/tests/replay_harness/test_stages.py
@@ -168,6 +168,17 @@ def _doc(engine: str, convention: str, stage_map: dict) -> dict:
     }
 
 
+def _complete(doc: dict) -> dict:
+    """Fill in every declared stage key so the document passes recording
+    validation. Round 3 requires an explicit key inventory, so a document built
+    for a single-key unit test is not a valid RECORDING on its own."""
+    for stage, inventory in stages.STAGE_KEYS.items():
+        body = doc["stages"].setdefault(stage, {})
+        for key in inventory["required"]:
+            body.setdefault(key, None)
+    return doc
+
+
 def test_polarity_negates_votes_and_geometry_but_not_comps():
     raw = _doc("clj", "raw-db", {
         "R01_ingest": {
@@ -176,8 +187,11 @@ def test_polarity_negates_votes_and_geometry_but_not_comps():
         },
         "R04_pca": {
             "mat": [[-1.0]],
+            # One comp with a 2-wide projection: the rank-one Q16 shape both
+            # engines emit (pca.py:470-478).
             "pca": {"center": [-0.5], "comps": [[1.0]],
-                    "comment-projection": [[-0.25]], "comment-extremity": [0.25]},
+                    "comment-projection": [[-0.25], [-0.75]],
+                    "comment-extremity": [0.25]},
         },
     })
     can = sc.canonicalize(raw)
@@ -658,14 +672,56 @@ def test_f6_non_finite_tokens_survive_raw_db_polarity_conversion():
     assert can["R01_ingest"]["rating-mat"][cell] == sc.NEG_INF_TOKEN
 
 
-def test_f6_matching_non_finite_geometry_compares_equal_across_polarity():
-    nm = {"rownames": [1], "colnames": [2], "matrix": [[sc.POS_INF_TOKEN]]}
-    flipped = {"rownames": [1], "colnames": [2], "matrix": [[sc.NEG_INF_TOKEN]]}
+def test_f6_matching_non_finite_geometry_is_reported_never_a_clean_match():
+    """Round 3 (R2-F5). Polarity conversion of the tokens still works — but two
+    engines AGREEING on an infinity is not clean data, and must never be hidden
+    behind a default "every stage within tolerance"."""
+    a = _doc("clj", "raw-db", {"R01_ingest": {"tids": [1]},
+                               "R04_pca": {"mat": [[sc.POS_INF_TOKEN]]}})
+    # raw-db carries the opposite vote sign; polarity conversion makes the two
+    # rating matrices agree, isolating the non-finite in `mat`.
+    a["stages"]["R01_ingest"]["rating-mat"] = {
+        "rownames": [9], "colnames": [1], "matrix": [[-1]]}
+    b = _doc("py", "delphi", {"R01_ingest": {"tids": [1]},
+                              "R04_pca": {"mat": [[sc.NEG_INF_TOKEN]]}})
+    b["stages"]["R01_ingest"]["rating-mat"] = {
+        "rownames": [9], "colnames": [1], "matrix": [[1]]}
+    rep = sc.compare_step(a, b)
+    k = rep["stages"]["R04_pca"]["keys"]["mat"]
+    # The raw-db "Infinity" became "-Infinity", so the two sides agree...
+    assert k["n_diff"] == 0 and k["n_nonfinite"] == 1
+    # ...but the status is NONFINITE, not MATCH, and it is not a divergence.
+    assert k["status"] == "NONFINITE"
+    assert rep["first_diverging_stage"] is None
+    assert rep["n_nonfinite"] == 1
+
+
+def test_f6_a_non_finite_in_an_integer_typed_field_is_structural():
+    """A vote, id or count is never NaN. Agreement on one is still invalid."""
+    nm = {"rownames": [1], "colnames": [2], "matrix": [[sc.NAN_TOKEN]]}
     rep = sc.compare_step(
-        _doc("clj", "raw-db", {"R01_ingest": {"rating-mat": nm}}),
-        _doc("py", "delphi", {"R01_ingest": {"rating-mat": flipped}}))
+        _doc("clj", "delphi", {"R01_ingest": {"rating-mat": nm}}),
+        _doc("py", "delphi", {"R01_ingest": {"rating-mat": nm}}))
     k = rep["stages"]["R01_ingest"]["keys"]["rating-mat"]
-    assert k["status"] == "MATCH" and k["n_nonfinite"] == 1
+    assert k["status"] == "DIVERGENT"
+    assert k["n_structural"] >= 1 and k["n_nonfinite"] == 1
+
+
+def test_f6_a_matching_non_finite_never_yields_a_clean_headline(tmp_path):
+    """End to end: the printed headline must say so."""
+    doc = _doc("py", "delphi", {"R01_ingest": {"tids": [1]},
+                               "R04_pca": {"mat": [[sc.NAN_TOKEN]]}})
+    doc["stages"]["R01_ingest"]["rating-mat"] = {
+        "rownames": [9], "colnames": [1], "matrix": [[1]]}
+    _complete(doc)
+    stages.write_stage_documents(tmp_path / "a", [doc], engine="py")
+    stages.write_stage_documents(tmp_path / "b", [doc], engine="py")
+    report = sc.compare_recordings(tmp_path / "a", tmp_path / "b")
+    assert report["input_valid"] is True, report["input_problems"]
+    assert report["headline_qualified"] is True
+    text = sc.format_report(report)
+    assert "every stage within tolerance" not in text
+    assert "NON-FINITE" in text and "[NONFINITE]" in text
 
 
 @pytest.mark.parametrize("a,b", [
@@ -710,3 +766,194 @@ def test_r03_reads_the_carried_in_conv_without_invoking_the_setter():
     conv._get_in_conv_participants = lambda: called.append(1) or set()
     assert stages.stage_r03_eligibility(conv)["in-conv"] == [1, 2, 3]
     assert called == []
+
+
+# ---------------------------------------------------------------------------
+# Round 3 — regressions for the five residual findings in the round-2 review
+# (R2-F1 … R2-F5). Each name says which finding it pins.
+# ---------------------------------------------------------------------------
+def _pca_conv(center, comps):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(pca={"center": center, "comps": comps})
+
+
+def _emit_pca(conv):
+    """Run the REAL emitter, stubbing only the unrelated imputation."""
+    from unittest.mock import patch
+
+    with patch.object(stages, "imputed_matrix", return_value=None):
+        return stages.stage_r04_pca(conv)["pca"]
+
+
+def test_r2f1_the_emitter_transposes_unconditionally_on_a_square_case():
+    """The producer always returns comments-by-components. When n_tids equals
+    n_components the two orientations are indistinguishable by shape, so a
+    conditional transpose emits the wrong array while declaring the right axes.
+    This drives the real emitter, not a hand-normalized document."""
+    conv = _pca_conv([0.2, 0.4], [[0.8, 0.6], [-0.6, 0.8]])
+    observed = np.array(_emit_pca(conv)["comment-projection"])
+    expected = stages.pca_project_cmnts(
+        np.asarray(conv.pca["center"]), np.asarray(conv.pca["comps"])).T
+    assert np.allclose(observed, expected)
+    assert observed.shape == (2, 2)
+
+
+def test_r2f1_the_emitter_transposes_unconditionally_on_a_nonsquare_case():
+    conv = _pca_conv([0.1, 0.2, 0.3], [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    observed = np.array(_emit_pca(conv)["comment-projection"])
+    expected = stages.pca_project_cmnts(
+        np.asarray(conv.pca["center"]), np.asarray(conv.pca["comps"])).T
+    assert np.allclose(observed, expected)
+    assert observed.shape == (2, 3)
+
+
+def test_r2f1_the_rank_one_projection_is_two_wide_and_declared():
+    """Q16: with fewer than two comps the projection is still 2-wide on both
+    engines, so the emitted comps-by-tids array has max(len(comps), 2) rows."""
+    conv = _pca_conv([0.1, 0.2, 0.3], [[1.0, 0.0, 0.0]])
+    observed = np.array(_emit_pca(conv)["comment-projection"])
+    assert observed.shape == (stages.PROJECTION_WIDTH, 3)
+    assert np.allclose(observed, 0.0)
+    # And the comparer accepts that shape rather than calling it structural.
+    doc = _doc("py", "delphi", {
+        "R01_ingest": {"tids": [1, 2, 3]},
+        "R04_pca": {"pca": {"center": [0.1, 0.2, 0.3], "comps": [[1.0, 0.0, 0.0]],
+                            "comment-projection": observed.tolist(),
+                            "comment-extremity": [0.0, 0.0, 0.0]}}})
+    k = sc.compare_step(doc, doc)["stages"]["R04_pca"]["keys"]["pca"]
+    assert k["n_structural"] == 0
+
+
+def test_r2f1_an_emitter_structural_error_is_never_graded_as_data():
+    """When the emitter cannot verify a shape it refuses, and the refusal must
+    travel to the comparer as a structural failure — not as a guess."""
+    err = stages.structural_error("could not verify orientation")
+    assert stages.STRUCTURAL_ERROR_KEY in err
+    doc_a = _doc("clj", "delphi", {"R04_pca": {"pca": {"comps": [[1.0]],
+                                                       "center": [1.0]}},
+                                   "R01_ingest": {"tids": [1]}})
+    doc_b = json.loads(json.dumps(doc_a))
+    doc_b["stages"]["R04_pca"]["pca"]["comps"] = err
+    k = sc.compare_step(doc_a, doc_b)["stages"]["R04_pca"]["keys"]["pca"]
+    assert k["status"] == "DIVERGENT"
+    assert any("emitter:" in msg for msg in k["structural"])
+
+
+def test_r2f2_a_recording_of_empty_stages_is_not_a_match(tmp_path):
+    """Every required stage present but mapped to {} is missing evidence, not
+    eleven stages that happened to agree."""
+    doc = _doc("py", "delphi", {})           # every stage present, all empty
+    stages.write_stage_documents(tmp_path / "a", [doc], engine="py")
+    stages.write_stage_documents(tmp_path / "b", [doc], engine="py")
+    report = sc.compare_recordings(tmp_path / "a", tmp_path / "b")
+    assert report["input_valid"] is False
+    assert report["headline_withheld"] is True
+    assert any("missing required key" in p for p in report["input_problems"])
+    assert "every stage within tolerance" not in sc.format_report(report)
+
+
+@pytest.mark.parametrize("field", ["tick", "input_digest"])
+def test_r2f2_null_identity_evidence_fails_validation(tmp_path, field):
+    doc = _complete(_doc("py", "delphi", {}))
+    doc[field] = None
+    stages.write_stage_documents(tmp_path, [doc], engine="py")
+    _, problems = sc.validate_recording(tmp_path)
+    assert any(field.replace("_", "_") in p for p in problems), problems
+
+
+def test_r2f2_a_manifest_disagreeing_with_its_document_is_an_input_problem(tmp_path):
+    doc = _complete(_doc("py", "delphi", {}))
+    stages.write_stage_documents(tmp_path, [doc], engine="py")
+    manifest = json.loads((tmp_path / "stages-manifest.json").read_text())
+    manifest["steps"][0]["tick"] = 999999
+    (tmp_path / "stages-manifest.json").write_text(json.dumps(manifest))
+    _, problems = sc.validate_recording(tmp_path)
+    assert any("tick" in p and "!= document" in p for p in problems), problems
+
+
+def test_r2f2_an_unknown_stage_key_is_an_input_problem(tmp_path):
+    doc = _complete(_doc("py", "delphi", {}))
+    doc["stages"]["R01_ingest"]["surprise"] = 1
+    stages.write_stage_documents(tmp_path, [doc], engine="py")
+    _, problems = sc.validate_recording(tmp_path)
+    assert any("unknown key" in p for p in problems), problems
+
+
+def test_r2f2_a_malformed_document_becomes_an_input_problem_not_an_exception(
+        tmp_path):
+    (tmp_path / "step-000.stages.json").write_text("[1, 2, 3]")
+    _, problems = sc.validate_recording(tmp_path)
+    assert problems and any("not an object" in p for p in problems)
+
+    (tmp_path / "step-000.stages.json").write_text("{not json")
+    _, problems = sc.validate_recording(tmp_path)
+    assert problems and any("unreadable" in p for p in problems)
+
+
+def test_r2f2_a_non_object_stages_container_is_reported_not_crashed(tmp_path):
+    doc = _complete(_doc("py", "delphi", {}))
+    doc["stages"] = ["nope"]
+    stages.write_stage_documents(tmp_path, [doc], engine="py")
+    _, problems = sc.validate_recording(tmp_path)
+    assert any("no stages object" in p for p in problems)
+    # And canonicalize must not raise on it either.
+    assert sc.canonicalize(doc)["R01_ingest"]["__stage__"].reason
+
+
+@pytest.mark.parametrize("other", [{}, set(), "", 0, False])
+def test_r2f3_c1_covers_only_null_against_an_empty_list(other):
+    """C1 promises `null` <-> `[]`. Nothing adjacent to it — an empty object, a
+    falsy scalar — is the documented pair."""
+    assert sc._is_null_empty_pair(None, other) is False
+    rep = sc.compare_step(
+        _doc("clj", "delphi", {"R02_moderation": {"mod-out": None}}),
+        _doc("py", "delphi", {"R02_moderation": {"mod-out": other}}))
+    assert rep["stages"]["R02_moderation"]["keys"]["mod-out"]["status"] != "CARVED"
+
+
+def test_r2f3_the_documented_pair_is_still_carved_both_directions():
+    for a, b in ((None, []), ([], None)):
+        rep = sc.compare_step(
+            _doc("clj", "delphi", {"R02_moderation": {"mod-out": a}}),
+            _doc("py", "delphi", {"R02_moderation": {"mod-out": b}}))
+        assert rep["stages"]["R02_moderation"]["keys"]["mod-out"]["status"] == \
+            "CARVED"
+
+
+@pytest.mark.parametrize("value", [True, False, "1", "abc", 1.5])
+def test_r2f4_equal_but_wrongly_typed_integer_fields_are_structural(value):
+    """Type is validated BEFORE equality, on both sides: two equally-malformed
+    operands must not pass as a match."""
+    rep = sc.compare_step(_doc("clj", "delphi", {"R01_ingest": {"n": value}}),
+                          _doc("py", "delphi", {"R01_ingest": {"n": value}}))
+    k = rep["stages"]["R01_ingest"]["keys"]["n"]
+    assert k["status"] == "DIVERGENT"
+    assert k["n_structural"] >= 1
+
+
+def test_r2f4_an_equal_float_typed_cluster_id_is_a_divergence():
+    """A float-spelled id is a contract violation even when the two agree."""
+    a = [{"id": 1.5, "members": [1], "center": [0.0, 0.0]}]
+    rep = sc.compare_step(_doc("clj", "delphi", {"R06_base_clusters":
+                                                 {"base-clusters": a}}),
+                          _doc("py", "delphi", {"R06_base_clusters":
+                                                {"base-clusters": a}}))
+    k = rep["stages"]["R06_base_clusters"]["keys"]["base-clusters"]
+    assert k["status"] == "DIVERGENT" and k["n_structural"] >= 1
+
+
+def test_r2f4_legitimate_integral_spellings_still_match():
+    """The typing rule must not break the two engines' real behaviour."""
+    rep = sc.compare_step(_doc("clj", "delphi", {"R01_ingest": {"n": 3}}),
+                          _doc("py", "delphi", {"R01_ingest": {"n": 3.0}}))
+    assert rep["stages"]["R01_ingest"]["keys"]["n"]["status"] == "MATCH"
+
+
+def test_r2f4_both_sides_null_in_a_nullable_integer_field_still_matches():
+    """`n-votes` and the moderation watermark are declared nullable."""
+    rep = sc.compare_step(
+        _doc("clj", "delphi", {"R02_moderation": {"last-mod-timestamp": None}}),
+        _doc("py", "delphi", {"R02_moderation": {"last-mod-timestamp": None}}))
+    assert rep["stages"]["R02_moderation"]["keys"]["last-mod-timestamp"][
+        "status"] == "MATCH"

--- a/delphi/tests/replay_harness/test_stages.py
+++ b/delphi/tests/replay_harness/test_stages.py
@@ -1177,3 +1177,133 @@ def test_r3f4_the_ads_tally_shape_is_key_scoped_not_field_scoped():
         "DIVERGENT"
     assert rep["stages"]["R10_tallies"]["keys"]["group-votes"]["status"] == \
         "DIVERGENT"
+
+
+# ---------------------------------------------------------------------------
+# Round 5 — regressions for the two residual findings in the round-4 review
+# (R4-F1, R4-F2). Astra's seven reproductions, plus the cases they imply.
+# ---------------------------------------------------------------------------
+def _recording_pair(tmp_path, mutate_b, *, target="doc"):
+    """Two real on-disk recordings, the second corrupted. Exercises the PUBLIC
+    compare_recordings path, not just validate_recording."""
+    for side in ("a", "b"):
+        stages.write_stage_documents(
+            tmp_path / side, [_complete(_doc("py", "delphi", {}))], engine="py")
+    name = "step-000.stages.json" if target == "doc" else "stages-manifest.json"
+    path = tmp_path / "b" / name
+    obj = json.loads(path.read_text())
+    mutate_b(obj)
+    path.write_text(json.dumps(obj))
+    return sc.compare_recordings(tmp_path / "a", tmp_path / "b")
+
+
+@pytest.mark.parametrize("target,key,value", [
+    ("doc", "engine", []),
+    ("doc", "engine", {}),
+    ("doc", "engine", ""),
+    ("doc", "engine", 7),
+    ("doc", "vote_sign_convention", {}),
+    ("doc", "vote_sign_convention", "sideways"),
+    ("doc", "vote_sign_convention", None),
+    ("manifest", "engine", []),
+    ("manifest", "vote_sign_convention", []),
+])
+def test_r4f1_malformed_metadata_is_a_named_problem_not_an_exception(
+        tmp_path, target, key, value):
+    """A wrong type, an unknown enum member or an empty value must be reported.
+    Building a set from an unhashable engine, or testing membership against one,
+    raised TypeError before the report was ever written."""
+    report = _recording_pair(tmp_path, lambda o: o.__setitem__(key, value),
+                             target=target)
+    assert report["input_valid"] is False
+    assert report["headline_withheld"] is True
+    assert report["input_problems"]
+    assert "every stage within tolerance" not in sc.format_report(report)
+
+
+@pytest.mark.parametrize("body", [[1], [1, 2], [{}], ["x"]])
+def test_r4f1_a_non_empty_array_stage_does_not_crash_the_public_compare(
+        tmp_path, body):
+    """A NON-EMPTY array is truthy, so `(stages.get(...) or {}).get(...)` raised
+    AttributeError on it — the empty-list and null cases missed this path."""
+    report = _recording_pair(
+        tmp_path, lambda o: o["stages"].__setitem__("R01_ingest", body))
+    assert report["input_valid"] is False
+    assert report["headline_withheld"] is True
+
+
+@pytest.mark.parametrize("body", [[1], "text", 7])
+def test_r4f1_canonicalize_survives_a_non_object_stage_body(body):
+    """Canonicalization must type-check rather than test truthiness."""
+    doc = _doc("py", "delphi", {})
+    doc["stages"]["R01_ingest"] = body
+    can = sc.canonicalize(doc)                      # must not raise
+    assert isinstance(can["R01_ingest"]["__stage__"], sc.Structural)
+
+
+def test_r4f1_an_invalid_document_is_not_sent_onward_to_be_compared(tmp_path):
+    """A usable step identity is not a licence to canonicalize a document that
+    validation has already rejected."""
+    report = _recording_pair(
+        tmp_path, lambda o: o["stages"].__setitem__("R09_group_clusters", [1]))
+    assert any("not comparable" in p for p in report["input_problems"])
+    assert report["aligned_steps"] == 0
+
+
+def test_r4f1_document_is_comparable_names_its_reason():
+    good = _complete(_doc("py", "delphi", {}))
+    assert sc.document_is_comparable(good) is None
+    assert "engine" in sc.document_is_comparable(dict(good, engine=[]))
+    assert "vote_sign_convention" in sc.document_is_comparable(
+        dict(good, vote_sign_convention="sideways"))
+    assert "stages" in sc.document_is_comparable(dict(good, stages=[1]))
+    bad_stage = json.loads(json.dumps(good))
+    bad_stage["stages"]["R01_ingest"] = [1]
+    assert "R01_ingest" in sc.document_is_comparable(bad_stage)
+
+
+@pytest.mark.parametrize("stage,key,value", [
+    ("R03_eligibility", "in-conv", [{}]),
+    ("R01_ingest", "tids", [{}]),
+    ("R10_tallies", "votes-base", {"7": {"A": [{}], "D": [0], "S": [0]}}),
+    ("R03_eligibility", "in-conv", [[]]),
+    ("R03_eligibility", "in-conv", [None]),
+    ("R03_eligibility", "in-conv", [1, {}]),
+    ("R02_moderation", "mod-out", [{"tid": 1}]),
+    ("R06_base_clusters", "bid-to-pid", [[{}]]),
+])
+def test_r4f2_a_malformed_element_of_an_integer_array_is_structural(
+        stage, key, value):
+    """A declared integer array holds integers. Equal malformed elements are
+    not a match — the rank descends with the recursion (R4-F2)."""
+    doc = _doc("py", "delphi", {stage: {key: value}})
+    k = sc.compare_step(doc, doc)["stages"][stage]["keys"][key]
+    assert k["status"] == "DIVERGENT"
+    assert k["n_structural"] >= 1
+
+
+@pytest.mark.parametrize("stage,key,value", [
+    ("R03_eligibility", "in-conv", [1, 2, 3]),
+    ("R01_ingest", "tids", [7, 3]),
+    ("R02_moderation", "mod-out", []),
+    ("R06_base_clusters", "bid-to-pid", [[1, 2], [3], []]),
+    ("R10_tallies", "votes-base", {"7": {"A": [1, 0], "D": [0, 1], "S": [1, 1]}}),
+    ("R10_tallies", "group-votes",
+     {"0": {"n-members": 2, "votes": {"7": {"A": 1, "D": 1, "S": 2}}}}),
+])
+def test_r4f2_well_formed_integer_containers_still_match(stage, key, value):
+    """bid-to-pid legitimately has one more array dimension than in-conv, and
+    the declaration has to say so rather than treating both as free trees."""
+    doc = _doc("py", "delphi", {stage: {key: value}})
+    assert sc.compare_step(doc, doc)["stages"][stage]["keys"][key]["status"] == \
+        "MATCH"
+
+
+def test_r4f2_the_declared_ranks_are_explicit_about_dimensionality():
+    assert sc.INTEGER_KEY_RANK[("R03_eligibility", "in-conv")] == sc.INT_ARRAY
+    assert sc.INTEGER_KEY_RANK[("R06_base_clusters", "bid-to-pid")] == \
+        sc.INT_ARRAY_2D
+    assert sc.KEY_SCOPED_INTEGER_RANK[("R10_tallies", "votes-base", "A")] == \
+        sc.INT_ARRAY
+    assert sc.KEY_SCOPED_INTEGER_RANK[("R10_tallies", "group-votes", "A")] == \
+        sc.SCALAR

--- a/delphi/tests/replay_harness/test_stages.py
+++ b/delphi/tests/replay_harness/test_stages.py
@@ -1,0 +1,390 @@
+"""Unit tests for the stage-dump emitter and the stage comparer (R-ORACLE).
+
+Covers the encoding contract both engines must satisfy — shape, key order,
+exact double round-trip — plus the comparer's canonicalization (polarity,
+identity keying, coupled component-sign flips), its per-key tolerance classes
+and its carve-outs.
+
+The end-to-end run against the real Clojure driver lives in
+``test_stage_oracle_e2e.py``; nothing here needs a JVM.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import struct
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from polismath.replay import stagecompare as sc
+from polismath.replay import stages
+
+
+# ---------------------------------------------------------------------------
+# Encoding contract: key order.
+# ---------------------------------------------------------------------------
+def test_object_keys_are_sorted_as_strings():
+    assert stages.canonical_json(stages.plain({"c": 3, "a": 1, "b": 2})) == \
+        '{"a":1,"b":2,"c":3}'
+
+
+def test_integer_keys_are_stringified_first_then_sorted():
+    # "10" precedes "2" — the same order replay.clj produces, because both
+    # engines stringify the key BEFORE sorting.
+    assert stages.canonical_json(stages.plain({2: 2, 10: 10, 1: 1})) == \
+        '{"1":1,"10":10,"2":2}'
+
+
+def test_nested_objects_are_sorted_at_every_level():
+    obj = stages.plain({"outer": {"x": {"z": 2, "a": 1}}})
+    assert stages.canonical_json(obj) == '{"outer":{"x":{"a":1,"z":2}}}'
+
+
+def test_stage_names_sort_into_pipeline_order():
+    assert stages.STAGE_ORDER == sorted(stages.STAGE_ORDER)
+    assert len(set(stages.STAGE_ORDER)) == len(stages.STAGE_ORDER)
+
+
+# ---------------------------------------------------------------------------
+# Encoding contract: numbers.
+# ---------------------------------------------------------------------------
+def test_integers_emit_without_a_decimal_point():
+    text = stages.canonical_json(stages.plain([0, 1, -7, 2 ** 31, np.int64(5)]))
+    assert text == "[0,1,-7,2147483648,5]"
+
+
+TRICKY_DOUBLES = [
+    0.0, -0.0, 1.0, -1.0, 0.1, 0.1 + 0.2, 1.0 / 3.0,
+    1e-5, 1e10, 1e300, 1e-300,
+    5e-324, 1.7976931348623157e308, 2.2250738585072014e-308,
+    math.nextafter(1.0, 2.0), math.nextafter(1.0, 0.0),
+    0.888888888888889, 2.8284271247461903, 1.635555555555556,
+]
+
+
+@pytest.mark.parametrize("value", TRICKY_DOUBLES)
+def test_doubles_round_trip_bit_for_bit(value: float):
+    """The emitter must never round: what comes back is the SAME double."""
+    back = json.loads(stages.canonical_json(stages.plain(value)))
+    assert struct.pack("<d", back) == struct.pack("<d", value)
+
+
+def test_random_doubles_round_trip_bit_for_bit():
+    rng = np.random.default_rng(20260908)
+    bits = rng.integers(0, 2 ** 64, size=5000, dtype=np.uint64)
+    for b in bits:
+        value = struct.unpack("<d", struct.pack("<Q", int(b)))[0]
+        if math.isnan(value) or math.isinf(value):
+            continue
+        back = json.loads(stages.canonical_json(stages.plain(value)))
+        assert struct.pack("<d", back) == struct.pack("<d", value)
+
+
+def test_non_finite_doubles_become_json_strings():
+    text = stages.canonical_json(
+        stages.plain([float("nan"), float("inf"), float("-inf")]))
+    assert text == '["NaN","Infinity","-Infinity"]'
+    # JSON has no NaN literal, so the result must still parse as standard JSON.
+    assert json.loads(text) == ["NaN", "Infinity", "-Infinity"]
+
+
+def test_canonical_json_refuses_a_raw_nan():
+    with pytest.raises(ValueError):
+        stages.canonical_json({"x": float("nan")})
+
+
+# ---------------------------------------------------------------------------
+# Encoding contract: shapes.
+# ---------------------------------------------------------------------------
+def test_dataframe_becomes_a_named_matrix_with_null_for_missing_cells():
+    df = pd.DataFrame({10: [-1.0, np.nan], 11: [1.0, 0.0]}, index=[1, 2])
+    nm = stages.dataframe_to_named_matrix(df)
+    assert set(nm) == {"rownames", "colnames", "matrix"}
+    assert nm["rownames"] == [1, 2]
+    assert nm["colnames"] == [10, 11]
+    # An unvoted cell is null, not 0 — nil vs 0 is meaning, not shape.
+    assert nm["matrix"] == [[-1.0, 1.0], [None, 0.0]]
+
+
+def test_sets_become_sorted_arrays():
+    assert stages.plain({10, 1, 3, 2}) == [1, 2, 3, 10]
+
+
+def test_plain_rejects_an_unsupported_value():
+    with pytest.raises(TypeError):
+        stages.plain(object())
+
+
+# ---------------------------------------------------------------------------
+# Input digest.
+# ---------------------------------------------------------------------------
+def test_input_digest_is_stable_and_prefixed():
+    votes = [(1, 2, 1, 1000), (1, 3, -1, 2000)]
+    a = stages.input_digest(votes, [])
+    assert a == stages.input_digest(votes, [])
+    assert a.startswith("sha256:")
+
+
+def test_input_digest_reacts_to_sign_and_to_moderation():
+    votes = [(1, 2, 1, 1000)]
+    base = stages.input_digest(votes, [])
+    assert base != stages.input_digest([(1, 2, -1, 1000)], [])
+    assert base != stages.input_digest(votes, [(2, 1, -1, 5)])
+
+
+def test_input_digest_matches_the_clojure_emitter_byte_for_byte():
+    """Pinned against the value ``replay.clj``'s ``step-input-digest`` produces
+    for the same batch, so a change to either encoder is caught here rather than
+    silently making the two manifests incomparable."""
+    payload = stages.canonical_json({
+        "mods": [[2, 1, -1, 5]],
+        "votes": [[1, 2, 1, 1000], [1, 3, -1, 2000]],
+    })
+    assert payload == (
+        '{"mods":[[2,1,-1,5]],"votes":[[1,2,1,1000],[1,3,-1,2000]]}')
+    assert stages.input_digest([(1, 2, 1, 1000), (1, 3, -1, 2000)],
+                               [(2, True, -1, 5)]).startswith("sha256:")
+
+
+# ---------------------------------------------------------------------------
+# Comparer: polarity, identity keying, sign orientation.
+# ---------------------------------------------------------------------------
+def _doc(engine: str, convention: str, stage_map: dict) -> dict:
+    full = {name: {} for name in stages.STAGE_ORDER}
+    for k, v in stage_map.items():
+        full[k] = v
+    return {
+        "engine": engine,
+        "input_digest": "sha256:deadbeef",
+        "schema": stages.STAGE_DUMP_SCHEMA,
+        "stages": full,
+        "step": 0,
+        "tick": 1,
+        "vote_sign_convention": convention,
+    }
+
+
+def test_polarity_negates_votes_and_geometry_but_not_comps():
+    raw = _doc("clj", "raw-db", {
+        "R01_ingest": {
+            "tids": [7],
+            "rating-mat": {"rownames": [1], "colnames": [7], "matrix": [[-1]]},
+        },
+        "R04_pca": {
+            "mat": [[-1.0]],
+            "pca": {"center": [-0.5], "comps": [[1.0]],
+                    "comment-projection": [[-0.25]], "comment-extremity": [0.25]},
+        },
+    })
+    can = sc.canonicalize(raw)
+    assert can["R01_ingest"]["rating-mat"]["1|7"] == 1
+    assert can["R04_pca"]["mat"]["1|7"] == 1.0
+    assert can["R04_pca"]["pca"]["center"]["7"] == 0.5
+    assert can["R04_pca"]["pca"]["comment-projection"]["0"]["7"] == 0.25
+    # comps are invariant: X^T X == (-X)^T (-X).
+    assert can["R04_pca"]["pca"]["comps"]["0"]["7"] == 1.0
+    # extremity is a norm.
+    assert can["R04_pca"]["pca"]["comment-extremity"]["7"] == 0.25
+
+
+def test_identity_keying_defeats_a_column_permutation():
+    """The two engines emit tids in different orders. A permuted-but-equal
+    matrix must compare clean."""
+    a = _doc("clj", "delphi", {"R01_ingest": {
+        "tids": [7, 3],
+        "rating-mat": {"rownames": [1], "colnames": [7, 3], "matrix": [[1, -1]]},
+    }})
+    b = _doc("py", "delphi", {"R01_ingest": {
+        "tids": [3, 7],
+        "rating-mat": {"rownames": [1], "colnames": [3, 7], "matrix": [[-1, 1]]},
+    }})
+    rep = sc.compare_step(a, b)
+    assert rep["stages"]["R01_ingest"]["status"] == "MATCH"
+
+
+def test_component_sign_flip_is_absorbed_and_coupled():
+    """A whole-component sign flip is not a divergence — but it must be applied
+    to the coupled arrays too, or base-cluster centers would then mismatch."""
+    common = {
+        "R01_ingest": {"tids": [1, 2]},
+        "R05_projections": {"proj": {"rownames": [9], "colnames": ["x", "y"],
+                                     "matrix": [[3.0, 4.0]]}},
+        "R06_base_clusters": {"base-clusters": [
+            {"id": 0, "center": [3.0, 4.0], "members": [9]}]},
+    }
+    a = _doc("clj", "delphi", dict(common, R04_pca={
+        "pca": {"center": [0.0, 0.0], "comps": [[0.6, 0.8], [0.8, -0.6]],
+                "comment-projection": [[1.0, 2.0], [3.0, 4.0]],
+                "comment-extremity": [1.0, 2.0]}}))
+    flipped = {
+        "R01_ingest": {"tids": [1, 2]},
+        "R05_projections": {"proj": {"rownames": [9], "colnames": ["x", "y"],
+                                     "matrix": [[-3.0, 4.0]]}},
+        "R06_base_clusters": {"base-clusters": [
+            {"id": 0, "center": [-3.0, 4.0], "members": [9]}]},
+    }
+    b = _doc("py", "delphi", dict(flipped, R04_pca={
+        "pca": {"center": [0.0, 0.0], "comps": [[-0.6, -0.8], [0.8, -0.6]],
+                "comment-projection": [[-1.0, -2.0], [3.0, 4.0]],
+                "comment-extremity": [1.0, 2.0]}}))
+    rep = sc.compare_step(a, b)
+    for stage in ("R04_pca", "R05_projections", "R06_base_clusters"):
+        assert rep["stages"][stage]["status"] == "MATCH", stage
+    assert rep["first_diverging_stage"] is None
+
+
+# ---------------------------------------------------------------------------
+# Comparer: tolerance classes and the first-diverging-stage rule.
+# ---------------------------------------------------------------------------
+def test_exact_family_has_zero_tolerance():
+    a = _doc("clj", "delphi", {"R01_ingest": {"n": 10}})
+    b = _doc("py", "delphi", {"R01_ingest": {"n": 11}})
+    rep = sc.compare_step(a, b)
+    assert rep["stages"]["R01_ingest"]["status"] == "DIVERGENT"
+    assert rep["stages"]["R01_ingest"]["keys"]["n"]["n_diff"] == 1
+    assert rep["stages"]["R01_ingest"]["keys"]["n"]["max_abs"] == 1.0
+
+
+def test_tight_family_absorbs_the_proposed_g_contract_bound():
+    tol = sc.TIGHT
+    assert tol.ok(1.0, 1.0 + 9e-5)      # inside 1e-6 + 1e-4*scale
+    assert not tol.ok(1.0, 1.0 + 1e-3)
+
+
+def test_geom_family_absorbs_the_documented_cold_tick_comps_noise():
+    # Q12/Q18: the two engines' cold-tick comps differ at ~1e-5 while the final
+    # blob still MATCHes, so geometry must not be graded at the tight bound.
+    # At scale 1 the tight bound is 1e-6 + 1e-4; a 1e-3 relative difference
+    # fails it and passes the geometry bound (1e-6 + 1e-2).
+    assert not sc.TIGHT.ok(1.0, 1.0 + 1e-3)
+    assert sc.GEOM.ok(1.0, 1.0 + 1e-3)
+    # Both still reject a difference far outside either bound.
+    assert not sc.GEOM.ok(1.0, 1.1)
+
+
+def test_max_abs_and_max_rel_are_measured_over_every_compared_pair():
+    """Headroom, not just failures: a fully-matching key still reports how close
+    it came to its tolerance."""
+    a = _doc("clj", "delphi", {"R12_priorities": {"comment-priorities": {"1": 1.0}}})
+    b = _doc("py", "delphi", {"R12_priorities": {"comment-priorities": {"1": 1.0 + 1e-9}}})
+    k = sc.compare_step(a, b)["stages"]["R12_priorities"]["keys"]["comment-priorities"]
+    assert k["n_diff"] == 0
+    assert 0 < k["max_abs"] < 1e-8
+    assert k["worst_path"] == "comment-priorities.1"
+
+
+def test_first_diverging_stage_is_the_earliest_one_in_pipeline_order():
+    a = _doc("clj", "delphi", {
+        "R03_eligibility": {"in-conv": [1, 2]},
+        "R12_priorities": {"comment-priorities": {"1": 1.0}},
+    })
+    b = _doc("py", "delphi", {
+        "R03_eligibility": {"in-conv": [1, 3]},
+        "R12_priorities": {"comment-priorities": {"1": 2.0}},
+    })
+    rep = sc.compare_step(a, b)
+    assert rep["first_diverging_stage"] == "R03_eligibility"
+    assert rep["stages"]["R12_priorities"]["status"] == "DIVERGENT"
+
+
+def test_a_structural_difference_diverges_even_with_no_numeric_error():
+    a = _doc("clj", "delphi", {"R06_base_clusters": {"bid-to-pid": [[1, 2]]}})
+    b = _doc("py", "delphi", {"R06_base_clusters": {"bid-to-pid": [[1, 2, 3]]}})
+    rep = sc.compare_step(a, b)
+    assert rep["stages"]["R06_base_clusters"]["status"] == "DIVERGENT"
+    assert rep["stages"]["R06_base_clusters"]["keys"]["bid-to-pid"]["n_structural"]
+
+
+# ---------------------------------------------------------------------------
+# Comparer: carve-outs.
+# ---------------------------------------------------------------------------
+def test_moderation_null_vs_empty_is_carved_not_divergent():
+    a = _doc("clj", "delphi", {"R02_moderation": {"mod-out": None}})
+    b = _doc("py", "delphi", {"R02_moderation": {"mod-out": []}})
+    rep = sc.compare_step(a, b)
+    assert rep["stages"]["R02_moderation"]["keys"]["mod-out"]["status"] == "CARVED"
+    assert rep["stages"]["R02_moderation"]["status"] == "MATCH"
+    assert rep["first_diverging_stage"] is None
+
+
+def test_a_carved_key_does_not_hide_a_real_shape_difference_elsewhere():
+    a = _doc("clj", "delphi", {"R03_eligibility": {"in-conv": None}})
+    b = _doc("py", "delphi", {"R03_eligibility": {"in-conv": []}})
+    rep = sc.compare_step(a, b)
+    assert rep["stages"]["R03_eligibility"]["status"] == "DIVERGENT"
+
+
+def test_silhouette_and_ptpt_stats_are_carved_with_their_reason_recorded():
+    assert sc.KEY_CARVE_OUT[("R09_group_clusters",
+                             "group-clusterings-silhouettes")] == "C3"
+    assert sc.KEY_CARVE_OUT[("R13_ptpt_stats", "ptpt-stats")] == "C4"
+    for cid in sc.AUTO_CARVED:
+        assert cid in sc.CARVE_OUTS
+        assert sc.CARVE_OUTS[cid].reason
+
+
+def test_q13_and_q18_are_documented_but_never_auto_suppressed():
+    """Chaotic cluster permutation is reported, because a path rule that hid it
+    would also hide real structural breakage (P-030 §5/R7)."""
+    assert "C2" in sc.CARVE_OUTS and "C2" not in sc.AUTO_CARVED
+    assert "C6" in sc.CARVE_OUTS and "C6" not in sc.AUTO_CARVED
+
+
+# ---------------------------------------------------------------------------
+# Comparer: recording-level plumbing.
+# ---------------------------------------------------------------------------
+def test_load_stage_dumps_rejects_a_foreign_schema(tmp_path):
+    (tmp_path / "step-000.stages.json").write_text(
+        json.dumps({"schema": "something-else/9", "step": 0, "stages": {}}))
+    with pytest.raises(ValueError, match="schema"):
+        sc.load_stage_dumps(tmp_path)
+
+
+def test_step_count_mismatch_is_reported_not_truncated_silently(tmp_path):
+    a_dir, b_dir = tmp_path / "a", tmp_path / "b"
+    stages.write_stage_documents(
+        a_dir, [_doc("clj", "delphi", {}), dict(_doc("clj", "delphi", {}), step=1)],
+        engine="clj")
+    stages.write_stage_documents(b_dir, [_doc("py", "delphi", {})])
+    rep = sc.compare_recordings(a_dir, b_dir)
+    assert rep["step_count_mismatch"] is True
+    assert rep["aligned_steps"] == 1
+    assert rep["n_steps_a"] == 2 and rep["n_steps_b"] == 1
+
+
+def test_write_stage_documents_writes_a_manifest_and_clears_stale_steps(tmp_path):
+    out = stages.write_stage_documents(
+        tmp_path, [_doc("py", "delphi", {}), dict(_doc("py", "delphi", {}), step=1)])
+    manifest = json.loads((out / "stages-manifest.json").read_text())
+    assert manifest["schema"] == stages.STAGE_DUMP_SCHEMA
+    assert manifest["n_steps"] == 2
+    assert manifest["stage_order"] == stages.STAGE_ORDER
+    assert [r["index"] for r in manifest["steps"]] == [0, 1]
+    assert [r["file"] for r in manifest["steps"]] == [
+        "step-000.stages.json", "step-001.stages.json"]
+
+    # A shorter re-run must not leave the stale step-001 behind.
+    stages.write_stage_documents(tmp_path, [_doc("py", "delphi", {})])
+    assert sorted(p.name for p in tmp_path.glob("step-*.stages.json")) == [
+        "step-000.stages.json"]
+
+
+def test_stage_dirs_are_siblings_of_the_blob_dirs():
+    """Stage files must never land in ``py/`` or ``clj/``: certify globs
+    ``step-*.json`` there for its inventory and digest sets, and
+    ``store.write_recording`` deletes that glob before each write."""
+    assert stages.STAGE_DIR_NAME == {"py": "py-stages", "clj": "clj-stages"}
+
+
+def test_certify_does_not_import_the_stage_oracle():
+    """The grading rule, enforced: stage dumps are diagnostics, never a gate."""
+    import inspect
+
+    from polismath.replay import certify
+
+    src = inspect.getsource(certify)
+    assert "stagecompare" not in src
+    assert "replay.stages" not in src and "import stages" not in src

--- a/docs/engine-stage-oracles.md
+++ b/docs/engine-stage-oracles.md
@@ -1,0 +1,321 @@
+# Engine stage oracles
+
+**What this is.** A way to ask *where* two implementations of the Polis math
+engine first disagree, instead of only being told that their final `math_main`
+blobs differ.
+
+Both replay drivers can dump the intermediate outputs of the tick pipeline —
+one file per replay step, in a shared JSON shape — and a comparer diffs the two
+dumps stage by stage and names the **first diverging stage**.
+
+**What this is not.** A gate. Stage dumps are **diagnostics only**. The single
+PASS / APPROVED_DIFFERENCE / FAIL / INCONCLUSIVE authority remains
+`polismath.replay.certify` on the final blob. Nothing in this document changes a
+verdict, and `certify` does not import either module (there is a test that
+asserts it).
+
+The reason is not squeamishness. The two live engines already differ at ~1e-16
+inside `proj` and at ~1e-5 in cold-tick `comps` while the final blob still
+MATCHes — noise the acceptance policy deliberately tolerates. A stage-level
+exact comparison would fail on exactly that noise, so a stage dump that voted
+would be a worse gate than the one we have.
+
+---
+
+## Producing the dumps
+
+A *recording directory* holds both engines' output for one (dataset, schedule):
+
+```
+<recording>/
+  schedule.json
+  provenance.json
+  clj/                 # Clojure prep-main blobs      (certify's reference)
+  py/                  # Python  step payloads        (certify's candidate)
+  clj-stages/          # Clojure stage dumps          <- this document
+  py-stages/           # Python  stage dumps          <- this document
+```
+
+The stage directories are **siblings** of the blob directories, never inside
+them. `certify` globs `step-*` and `step-*.json` inside an engine directory for
+its inventory and digest sets (`certify.py:868,873,1283`),
+`store.write_recording` deletes `step-*.json` there before every write, and
+`store.load_step_blobs` reads that same glob as step payloads. A stage file
+inside `clj/` or `py/` would be picked up by all three.
+
+### Clojure
+
+```bash
+cd math
+clojure -M:replay \
+  --schedule <schedule.json> \
+  --votes    ../delphi/real_data/<dataset>/*-votes.csv \
+  --out      <recording> \
+  --stage-json
+```
+
+`--stage-json` is a sibling sink beside the always-on blob writer and the
+optional `--edn` dump. It is off by default and it does not touch the recorded
+`prep-main` blob: the same schedule run with and without it produces a
+byte-identical `clj/step-NNN.blob.json`. With `--repeats N > 1` the stage
+dumps follow the blob layout: rep 0 flat in `clj-stages/`, every rep also in
+`clj-stages/rep-<i>/`.
+
+### Python
+
+```bash
+cd delphi
+OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+uv run python -m polismath.replay.stages \
+  --dataset vw --preset single-cut --out <recording>
+```
+
+or, in process:
+
+```python
+from polismath.replay import real_data, stages, certify
+
+ds   = real_data.load_export_votes("vw")
+spec = certify.build_effective_spec(entry, ds)      # the battery's own spec
+stages.run_stage_dump(ds, spec, out_dir=recording / "py-stages")
+```
+
+`run_stage_dump` folds with `driver.run_replay` itself, through its `on_step`
+hook, so a stage dump can never drift from the recording `certify` consumes.
+
+### A third engine
+
+Write the same `polis-stage-dump/1` files into `<recording>/<engine>-stages/`
+and point the comparer at the directory. Nothing about the format is Python- or
+Clojure-specific.
+
+---
+
+## Reading the diff
+
+```bash
+cd delphi
+uv run python -m polismath.replay.stagecompare \
+  --recording <recording> [--verbose] [--out report.json]
+```
+
+```
+Stage comparison (clj vs py)
+  DIAGNOSTICS ONLY — certify on the final blob is the sole PASS/FAIL authority.
+  A: …/clj-stages  (1 steps)
+  B: …/py-stages   (1 steps)
+  first diverging stage: none — every stage within tolerance
+  step 0: first diverging stage = none
+      [MATCH] R04_pca.pca (geom): 0/750 out of tolerance,
+              max_abs=9.031e-08 max_rel=1.739e-06
+              worst=pca.comment-projection.1.4
+      [CARVED C4] R13_ptpt_stats.ptpt-stats (exact): 52/134 out of tolerance,
+              max_abs=2.800e+01 max_rel=5.000e-01 worst=ptpt-stats.49.n-votes
+```
+
+Per key you get: how many numeric pairs were compared, how many fell outside
+that key's tolerance, and the **max absolute and max relative error over every
+compared pair** with the path that produced the largest one. `max_abs` /
+`max_rel` are reported even when the key matches — on a matching key they are
+the headroom, i.e. how close that stage came to its bound. Exit status is always
+0; this tool does not fail a build.
+
+Two caveats when reading the numbers:
+
+* **`max_rel` near zero is not meaningful.** When one side is exactly 0.0 and
+  the other is 2e-7, the relative error is 1.0 while the absolute error is
+  comfortably inside the bound. Read `max_abs` first.
+* **`n_compared` counts numeric leaves, not entities.** A 67×67 `bucket-dists`
+  contributes 4 489 comparisons.
+
+### What "first diverging stage" means
+
+Stages run in a fixed pipeline order, and each consumes the previous ones'
+output:
+
+| stage | Clojure graph nodes |
+|---|---|
+| `R01_ingest` | `raw-rating-mat`, `rating-mat`, `tids`, `n`, `n-cmts`, `last-vote-timestamp` |
+| `R02_moderation` | `mod-in`, `mod-out`, `meta-tids`, `last-mod-timestamp` |
+| `R03_eligibility` | `user-vote-counts`, `in-conv` |
+| `R04_pca` | `mat` (imputed), `pca` = center / comps / comment-projection / comment-extremity |
+| `R05_projections` | `proj` (as a named matrix over participant ids) |
+| `R06_base_clusters` | `base-clusters`, `base-clusters-proj`, `base-clusters-weights`, `bid-to-pid`, `bucket-dists` |
+| `R09_group_clusters` | `group-clusterings`, `group-clusterings-silhouettes`, `group-k-smoother`, `group-clusters` |
+| `R10_tallies` | `votes-base`, `group-votes`, `group-aware-consensus` |
+| `R11_repness` | `repness`, `consensus` |
+| `R12_priorities` | `comment-priorities` |
+| `R13_ptpt_stats` | `ptpt-stats` |
+
+The **first diverging stage** is the earliest stage carrying a difference that
+is outside its declared tolerance *and* outside the declared carve-outs.
+
+It is the only number worth acting on. A difference at stage *N* mechanically
+propagates into every later stage, so a report showing eight divergent stages is
+usually one bug at the earliest of them and seven consequences. Fix the first;
+re-run; look again. Correspondingly, a divergence at a *later* stage with every
+earlier stage clean is a genuinely local bug in that stage's own arithmetic —
+the most useful signal this tool produces.
+
+Stage names are zero-padded (`R01…R13`) so that lexicographic key order in the
+JSON *is* pipeline order.
+
+### Tolerance classes
+
+| class | bound | applies to |
+|---|---|---|
+| `exact` | `a == b` | typed ids, counts, membership, eligibility, vote meaning, cursors, the k-smoother state |
+| `tight` | `abs(a-b) <= 1e-6 + 1e-4·max(\|a\|,\|b\|)` | numeric statistics: `mat`, tallies-derived consensus, repness/consensus stats, comment priorities |
+| `geom` | `abs(a-b) <= 1e-6 + 1e-2·max(\|a\|,\|b\|)` | PCA-derived geometry: `pca`, `proj`, cluster centers, `bucket-dists`, silhouettes |
+
+`tight` is the bound `P-022-G-engine-contract.md` §numeric-policy proposes for
+finite numeric statistics with zero outlier allowance. `geom` is deliberately
+looser because the two engines' cold-tick `comps` are documented to differ at
+~1e-5 while the final blob still MATCHes; it is the same relative bound
+`stepcompare.StepComparer` already defaults to for PCA-family paths.
+
+Non-numeric leaves (ids, booleans, strings, membership lists) are compared
+exactly whatever a key's numeric class is, and a shape difference — a missing
+key, a length mismatch — is always a divergence, never a tolerance question.
+
+### What the comparer normalizes first
+
+Three transformations, applied to each side before diffing, so that only real
+differences survive.
+
+1. **Polarity.** Clojure computes in raw-DB convention (AGREE = −1); Python
+   computes in Delphi convention (AGREE = +1) and negates only at its blob
+   emission boundary. Each dump declares its `vote_sign_convention`, and a
+   `raw-db` dump has its vote-valued and geometry nodes negated into Delphi
+   convention before comparison. The negation set is `rating-mat`,
+   `raw-rating-mat`, `mat`, `pca.center`, `pca.comment-projection`, `proj`, and
+   every base-/group-cluster `center`. Deliberately *not* negated: `comps`
+   (`XᵀX == (−X)ᵀ(−X)`, so power iteration from the same start vector returns
+   the identical vector), `comment-extremity` and `bucket-dists` (norms and
+   distances), and every count and tally (counts are relabelled, not rescaled).
+
+   The **emitters do not do this**. Each writes its engine's native numbers, so
+   the file stays a faithful record of what that engine actually computed and
+   the interpretation lives in one auditable place.
+
+2. **Identity keying.** Named matrices become `{rowname|colname: cell}`, and
+   every tid-, pid- or bid-indexed array becomes a dict keyed by that id. Clojure
+   emits `tids` in hash/insertion order and Python in sorted order; each blob is
+   internally consistent, so array position is not semantics. Without this every
+   run would report thousands of phantom differences.
+
+3. **Coupled component sign.** Each principal component is oriented so its
+   largest-magnitude entry is positive (first tid on ties), and the arrays coupled
+   to it — that component's `comment-projection` row, the matching `proj`
+   column, and coordinate *k* of every base- and group-cluster center — are
+   flipped with it. `pca.center` is a data mean and is never flipped. This is
+   `crosslang.canonicalize_blob`'s rule, applied one level deeper.
+
+---
+
+## Carve-outs — differences that are expected
+
+From P-030 §Q13/Q18 and the engines' own documented boundaries. Four are applied
+automatically (the key reports `CARVED` instead of `DIVERGENT`, with its numbers
+still printed, and it does not become the first diverging stage). Two are
+documented but never auto-suppressed.
+
+| id | key | auto | why it is expected |
+|---|---|---|---|
+| **C1** | `mod-in`, `mod-out`, `meta-tids` | yes | Clojure emits `nil` until a `mod-update` has written the set; Python emits an empty set. `null` vs `[]` on those three keys only — a genuinely absent value anywhere else still reports. Python's own blob boundary already mirrors the Clojure rule via `moderation_applied`, and the stage emitter applies the same gate, so in practice this fires rarely. |
+| **C2** | cluster ids / membership on warm chains | **no** | **Q13.** Warm-chain split-loop extraction order is knife-edge chaotic on tie-dense geometry: within-engine gaps at 2.5e-16 and 5.6e-17 against cross-engine projection noise at ~1e-5, eleven orders larger. No arithmetic replication reproduces the order. Ledgered on `FP-912391ece7 / FP-c29173e1ba / FP-98dc728043`; carved in the battery by swapping `pc-revote-01` for `pc-revote-02`. |
+| **C3** | `group-clusterings-silhouettes` | yes | The two engines score with **different estimators**: Clojure's `clusters/silhouette` over `bucket-dists`, Python's `calculate_silhouette_sklearn` over the base-cluster centers. The values are expected to differ. What must agree is the *argmax* they feed, which is visible in `group-k-smoother` and the group count — both compared exactly. |
+| **C4** | `ptpt-stats` | yes | The engines compute **different statistics under the same name**. Clojure emits `coreness` / `centricness` / `extremeness` (geometry over the participant projection); Python emits `n_agree` / `n_disagree` / `n_pass` / `group_correlations`. Even the two same-named fields disagree by construction: Clojure's `n-votes` is `user-vote-counts` over the *raw* rating matrix, Python's `n_votes` counts non-zero cells of the moderation-applied matrix, and Python omits participants with no votes entirely. `math_ptptstats` has no reader anywhere in Node or the clients, so this is verification surface only. |
+| **C5** | `mat`, all-NaN column | yes | Python substitutes a 0.0 column mean where Clojure would divide by zero. Unreachable on a real conversation — every column carries at least one vote. |
+| **C6** | cluster ids on coincident centers | **no** | **Q18.** `uniqify`'s exact-center-equality predicate is value-dependent ulp luck: `merge-clusters`' weighted mean preserves the input value for some doubles and rounds one ulp for others, so whether a merge *chain* over coincident singletons continues — and which id survives — depends on the 17th digit. Root cause of all 11 `carved-out` entries in `delphi/docs/divergences.json`. |
+
+**Why C2 and C6 are not auto-suppressed.** They are chaotic, not addressable by
+a path rule. A rule that hid "cluster ids differ" would also hide real
+structural breakage in the lineage code, which is precisely what R7 exists to
+catch. So they are reported, and this table is how a reader recognises the
+fingerprint. P-030 §5/R7 says it directly: if a divergence's path pattern
+matches a carved-out fingerprint on a mod-heavy warm chain, probe it with the
+split-probe before spending a day on it — the correct action is to record it,
+not to fix it.
+
+---
+
+## The file format
+
+`polis-stage-dump/1`. One document per step, plus a manifest.
+
+```json
+{
+  "engine": "clj",
+  "input_digest": "sha256:a3d12bdc…",
+  "schema": "polis-stage-dump/1",
+  "stages": { "R01_ingest": { "n": 69, "n-cmts": 125, … }, … },
+  "step": 0,
+  "tick": 1732040170000,
+  "vote_sign_convention": "raw-db"
+}
+```
+
+`stages-manifest.json` carries `{engine, n_steps, schema, stage_order, steps,
+vote_sign_convention}` where each step row is `{file, index, input_digest,
+tick}`.
+
+Encoding rules, identical on both engines:
+
+* **Key order.** Every object's keys are sorted ascending as strings. Integer
+  and keyword map keys are stringified *first* and then sorted, so `"10"`
+  precedes `"2"` on both sides.
+* **Integers** — ids, counts, timestamps, vote values — are JSON integers with
+  no decimal point.
+* **Doubles** use the shortest decimal that round-trips to the same double
+  (`Double/toString` on JDK 19+, `repr(float)` in Python). **Nothing is ever
+  rounded**: the compared numbers are the exact doubles the engine computed.
+  Exponent *formatting* differs across the two languages (`1.0E-5` vs `1e-05`)
+  and does not matter — the comparison parses, it does not diff bytes.
+* **Non-finite doubles** become the JSON strings `"NaN"`, `"Infinity"`,
+  `"-Infinity"`; JSON has no literal for them and silently emitting one would
+  make the file unparseable by a strict reader.
+* **A named matrix** is `{"rownames": […], "colnames": […], "matrix": [[…]]}`
+  with missing cells as `null` — a nil vote and a 0 vote are different meanings.
+* **Sets** become sorted arrays; keywords become their bare name.
+* **`input_digest`** is `sha256` over the step's fed batch in *export/Delphi*
+  sign convention (`{"mods": [[tid, is_meta, mod, modified], …], "votes":
+  [[pid, tid, sign, created], …]}`, canonical JSON, fed order). Taking it in
+  export convention is what makes the two engines' digests comparable despite
+  the raw-DB flip Clojure applies before `conv-update`. **If the digests differ,
+  stop**: the engines were not fed the same batch and every other number in the
+  report is meaningless.
+
+Dumps are large — for `vw` (69 participants, 125 comments) roughly 350 KB per
+step per engine, dominated by `bucket-dists` and the two vote matrices. They are
+regenerated, not checked in.
+
+---
+
+## Tests
+
+```bash
+cd delphi
+uv run python -m pytest tests/replay_harness/test_stages.py -q
+RUN_CLJ_INTEGRATION=1 uv run python -m pytest \
+  tests/replay_harness/test_stage_oracle_e2e.py -q
+
+cd math
+clojure -M:test          # includes test/stage_json_test.clj
+```
+
+`test_stages.py` and `stage_json_test.clj` pin the encoding contract on both
+sides — key order, integer formatting, exact double round-trip over a 5 000-value
+random sample, non-finite handling, named-matrix shape — plus the comparer's
+canonicalization, tolerance classes and carve-outs.
+
+`test_stage_oracle_e2e.py` runs the whole loop on the smallest public battery
+case (`vw:single-cut`). The Clojure half is opt-in behind
+`RUN_CLJ_INTEGRATION=1`; the Python half and a self-comparison negative control
+run unconditionally. It asserts what the harness owes — both dumps exist, the
+input digests match, every stage is present with an error report — and
+deliberately asserts **no verdict**, because a numeric threshold there would
+quietly become the gate the plan forbids.
+
+Measured results on the public battery cases are recorded in
+`cost-reduction/04-plans/P-030-R-ORACLE-implementation-notes.md`.

--- a/docs/engine-stage-oracles.md
+++ b/docs/engine-stage-oracles.md
@@ -212,6 +212,14 @@ malformed operands cannot slip through: `True` vs `True` for a count, `"1"` vs
 `"1"` for a tid, or a float-spelled cluster id `1.5` on both sides are all
 divergences, not matches.
 
+So is the **shape**. An integer position is declared scalar or array and
+validated before any recursion, because `n = {}` on both sides is not a count
+that happens to agree — it is not a count. The declaration is *key-scoped* where
+it has to be: `A`/`D`/`S` are per-base-cluster bucket arrays in `votes-base` and
+per-group scalar totals in `group-votes`, so a rule keyed on the field name
+alone gets one of them wrong. It applies at the declared position only, so
+`bid-to-pid` remains an array of arrays.
+
 The remaining, genuinely continuous leaves get one of two bounds:
 
 | class | bound | applies to |
@@ -300,7 +308,11 @@ differences survive.
    truncates every comment to 0.0 on both components (Q16), and the Python port
    matches. So the emitted array has `max(len(comps), 2)` rows, and the comparer
    requires exactly that — an extra component row is a structural error, not a
-   row to drop.
+   row to drop. The **padded row is compared like any other**: it takes a
+   declared sign (`+1`, inert because it is all zeros) and its all-zero
+   construction is checked, so a stray value there is a structural defect even
+   when both engines carry it. It is never zipped away against a shorter list
+   of component signs.
 
    When an emitter *cannot* verify a shape it refuses rather than guessing: it
    writes a `__structural_error__` sentinel, which the comparer lifts into a
@@ -364,9 +376,15 @@ two are a complete, aligned, same-input pair. It checks that:
   happens to equal the other side's;
 * every document declares a supported `vote_sign_convention` and the expected
   `comment_projection_axes`, and carries **all eleven stages, each with its full
-  declared key inventory**. A stage present but mapped to `{}` is a hole in the
-  recording, not eleven stages that happened to agree; an unknown stage or key
-  is reported too;
+  declared key inventory**. A stage present but mapped to `{}`, to `null`, or to
+  an array is a hole in the recording, not a stage that happened to agree; an
+  unknown stage or key is reported too;
+* the digest is **64 lower-case hex digits**, not merely a `sha256:` prefix;
+* each manifest row **names a real step file** — matching `step-NNN.stages.json`,
+  unique, and present in the recording — and agrees with *that document* on all
+  five identity fields (index, tick, digest, engine, polarity); every step file
+  on disk appears in the manifest; and the recording declares **one** engine and
+  **one** polarity throughout, matching the manifest's;
 * a malformed document — not an object, unparseable JSON, a non-object `stages`
   container, a non-integer step — becomes an input problem rather than an
   exception;

--- a/docs/engine-stage-oracles.md
+++ b/docs/engine-stage-oracles.md
@@ -111,24 +111,43 @@ uv run python -m polismath.replay.stagecompare \
 
 ```
 Stage comparison (clj vs py)
-  DIAGNOSTICS ONLY — certify on the final blob is the sole PASS/FAIL authority.
+  DIAGNOSTICS ONLY — certify never consumes these statuses; the final-blob
+  gate is untouched (P-030 §2.3).
   A: …/clj-stages  (1 steps)
   B: …/py-stages   (1 steps)
   first diverging stage: none — every stage within tolerance
   step 0: first diverging stage = none
-      [MATCH] R04_pca.pca (geom): 0/750 out of tolerance,
-              max_abs=9.031e-08 max_rel=1.739e-06
-              worst=pca.comment-projection.1.4
-      [CARVED C4] R13_ptpt_stats.ptpt-stats (exact): 52/134 out of tolerance,
-              max_abs=2.800e+01 max_rel=5.000e-01 worst=ptpt-stats.49.n-votes
+      [ENGINE_LOCAL] R13_ptpt_stats.participant-info-legacy: not graded
+                     (present on b)
 ```
 
-Per key you get: how many numeric pairs were compared, how many fell outside
-that key's tolerance, and the **max absolute and max relative error over every
-compared pair** with the path that produced the largest one. `max_abs` /
+and with `--verbose`, every key including the ones that matched:
+
+```
+      [MATCH] R04_pca.pca (geom-legacy): 0/750 out of tolerance,
+              max_abs=9.031e-08 max_rel=1.739e-06
+              worst=pca.comment-projection.1.i:4
+      [MATCH] R13_ptpt_stats.ptpt-stats (tight): 0/335 out of tolerance,
+              max_abs=1.186e-07 max_rel=2.004e-06
+              worst=ptpt-stats.i:66.centricness
+```
+
+Per key you get a **status** — `MATCH`, `DIVERGENT`, `CARVED`, `NONFINITE` or
+`ENGINE_LOCAL` — plus how many numeric pairs were compared, how many fell
+outside that key's tolerance, and the **max absolute and max relative error over
+every compared pair** with the path that produced the largest one. `max_abs` /
 `max_rel` are reported even when the key matches — on a matching key they are
 the headroom, i.e. how close that stage came to its bound. Exit status is always
 0; this tool does not fail a build.
+
+**`NONFINITE` is not a pass.** Two engines *agreeing* on a `NaN` or an infinity
+is not a divergence, but it is not clean data either. Such a key gets its own
+status, always prints (even without `--verbose`), and qualifies the headline:
+the report says how many non-finite values are present instead of "every stage
+within tolerance". A non-finite in an *integer-typed* field — a vote, an id, a
+count — is stronger still: it is a structural defect and a divergence, because
+those fields are never non-finite. Matching invalid data is never hidden behind
+a clean default.
 
 Two caveats when reading the numbers:
 
@@ -187,6 +206,11 @@ divergence, not a rounding), and it stops the float round trip from erasing a
 one-unit difference above 2^53. A non-integral value, or a boolean, in an
 integer-typed field is a structural defect, not a number. The two engines'
 legitimate spellings of the same integer — Clojure `-1`, Python `-1.0` — agree.
+
+The type is checked **before equality, on both sides**, so two *equally*
+malformed operands cannot slip through: `True` vs `True` for a count, `"1"` vs
+`"1"` for a tid, or a float-spelled cluster id `1.5` on both sides are all
+divergences, not matches.
 
 The remaining, genuinely continuous leaves get one of two bounds:
 
@@ -262,12 +286,25 @@ differences survive.
    data mean and is never flipped. This is `crosslang.canonicalize_blob`'s rule,
    applied one level deeper.
 
-   The axis orientation of `comment-projection` is **read from the dump's
-   declared `comment_projection_axes`, never inferred from array lengths**: when
-   a conversation has exactly as many comments as components, lengths cannot
-   distinguish an *n*×2 from a 2×*n*, and a comparer that guessed would silently
-   compare a transposed array. Both emitters write `comps-by-tids` and say so; a
+   The axis orientation of `comment-projection` is **fixed by the producer and
+   declared on the wire, never inferred from array lengths** — not in the
+   comparer and not in the emitter. `pca_project_cmnts` always returns
+   comments-by-components, so the Python emitter transposes *unconditionally*;
+   a transpose conditioned on a shape comparison would emit the wrong array
+   whenever a conversation has as many comments as components, while still
+   declaring the right axes. Both emitters write `comps-by-tids` and say so; a
    dump that does not declare it is refused.
+
+   The projection is **always at least two rows wide**, even when the PCA has a
+   single component: in that rank-one case Clojure's `[pc1 pc2]` destructure
+   truncates every comment to 0.0 on both components (Q16), and the Python port
+   matches. So the emitted array has `max(len(comps), 2)` rows, and the comparer
+   requires exactly that — an extra component row is a structural error, not a
+   row to drop.
+
+   When an emitter *cannot* verify a shape it refuses rather than guessing: it
+   writes a `__structural_error__` sentinel, which the comparer lifts into a
+   structural failure. A refusal is never graded as data.
 
 ---
 
@@ -282,7 +319,7 @@ are notes for the reader and suppress nothing.
 
 | id | scope | key | why it is expected |
 |---|---|---|---|
-| **C1** | `null` ↔ `[]` **only** | `mod-in`, `mod-out`, `meta-tids` | Clojure emits `nil` until a `mod-update` has written the set; Python emits an empty set. That exact value pair is suppressed and nothing else: `[1]` → `[2]`, `null` → `[2]`, a missing key or a wrong type all report as divergences. Python's own blob boundary already mirrors the Clojure rule via `moderation_applied`, and the stage emitter applies the same gate, so this rarely fires. |
+| **C1** | `null` ↔ `[]` **only**, type-checked | `mod-in`, `mod-out`, `meta-tids` | Clojure emits `nil` until a `mod-update` has written the set; Python emits an empty set. That exact pair is suppressed — one side literally `None`, the other literally an empty JSON *list* — and nothing adjacent to it: `[1]` → `[2]`, `null` → `[2]`, `null` → `{}`, a missing key or a wrong type all report as divergences. Python's own blob boundary already mirrors the Clojure rule via `moderation_applied`, and the stage emitter applies the same gate, so this rarely fires. |
 | **C2** | none — documented only | cluster ids / membership on warm chains | **Q13.** Warm-chain split-loop extraction order is knife-edge chaotic on tie-dense geometry: within-engine gaps at 2.5e-16 and 5.6e-17 against cross-engine projection noise at ~1e-5, eleven orders larger. Ledgered on `FP-912391ece7 / FP-c29173e1ba / FP-98dc728043`; carved in the *battery* by swapping `pc-revote-01` for `pc-revote-02`. |
 | **C3** | numeric **values** only | `group-clusterings-silhouettes` | The two engines score with **different estimators**: Clojure's `clusters/silhouette` over `bucket-dists`, Python's `calculate_silhouette_sklearn` over the base-cluster centers. Different numbers are expected. The candidate inventory (*which* k were scored), the argmax they feed, the smoother state and group membership are all **outside** the exception and compared normally — a missing k is a coverage problem, not an estimator difference. |
 | **C4** | none — documented only | `participant-info-legacy` | This engine's `participant_info` is a vote-correlation *report* statistic (`n_agree`/`n_disagree`/`n_pass`/`group_correlations`). It is not engine-contract surface and has no Clojure counterpart, so it rides along as an **engine-local** key, reported and never graded. It is **not** a waiver on `ptpt-stats`: see below. |
@@ -317,10 +354,22 @@ the comparer validates each recording and refuses to print a headline unless the
 two are a complete, aligned, same-input pair. It checks that:
 
 * both directories exist and carry a `stages-manifest.json`;
-* the manifest's schema, `stage_order` and `n_steps` are right, its inventory
-  matches the files actually on disk, and every file it names is present;
+* the manifest's schema, `stage_order`, `engine`, axes declaration and `n_steps`
+  are right, its inventory matches the files actually on disk, every file it
+  names is present, and **each manifest row agrees with the document it names**
+  on `tick` and `input_digest` — an inventory that disagrees with its own
+  contents is not an inventory of this recording;
+* every document carries a **typed** step identity, tick, `sha256:` digest and
+  engine — a null tick or a null digest is missing evidence, not a value that
+  happens to equal the other side's;
 * every document declares a supported `vote_sign_convention` and the expected
-  `comment_projection_axes`, and carries **all eleven stages**;
+  `comment_projection_axes`, and carries **all eleven stages, each with its full
+  declared key inventory**. A stage present but mapped to `{}` is a hole in the
+  recording, not eleven stages that happened to agree; an unknown stage or key
+  is reported too;
+* a malformed document — not an object, unparseable JSON, a non-object `stages`
+  container, a non-integer step — becomes an input problem rather than an
+  exception;
 * step identities are unique, and the two sides are aligned **by step identity**,
   not by position — two recordings that both hold "one step" are not comparable
   if one is step 0 and the other step 7;

--- a/docs/engine-stage-oracles.md
+++ b/docs/engine-stage-oracles.md
@@ -8,11 +8,12 @@ Both replay drivers can dump the intermediate outputs of the tick pipeline —
 one file per replay step, in a shared JSON shape — and a comparer diffs the two
 dumps stage by stage and names the **first diverging stage**.
 
-**What this is not.** A gate. Stage dumps are **diagnostics only**. The single
-PASS / APPROVED_DIFFERENCE / FAIL / INCONCLUSIVE authority remains
-`polismath.replay.certify` on the final blob. Nothing in this document changes a
-verdict, and `certify` does not import either module (there is a test that
-asserts it).
+**What this is not.** A gate. Stage dumps are **diagnostics only**. The comparer
+does emit per-key statuses — MATCH, DIVERGENT, CARVED, ENGINE_LOCAL — but the
+accurate promise is narrower and stronger than "no verdicts": **`certify` never
+consumes any of them**, and there is a test asserting it imports neither module.
+The single PASS / APPROVED_DIFFERENCE / FAIL / INCONCLUSIVE authority remains
+`polismath.replay.certify` on the final blob.
 
 The reason is not squeamishness. The two live engines already differ at ~1e-16
 inside `proj` and at ~1e-5 in cold-tick `comps` while the final blob still
@@ -83,6 +84,15 @@ stages.run_stage_dump(ds, spec, out_dir=recording / "py-stages")
 `run_stage_dump` folds with `driver.run_replay` itself, through its `on_step`
 hook, so a stage dump can never drift from the recording `certify` consumes.
 
+**Captures vs reconstructions.** Where an engine persists a node, the stage
+function *captures* it. Where it does not, the stage function *reconstructs* the
+node by calling that engine's own code on stored state — on the Python side that
+is `mat` (the imputation block of `pca_project_dataframe`),
+`pca.comment-projection` / `comment-extremity`, the base-cluster derived
+matrices, the per-k silhouettes, `user-vote-counts`, and the R13 geometry
+(`math_writer.derive_ptptstats`). A reconstruction is faithful to the engine's
+code, but it is not evidence that the engine executed it during the tick.
+
 ### A third engine
 
 Write the same `polis-stage-dump/1` files into `<recording>/<engine>-stages/`
@@ -145,15 +155,19 @@ output:
 | `R10_tallies` | `votes-base`, `group-votes`, `group-aware-consensus` |
 | `R11_repness` | `repness`, `consensus` |
 | `R12_priorities` | `comment-priorities` |
-| `R13_ptpt_stats` | `ptpt-stats` |
+| `R13_ptpt_stats` | `ptpt-stats` (the contract geometry), plus this engine's ungraded `participant-info-legacy` |
 
 The **first diverging stage** is the earliest stage carrying a difference that
 is outside its declared tolerance *and* outside the declared carve-outs.
 
-It is the only number worth acting on. A difference at stage *N* mechanically
-propagates into every later stage, so a report showing eight divergent stages is
-usually one bug at the earliest of them and seven consequences. Fix the first;
-re-run; look again. Correspondingly, a divergence at a *later* stage with every
+It is the number to act on first. A difference at stage *N* feeds every later
+stage, so a report showing eight divergent stages is usually one bug at the
+earliest of them and seven consequences. Fix the first; re-run; look again.
+
+It is a *suggested cause*, not a proof. The tool cannot show that the later
+differences are only propagation, and it cannot rule out a second, independent
+bug further down the pipeline — so keep reading the later stages after you fix
+the first one. Correspondingly, a divergence at a *later* stage with every
 earlier stage clean is a genuinely local bug in that stage's own arithmetic —
 the most useful signal this tool produces.
 
@@ -162,21 +176,46 @@ JSON *is* pipeline order.
 
 ### Tolerance classes
 
+**Integer leaves never see a tolerance at all.** Typed IDs, counts, membership,
+eligibility, vote meaning and watermarks — `id`, `pid`, `gid`, `tid`, `members`,
+`n`, `n-cmts`, `n-votes`, `n-agree`, `n-success`, `n-trials`, `n-members`, the
+`A`/`D`/`S` buckets, the k-smoother state, both timestamps, and every cell of
+the two vote matrices — are compared as **exact integers, without ever being
+converted to float**. This matters twice over: it stops a `geom` class on a
+containing key from leaking onto the cluster `id` inside it (200 vs 201 is a
+divergence, not a rounding), and it stops the float round trip from erasing a
+one-unit difference above 2^53. A non-integral value, or a boolean, in an
+integer-typed field is a structural defect, not a number. The two engines'
+legitimate spellings of the same integer — Clojure `-1`, Python `-1.0` — agree.
+
+The remaining, genuinely continuous leaves get one of two bounds:
+
 | class | bound | applies to |
 |---|---|---|
-| `exact` | `a == b` | typed ids, counts, membership, eligibility, vote meaning, cursors, the k-smoother state |
-| `tight` | `abs(a-b) <= 1e-6 + 1e-4·max(\|a\|,\|b\|)` | numeric statistics: `mat`, tallies-derived consensus, repness/consensus stats, comment priorities |
-| `geom` | `abs(a-b) <= 1e-6 + 1e-2·max(\|a\|,\|b\|)` | PCA-derived geometry: `pca`, `proj`, cluster centers, `bucket-dists`, silhouettes |
+| `tight` | `abs(a-b) <= 1e-6 + 1e-4 · max(abs(a), abs(b))` | numeric statistics: `mat`, group-aware consensus, repness/consensus stats, comment priorities, the ptptstats geometry |
+| `geom-legacy` | `abs(a-b) <= 1e-6 + 1e-2 · max(abs(a), abs(b))` | PCA-derived geometry: `pca`, `proj`, cluster centers, `bucket-dists`, silhouettes |
 
-`tight` is the bound `P-022-G-engine-contract.md` §numeric-policy proposes for
-finite numeric statistics with zero outlier allowance. `geom` is deliberately
-looser because the two engines' cold-tick `comps` are documented to differ at
-~1e-5 while the final blob still MATCHes; it is the same relative bound
-`stepcompare.StepComparer` already defaults to for PCA-family paths.
+`tight` is the bound `P-022-G-engine-contract.md` proposes for finite numeric
+statistics with zero outlier allowance. It is a **proposed diagnostic
+reference**, not an admitted one: it has never been measured against the full
+battery.
 
-Non-numeric leaves (ids, booleans, strings, membership lists) are compared
-exactly whatever a key's numeric class is, and a shape difference — a missing
-key, a length mismatch — is always a divergence, never a tolerance question.
+`geom-legacy` is named for what it is — the 1e-2 relative bound
+`stepcompare.StepComparer` already defaults to for PCA-family paths, kept so
+this tool's geometry verdicts line up with the comparer already in use. It is
+**not** the proposed contract bound, and the documented ~1e-5 cross-engine noise
+does not establish that 1e-2 is necessary: 1e-5 is two orders below this ceiling
+and already inside `tight`'s relative coefficient at most scales. G permits a
+higher ceiling only under scoped, independently measured reference jitter, which
+nobody has measured here. So every `geom-legacy` key **also reports
+`n_over_tight`** — how many of its values the stricter reference would reject —
+and the bound is never tuned from candidate output. On the public battery
+`n_over_tight` is **0 everywhere**: the looseness is currently carrying nothing.
+
+Non-numeric leaves (booleans, strings, membership lists) are compared exactly
+whatever a key's numeric class is, and a shape difference — a missing key, a
+length mismatch, a duplicate identity — is always a divergence, never a
+tolerance question.
 
 ### What the comparer normalizes first
 
@@ -198,36 +237,67 @@ differences survive.
    the file stays a faithful record of what that engine actually computed and
    the interpretation lives in one auditable place.
 
-2. **Identity keying.** Named matrices become `{rowname|colname: cell}`, and
-   every tid-, pid- or bid-indexed array becomes a dict keyed by that id. Clojure
-   emits `tids` in hash/insertion order and Python in sorted order; each blob is
-   internally consistent, so array position is not semantics. Without this every
-   run would report thousands of phantom differences.
+2. **Identity keying, after validation.** Named matrices become
+   `{rowlabel|collabel: cell}` and every tid-, pid- or bid-indexed array becomes
+   a dict keyed by that id. Clojure emits `tids` in hash/insertion order and
+   Python in sorted order; each blob is internally consistent, so array position
+   is not semantics. Without this every run would report thousands of phantom
+   differences.
 
-3. **Coupled component sign.** Each principal component is oriented so its
-   largest-magnitude entry is positive (first tid on ties), and the arrays coupled
-   to it — that component's `comment-projection` row, the matching `proj`
-   column, and coordinate *k* of every base- and group-cluster center — are
-   flipped with it. `pca.center` is a data mean and is never flipped. This is
-   `crosslang.canonicalize_blob`'s rule, applied one level deeper.
+   Two safeguards make that keying honest. Labels are **type-tagged**, so the
+   integer `1` and the string `"1"` are different rows rather than colliding into
+   one. And the shape is **validated first**: a matrix whose row count disagrees
+   with its rownames, a ragged row, a duplicate row or column identity, an array
+   whose length disagrees with `tids`, a cluster list with a duplicate id, a
+   ptptstats row list with a duplicate or missing pid — each becomes a
+   **structural error**, reported as such. It is never a synthesized number,
+   because a number can be absorbed by a tolerance and a dropped cell can hide a
+   real difference behind a clean MATCH.
+
+3. **Coupled component sign, on declared axes.** Each principal component is
+   oriented so its largest-magnitude entry is positive (first tid in canonical
+   order on ties), and the arrays coupled to it — that component's
+   `comment-projection` row, the matching `proj` column, and coordinate *k* of
+   every base- and group-cluster center — are flipped with it. `pca.center` is a
+   data mean and is never flipped. This is `crosslang.canonicalize_blob`'s rule,
+   applied one level deeper.
+
+   The axis orientation of `comment-projection` is **read from the dump's
+   declared `comment_projection_axes`, never inferred from array lengths**: when
+   a conversation has exactly as many comments as components, lengths cannot
+   distinguish an *n*×2 from a 2×*n*, and a comparer that guessed would silently
+   compare a transposed array. Both emitters write `comps-by-tids` and say so; a
+   dump that does not declare it is refused.
 
 ---
 
 ## Carve-outs — differences that are expected
 
-From P-030 §Q13/Q18 and the engines' own documented boundaries. Four are applied
-automatically (the key reports `CARVED` instead of `DIVERGENT`, with its numbers
-still printed, and it does not become the first diverging stage). Two are
-documented but never auto-suppressed.
+From P-030 §Q13/Q18 and the engines' own documented boundaries.
 
-| id | key | auto | why it is expected |
+**The rule a carve-out must obey: it may never suppress a real difference.**
+Each one below has a narrow, mechanical scope, and anything outside that scope is
+reported normally. Only two carve-outs have a comparison rule at all; the rest
+are notes for the reader and suppress nothing.
+
+| id | scope | key | why it is expected |
 |---|---|---|---|
-| **C1** | `mod-in`, `mod-out`, `meta-tids` | yes | Clojure emits `nil` until a `mod-update` has written the set; Python emits an empty set. `null` vs `[]` on those three keys only — a genuinely absent value anywhere else still reports. Python's own blob boundary already mirrors the Clojure rule via `moderation_applied`, and the stage emitter applies the same gate, so in practice this fires rarely. |
-| **C2** | cluster ids / membership on warm chains | **no** | **Q13.** Warm-chain split-loop extraction order is knife-edge chaotic on tie-dense geometry: within-engine gaps at 2.5e-16 and 5.6e-17 against cross-engine projection noise at ~1e-5, eleven orders larger. No arithmetic replication reproduces the order. Ledgered on `FP-912391ece7 / FP-c29173e1ba / FP-98dc728043`; carved in the battery by swapping `pc-revote-01` for `pc-revote-02`. |
-| **C3** | `group-clusterings-silhouettes` | yes | The two engines score with **different estimators**: Clojure's `clusters/silhouette` over `bucket-dists`, Python's `calculate_silhouette_sklearn` over the base-cluster centers. The values are expected to differ. What must agree is the *argmax* they feed, which is visible in `group-k-smoother` and the group count — both compared exactly. |
-| **C4** | `ptpt-stats` | yes | The engines compute **different statistics under the same name**. Clojure emits `coreness` / `centricness` / `extremeness` (geometry over the participant projection); Python emits `n_agree` / `n_disagree` / `n_pass` / `group_correlations`. Even the two same-named fields disagree by construction: Clojure's `n-votes` is `user-vote-counts` over the *raw* rating matrix, Python's `n_votes` counts non-zero cells of the moderation-applied matrix, and Python omits participants with no votes entirely. `math_ptptstats` has no reader anywhere in Node or the clients, so this is verification surface only. |
-| **C5** | `mat`, all-NaN column | yes | Python substitutes a 0.0 column mean where Clojure would divide by zero. Unreachable on a real conversation — every column carries at least one vote. |
-| **C6** | cluster ids on coincident centers | **no** | **Q18.** `uniqify`'s exact-center-equality predicate is value-dependent ulp luck: `merge-clusters`' weighted mean preserves the input value for some doubles and rounds one ulp for others, so whether a merge *chain* over coincident singletons continues — and which id survives — depends on the 17th digit. Root cause of all 11 `carved-out` entries in `delphi/docs/divergences.json`. |
+| **C1** | `null` ↔ `[]` **only** | `mod-in`, `mod-out`, `meta-tids` | Clojure emits `nil` until a `mod-update` has written the set; Python emits an empty set. That exact value pair is suppressed and nothing else: `[1]` → `[2]`, `null` → `[2]`, a missing key or a wrong type all report as divergences. Python's own blob boundary already mirrors the Clojure rule via `moderation_applied`, and the stage emitter applies the same gate, so this rarely fires. |
+| **C2** | none — documented only | cluster ids / membership on warm chains | **Q13.** Warm-chain split-loop extraction order is knife-edge chaotic on tie-dense geometry: within-engine gaps at 2.5e-16 and 5.6e-17 against cross-engine projection noise at ~1e-5, eleven orders larger. Ledgered on `FP-912391ece7 / FP-c29173e1ba / FP-98dc728043`; carved in the *battery* by swapping `pc-revote-01` for `pc-revote-02`. |
+| **C3** | numeric **values** only | `group-clusterings-silhouettes` | The two engines score with **different estimators**: Clojure's `clusters/silhouette` over `bucket-dists`, Python's `calculate_silhouette_sklearn` over the base-cluster centers. Different numbers are expected. The candidate inventory (*which* k were scored), the argmax they feed, the smoother state and group membership are all **outside** the exception and compared normally — a missing k is a coverage problem, not an estimator difference. |
+| **C4** | none — documented only | `participant-info-legacy` | This engine's `participant_info` is a vote-correlation *report* statistic (`n_agree`/`n_disagree`/`n_pass`/`group_correlations`). It is not engine-contract surface and has no Clojure counterpart, so it rides along as an **engine-local** key, reported and never graded. It is **not** a waiver on `ptpt-stats`: see below. |
+| **C5** | none — documented only | `mat`, all-NaN column | Python substitutes a 0.0 column mean where Clojure would divide by zero. Unreachable on a real conversation (every column carries at least one vote), so there is no comparison rule — if it were ever observed it would report as an ordinary divergence. |
+| **C6** | none — documented only | cluster ids on coincident centers | **Q18.** `uniqify`'s exact-center-equality predicate is value-dependent ulp luck: `merge-clusters`' weighted mean preserves the input value for some doubles and rounds one ulp for others, so whether a merge *chain* over coincident singletons continues — and which id survives — depends on the 17th digit. Root cause of all 11 `carved-out` entries in `delphi/docs/divergences.json`. |
+
+**There is no carve-out on `ptpt-stats`.** The engine contract names six
+columnar geometric statistics — pid, gid, n-votes, centricness, coreness,
+extremeness — and this engine already implements them in
+`polismath.poller.math_writer.derive_ptptstats`, the production output adapter,
+a verbatim port of `repness/participant-stats` pinned against a live Clojure
+reference row. The stage reads *that*, with the raw `user-vote-counts` Clojure's
+`n-votes` is taken from, and compares pid/gid/n-votes exactly and the three
+geometric floats tolerantly. The absence of a Node reader for `math_ptptstats`
+is not a reason to waive anything.
 
 **Why C2 and C6 are not auto-suppressed.** They are chaotic, not addressable by
 a path rule. A rule that hid "cluster ids differ" would also hide real
@@ -237,6 +307,34 @@ fingerprint. P-030 §5/R7 says it directly: if a divergence's path pattern
 matches a carved-out fingerprint on a mod-heavy warm chain, probe it with the
 split-probe before spending a day on it — the correct action is to record it,
 not to fix it.
+
+---
+
+## Incomplete or misaligned input
+
+**A comparison that could not happen is not agreement.** Before diffing anything,
+the comparer validates each recording and refuses to print a headline unless the
+two are a complete, aligned, same-input pair. It checks that:
+
+* both directories exist and carry a `stages-manifest.json`;
+* the manifest's schema, `stage_order` and `n_steps` are right, its inventory
+  matches the files actually on disk, and every file it names is present;
+* every document declares a supported `vote_sign_convention` and the expected
+  `comment_projection_axes`, and carries **all eleven stages**;
+* step identities are unique, and the two sides are aligned **by step identity**,
+  not by position — two recordings that both hold "one step" are not comparable
+  if one is step 0 and the other step 7;
+* the two engines were fed the same batch (equal `input_digest`) and reached the
+  same `tick`.
+
+Anything unmet lands in `input_problems`, sets `input_valid: false` and
+`headline_withheld: true`, and the report prints `INCOMPLETE OR MISALIGNED
+INPUT` with the reasons instead of a first-diverging-stage line. Two empty
+directories now say so, rather than reporting that every stage is within
+tolerance.
+
+This is input validity, not a gate: an invalid input makes the *diagnostic*
+unusable, and says nothing about any engine.
 
 ---
 
@@ -268,16 +366,18 @@ Encoding rules, identical on both engines:
 * **Integers** — ids, counts, timestamps, vote values — are JSON integers with
   no decimal point.
 * **Doubles** use the shortest decimal that round-trips to the same double
-  (`Double/toString` on JDK 19+, `repr(float)` in Python). **Nothing is ever
-  rounded**: the compared numbers are the exact doubles the engine computed.
-  Exponent *formatting* differs across the two languages (`1.0E-5` vs `1e-05`)
-  and does not matter — the comparison parses, it does not diff bytes.
+  (`Double/toString` on JDK 19+, `repr(float)` in Python). Exponent *formatting*
+  differs across the two languages (`1.0E-5` vs `1e-05`) and does not matter —
+  the comparison parses, it does not diff bytes.
 * **Non-finite doubles** become the JSON strings `"NaN"`, `"Infinity"`,
   `"-Infinity"`; JSON has no literal for them and silently emitting one would
   make the file unparseable by a strict reader.
 * **A named matrix** is `{"rownames": […], "colnames": […], "matrix": [[…]]}`
   with missing cells as `null` — a nil vote and a 0 vote are different meanings.
 * **Sets** become sorted arrays; keywords become their bare name.
+* **`comment_projection_axes`** declares the orientation of
+  `pca.comment-projection` (`comps-by-tids` on both engines). A dump without it
+  is refused rather than guessed at.
 * **`input_digest`** is `sha256` over the step's fed batch in *export/Delphi*
   sign convention (`{"mods": [[tid, is_meta, mod, modified], …], "votes":
   [[pid, tid, sign, created], …]}`, canonical JSON, fed order). Taking it in
@@ -285,6 +385,34 @@ Encoding rules, identical on both engines:
   the raw-DB flip Clojure applies before `conv-update`. **If the digests differ,
   stop**: the engines were not fed the same batch and every other number in the
   report is meaningless.
+
+### What the encoding is and is not lossless for
+
+**Verified.** Finite `binary64` survives the wire in both directions,
+bit-for-bit: 265 values Clojure→Python and 265 Python→Clojure, including signed
+zero, the minimum subnormal, the maximum finite value and adjacent representable
+neighbours, plus a 5 000-value random-bit sample within each runtime. Ordinary
+signed-64-bit JSON integers are preserved on output by both emitters, and the
+comparer compares them as integers rather than through a float.
+
+**Not claimed.** This is not a general, lossless serializer for arbitrary engine
+values, and the following are deliberate, tested limits of the admitted value
+domain rather than defects to be discovered later:
+
+* map keys are **stringified**, so integer `1` and string `"1"` collapse into one
+  key on both engines;
+* the JSON string `"NaN"` and the non-finite token for NaN are
+  **indistinguishable** on the wire — the same is true of the two infinities;
+* Clojure `Ratio` (e.g. `1/3`) is projected to the nearest double
+  (`0.3333333333333333`), and keyword / set / type identity is projected away;
+* a pandas `NaN` cell in a vote matrix means **missing vote** and becomes `null`,
+  not a non-finite token — a field-level rule, not a number rule;
+* the JSON is canonical *within* each engine, but the two engines' bytes are not
+  identical, because their decimal spellings differ. Numeric round-trip
+  equivalence is the claim; byte equality is not.
+
+If exact source-type reconstruction is ever needed, rationals and non-finite
+values will have to be tagged rather than projected.
 
 Dumps are large — for `vw` (69 participants, 125 comments) roughly 350 KB per
 step per engine, dominated by `bucket-dists` and the two vote matrices. They are
@@ -308,6 +436,13 @@ clojure -M:test          # includes test/stage_json_test.clj
 sides — key order, integer formatting, exact double round-trip over a 5 000-value
 random sample, non-finite handling, named-matrix shape — plus the comparer's
 canonicalization, tolerance classes and carve-outs.
+
+The `test_f1_…` through `test_f6_…` group is the regression set for the six
+findings in `cost-reduction/04-plans/P-030-R-ORACLE-astra-review.md`, one
+behaviour per name: the contract geometry at R13, C1's narrow scope, integer
+identities never seeing a tolerance, malformed matrices and undeclared axes
+becoming structural errors, incomplete input withholding the headline, and the
+non-finite tokens surviving polarity conversion.
 
 `test_stage_oracle_e2e.py` runs the whole loop on the smallest public battery
 case (`vw:single-cut`). The Clojure half is opt-in behind

--- a/docs/engine-stage-oracles.md
+++ b/docs/engine-stage-oracles.md
@@ -212,13 +212,20 @@ malformed operands cannot slip through: `True` vs `True` for a count, `"1"` vs
 `"1"` for a tid, or a float-spelled cluster id `1.5` on both sides are all
 divergences, not matches.
 
-So is the **shape**. An integer position is declared scalar or array and
-validated before any recursion, because `n = {}` on both sides is not a count
-that happens to agree — it is not a count. The declaration is *key-scoped* where
-it has to be: `A`/`D`/`S` are per-base-cluster bucket arrays in `votes-base` and
-per-group scalar totals in `group-votes`, so a rule keyed on the field name
-alone gets one of them wrong. It applies at the declared position only, so
-`bid-to-pid` remains an array of arrays.
+So is the **shape** — and the shape of everything below it. Each integer
+position carries a declared **rank**: `("scalar",)` for a count,
+`("array", "scalar")` for a list of ids, `("array", "array", "scalar")` for
+`bid-to-pid`, the one legitimately two-dimensional integer key. The rank is
+validated before any recursion and descends *with* it, so `n = {}` on both sides
+is not a count that happens to agree (it is not a count), and `in-conv = [{}]` is
+a malformed element rather than an unconstrained subtree. A null element of an
+integer array is structural too — a top-level integer field may legitimately be
+null (a nullable `n-votes`, a watermark on a votes tick, a moderation set before
+any `mod-update`), but an array of ids holds ids.
+
+The declaration is *key-scoped* where it has to be: `A`/`D`/`S` are
+per-base-cluster bucket arrays in `votes-base` and per-group scalar totals in
+`group-votes`, so a rule keyed on the field name alone gets one of them wrong.
 
 The remaining, genuinely continuous leaves get one of two bounds:
 
@@ -386,8 +393,15 @@ two are a complete, aligned, same-input pair. It checks that:
   on disk appears in the manifest; and the recording declares **one** engine and
   **one** polarity throughout, matching the manifest's;
 * a malformed document — not an object, unparseable JSON, a non-object `stages`
-  container, a non-integer step — becomes an input problem rather than an
-  exception;
+  container, a non-integer step, an unusable `engine` or `vote_sign_convention`
+  (wrong type, unknown value, empty) — becomes a named input problem rather than
+  an exception. Metadata is type- and enum-checked *before* it is used as a set
+  member or a membership test, and every container is type-checked rather than
+  tested for truthiness: a **non-empty** array in a stage position is truthy, and
+  used to raise where the empty and null cases did not;
+* a document that fails any of this is **not sent onward to be compared**. A
+  usable step identity is not a licence to canonicalize a document validation has
+  already rejected;
 * step identities are unique, and the two sides are aligned **by step identity**,
   not by position — two recordings that both hold "one step" are not comparable
   if one is step 0 and the other step 7;

--- a/math/dev/replay.clj
+++ b/math/dev/replay.clj
@@ -402,6 +402,15 @@
 
 (def stage-dump-schema "polis-stage-dump/1")
 
+(def comment-projection-axes
+  "Axis orientation of :pca :comment-projection, DECLARED in every document
+  rather than inferred downstream: Clojure's with-proj-and-extremtiy
+  (conversation.clj:341-352) emits n-comps rows of n-tids values, and the Python
+  twin transposes to match. A comparer that guessed the orientation from array
+  lengths would misread every square case (n-tids = n-comps), so the orientation
+  is part of the wire contract."
+  "comps-by-tids")
+
 (def stage-node-map
   "Ordered [stage-name [[json-key graph-node-key] …]] — the node list P-030 §2.3
   enumerates, grouped by the port plan's R-stage. Stage names are zero-padded so
@@ -600,6 +609,7 @@
   "The `polis-stage-dump/1` document for one step of one engine."
   [step conv]
   (sorted-map
+    "comment_projection_axes" comment-projection-axes
     "engine"       "clj"
     "input_digest" (step-input-digest step)
     "schema"       stage-dump-schema
@@ -639,7 +649,8 @@
   (let [rows (mapv (fn [[s conv]] (write-stage-json! dir s conv)) results)]
     (spit (io/file dir "stages-manifest.json")
           (stage-json-string
-            (sorted-map "engine"      "clj"
+            (sorted-map "comment_projection_axes" comment-projection-axes
+                        "engine"      "clj"
                         "n_steps"     (count rows)
                         "schema"      stage-dump-schema
                         "stage_order" stage-order

--- a/math/dev/replay.clj
+++ b/math/dev/replay.clj
@@ -354,6 +354,299 @@
     (when edn? (write-edn! dir s conv (->conv-votes (:votes s))))))
 
 ;; ---------------------------------------------------------------------------
+;; Stage dump (--stage-json) — R-ORACLE, P-030 §2.3.
+;;
+;; A SIBLING sink beside write-blob!/write-edn!. It writes one JSON file per
+;; step carrying the plumbing-graph node outputs the port plan enumerates, so a
+;; second engine can be localised to its FIRST DIVERGING STAGE instead of only
+;; being told that the final blob differs.
+;;
+;; Discipline (P-030 §2.3, the same B1 used for step-NNN.meta.json):
+;;   * harness-only — the recorded prep-main blob and the --edn dump are
+;;     untouched, and this sink is off unless --stage-json is passed;
+;;   * output lands in a SIBLING directory `<out>/clj-stages/`, never inside
+;;     `clj/`: certify globs `step-*` / `step-*.json` there for its inventory
+;;     and digest sets (certify.py:868,873,1283) and store.load_step_blobs
+;;     globs `step-*.json`, so a stage file inside an engine dir would be read
+;;     as a step payload;
+;;   * DIAGNOSTICS ONLY — never a gate. certify remains the sole PASS/FAIL
+;;     authority on the final blob.
+;;
+;; Encoding contract (schema `polis-stage-dump/1`), mirrored byte-for-byte by
+;; delphi/polismath/replay/stages.py:
+;;   * every JSON object's keys are sorted ascending as strings (map keys that
+;;     are integers/keywords are stringified FIRST, then sorted, so "10" < "2"
+;;     on both engines);
+;;   * integers (ids, counts, timestamps, vote values) are emitted as JSON
+;;     integers with no decimal point;
+;;   * doubles are emitted with Double/toString — the shortest decimal that
+;;     round-trips to the same double (JDK 19+ implements the correct shortest
+;;     repr; Python's repr(float) is the same shortest-round-trip rule). NO
+;;     rounding, ever: the compared numbers are the exact doubles;
+;;   * non-finite doubles become the JSON STRINGS "NaN"/"Infinity"/"-Infinity"
+;;     (JSON has no literal for them) so they survive the round trip visibly;
+;;   * a NamedMatrix becomes {"rownames":[…],"colnames":[…],"matrix":[[…]]}
+;;     with nil cells as null, so the diff can key cells by (rowname,colname)
+;;     rather than by cross-engine-arbitrary position;
+;;   * sets become sorted arrays; keywords become their bare name.
+;;
+;; VOTE-SIGN CONVENTION. This sink emits the engine's NATIVE numbers. Clojure
+;; computes in raw-DB convention (AGREE=-1, utils.clj:40-49) while the Python
+;; engine computes in Delphi convention (AGREE=+1) and negates only at its blob
+;; emission boundary (conversation.py:1767-1788), so the vote-valued and
+;; geometry stage nodes differ by sign BEFORE that boundary. The dump records
+;; `vote_sign_convention` and stagecompare.py applies the negation set; the
+;; emitter deliberately does not, so that the file is a faithful record of what
+;; this engine actually computed.
+;; ---------------------------------------------------------------------------
+
+(def stage-dump-schema "polis-stage-dump/1")
+
+(def stage-node-map
+  "Ordered [stage-name [[json-key graph-node-key] …]] — the node list P-030 §2.3
+  enumerates, grouped by the port plan's R-stage. Stage names are zero-padded so
+  that lexicographic key order (the encoding contract) IS pipeline order.
+
+  Omitted deliberately: :keep-votes and :customs (the fed batch, already covered
+  by input_digest), and the dead :subgroup-* trio (CLOJURE_QUIRKS Q7 — computed
+  and persisted but consumed nowhere; certify.py:87-88 drops them too)."
+  [["R01_ingest"          [["last-vote-timestamp" :last-vote-timestamp]
+                           ["n"                   :n]
+                           ["n-cmts"              :n-cmts]
+                           ["raw-rating-mat"      :raw-rating-mat]
+                           ["rating-mat"          :rating-mat]
+                           ["tids"                :tids]]]
+   ["R02_moderation"      [["last-mod-timestamp"  :last-mod-timestamp]
+                           ["meta-tids"           :meta-tids]
+                           ["mod-in"              :mod-in]
+                           ["mod-out"             :mod-out]]]
+   ["R03_eligibility"     [["in-conv"             :in-conv]
+                           ["user-vote-counts"    :user-vote-counts]]]
+   ["R04_pca"             [["mat"                 :mat]
+                           ["pca"                 :pca]]]
+   ["R05_projections"     [["proj"                :proj-nmat]]]
+   ["R06_base_clusters"   [["base-clusters"         :base-clusters]
+                           ["base-clusters-proj"    :base-clusters-proj]
+                           ["base-clusters-weights" :base-clusters-weights]
+                           ["bid-to-pid"            :bid-to-pid]
+                           ["bucket-dists"          :bucket-dists]]]
+   ["R09_group_clusters"  [["group-clusterings"             :group-clusterings]
+                           ["group-clusterings-silhouettes" :group-clusterings-silhouettes]
+                           ["group-clusters"                :group-clusters]
+                           ["group-k-smoother"              :group-k-smoother]]]
+   ["R10_tallies"         [["group-aware-consensus" :group-aware-consensus]
+                           ["group-votes"           :group-votes]
+                           ["votes-base"            :votes-base]]]
+   ["R11_repness"         [["consensus"           :consensus]
+                           ["repness"             :repness]]]
+   ["R12_priorities"      [["comment-priorities"  :comment-priorities]]]
+   ["R13_ptpt_stats"      [["ptpt-stats"          :ptpt-stats]]]])
+
+(def stage-order (mapv first stage-node-map))
+
+;; --- coercion: engine values -> plain data (sorted-maps / vectors / scalars) --
+
+(declare ->plain)
+
+(defn- plain-key
+  "Stringify a map key. Integer keys become their decimal form (NOT 12.0), so
+  the tid/pid/gid keys agree with Python's str(int(k))."
+  [k]
+  (cond
+    (keyword? k) (name k)
+    (string? k)  k
+    (integer? k) (str (bigint k))
+    (nil? k)     "null"
+    :else        (str k)))
+
+(defn- sort-plain-coll
+  "Deterministic ascending order for a set's elements: numerically when they are
+  all comparable, else by their printed form."
+  [coll]
+  (try (vec (sort coll))
+       (catch ClassCastException _ (vec (sort-by pr-str coll)))))
+
+(defn- nmat-rows
+  "Rows of a NamedMatrix's backing matrix as nested Clojure collections. The
+  backing store is a persistent vector-of-vectors whenever the matrix carries
+  nils (vectorz cannot hold nil) and a vectorz array otherwise."
+  [x]
+  (let [m (nm/get-matrix x)]
+    (if (instance? mikera.arrayz.INDArray m)
+      (matrix/to-nested-vectors m)
+      m)))
+
+(defn ->plain
+  "Coerce an engine value into plain data (sorted-map / vector / Long / Double /
+  String / Boolean / nil) ready for write-plain!. Throws on anything it does not
+  recognise rather than silently emitting a printed representation."
+  [x]
+  (cond
+    (nil? x)     nil
+    (boolean? x) x
+    (keyword? x) (name x)
+    (string? x)  x
+    (integer? x) (long x)
+    (number? x)  (double x)
+    ;; NamedMatrix is a deftype (not a map) — checked before map?/sequential?.
+    (satisfies? nm/PNamedMatrix x)
+    (sorted-map "colnames" (mapv ->plain (nm/colnames x))
+                "matrix"   (mapv (fn [row] (mapv ->plain row)) (nmat-rows x))
+                "rownames" (mapv ->plain (nm/rownames x)))
+    (instance? mikera.arrayz.INDArray x) (->plain (matrix/to-nested-vectors x))
+    (set? x)     (mapv ->plain (sort-plain-coll x))
+    (map? x)     (into (sorted-map)
+                       (map (fn [[k v]] [(plain-key k) (->plain v)]) x))
+    (or (sequential? x) (instance? java.util.List x)) (mapv ->plain x)
+    (instance? java.util.Map x)
+    (into (sorted-map) (map (fn [[k v]] [(plain-key k) (->plain v)]) x))
+    :else (throw (ex-info "stage-json: unsupported value type"
+                          {:type (str (type x)) :value (pr-str x)}))))
+
+;; --- the writer: canonical JSON with sorted keys and exact doubles ----------
+
+(defn- json-escape
+  ^String [^String s]
+  (let [sb (StringBuilder. (+ 2 (.length s)))]
+    (dotimes [i (.length s)]
+      (let [c (.charAt s i)]
+        (cond
+          (= c \")     (.append sb "\\\"")
+          (= c \\)     (.append sb "\\\\")
+          (= c \newline)  (.append sb "\\n")
+          (= c \return)   (.append sb "\\r")
+          (= c \tab)      (.append sb "\\t")
+          (= c \backspace)(.append sb "\\b")
+          (= c \formfeed) (.append sb "\\f")
+          (< (int c) 0x20) (.append sb (format "\\u%04x" (int c)))
+          :else (.append sb c))))
+    (.toString sb)))
+
+(defn double->json
+  "The shortest decimal that round-trips to this exact double (Double/toString;
+  JDK 19+ implements the correct shortest representation). Non-finite doubles
+  have no JSON literal, so they are emitted as quoted strings."
+  ^String [^double d]
+  (cond
+    (Double/isNaN d) "\"NaN\""
+    (= d Double/POSITIVE_INFINITY) "\"Infinity\""
+    (= d Double/NEGATIVE_INFINITY) "\"-Infinity\""
+    :else (Double/toString d)))
+
+(defn- write-plain!
+  [^StringBuilder sb x]
+  (cond
+    (nil? x)     (.append sb "null")
+    (true? x)    (.append sb "true")
+    (false? x)   (.append sb "false")
+    (string? x)  (doto sb (.append \") (.append (json-escape x)) (.append \"))
+    (integer? x) (.append sb (str (long x)))
+    (number? x)  (.append sb (double->json (double x)))
+    (map? x)     (do (.append sb \{)
+                     (loop [entries (seq x) first? true]
+                       (when-let [[k v] (first entries)]
+                         (when-not first? (.append sb \,))
+                         (doto sb (.append \") (.append (json-escape k)) (.append \")
+                                  (.append \:))
+                         (write-plain! sb v)
+                         (recur (next entries) false)))
+                     (.append sb \}))
+    (sequential? x) (do (.append sb \[)
+                        (loop [items (seq x) first? true]
+                          (when (seq items)
+                            (when-not first? (.append sb \,))
+                            (write-plain! sb (first items))
+                            (recur (next items) false)))
+                        (.append sb \]))
+    :else (throw (ex-info "stage-json: unwritable plain value"
+                          {:type (str (type x))}))))
+
+(defn stage-json-string
+  "Serialize already-plain data (see ->plain) as canonical stage-dump JSON."
+  ^String [plain]
+  (let [sb (StringBuilder.)]
+    (write-plain! sb plain)
+    (.toString sb)))
+
+;; --- input digest -----------------------------------------------------------
+
+(defn- sha256-hex
+  [^String s]
+  (let [md (MessageDigest/getInstance "SHA-256")]
+    (->> (.digest md (.getBytes s "UTF-8"))
+         (map #(format "%02x" (bit-and % 0xff)))
+         (apply str))))
+
+(defn step-input-digest
+  "sha256 over this step's fed inputs, in a form BOTH engines can reproduce.
+
+  Votes are digested in EXPORT/Delphi sign convention (AGREE=+1) — the sign the
+  CSV carries — not in the raw-DB convention conv-update consumes, so the clj
+  and py digests agree for the same batch. Rows keep fed order (the schedule
+  slicer's stable order); booleans are 0/1."
+  [step]
+  (let [votes (mapv (fn [{:keys [pid tid sign t-ms]}]
+                      [(long pid) (long tid) (long sign) (long t-ms)])
+                    (:votes step))
+        mods  (mapv (fn [{:keys [tid is_meta mod modified]}]
+                      [(long tid) (if is_meta 1 0) (long mod) (long modified)])
+                    (:mods step))]
+    (str "sha256:"
+         (sha256-hex (stage-json-string (sorted-map "mods" mods "votes" votes))))))
+
+;; --- the sink ---------------------------------------------------------------
+
+(defn stage-document
+  "The `polis-stage-dump/1` document for one step of one engine."
+  [step conv]
+  (sorted-map
+    "engine"       "clj"
+    "input_digest" (step-input-digest step)
+    "schema"       stage-dump-schema
+    "stages"       (into (sorted-map)
+                         (map (fn [[stage-name nodes]]
+                                [stage-name
+                                 (into (sorted-map)
+                                       (map (fn [[json-key node-key]]
+                                              [json-key (->plain (get conv node-key))])
+                                            nodes))])
+                              stage-node-map))
+    "step"         (long (:index step))
+    "tick"         (some-> (:last-vote-timestamp conv) long)
+    "vote_sign_convention" "raw-db"))
+
+(defn write-stage-json!
+  "Write `step-NNN.stages.json` and return this step's manifest row."
+  [dir step conv]
+  (let [doc  (stage-document step conv)
+        name (format "step-%03d.stages.json" (:index step))]
+    (spit (io/file dir name) (stage-json-string doc))
+    (sorted-map "file"         name
+                "index"        (long (:index step))
+                "input_digest" (get doc "input_digest")
+                "tick"         (get doc "tick"))))
+
+(defn write-stage-results!
+  "Write the whole stage recording (per-step dumps + stages-manifest.json) for
+  one replay pass into `dir` (a SIBLING of the engine's blob dir)."
+  [^java.io.File dir results]
+  (.mkdirs dir)
+  ;; A prior run with more steps would otherwise leave stale higher-index
+  ;; dumps that a reader globbing step-*.stages.json would mix in.
+  (doseq [^java.io.File stale (.listFiles dir)]
+    (when (re-matches #"step-\d+\.stages\.json" (.getName stale))
+      (.delete stale)))
+  (let [rows (mapv (fn [[s conv]] (write-stage-json! dir s conv)) results)]
+    (spit (io/file dir "stages-manifest.json")
+          (stage-json-string
+            (sorted-map "engine"      "clj"
+                        "n_steps"     (count rows)
+                        "schema"      stage-dump-schema
+                        "stage_order" stage-order
+                        "steps"       rows
+                        "vote_sign_convention" "raw-db")))))
+
+;; ---------------------------------------------------------------------------
 ;; Provenance.
 ;; ---------------------------------------------------------------------------
 
@@ -376,7 +669,7 @@
 
 (defn build-provenance
   [{:keys [schedule schedule-id source votes-path comments-path zid meta-tids
-           meta-tids-source warm-start repeats n-steps edn?
+           meta-tids-source warm-start repeats n-steps edn? stage-json?
            moderation n-mod-events n-mod-skipped restart-after]}]
   {:engine "clj"
    :moderation (or moderation "none")
@@ -391,6 +684,7 @@
    :n_steps n-steps
    :repeats repeats
    :edn edn?
+   :stage_json (boolean stage-json?)
    :warm_start warm-start
    :warm_start_note "chain is implicit: the reduce threads conv; :pca :comps seed the next step's start-vectors (conversation.clj:381-387)"
    :vote_sign_convention "raw-db"
@@ -495,6 +789,8 @@
    ["-r" "--repeats N" "Full-replay repeats for §9 self-jitter (default 1)."
     :default 1 :parse-fn #(Integer/parseInt %)]
    [nil "--edn" "Also write per-step full-state EDN (conv-update-dump shape)."]
+   [nil "--stage-json"
+    "Also write per-step stage dumps (polis-stage-dump/1) to <out>/clj-stages/."]
    ["-h" "--help"]])
 
 (defn -main [& args]
@@ -526,8 +822,13 @@
             zid         (or (:zid options) dataset)
             repeats     (:repeats options)
             edn?        (boolean (:edn options))
+            stage-json? (boolean (:stage-json options))
             out         (io/file (:out options))
-            clj-dir     (io/file out "clj")]
+            clj-dir     (io/file out "clj")
+            ;; SIBLING of clj/ on purpose — certify globs step-* inside the
+            ;; engine dir for its inventory/digest sets (certify.py:868,873,
+            ;; 1283) and store.load_step_blobs globs step-*.json there.
+            stage-root  (io/file out "clj-stages")]
 
         (when-not (contains? #{"none" "interleave-by-timestamp" nil} moderation)
           (throw (ex-info
@@ -608,12 +909,22 @@
           ;; cross-language surface); rep i>0 (and rep 0) go to clj/rep-i/.
           (dotimes [rep repeats]
             (let [results (run-once zid meta-tids steps restart-after)
-                  rep-dir (if (> repeats 1) (io/file clj-dir (str "rep-" rep)) clj-dir)]
+                  rep-dir (if (> repeats 1) (io/file clj-dir (str "rep-" rep)) clj-dir)
+                  stage-dir (if (> repeats 1)
+                              (io/file stage-root (str "rep-" rep))
+                              stage-root)]
               (write-results! rep-dir results edn?)
               (when (and (> repeats 1) (zero? rep))
                 (write-results! clj-dir results edn?))
+              (when stage-json?
+                (write-stage-results! stage-dir results)
+                (when (and (> repeats 1) (zero? rep))
+                  (write-stage-results! stage-root results)))
               (binding [*out* *err*]
-                (println (format "  rep %d/%d written → %s" (inc rep) repeats (str rep-dir))))))
+                (println (format "  rep %d/%d written → %s" (inc rep) repeats (str rep-dir)))
+                (when stage-json?
+                  (println (format "  rep %d/%d stage dumps → %s"
+                                   (inc rep) repeats (str stage-dir)))))))
 
           ;; Provenance (recording dir + a clj/ mirror so a later Python run's
           ;; provenance.json cannot clobber ours).
@@ -622,7 +933,7 @@
                         :votes-path (:votes options) :comments-path (:comments options)
                         :zid zid :meta-tids meta-tids :meta-tids-source meta-src
                         :warm-start warm-start :repeats repeats
-                        :n-steps (count steps) :edn? edn?
+                        :n-steps (count steps) :edn? edn? :stage-json? stage-json?
                         :moderation moderation
                         :n-mod-events (count mod-events)
                         :n-mod-skipped n-mod-skipped

--- a/math/dev/replay.clj
+++ b/math/dev/replay.clj
@@ -631,10 +631,14 @@
   (let [doc  (stage-document step conv)
         name (format "step-%03d.stages.json" (:index step))]
     (spit (io/file dir name) (stage-json-string doc))
-    (sorted-map "file"         name
+    ;; Self-describing row: a manifest must be checkable against the document
+    ;; it names on all four identity fields plus the emission polarity.
+    (sorted-map "engine"       (get doc "engine")
+                "file"         name
                 "index"        (long (:index step))
                 "input_digest" (get doc "input_digest")
-                "tick"         (get doc "tick"))))
+                "tick"         (get doc "tick")
+                "vote_sign_convention" (get doc "vote_sign_convention"))))
 
 (defn write-stage-results!
   "Write the whole stage recording (per-step dumps + stages-manifest.json) for

--- a/math/test/stage_json_test.clj
+++ b/math/test/stage_json_test.clj
@@ -1,0 +1,196 @@
+;; Copyright (C) 2012-present, The Authors. This program is free software: you can redistribute it and/or  modify it under the terms of the GNU Affero General Public License, version 3, as published by the Free Software Foundation. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(ns stage-json-test
+  "Unit tests for the --stage-json emitter in dev/replay.clj (R-ORACLE,
+  P-030 §2.3).
+
+  The driver lives under dev/ and is loaded by the :replay alias with `-i`
+  rather than being on the classpath (deps.edn comments why: dev/user.clj would
+  be auto-loaded and it requires oz/cider, which are not base deps). So this
+  namespace load-files it, exactly as the alias does, relative to math/ — the
+  directory `clojure -M:test` runs from."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.io :as io]
+            [cheshire.core :as json]
+            [polismath.math.named-matrix :as nm]))
+
+(def ^:private driver-loaded?
+  (let [f (io/file "dev/replay.clj")]
+    (when (.exists f)
+      (load-file (.getPath f))
+      true)))
+
+(defn- v [sym] @(ns-resolve 'replay sym))
+
+(deftest driver-loads
+  (is driver-loaded?
+      "dev/replay.clj must be loadable from math/ (run tests with cwd=math)"))
+
+;; ---------------------------------------------------------------------------
+;; Key order.
+;; ---------------------------------------------------------------------------
+
+(deftest key-order-is-sorted-as-strings
+  (when driver-loaded?
+    (let [->plain (v '->plain)
+          write   (v 'stage-json-string)]
+      (testing "keyword keys are emitted in sorted order regardless of literal order"
+        (is (= "{\"a\":1,\"b\":2,\"c\":3}"
+               (write (->plain {:c 3 :a 1 :b 2})))))
+      (testing "integer keys are stringified FIRST, then sorted as strings —
+                so \"10\" precedes \"2\", which is what Python's sort_keys does
+                after the same stringification"
+        (is (= "{\"1\":1,\"10\":10,\"2\":2}"
+               (write (->plain {2 2, 10 10, 1 1})))))
+      (testing "nested objects are sorted at every level"
+        (is (= "{\"outer\":{\"x\":{\"a\":1,\"z\":2}}}"
+               (write (->plain {:outer {:x {:z 2 :a 1}}}))))))))
+
+(deftest stage-names-sort-into-pipeline-order
+  (when driver-loaded?
+    (let [order (v 'stage-order)]
+      (is (= order (vec (sort order)))
+          "zero-padded stage names must make lexicographic order == pipeline order")
+      (is (= (count order) (count (distinct order)))))))
+
+;; ---------------------------------------------------------------------------
+;; Numbers: integers stay integers, doubles round-trip exactly.
+;; ---------------------------------------------------------------------------
+
+(deftest integers-emit-without-a-decimal-point
+  (when driver-loaded?
+    (let [->plain (v '->plain) write (v 'stage-json-string)]
+      (is (= "[0,1,-7,2147483648,9007199254740993]"
+             (write (->plain [0 1 -7 2147483648 9007199254740993]))))
+      (is (= "{\"id\":42}" (write (->plain {:id (int 42)})))))))
+
+(def ^:private tricky-doubles
+  [0.0 -0.0 1.0 -1.0 0.1 (+ 0.1 0.2) (/ 1.0 3.0)
+   1.0E-5 1.0E10 1.0E300 1.0E-300
+   Double/MIN_VALUE Double/MAX_VALUE
+   (Math/nextUp 1.0) (Math/nextDown 1.0)
+   4.9E-324 2.2250738585072014E-308
+   0.888888888888889 2.8284271247461903 1.635555555555556])
+
+(deftest doubles-round-trip-bit-for-bit
+  (when driver-loaded?
+    (let [write (v 'stage-json-string) ->plain (v '->plain)]
+      (testing "every emitted double parses back to the SAME double — the
+                emitter uses the shortest round-tripping repr and never rounds"
+        (doseq [d tricky-doubles]
+          (let [text (write (->plain d))
+                back (Double/parseDouble text)]
+            (is (= (Double/doubleToRawLongBits (double d))
+                   (Double/doubleToRawLongBits back))
+                (str "round-trip failed for " d " (emitted " text ")")))))
+      (testing "a large random sample of doubles also round-trips"
+        (let [rng (java.util.Random. 20260908)]
+          (dotimes [_ 5000]
+            (let [d (Double/longBitsToDouble (.nextLong rng))]
+              (when (and (not (Double/isNaN d)) (not (Double/isInfinite d)))
+                (is (= (Double/doubleToRawLongBits d)
+                       (Double/doubleToRawLongBits
+                         (Double/parseDouble (write (->plain d))))))))))))))
+
+(deftest non-finite-doubles-become-json-strings
+  (when driver-loaded?
+    (let [write (v 'stage-json-string) ->plain (v '->plain)]
+      (is (= "[\"NaN\",\"Infinity\",\"-Infinity\"]"
+             (write (->plain [Double/NaN
+                              Double/POSITIVE_INFINITY
+                              Double/NEGATIVE_INFINITY]))))
+      (testing "and the result is still parseable JSON (JSON has no NaN literal)"
+        (is (= ["NaN" "Infinity" "-Infinity"]
+               (json/parse-string
+                 (write (->plain [Double/NaN
+                                  Double/POSITIVE_INFINITY
+                                  Double/NEGATIVE_INFINITY])))))))))
+
+;; ---------------------------------------------------------------------------
+;; Shapes.
+;; ---------------------------------------------------------------------------
+
+(deftest named-matrix-emits-rownames-colnames-matrix
+  (when driver-loaded?
+    (let [->plain (v '->plain) write (v 'stage-json-string)
+          m (nm/update-nmat (nm/named-matrix)
+                            [[1 10 -1] [1 11 1] [2 10 0]])
+          parsed (json/parse-string (write (->plain m)))]
+      (is (= #{"rownames" "colnames" "matrix"} (set (keys parsed))))
+      (is (= [1 2] (get parsed "rownames")))
+      (is (= [10 11] (get parsed "colnames")))
+      (testing "an unvoted cell is null, not 0 — nil vs 0 is meaning, not shape"
+        (is (= [[-1 1] [0 nil]] (get parsed "matrix")))))))
+
+(deftest sets-become-sorted-arrays-and-keywords-become-names
+  (when driver-loaded?
+    (let [->plain (v '->plain) write (v 'stage-json-string)]
+      (is (= "[1,2,3,10]" (write (->plain #{10 1 3 2}))))
+      (is (= "\"agree\"" (write (->plain :agree))))
+      (is (= "{\"repful-for\":\"disagree\"}"
+             (write (->plain {:repful-for :disagree})))))))
+
+(deftest unsupported-values-throw-rather-than-being-printed
+  (when driver-loaded?
+    (let [->plain (v '->plain)]
+      (is (thrown? clojure.lang.ExceptionInfo (->plain (Object.)))))))
+
+(deftest json-escapes-control-characters
+  (when driver-loaded?
+    (let [->plain (v '->plain) write (v 'stage-json-string)
+          s "a\"b\\c\nd\te"]
+      (is (= s (json/parse-string (write (->plain s))))))))
+
+;; ---------------------------------------------------------------------------
+;; Input digest.
+;; ---------------------------------------------------------------------------
+
+(deftest input-digest-is-in-export-sign-convention
+  (when driver-loaded?
+    (let [digest (v 'step-input-digest)
+          step {:index 0
+                :votes [{:pid 1 :tid 2 :sign 1 :t-ms 1000}
+                        {:pid 1 :tid 3 :sign -1 :t-ms 2000}]
+                :mods []}]
+      (testing "stable and prefixed"
+        (is (= (digest step) (digest step)))
+        (is (.startsWith ^String (digest step) "sha256:")))
+      (testing "the digest is over the CSV/export sign, so it is not disturbed by
+                the raw-DB flip conv-update consumes — it is what makes the clj
+                and py manifests comparable"
+        (is (not= (digest step)
+                  (digest (update step :votes
+                                  (fn [vs] (mapv #(update % :sign -) vs)))))))
+      (testing "moderation rows participate"
+        (is (not= (digest step)
+                  (digest (assoc step :mods
+                                 [{:tid 2 :is_meta true :mod -1 :modified 5}]))))))))
+
+;; ---------------------------------------------------------------------------
+;; Document shape.
+;; ---------------------------------------------------------------------------
+
+(deftest stage-document-carries-every-stage-and-the-manifest-fields
+  (when driver-loaded?
+    (let [doc-fn (v 'stage-document)
+          write  (v 'stage-json-string)
+          order  (v 'stage-order)
+          conv   {:last-vote-timestamp 1234 :n 0 :n-cmts 0}
+          step   {:index 3 :votes [] :mods []}
+          text   (write (doc-fn step conv))
+          parsed (json/parse-string text)]
+      (is (= #{"engine" "input_digest" "schema" "stages" "step" "tick"
+               "vote_sign_convention"}
+             (set (keys parsed))))
+      (is (= "polis-stage-dump/1" (get parsed "schema")))
+      (is (= "clj" (get parsed "engine")))
+      (is (= "raw-db" (get parsed "vote_sign_convention")))
+      (is (= 3 (get parsed "step")))
+      (is (= 1234 (get parsed "tick")))
+      (testing "stages appear in the emitted TEXT in pipeline order (a parsed
+                map is unordered, so the byte order is what must be asserted)"
+        (is (= (vec order)
+               (vec (sort-by #(.indexOf ^String text (str "\"" % "\"")) order)))))
+      (testing "a node the conv does not carry is null, never dropped"
+        (is (contains? (get-in parsed ["stages" "R04_pca"]) "pca"))
+        (is (nil? (get-in parsed ["stages" "R04_pca" "pca"])))))))

--- a/math/test/stage_json_test.clj
+++ b/math/test/stage_json_test.clj
@@ -179,9 +179,12 @@
           step   {:index 3 :votes [] :mods []}
           text   (write (doc-fn step conv))
           parsed (json/parse-string text)]
-      (is (= #{"engine" "input_digest" "schema" "stages" "step" "tick"
-               "vote_sign_convention"}
+      (is (= #{"comment_projection_axes" "engine" "input_digest" "schema"
+               "stages" "step" "tick" "vote_sign_convention"}
              (set (keys parsed))))
+      (testing "the comment-projection axis orientation is DECLARED, so a
+                comparer never has to guess it from array lengths (Astra F4)"
+        (is (= "comps-by-tids" (get parsed "comment_projection_axes"))))
       (is (= "polis-stage-dump/1" (get parsed "schema")))
       (is (= "clj" (get parsed "engine")))
       (is (= "raw-db" (get parsed "vote_sign_convention")))

--- a/math/test/test_runner.clj
+++ b/math/test/test_runner.clj
@@ -12,6 +12,7 @@
             [stats-test]
             [utils-test]
             [ptpt-stats-test]
+            [stage-json-test]
             [clojure.test :as test]))
 
 
@@ -36,7 +37,8 @@
       silhouette-test
       stats-test
       utils-test
-      ptpt-stats-test]))
+      ptpt-stats-test
+      stage-json-test]))
 
 ;(-main)
 ;(test/run-tests 'conversation-test)


### PR DESCRIPTION
Part of the Clojure-deprecation verification program (P-030 stage R-ORACLE). The certification gate compares only the final math blob; the Clojure replay tool already computes every intermediate but never exposed it. This makes each pipeline stage comparable across engines, as diagnostics only: `certify`'s verdict logic and the strict gate are untouched (a test asserts `certify` imports neither new module).

- `math/dev/replay.clj`: a `--stage-json` sibling sink (`polis-stage-dump/1`): one JSON per step with sorted string keys, exact doubles via `Double/toString`, matrices as `{rownames, colnames, matrix}`, non-finite values as strings, and a per-step manifest (index, tick, input digest). Written next to, not inside, the `clj/` directory that `certify` globs. `--edn` output and the blob are byte-identical with the flag on.
- `delphi/polismath/replay/stages.py`: eleven stage functions over an additive `run_replay(on_step=...)` hook; `stagecompare.py` diffs Clojure vs Python dumps with per-stage tolerance classes, polarity and identity-keying canonicalization, the known carve-outs, and reports the first diverging stage plus max abs/rel error per key.
- Tests: Clojure (66 tests / 5,202 assertions) and Python (51 unit + 4 end-to-end). `docs/engine-stage-oracles.md`.

Result on the smallest public battery entry: no diverging stage; max errors from 1e-16 on vote matrices to 1.4e-06 on comment priorities; all exact-class keys bit-identical. On an eight-step warm chain: no diverging stage on any step. One real, previously unstated gap surfaced: under `ptptstats` the two engines compute different statistics, and even `n-votes` differs by definition (raw vs moderation-applied matrix). Nothing in Node or the clients reads it; it is carved out and documented.

Not exercised here: the moderation-heavy and prod-clone battery entries are absent from this checkout, so the moderation stage compared zero values; the restart seam is not run. The delphi suite's 25 failures + 7 errors are pre-existing on `edge` (the #2701 × #2705 interaction fixed by #2716) and reproduce identically on a clean edge worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s