### PR TITLE
fix(server): DynamoDB clients for the narrative store fall back to the default credential chain (P-036)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,14 +113,16 @@ services:
       # Ollama connection
       - OLLAMA_HOST=${OLLAMA_HOST}
       - OLLAMA_MODEL=${OLLAMA_MODEL}
-      # AWS environment variables (will be provided in prod)
+      # AWS credentials. Declared ONCE: this single pair is shared by every AWS
+      # client in the delphi container (DynamoDB and the S3/MinIO clients), so a
+      # second declaration would silently win and swap one service's identity for
+      # the other's. Locally example.env sets the MinIO pair; in prod the real
+      # values come from the deployment env document.
       - AWS_REGION=${AWS_REGION:-us-east-1}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
-      # S3 storage for visualization files
-      - AWS_S3_ENDPOINT=${AWS_S3_ENDPOINT}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-minioadmin}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-minioadmin}
+      # S3 storage for visualization files
+      - AWS_S3_ENDPOINT=${AWS_S3_ENDPOINT}
       - AWS_S3_BUCKET_NAME=${AWS_S3_BUCKET_NAME:-polis-delphi}
       # API keys for LLM services
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,6 +152,17 @@ If you are deploying to a custom domain (not `pol.is`) then you need to update b
 - **`MAILGUN_API_KEY`**, **`MAILGUN_DOMAIN`** If using Mailgun as an email transport.
 - **`AWS_REGION`** Used for some data import/export.
 - **`AWS_ACCESS_KEY_ID`**, **`AWS_SECRET_ACCESS_KEY`** Useful for AWS SDK operations.
+  Leave both **unset** in production to use the AWS default credential provider
+  chain (the EC2 instance role). Set both to real static credentials to use them
+  explicitly; temporary credentials are not supported here, as `AWS_SESSION_TOKEN`
+  is not read — put those on the default chain instead. Setting either to the
+  literal string `local` is rejected: the SDK's environment provider would send
+  that placeholder to AWS, so the DynamoDB clients refuse to start and report
+  `polis_err_aws_credentials_placeholder`. For local development set
+  `DYNAMODB_ENDPOINT` (and `AWS_S3_ENDPOINT` for MinIO) instead. These two
+  variables are shared by every AWS client in the server and delphi containers —
+  DynamoDB, S3/MinIO, SES and SQS — so declare each exactly once per environment
+  file.
 - **`ANTHROPIC_API_KEY`** For using Anthropic as a generative AI model.
 - **`GEMINI_API_KEY`** For using Gemini as a generative AI model.
 - **`OPENAI_API_KEY`** For using OpenAI as a generative AI model.

--- a/example.env
+++ b/example.env
@@ -165,9 +165,17 @@ MAILGUN_API_KEY=
 MAILGUN_DOMAIN=
 # Read from process.env by aws-sdk
 # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-environment.html
-AWS_REGION=
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
+# Declared ONCE, here. This single credential pair is shared by every AWS client
+# in the server and delphi containers -- DynamoDB, S3/MinIO, SES and SQS -- so a
+# second declaration further down this file would silently win (last one wins in
+# a dotenv file) and hand one service the other's identity. The values below are
+# the local MinIO credentials, which also satisfy DynamoDB Local; see the S3
+# STORAGE section for the endpoint they belong to.
+# In production leave these blank so the AWS SDK uses its default credential
+# provider chain (the EC2 instance role).
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
 SQS_LOCAL_ENDPOINT=
 SQS_QUEUE_URL=http://localstack:4566/000000000000/import-jobs-queue
 # This value is written by the server app if SHOULD_USE_TRANSLATION_API is true.
@@ -216,12 +224,14 @@ CDK_ENABLE_OLLAMA=false
 
 
 ###### S3 STORAGE ######
-# MinIO configuration for local S3-compatible storage
+# MinIO configuration for local S3-compatible storage.
+# AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_REGION are deliberately NOT
+# repeated here -- they are declared once near the top of this file and are
+# already set to the MinIO pair. Re-declaring them here would make the file
+# order, rather than intent, decide which service's credentials the server and
+# delphi containers end up using.
 AWS_S3_ENDPOINT=http://host.docker.internal:9000
-AWS_ACCESS_KEY_ID=minioadmin
-AWS_SECRET_ACCESS_KEY=minioadmin
 AWS_S3_BUCKET_NAME=polis-delphi
-AWS_REGION=us-east-1
 
 
 ###### OIDC Config ######

