### PR TITLE
chore(cdk): pin aws-cdk-lib, constructs and the CDK CLI to the resolved versions

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,9 +8,9 @@
       "name": "cdk",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-cdk/aws-lambda-python-alpha": "*",
-        "aws-cdk-lib": "*",
-        "constructs": "^10.0.0"
+        "@aws-cdk/aws-lambda-python-alpha": "2.218.0-alpha.0",
+        "aws-cdk-lib": "2.218.0",
+        "constructs": "10.4.2"
       },
       "bin": {
         "cdk": "bin/cdk.js"
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "22.7.9",
-        "aws-cdk": "^2.1018.0",
+        "aws-cdk": "2.1029.3",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -13,15 +13,15 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "22.7.9",
-    "aws-cdk": "^2.1018.0",
+    "aws-cdk": "2.1029.3",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.6.3"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "latest",
-    "aws-cdk-lib": "latest",
-    "constructs": "^10.0.0"
+    "@aws-cdk/aws-lambda-python-alpha": "2.218.0-alpha.0",
+    "aws-cdk-lib": "2.218.0",
+    "constructs": "10.4.2"
   }
 }


### PR DESCRIPTION
`cdk/package.json` pinned `aws-cdk-lib` to `latest` (and `constructs`/the CLI to ranges), so every `npm install` could change the synthesized template underneath a deploy. This pins exactly what the lockfile already resolves, with no upgrade: `aws-cdk-lib 2.218.0`, `constructs 10.4.2`, `@aws-cdk/aws-lambda-python-alpha 2.218.0-alpha.0`, `aws-cdk` CLI `2.1029.3`. The lock's resolved entries and integrity hashes are untouched (four range lines change).

Proof: `CdkStack.template.json` is byte-identical before and after (same sha256, 96,542 bytes); `assets.json` and `tree.json` identical too, so no asset hash moves and the first `cdk diff` after this should be empty. `npm ci` installs exactly those versions.

Note for operators: no GitHub workflow runs cdk (the deploy workflow only pushes images and triggers CodeDeploy); infra is deployed by hand, so the pin matters for whoever runs `npm ci` in `cdk/`.

Surfaced read-only while here, not changed: the `CDKToolkit` bootstrap stack has been `UPDATE_ROLLBACK_COMPLETE` since 2025-10-10 because its container-assets ECR repository no longer exists (likely removed during an ECR cleanup); file-asset deploys still work, but a future `cdk bootstrap` or any Docker image asset would fail. Options are written up privately for a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s