--- a/server/__tests__/unit/dynamoClient.test.ts
+++ b/server/__tests__/unit/dynamoClient.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Credential-precedence tests for the shared DynamoDB client builder.
+ *
+ * Regression cover for the defect where `utils/storage.ts` and
+ * `routes/delphi/batchReports.ts` had no default-credential-chain fallback and
+ * therefore sent the literal "local" placeholder that `config.ts` substitutes
+ * for unset AWS environment variables.
+ */
+import {
+  buildDynamoClientConfig,
+  CONFIG_PLACEHOLDER,
+  DEFAULT_REGION,
+  LOCAL_ENDPOINT_ACCESS_KEY_ID,
+  LOCAL_ENDPOINT_SECRET_ACCESS_KEY,
+} from "../../src/utils/dynamoClient";
+
+jest.mock("../../src/utils/logger", () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+describe("buildDynamoClientConfig credential precedence", () => {
+  describe("branch 1: explicit endpoint (DynamoDB Local)", () => {
+    it("uses the endpoint with synthetic credentials", () => {
+      const config = buildDynamoClientConfig({
+        endpoint: "http://host.docker.internal:8000",
+        region: "us-east-1",
+        accessKeyId: "REAL_LOOKING_ID",
+        secretAccessKey: "REAL_LOOKING_SECRET",
+      });
+
+      expect(config.endpoint).toBe("http://host.docker.internal:8000");
+      expect(config.credentials).toEqual({
+        accessKeyId: LOCAL_ENDPOINT_ACCESS_KEY_ID,
+        secretAccessKey: LOCAL_ENDPOINT_SECRET_ACCESS_KEY,
+      });
+      // Configured credentials must not be forwarded to the local endpoint.
+      expect(JSON.stringify(config)).not.toContain("REAL_LOOKING_SECRET");
+    });
+
+    it("takes precedence over configured credentials and placeholders alike", () => {
+      const config = buildDynamoClientConfig({
+        endpoint: "http://dynamodb:8000",
+        region: CONFIG_PLACEHOLDER,
+        accessKeyId: CONFIG_PLACEHOLDER,
+        secretAccessKey: CONFIG_PLACEHOLDER,
+      });
+
+      expect(config.endpoint).toBe("http://dynamodb:8000");
+      expect(config.region).toBe(DEFAULT_REGION);
+      expect(config.credentials).toEqual({
+        accessKeyId: LOCAL_ENDPOINT_ACCESS_KEY_ID,
+        secretAccessKey: LOCAL_ENDPOINT_SECRET_ACCESS_KEY,
+      });
+    });
+  });
+
+  describe("branch 2: real configured credentials", () => {
+    it("passes both keys through when no endpoint is set", () => {
+      const config = buildDynamoClientConfig({
+        endpoint: null,
+        region: "us-west-2",
+        accessKeyId: "CONFIGURED_ID",
+        secretAccessKey: "CONFIGURED_SECRET",
+      });
+
+      expect(config.endpoint).toBeUndefined();
+      expect(config.region).toBe("us-west-2");
+      expect(config.credentials).toEqual({
+        accessKeyId: "CONFIGURED_ID",
+        secretAccessKey: "CONFIGURED_SECRET",
+      });
+    });
+
+    it("falls through to the default chain when only one key is set", () => {
+      const config = buildDynamoClientConfig({
+        endpoint: null,
+        region: "us-east-1",
+        accessKeyId: "CONFIGURED_ID",
+        secretAccessKey: null,
+      });
+
+      expect(config.credentials).toBeUndefined();
+    });
+  });
+
+  describe("branch 3: default AWS credential provider chain", () => {
+    it("omits credentials when nothing is configured", () => {
+      const config = buildDynamoClientConfig({
+        endpoint: null,
+        region: null,
+        accessKeyId: null,
+        secretAccessKey: null,
+      });
+
+      expect(config.credentials).toBeUndefined();
+      expect(config.endpoint).toBeUndefined();
+      expect(config.region).toBe(DEFAULT_REGION);
+    });
+
+    it('treats the "local" placeholder as unset and never sends it to AWS', () => {
+      // This is the exact shape config.ts produces when AWS_ACCESS_KEY_ID,
+      // AWS_SECRET_ACCESS_KEY and AWS_REGION are all unset in prod.
+      const config = buildDynamoClientConfig({
+        endpoint: null,
+        region: CONFIG_PLACEHOLDER,
+        accessKeyId: CONFIG_PLACEHOLDER,
+        secretAccessKey: CONFIG_PLACEHOLDER,
+      });
+
+      expect(config.credentials).toBeUndefined();
+      expect(config.region).toBe(DEFAULT_REGION);
+      expect(config.region).not.toBe(CONFIG_PLACEHOLDER);
+      expect(JSON.stringify(config)).not.toContain(CONFIG_PLACEHOLDER);
+    });
+
+    it("keeps a real region while still using the default chain", () => {
+      const config = buildDynamoClientConfig({
+        endpoint: null,
+        region: "us-east-1",
+        accessKeyId: CONFIG_PLACEHOLDER,
+        secretAccessKey: CONFIG_PLACEHOLDER,
+      });
+
+      expect(config.region).toBe("us-east-1");
+      expect(config.credentials).toBeUndefined();
+    });
+
+    it("treats empty strings as unset", () => {
+      const config = buildDynamoClientConfig({
+        endpoint: "",
+        region: "",
+        accessKeyId: "",
+        secretAccessKey: "",
+      });
+
+      expect(config.endpoint).toBeUndefined();
+      expect(config.credentials).toBeUndefined();
+      expect(config.region).toBe(DEFAULT_REGION);
+    });
+  });
+});

--- a/server/__tests__/unit/dynamoClient.test.ts
+++ b/server/__tests__/unit/dynamoClient.test.ts
@@ -7,27 +7,50 @@
  * for unset AWS environment variables.
  */
 import {
+  AwsCredentialsConfigurationError,
   buildDynamoClientConfig,
   CONFIG_PLACEHOLDER,
   DEFAULT_REGION,
   LOCAL_ENDPOINT_ACCESS_KEY_ID,
   LOCAL_ENDPOINT_SECRET_ACCESS_KEY,
+  makeDynamoClient,
+  PLACEHOLDER_CREDENTIALS_ERROR_CODE,
 } from "../../src/utils/dynamoClient";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 
 jest.mock("../../src/utils/logger", () => ({
   __esModule: true,
   default: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
 
+jest.mock("@aws-sdk/client-dynamodb", () => ({
+  __esModule: true,
+  DynamoDBClient: jest.fn(),
+}));
+
+const DynamoDBClientMock = DynamoDBClient as unknown as jest.Mock;
+
+/** An environment with neither AWS credential variable set. */
+const EMPTY_ENV = {};
+
+/** The environment as it looks when the placeholder is set explicitly. */
+const PLACEHOLDER_ENV = {
+  AWS_ACCESS_KEY_ID: CONFIG_PLACEHOLDER,
+  AWS_SECRET_ACCESS_KEY: CONFIG_PLACEHOLDER,
+};
+
 describe("buildDynamoClientConfig credential precedence", () => {
   describe("branch 1: explicit endpoint (DynamoDB Local)", () => {
     it("uses the endpoint with synthetic credentials", () => {
-      const config = buildDynamoClientConfig({
-        endpoint: "http://host.docker.internal:8000",
-        region: "us-east-1",
-        accessKeyId: "REAL_LOOKING_ID",
-        secretAccessKey: "REAL_LOOKING_SECRET",
-      });
+      const config = buildDynamoClientConfig(
+        {
+          endpoint: "http://host.docker.internal:8000",
+          region: "us-east-1",
+          accessKeyId: "REAL_LOOKING_ID",
+          secretAccessKey: "REAL_LOOKING_SECRET",
+        },
+        EMPTY_ENV
+      );
 
       expect(config.endpoint).toBe("http://host.docker.internal:8000");
       expect(config.credentials).toEqual({
@@ -39,12 +62,15 @@ describe("buildDynamoClientConfig credential precedence", () => {
     });
 
     it("takes precedence over configured credentials and placeholders alike", () => {
-      const config = buildDynamoClientConfig({
-        endpoint: "http://dynamodb:8000",
-        region: CONFIG_PLACEHOLDER,
-        accessKeyId: CONFIG_PLACEHOLDER,
-        secretAccessKey: CONFIG_PLACEHOLDER,
-      });
+      const config = buildDynamoClientConfig(
+        {
+          endpoint: "http://dynamodb:8000",
+          region: CONFIG_PLACEHOLDER,
+          accessKeyId: CONFIG_PLACEHOLDER,
+          secretAccessKey: CONFIG_PLACEHOLDER,
+        },
+        PLACEHOLDER_ENV
+      );
 
       expect(config.endpoint).toBe("http://dynamodb:8000");
       expect(config.region).toBe(DEFAULT_REGION);
@@ -57,12 +83,15 @@ describe("buildDynamoClientConfig credential precedence", () => {
 
   describe("branch 2: real configured credentials", () => {
     it("passes both keys through when no endpoint is set", () => {
-      const config = buildDynamoClientConfig({
-        endpoint: null,
-        region: "us-west-2",
-        accessKeyId: "CONFIGURED_ID",
-        secretAccessKey: "CONFIGURED_SECRET",
-      });
+      const config = buildDynamoClientConfig(
+        {
+          endpoint: null,
+          region: "us-west-2",
+          accessKeyId: "CONFIGURED_ID",
+          secretAccessKey: "CONFIGURED_SECRET",
+        },
+        EMPTY_ENV
+      );
 
       expect(config.endpoint).toBeUndefined();
       expect(config.region).toBe("us-west-2");
@@ -73,12 +102,15 @@ describe("buildDynamoClientConfig credential precedence", () => {
     });
 
     it("falls through to the default chain when only one key is set", () => {
-      const config = buildDynamoClientConfig({
-        endpoint: null,
-        region: "us-east-1",
-        accessKeyId: "CONFIGURED_ID",
-        secretAccessKey: null,
-      });
+      const config = buildDynamoClientConfig(
+        {
+          endpoint: null,
+          region: "us-east-1",
+          accessKeyId: "CONFIGURED_ID",
+          secretAccessKey: null,
+        },
+        EMPTY_ENV
+      );
 
       expect(config.credentials).toBeUndefined();
     });
@@ -86,27 +118,35 @@ describe("buildDynamoClientConfig credential precedence", () => {
 
   describe("branch 3: default AWS credential provider chain", () => {
     it("omits credentials when nothing is configured", () => {
-      const config = buildDynamoClientConfig({
-        endpoint: null,
-        region: null,
-        accessKeyId: null,
-        secretAccessKey: null,
-      });
+      const config = buildDynamoClientConfig(
+        {
+          endpoint: null,
+          region: null,
+          accessKeyId: null,
+          secretAccessKey: null,
+        },
+        EMPTY_ENV
+      );
 
       expect(config.credentials).toBeUndefined();
       expect(config.endpoint).toBeUndefined();
       expect(config.region).toBe(DEFAULT_REGION);
     });
 
-    it('treats the "local" placeholder as unset and never sends it to AWS', () => {
-      // This is the exact shape config.ts produces when AWS_ACCESS_KEY_ID,
-      // AWS_SECRET_ACCESS_KEY and AWS_REGION are all unset in prod.
-      const config = buildDynamoClientConfig({
-        endpoint: null,
-        region: CONFIG_PLACEHOLDER,
-        accessKeyId: CONFIG_PLACEHOLDER,
-        secretAccessKey: CONFIG_PLACEHOLDER,
-      });
+    it('treats a config-generated "local" placeholder as unset', () => {
+      // The exact shape config.ts produces when AWS_ACCESS_KEY_ID,
+      // AWS_SECRET_ACCESS_KEY and AWS_REGION are all *absent* from the
+      // environment: config.ts invents the placeholders, the environment holds
+      // nothing, and the default chain is safe to use.
+      const config = buildDynamoClientConfig(
+        {
+          endpoint: null,
+          region: CONFIG_PLACEHOLDER,
+          accessKeyId: CONFIG_PLACEHOLDER,
+          secretAccessKey: CONFIG_PLACEHOLDER,
+        },
+        EMPTY_ENV
+      );
 
       expect(config.credentials).toBeUndefined();
       expect(config.region).toBe(DEFAULT_REGION);
@@ -115,28 +155,145 @@ describe("buildDynamoClientConfig credential precedence", () => {
     });
 
     it("keeps a real region while still using the default chain", () => {
-      const config = buildDynamoClientConfig({
-        endpoint: null,
-        region: "us-east-1",
-        accessKeyId: CONFIG_PLACEHOLDER,
-        secretAccessKey: CONFIG_PLACEHOLDER,
-      });
+      const config = buildDynamoClientConfig(
+        {
+          endpoint: null,
+          region: "us-east-1",
+          accessKeyId: CONFIG_PLACEHOLDER,
+          secretAccessKey: CONFIG_PLACEHOLDER,
+        },
+        EMPTY_ENV
+      );
 
       expect(config.region).toBe("us-east-1");
       expect(config.credentials).toBeUndefined();
     });
 
     it("treats empty strings as unset", () => {
-      const config = buildDynamoClientConfig({
-        endpoint: "",
-        region: "",
-        accessKeyId: "",
-        secretAccessKey: "",
-      });
+      const config = buildDynamoClientConfig(
+        {
+          endpoint: "",
+          region: "",
+          accessKeyId: "",
+          secretAccessKey: "",
+        },
+        EMPTY_ENV
+      );
 
       expect(config.endpoint).toBeUndefined();
       expect(config.credentials).toBeUndefined();
       expect(config.region).toBe(DEFAULT_REGION);
+    });
+  });
+
+  /**
+   * Review finding F1. Omitting `credentials` does not stop the SDK's own
+   * environment provider from re-reading `process.env` afterwards, so an
+   * explicitly-set placeholder would still reach AWS. When that would happen,
+   * the builder refuses rather than pretending to have filtered it.
+   */
+  describe("placeholder present in the environment (not merely unset)", () => {
+    beforeEach(() => {
+      DynamoDBClientMock.mockClear();
+    });
+
+    it("throws a named configuration error instead of using the default chain", () => {
+      expect(() =>
+        buildDynamoClientConfig(
+          {
+            endpoint: null,
+            region: CONFIG_PLACEHOLDER,
+            accessKeyId: CONFIG_PLACEHOLDER,
+            secretAccessKey: CONFIG_PLACEHOLDER,
+          },
+          PLACEHOLDER_ENV
+        )
+      ).toThrow(AwsCredentialsConfigurationError);
+    });
+
+    it("reports polis_err_aws_credentials_placeholder", () => {
+      expect.assertions(3);
+      try {
+        buildDynamoClientConfig({}, PLACEHOLDER_ENV);
+      } catch (error) {
+        const configError = error as AwsCredentialsConfigurationError;
+        expect(configError.code).toBe(PLACEHOLDER_CREDENTIALS_ERROR_CODE);
+        expect(configError.name).toBe("AwsCredentialsConfigurationError");
+        // The message names the variables, never a credential value.
+        expect(configError.message).toContain("AWS_ACCESS_KEY_ID");
+      }
+    });
+
+    it("throws when only the access key id is the placeholder", () => {
+      expect(() =>
+        buildDynamoClientConfig(
+          {
+            accessKeyId: CONFIG_PLACEHOLDER,
+            secretAccessKey: "REAL_LOOKING_SECRET",
+          },
+          { AWS_ACCESS_KEY_ID: CONFIG_PLACEHOLDER }
+        )
+      ).toThrow(AwsCredentialsConfigurationError);
+    });
+
+    it("does not construct a client when it throws", () => {
+      expect(() => makeDynamoClient({}, PLACEHOLDER_ENV)).toThrow(
+        AwsCredentialsConfigurationError
+      );
+      expect(DynamoDBClientMock).not.toHaveBeenCalled();
+    });
+
+    it("still constructs a client when the environment is clean", () => {
+      const client = makeDynamoClient({}, EMPTY_ENV);
+
+      expect(client).toBeDefined();
+      expect(DynamoDBClientMock).toHaveBeenCalledTimes(1);
+      expect(DynamoDBClientMock.mock.calls[0][0].credentials).toBeUndefined();
+    });
+
+    it("does not throw in local-endpoint mode, which never reads the environment provider", () => {
+      const config = buildDynamoClientConfig(
+        { endpoint: "http://dynamodb:8000" },
+        PLACEHOLDER_ENV
+      );
+
+      expect(config.credentials).toEqual({
+        accessKeyId: LOCAL_ENDPOINT_ACCESS_KEY_ID,
+        secretAccessKey: LOCAL_ENDPOINT_SECRET_ACCESS_KEY,
+      });
+    });
+
+    it("does not throw when a real pair is configured explicitly", () => {
+      // Explicit credentials short-circuit the chain, so a stale placeholder
+      // elsewhere in the environment is never consulted.
+      const config = buildDynamoClientConfig(
+        { accessKeyId: "CONFIGURED_ID", secretAccessKey: "CONFIGURED_SECRET" },
+        PLACEHOLDER_ENV
+      );
+
+      expect(config.credentials).toEqual({
+        accessKeyId: "CONFIGURED_ID",
+        secretAccessKey: "CONFIGURED_SECRET",
+      });
+    });
+
+    it("reads the live process.env by default", () => {
+      // eslint-disable-next-line no-restricted-properties
+      const realEnv = process.env;
+      // eslint-disable-next-line no-restricted-properties
+      process.env = {
+        ...realEnv,
+        AWS_ACCESS_KEY_ID: CONFIG_PLACEHOLDER,
+        AWS_SECRET_ACCESS_KEY: CONFIG_PLACEHOLDER,
+      };
+      try {
+        expect(() => buildDynamoClientConfig({})).toThrow(
+          AwsCredentialsConfigurationError
+        );
+      } finally {
+        // eslint-disable-next-line no-restricted-properties
+        process.env = realEnv;
+      }
     });
   });
 });

--- a/server/src/routes/delphi/batchReports.ts
+++ b/server/src/routes/delphi/batchReports.ts
@@ -4,17 +4,11 @@ import { DynamoDB } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
 import logger from "../../utils/logger";
 import { getZidFromReport } from "../../utils/parameter";
-import Config from "../../config";
+import { buildDynamoClientConfig } from "../../utils/dynamoClient";
 
-// Initialize DynamoDB client
-const dynamoDbClient = new DynamoDB({
-  endpoint: Config.DYNAMODB_ENDPOINT as string,
-  region: Config.AWS_REGION as string,
-  credentials: {
-    accessKeyId: Config.AWS_ACCESS_KEY_ID as string,
-    secretAccessKey: Config.AWS_SECRET_ACCESS_KEY as string,
-  },
-});
+// Initialize DynamoDB client. Shared credential precedence: local endpoint ->
+// real configured keys -> default AWS credential provider chain (instance role).
+const dynamoDbClient = new DynamoDB(buildDynamoClientConfig());
 
 // Create DocumentClient
 const docClient = DynamoDBDocument.from(dynamoDbClient);

--- a/server/src/routes/delphi/batchReports.ts
+++ b/server/src/routes/delphi/batchReports.ts
@@ -75,7 +75,8 @@ export async function handle_POST_delphi_batch_reports(
     const max_batch_size = (req.body.max_batch_size as number) || 20;
     const no_cache = (req.body.no_cache as boolean) || false;
 
-    // No need to configure DynamoDB client here, it's done at module level
+    // No need to configure the DynamoDB client here; getDocClient() builds it
+    // on first use, inside this try block.
 
     // Generate job_id using report_id to avoid exposing ZID
     const timestamp = Math.floor(Date.now() / 1000);

--- a/server/src/routes/delphi/batchReports.ts
+++ b/server/src/routes/delphi/batchReports.ts
@@ -6,12 +6,21 @@ import logger from "../../utils/logger";
 import { getZidFromReport } from "../../utils/parameter";
 import { buildDynamoClientConfig } from "../../utils/dynamoClient";
 
-// Initialize DynamoDB client. Shared credential precedence: local endpoint ->
-// real configured keys -> default AWS credential provider chain (instance role).
-const dynamoDbClient = new DynamoDB(buildDynamoClientConfig());
+// DynamoDB client. Shared credential precedence: local endpoint -> real
+// configured keys -> default AWS credential provider chain (instance role).
+//
+// Built lazily on first use, not at module load: `buildDynamoClientConfig`
+// throws on a placeholder credential left in the environment, and a
+// misconfiguration should fail this one route rather than prevent the server
+// from starting. Memoized, so the client is still constructed once.
+let docClient: DynamoDBDocument | undefined;
 
-// Create DocumentClient
-const docClient = DynamoDBDocument.from(dynamoDbClient);
+function getDocClient(): DynamoDBDocument {
+  if (!docClient) {
+    docClient = DynamoDBDocument.from(new DynamoDB(buildDynamoClientConfig()));
+  }
+  return docClient;
+}
 
 /**
  * Handler for Delphi API route that generates batch narrative reports
@@ -129,7 +138,7 @@ export async function handle_POST_delphi_batch_reports(
       })}`
     );
 
-    await docClient.put({
+    await getDocClient().put({
       TableName: "Delphi_JobQueue",
       Item: jobItem,
     });

--- a/server/src/routes/reportNarrative.ts
+++ b/server/src/routes/reportNarrative.ts
@@ -16,6 +16,7 @@ import { create } from "xmlbuilder2";
 import { sendCommentGroupsSummary } from "../report";
 import { getTopicsFromRID } from "../report_experimental/topics-example";
 import DynamoStorageService, { StorageError } from "../utils/storage";
+import { AwsCredentialsConfigurationError } from "../utils/dynamoClient";
 import { PathLike } from "node:fs";
 import config from "../config";
 import logger from "../utils/logger";
@@ -298,7 +299,10 @@ const getModelResponse = async (
         const textBlock = responseClaude.content.find((b) => b.type === "text");
         const rawText = textBlock?.type === "text" ? textBlock.text : "";
         // Strip markdown code fences if present
-        return rawText.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
+        return rawText
+          .replace(/^```(?:json)?\s*/i, "")
+          .replace(/\s*```$/, "")
+          .trim();
       }
       case "openai": {
         if (!openai) {
@@ -884,16 +888,19 @@ export async function handle_GET_reportNarrative(
   req: { p: { rid: string; delphiEnabled: boolean }; query: QueryParams },
   res: Response
 ) {
-  const storage = new DynamoStorageService(
-    "report_narrative_store",
-    req.query.noCache === "true"
-  );
+  let storage: DynamoStorageService;
 
-  // Initialize storage with improved error handling
+  // Initialize storage with improved error handling. Construction is inside the
+  // try because it resolves AWS credentials and throws a named configuration
+  // error on a placeholder credential in the environment.
   try {
     if (!req.p.delphiEnabled) {
       throw new Error("Unauthorized");
     }
+    storage = new DynamoStorageService(
+      "report_narrative_store",
+      req.query.noCache === "true"
+    );
     const initResult = await storage.initTable();
     if (!initResult.success) {
       const error = initResult.error!;
@@ -921,6 +928,12 @@ export async function handle_GET_reportNarrative(
     }
   } catch (error) {
     logger.error("Storage initialization failed:", error);
+    if (error instanceof AwsCredentialsConfigurationError) {
+      failJson(res, 503, error.code, {
+        hint: "Storage service credentials are misconfigured. Please contact support.",
+      });
+      return;
+    }
     failJson(res, 503, "polis_err_report_storage", {
       hint: "Storage service error. Please try again later.",
     });

--- a/server/src/utils/dynamoClient.ts
+++ b/server/src/utils/dynamoClient.ts
@@ -1,0 +1,102 @@
+import { DynamoDBClient, DynamoDBClientConfig } from "@aws-sdk/client-dynamodb";
+import config from "../config";
+import logger from "./logger";
+
+/**
+ * Shared DynamoDB client construction.
+ *
+ * Every DynamoDB client in the server must resolve credentials the same way:
+ *
+ *   1. `DYNAMODB_ENDPOINT` set  -> DynamoDB Local. Send synthetic credentials;
+ *      DynamoDB Local accepts any syntactically valid pair and never validates
+ *      them, so no real credential is ever needed (or leaked) locally.
+ *   2. Real `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` -> use them explicitly.
+ *   3. Otherwise -> pass no `credentials`, so the AWS SDK uses its default
+ *      credential provider chain (on EC2 that is the instance role).
+ *
+ * The placeholder guard in step 2 is load-bearing. `config.ts` substitutes the
+ * literal string "local" for `awsAccessKeyId`, `awsSecretAccessKey` and
+ * `awsRegion` when the corresponding environment variables are unset, so a
+ * plain truthiness check would send `accessKeyId="local"` to region "local" and
+ * fail at the first call rather than falling through to the instance role.
+ * A placeholder must never reach AWS: it is treated exactly like "unset".
+ */
+
+/** Literal that `config.ts` substitutes for unset AWS environment variables. */
+export const CONFIG_PLACEHOLDER = "local";
+
+/** Credentials used against DynamoDB Local; not valid anywhere else. */
+export const LOCAL_ENDPOINT_ACCESS_KEY_ID = "DUMMYIDEXAMPLE";
+export const LOCAL_ENDPOINT_SECRET_ACCESS_KEY = "DUMMYEXAMPLEKEY";
+
+/** Region used when none is configured, or when the placeholder is configured. */
+export const DEFAULT_REGION = "us-east-1";
+
+export interface DynamoClientSource {
+  endpoint?: string | null;
+  region?: string | null;
+  accessKeyId?: string | null;
+  secretAccessKey?: string | null;
+}
+
+/**
+ * A configured value is only real if it is non-empty and is not the "local"
+ * placeholder that `config.ts` supplies for unset environment variables.
+ */
+function realValue(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  if (value === CONFIG_PLACEHOLDER) return undefined;
+  return value;
+}
+
+function sourceFromConfig(): DynamoClientSource {
+  return {
+    endpoint: config.dynamoDbEndpoint,
+    region: config.awsRegion,
+    accessKeyId: config.awsAccessKeyId,
+    secretAccessKey: config.awsSecretAccessKey,
+  };
+}
+
+/**
+ * Build the `DynamoDBClientConfig` for the current environment.
+ *
+ * Exported separately from `makeDynamoClient` so callers that need a different
+ * SDK wrapper (e.g. the `DynamoDB` aggregated client) share the same precedence.
+ */
+export function buildDynamoClientConfig(
+  source: DynamoClientSource = sourceFromConfig()
+): DynamoDBClientConfig {
+  const endpoint = realValue(source.endpoint);
+  const accessKeyId = realValue(source.accessKeyId);
+  const secretAccessKey = realValue(source.secretAccessKey);
+
+  const clientConfig: DynamoDBClientConfig = {
+    region: realValue(source.region) || DEFAULT_REGION,
+  };
+
+  if (endpoint) {
+    clientConfig.endpoint = endpoint;
+    clientConfig.credentials = {
+      accessKeyId: LOCAL_ENDPOINT_ACCESS_KEY_ID,
+      secretAccessKey: LOCAL_ENDPOINT_SECRET_ACCESS_KEY,
+    };
+    logger.info(`Using local DynamoDB at endpoint: ${endpoint}`);
+    return clientConfig;
+  }
+
+  if (accessKeyId && secretAccessKey) {
+    clientConfig.credentials = { accessKeyId, secretAccessKey };
+    logger.info("Using production DynamoDB with AWS credentials");
+    return clientConfig;
+  }
+
+  // No endpoint and no real keys: let the SDK resolve an identity itself.
+  logger.info("Using default AWS credential provider chain");
+  return clientConfig;
+}
+
+/** Construct a `DynamoDBClient` with the shared credential precedence. */
+export function makeDynamoClient(source?: DynamoClientSource): DynamoDBClient {
+  return new DynamoDBClient(buildDynamoClientConfig(source));
+}

--- a/server/src/utils/dynamoClient.ts
+++ b/server/src/utils/dynamoClient.ts
@@ -19,7 +19,48 @@ import logger from "./logger";
  * `awsRegion` when the corresponding environment variables are unset, so a
  * plain truthiness check would send `accessKeyId="local"` to region "local" and
  * fail at the first call rather than falling through to the instance role.
- * A placeholder must never reach AWS: it is treated exactly like "unset".
+ *
+ * ## The contract on the placeholder, stated precisely
+ *
+ * Filtering the placeholder out of the *options object* is not by itself enough
+ * to keep it away from AWS, and the two cases must be distinguished:
+ *
+ *   - **`AWS_ACCESS_KEY_ID` genuinely unset.** `config.ts` invents "local"
+ *     internally; the environment holds nothing. Dropping `credentials` hands
+ *     the SDK a clean default chain, which reaches the instance role. This is
+ *     the production incident this module was written for, and it is safe.
+ *
+ *   - **`AWS_ACCESS_KEY_ID` explicitly set to the literal "local".** Omitting
+ *     `credentials` does *not* remove it: the default chain's own environment
+ *     provider (`fromEnv`) re-reads `process.env` after our filtering and
+ *     resolves `accessKeyId="local"` anyway. Silently filtering here would
+ *     promise more than it delivers.
+ *
+ * So in the second case this module refuses to build a client at all and throws
+ * {@link AwsCredentialsConfigurationError} (`polis_err_aws_credentials_placeholder`)
+ * before construction — a named configuration error at the call site rather than
+ * an opaque `UnrecognizedClientException` from AWS later. The alternative,
+ * scrubbing `process.env` or installing a custom provider chain, would change
+ * credential resolution for every other AWS client in the process, which this
+ * module has no business doing.
+ *
+ * The check applies only when the default chain would otherwise be used. Local
+ * endpoint mode (branch 1) and an explicitly supplied real pair (branch 2) never
+ * consult the environment provider, so neither is affected.
+ *
+ * "Placeholder" means exactly the literal {@link CONFIG_PLACEHOLDER}. No attempt
+ * is made to judge whether an arbitrary key *looks* valid; a real credential is
+ * never rejected.
+ *
+ * ## Known limitation: `AWS_SESSION_TOKEN`
+ *
+ * An explicitly configured pair (branch 2) carries no session token, so static
+ * credentials are supported but temporary ones are not. This is inherited, not
+ * new: `config.ts` does not read `AWS_SESSION_TOKEN` and none of the other
+ * eleven DynamoDB clients in `server/src/` pass one either. Temporary
+ * credentials belong on the default chain (branch 3), which resolves the token
+ * itself. Adding token passthrough would be a change to every client's
+ * behaviour and is deliberately out of scope here.
  */
 
 /** Literal that `config.ts` substitutes for unset AWS environment variables. */
@@ -32,11 +73,39 @@ export const LOCAL_ENDPOINT_SECRET_ACCESS_KEY = "DUMMYEXAMPLEKEY";
 /** Region used when none is configured, or when the placeholder is configured. */
 export const DEFAULT_REGION = "us-east-1";
 
+/** Error code reported when the environment holds a placeholder credential. */
+export const PLACEHOLDER_CREDENTIALS_ERROR_CODE =
+  "polis_err_aws_credentials_placeholder";
+
+/**
+ * Thrown instead of building a client whose credentials the AWS SDK would
+ * resolve from a placeholder left in the environment. Carries a stable
+ * `code` so routes can report it without string-matching the message.
+ */
+export class AwsCredentialsConfigurationError extends Error {
+  readonly code = PLACEHOLDER_CREDENTIALS_ERROR_CODE;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "AwsCredentialsConfigurationError";
+    // Required for `instanceof` to work when compiled below ES2015.
+    Object.setPrototypeOf(this, AwsCredentialsConfigurationError.prototype);
+  }
+}
+
 export interface DynamoClientSource {
   endpoint?: string | null;
   region?: string | null;
   accessKeyId?: string | null;
   secretAccessKey?: string | null;
+}
+
+/** Just the environment entries the AWS SDK's `fromEnv` provider reads. */
+export interface DynamoClientEnv {
+  AWS_ACCESS_KEY_ID?: string;
+  AWS_SECRET_ACCESS_KEY?: string;
+  // Index signature so `process.env` (NodeJS.ProcessEnv) is assignable.
+  [key: string]: string | undefined;
 }
 
 /**
@@ -59,13 +128,41 @@ function sourceFromConfig(): DynamoClientSource {
 }
 
 /**
+ * Names of the environment variables that are set to the placeholder literal.
+ *
+ * Only these two matter: they are what the SDK's environment credential
+ * provider reads once we omit `credentials`.
+ */
+function placeholdersInEnv(env: DynamoClientEnv): string[] {
+  const names: string[] = [];
+  if (env.AWS_ACCESS_KEY_ID === CONFIG_PLACEHOLDER) {
+    names.push("AWS_ACCESS_KEY_ID");
+  }
+  if (env.AWS_SECRET_ACCESS_KEY === CONFIG_PLACEHOLDER) {
+    names.push("AWS_SECRET_ACCESS_KEY");
+  }
+  return names;
+}
+
+/**
  * Build the `DynamoDBClientConfig` for the current environment.
  *
  * Exported separately from `makeDynamoClient` so callers that need a different
  * SDK wrapper (e.g. the `DynamoDB` aggregated client) share the same precedence.
+ *
+ * @throws {AwsCredentialsConfigurationError} when the default credential chain
+ * would be used but the environment holds the "local" placeholder, which the
+ * chain's environment provider would pick up. See the contract above.
  */
 export function buildDynamoClientConfig(
-  source: DynamoClientSource = sourceFromConfig()
+  source: DynamoClientSource = sourceFromConfig(),
+  // `process.env` rather than `config.ts` on purpose: this must mirror exactly
+  // what the SDK's environment credential provider reads, at the moment it
+  // would read it. `config.ts` snapshots the environment at module load and
+  // rewrites an unset value to the "local" placeholder, which erases the very
+  // distinction this guard exists to make.
+  // eslint-disable-next-line no-restricted-properties
+  env: DynamoClientEnv = process.env
 ): DynamoDBClientConfig {
   const endpoint = realValue(source.endpoint);
   const accessKeyId = realValue(source.accessKeyId);
@@ -91,12 +188,38 @@ export function buildDynamoClientConfig(
     return clientConfig;
   }
 
-  // No endpoint and no real keys: let the SDK resolve an identity itself.
+  // About to fall back to the default chain. If the placeholder is actually
+  // present in the environment, the chain's environment provider would resolve
+  // it and send it to AWS, so refuse to build the client instead.
+  const placeholders = placeholdersInEnv(env);
+  if (placeholders.length > 0) {
+    const message =
+      `${placeholders.join(" and ")} ` +
+      `${placeholders.length > 1 ? "are" : "is"} set to the placeholder ` +
+      `"${CONFIG_PLACEHOLDER}". The AWS SDK's default credential chain would ` +
+      `read that value from the environment and send it to AWS. Set real ` +
+      `credentials, set DYNAMODB_ENDPOINT for local development, or unset ` +
+      `these variables so the default credential provider chain (the EC2 ` +
+      `instance role) can be used.`;
+    logger.error(`${PLACEHOLDER_CREDENTIALS_ERROR_CODE}: ${message}`);
+    throw new AwsCredentialsConfigurationError(message);
+  }
+
+  // No endpoint, no real keys, no placeholder in the environment: let the SDK
+  // resolve an identity itself.
   logger.info("Using default AWS credential provider chain");
   return clientConfig;
 }
 
-/** Construct a `DynamoDBClient` with the shared credential precedence. */
-export function makeDynamoClient(source?: DynamoClientSource): DynamoDBClient {
-  return new DynamoDBClient(buildDynamoClientConfig(source));
+/**
+ * Construct a `DynamoDBClient` with the shared credential precedence.
+ *
+ * @throws {AwsCredentialsConfigurationError} see {@link buildDynamoClientConfig}.
+ * Nothing is constructed when it throws.
+ */
+export function makeDynamoClient(
+  source?: DynamoClientSource,
+  env?: DynamoClientEnv
+): DynamoDBClient {
+  return new DynamoDBClient(buildDynamoClientConfig(source, env));
 }

--- a/server/src/utils/storage.ts
+++ b/server/src/utils/storage.ts
@@ -12,17 +12,7 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import config from "../config";
 import logger from "./logger";
-
-type Credentials = {
-  accessKeyId: string;
-  secretAccessKey: string;
-};
-
-type ClientConfig = {
-  region: string;
-  endpoint?: string;
-  credentials: Credentials;
-};
+import { makeDynamoClient } from "./dynamoClient";
 
 export interface StorageError {
   name: string;
@@ -41,20 +31,9 @@ export default class DynamoStorageService {
   private cacheDisabled: boolean;
 
   constructor(tableName: string, disableCache?: boolean) {
-    const credentials: Credentials = {
-      accessKeyId: config.awsAccessKeyId,
-      secretAccessKey: config.awsSecretAccessKey,
-    };
-    const clientConfig: ClientConfig = {
-      region: config.awsRegion,
-      credentials,
-    };
-
-    if (config.dynamoDbEndpoint) {
-      clientConfig.endpoint = config.dynamoDbEndpoint;
-    }
-
-    this.client = new DynamoDBClient(clientConfig);
+    // Shared credential precedence: local endpoint -> real configured keys ->
+    // default AWS credential provider chain (the EC2 instance role in prod).
+    this.client = makeDynamoClient();
     this.tableName = tableName;
     this.cacheDisabled = disableCache || false;
   }


### PR DESCRIPTION
Two of the thirteen DynamoDB clients in `server/src/` (the report narrative store in `utils/storage.ts` and `routes/delphi/batchReports.ts`) were built with no default-credential-chain fallback. When `AWS_ACCESS_KEY_ID` is unset, `config.ts` substitutes the literal placeholder `"local"` for key, secret and region, so `initTable()` failed and the route answered 503 before ever reaching AWS. On production, where the instance role is the intended identity, that path could never work, which is consistent with the table showing zero reads and zero writes over 14 days.

Commit 1: a shared `makeDynamoClient()` with the same precedence the other eleven clients use: explicit endpoint (local emulator) → real keys → default provider chain (instance role). The `"local"` placeholder and empty strings are treated as unset in every position, including region (falls back to `us-east-1`). Both clients now use it. Eight unit tests cover the three branches, including the exact placeholder triple `config.ts` emits.

Commit 2: `docker-compose.yml` and `example.env` declared `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` twice (the MinIO value won); now one declaration each with the values that already won, so `docker compose config` is identical to `edge` for every service.

Success paths are byte-identical; only the failure path changes. No IAM or CDK change here; the instance-role grant for the narrative-store table is a separate CDK change under P-035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s