### PR TITLE
certify: standing vote-polarity property, storage convention constant, manifest/3 (P-023 slice 1)

### DIFF
--- a/delphi/polismath/conversation/conversation.py
+++ b/delphi/polismath/conversation/conversation.py
@@ -31,6 +31,7 @@ from polismath.pca_kmeans_rep.legacy_kmeans import (
     kmeans as legacy_kmeans,
 )
 from polismath.utils.clj_hash import clojure_hash_map_key_order
+from polismath.utils.output_profile import assert_restorable
 
 
 # Configure logging
@@ -2680,13 +2681,26 @@ class Conversation:
     def from_dict(cls, data: Dict[str, Any]) -> 'Conversation':
         """
         Create a conversation from a dictionary.
-        
+
         Args:
            data: Dictionary representation of a conversation
-            
+
         Returns:
             Conversation instance
+
+        Raises:
+            OutputProfileError: if ``data`` is a PROJECTED comparison view
+            rather than a raw serialization (P-023 rev3 R3-1). A projected
+            ``PREP_MAIN_KEYS`` view is a legal kebab-only blob — no alias pair,
+            so the C9 relation never runs — and the ``group_clusters`` read at
+            the bottom of this method would then default to ``[]``, silently
+            restoring a conversation with no groups. The marker is the only
+            thing that distinguishes the two, so it is checked here, at the
+            restore boundary itself. Unmarked raw blobs (everything any
+            producer emits) are unaffected.
         """
+        assert_restorable(data, label="Conversation.from_dict")
+
         # Create empty conversation. to_dict emits the id under 'zid' (both
         # modes — it renames conversation_id at emission), matching Clojure
         # prep-main blobs; accept either key so a recorded blob round-trips

--- a/delphi/polismath/database/postgres.py
+++ b/delphi/polismath/database/postgres.py
@@ -26,6 +26,10 @@ import pandas as pd
 
 from polismath.utils.general import postgres_vote_to_delphi
 from polismath.utils.serialization import convert_numpy_types
+from polismath.utils.vote_convention import (
+    STORAGE_AGREE_VALUE,
+    validate_storage_agree_value,
+)
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -272,13 +276,24 @@ class WorkerTasks(Base):
 class PostgresClient:
     """PostgreSQL client for Pol.is math."""
 
-    def __init__(self, config: Optional[PostgresConfig] = None):
+    def __init__(
+        self,
+        config: Optional[PostgresConfig] = None,
+        storage_agree_value: int = STORAGE_AGREE_VALUE,
+    ):
         """
         Initialize PostgreSQL client.
 
         Args:
             config: PostgreSQL configuration
+            storage_agree_value: the DECLARED raw storage sign of AGREE in the
+                database this client reads, -1 or +1 (P-022-G rev4). Validated
+                here so an unknown convention fails at construction rather than
+                silently mis-signing every vote at ingress. Production remains
+                -1 until the P-023 storage migration.
         """
+        self.storage_agree_value = validate_storage_agree_value(
+            storage_agree_value)
         self.config = config or PostgresConfig.from_env()
         self.engine = None
         self.session_factory = None
@@ -544,7 +559,8 @@ class PostgresClient:
             {
                 "pid": v["pid"],
                 "tid": v["tid"],
-                "vote": postgres_vote_to_delphi(int(v["vote"])),
+                "vote": postgres_vote_to_delphi(
+                    int(v["vote"]), self.storage_agree_value),
                 "created": v["created"],
             }
             for v in votes
@@ -582,7 +598,8 @@ class PostgresClient:
                 "zid": int(v["zid"]),
                 "pid": v["pid"],
                 "tid": v["tid"],
-                "vote": postgres_vote_to_delphi(int(v["vote"])),
+                "vote": postgres_vote_to_delphi(
+                    int(v["vote"]), self.storage_agree_value),
                 "created": v["created"],
             }
             for v in rows

--- a/delphi/polismath/replay/certify.py
+++ b/delphi/polismath/replay/certify.py
@@ -60,8 +60,14 @@ from polismath.replay.crosslang import (
     load_clj_blobs,
     project_prep_main,
 )
+from polismath.replay.polarity import (
+    DEFAULT_CONVENTIONS,
+    ConventionDescriptor,
+    run_standing_property,
+)
 from polismath.replay.stepcompare import DEFAULT_TOLERANT_STAT_KEYS, StepComparer
 from polismath.replay.types import ReplayDataset
+from polismath.utils.output_profile import OUTPUT_PROFILE_KEY, profile_of
 
 #: Frozen schedule-id suffix + fingerprint component. Battery schedule ids
 #: and ledger fingerprint keys were minted while the engine still had a mode
@@ -287,6 +293,22 @@ def validate_checkpoint_blob(
         raise CertifyError(
             "checkpoint-schema",
             f"{label}: checkpoint blob must be a JSON object, got {type(blob).__name__}")
+
+    # A PROJECTED comparison view is not a checkpoint (P-023 rev3, R3-1). It is
+    # a legal kebab-only blob — no alias pair, so C9 never runs — and every
+    # remaining field is well typed, so nothing below would object; recorded or
+    # restored, it would silently lose the raw extensions (the group_clusters
+    # twin, proj) that the restore path reads. The output-profile marker is the
+    # only thing that distinguishes it, so it is refused here as well as at
+    # Conversation.from_dict.
+    marked = profile_of(blob)
+    if marked is not None:
+        raise CertifyError(
+            "checkpoint-schema",
+            f"{label}: blob carries the output-profile marker "
+            f"{OUTPUT_PROFILE_KEY!r} ({marked.get('profile')!r}, vote_axis "
+            f"{marked.get('vote_axis')!r}): a projected comparison view is "
+            f"never a raw checkpoint")
 
     # UNTOUCHED-RAW checks first, before any normalization (P-022 B1 review,
     # round 3). Building the canonical dict is lossy: aliased raw keys collapse
@@ -855,13 +877,21 @@ def _write_temp_schedule(spec: sched.ScheduleSpec, root: Path) -> Path:
 
 
 #: Recording-cache manifest schema version. BUMP this to invalidate every
-#: existing cached recording at once. Version 3 adds checkpoint content hashes
+#: existing cached recording at once. Version 4 (P-023) adds the DECLARED
+#: polarity conventions — storage_agree_value, input/output convention and pair
+#: side — to the read/write cache predicate: without them P-023's mandatory
+#: "change s without votes" control is a CACHE HIT (same votes file, same
+#: schedule, same engine tree) and returns the stale recording instead of
+#: executing, so the control never reaches its gate. The bump is what forces
+#: every existing recording to be re-produced rather than accepted under an
+#: undeclared convention; a documentation-only key change is insufficient.
+#: Version 3 adds checkpoint content hashes
 #: and requires cursor metadata on both engines. Version 2 (M3/P-019): the py
 #: manifest now keys on the comments CSV (moderation events Python loads from
 #: it), and the schedule hash now covers restart_after/clojure — recordings made
 #: under the old keys must not be reused, or a comments-only or restart-only edit
 #: would compare a fresh run against a stale one and report its old MATCH.
-_RECORDING_MANIFEST_VERSION = 3
+_RECORDING_MANIFEST_VERSION = 4
 
 
 def _recording_hashes(directory: Path) -> dict[str, str]:
@@ -886,7 +916,7 @@ def _manifest_matches(manifest_path: Path, expected: dict[str, Any]) -> bool:
     if not isinstance(existing, dict):
         raise CertifyError("recording-manifest", "recording manifest must be an object")
     # Old versions require a fresh producer run, never acceptance of old steps.
-    if existing.get("manifest_version") in (1, 2):
+    if existing.get("manifest_version") in (1, 2, 3):
         return False
     if type(existing.get("manifest_version")) is not int or existing["manifest_version"] != _RECORDING_MANIFEST_VERSION:
         raise CertifyError("recording-manifest", "unknown or missing recording manifest version")
@@ -969,6 +999,7 @@ def run_provenance(root: Path, battery_path: str | Path | None = None) -> dict[s
         "math_src_sha256": math_src_sha256,
         "comparer_cfg_sha256": _comparer_cfg_hash(_acceptance_projecting_comparer()),
         "recording_manifest_version": _RECORDING_MANIFEST_VERSION,
+        "conventions": DEFAULT_CONVENTIONS.cache_fields(),
         "battery_path": str(battery_path) if battery_path is not None else None,
         "root": str(root),
         "deferred": ["runtime_versions", "architecture", "image_digest",
@@ -979,6 +1010,7 @@ def run_provenance(root: Path, battery_path: str | Path | None = None) -> dict[s
 def ensure_py_recording(
     entry: BatteryEntry, spec: sched.ScheduleSpec, votes_sha: str, *, root: Path,
     refresh: bool = False, comments_csv: Path | None = None,
+    conventions: ConventionDescriptor = DEFAULT_CONVENTIONS,
 ) -> tuple[Path, bool]:
     """Reuse ``<root>/<ds>/<sid>/py/`` iff its cache manifest matches (votes
     sha256, schedule hash, ENGINE-scoped tree hash, and — when ``comments_csv``
@@ -1006,6 +1038,7 @@ def ensure_py_recording(
         "votes_sha256": votes_sha,
         "schedule_hash": canonical_schedule_hash(spec),
         "engine_tree_sha256": _engine_tree_hash_cached(),
+        **conventions.cache_fields(),
     }
     if comments_csv is not None:
         expected["comments_csv_sha256"] = sha256_file(comments_csv)
@@ -1026,6 +1059,7 @@ def ensure_py_recording(
 def ensure_clj_recording(
     entry: BatteryEntry, spec: sched.ScheduleSpec, votes_sha: str, votes_csv: Path, *,
     root: Path, refresh: bool = False, comments_csv: Path | None = None,
+    conventions: ConventionDescriptor = DEFAULT_CONVENTIONS,
 ) -> tuple[Path, bool]:
     """Reuse ``<root>/<ds>/<sid>/clj/`` iff its cache manifest matches (votes
     sha256, schedule hash, sha256 of dev/replay.clj, sha256 of math/src, and
@@ -1049,6 +1083,7 @@ def ensure_clj_recording(
         "schedule_hash": canonical_schedule_hash(spec),
         "replay_clj_sha256": replay_clj_sha256,
         "math_src_sha256": math_src_sha256,
+        **conventions.cache_fields(),
     }
     if comments_csv is not None:
         expected["comments_csv_sha256"] = sha256_file(comments_csv)
@@ -1468,6 +1503,7 @@ def run_battery(
     entries: list[BatteryEntry], *, root: Path | None = None, refresh_clj: bool = False,
     refresh_py: bool = False, ledger_path: str | Path | None = None, only: str | None = None,
     workers: int = 1, battery_path: str | Path | None = None,
+    standing_properties: bool = True,
 ) -> dict[str, Any]:
     """Certify every (filtered) entry, persist the ledger once, and write the
     machine report to ``<root>/certify_report.json``. Does NOT print — see
@@ -1477,7 +1513,16 @@ def run_battery(
     hash-first compare) across threads — entries are independent by
     construction (disjoint recording dirs, atomic verdict-cache writes). The
     ledger fold stays strictly serial and in battery order, so the report and
-    ledger are identical to a ``workers=1`` run."""
+    ledger are identical to a ``workers=1`` run.
+
+    STANDING PROPERTIES. Every run also executes P-023's compensated polarity
+    property — ``E(V, s) == E(-V, -s)`` through both real ingress paths, from
+    fresh state, plus every mandatory negative control — and a FAIL there fails
+    the gate exactly like a divergent entry. It is a standing property, not a
+    per-entry check: it holds of the ENGINE, so it must run even on a battery
+    whose entries all come back from cache (which is otherwise the case where
+    nothing executes at all). ``standing_properties=False`` is for tests that
+    exercise the battery plumbing itself."""
     root = root or st.replays_root()
     ledger_path = ledger_path or default_ledger_path()
     ledger = load_ledger(ledger_path)
@@ -1509,6 +1554,23 @@ def run_battery(
         if p.spec.coverage == "prefix-diagnostic" and p.entry.dataset not in full_datasets:
             errors[(p.entry.dataset, p.entry.schedule_id)] = _entry_error(
                 p.entry, CertifyError("inventory", "prefix diagnostic requires a full-stream companion"))
+    standing: list[dict[str, Any]] = []
+    if standing_properties:
+        try:
+            polarity = run_standing_property(project=project_acceptance)
+        except Exception as exc:  # noqa: BLE001 — a broken property is a FAIL
+            polarity = {"property": "P-023 compensated polarity pair",
+                        "verdict": "FAIL",
+                        "problems": [f"{type(exc).__name__}: {exc}"]}
+        standing.append({
+            "property": polarity["property"],
+            "verdict": polarity["verdict"],
+            "problems": polarity["problems"],
+            "pairs": len(polarity.get("pairs", [])),
+            "controls": len(polarity.get("controls", [])),
+            "storage_agree_value": polarity.get("storage_agree_value"),
+        })
+
     run_id = str(uuid.uuid4())
     started = datetime.now(timezone.utc).isoformat()
     manifest = {
@@ -1520,6 +1582,7 @@ def run_battery(
                           "battery_path": str(battery_path) if battery_path is not None else None,
                           "root": str(root)},
         "provenance": run_provenance(root, battery_path),
+        "standing_properties": standing,
         "configuration_errors": configuration_errors, "inventory": inventory,
         "entries": [{"dataset": e.dataset, "schedule_id": e.schedule_id,
                      "role": e.role or f"{e.dataset}:{e.schedule_id}", "optional": e.optional,
@@ -1563,7 +1626,9 @@ def run_battery(
             item["cache"] = result.get("cache")
             item["result"] = result
     verdict = "PASS"
-    if configuration_errors or any(e["status"] == "FAIL" for e in manifest["entries"]):
+    if (configuration_errors
+            or any(e["status"] == "FAIL" for e in manifest["entries"])
+            or any(p["verdict"] != "PASS" for p in standing)):
         verdict = "FAIL"
     elif only is not None or any(e["status"] != "PASS" for e in manifest["entries"]):
         verdict = "INCONCLUSIVE"
@@ -1572,6 +1637,7 @@ def run_battery(
     report = {"battery": results, "root": str(root), "verdict": verdict,
               "partial": only is not None, "inventory": inventory,
               "configuration_errors": configuration_errors,
+              "standing_properties": standing,
               "run_id": run_id, "run_manifest": str(manifest_path)}
     _write_json(root / "certify_report.json", report)
     return report
@@ -1634,6 +1700,13 @@ def render_run_lines(report: dict[str, Any], *, max_lines: int = 40) -> list[str
     '+N more' line if the battery is too large to fit), and a footer."""
     header = [ACCEPTANCE_NOTICE, f"certify: {len(report['battery'])} entries  root={report['root']}"]
     footer = [_format_footer(report["battery"])]
+    for prop in report.get("standing_properties", []):
+        footer.append(
+            f"standing property: {prop['property']} {prop['verdict']} "
+            f"({prop['pairs']} pairs, {prop['controls']} negative controls, "
+            f"storage agree = {prop['storage_agree_value']})"
+            + ("" if prop["verdict"] == "PASS"
+               else "  " + "; ".join(prop["problems"][:2])))
     if report.get("partial"):
         header.append("PARTIAL RUN, NOT A GATE (--only)")
     if "verdict" in report:

--- a/delphi/polismath/replay/certify.py
+++ b/delphi/polismath/replay/certify.py
@@ -67,7 +67,11 @@ from polismath.replay.polarity import (
 )
 from polismath.replay.stepcompare import DEFAULT_TOLERANT_STAT_KEYS, StepComparer
 from polismath.replay.types import ReplayDataset
-from polismath.utils.output_profile import OUTPUT_PROFILE_KEY, profile_of
+from polismath.utils.output_profile import (
+    OUTPUT_PROFILE_KEY,
+    has_marker,
+    marker_problems,
+)
 
 #: Frozen schedule-id suffix + fingerprint component. Battery schedule ids
 #: and ledger fingerprint keys were minted while the engine still had a mode
@@ -301,14 +305,21 @@ def validate_checkpoint_blob(
     # twin, proj) that the restore path reads. The output-profile marker is the
     # only thing that distinguishes it, so it is refused here as well as at
     # Conversation.from_dict.
-    marked = profile_of(blob)
-    if marked is not None:
+    # Presence, not validity: a malformed marker value is a corrupted projected
+    # view, and treating it as unmarked raw data is how all four of
+    # {null, false, "projected", []} walked straight through this gate (Astra
+    # review #2730 F2). The reserved key is refused whenever it appears.
+    if has_marker(blob):
+        marked = blob[OUTPUT_PROFILE_KEY]
+        problems = marker_problems(marked)
+        detail = ("; ".join(problems) if problems else
+                  f"{marked.get('profile')!r}, vote_axis "
+                  f"{marked.get('vote_axis')!r}")
         raise CertifyError(
             "checkpoint-schema",
-            f"{label}: blob carries the output-profile marker "
-            f"{OUTPUT_PROFILE_KEY!r} ({marked.get('profile')!r}, vote_axis "
-            f"{marked.get('vote_axis')!r}): a projected comparison view is "
-            f"never a raw checkpoint")
+            f"{label}: blob carries the reserved output-profile marker "
+            f"{OUTPUT_PROFILE_KEY!r} ({detail}): a projected comparison view — "
+            f"malformed or not — is never a raw checkpoint")
 
     # UNTOUCHED-RAW checks first, before any normalization (P-022 B1 review,
     # round 3). Building the canonical dict is lossy: aliased raw keys collapse
@@ -1499,6 +1510,23 @@ def _write_run_manifest(root: Path, manifest: dict[str, Any]) -> Path:
     return path
 
 
+#: The standing property's verdict for one engine tree, memoized per PROCESS.
+#: It is a property of the ENGINE, not of a battery entry or a run: replaying
+#: it for every ``run_battery`` call in one process re-proves the same fact
+#: about the same bytes (the key is the engine tree hash the recording cache
+#: already keys on), and a battery that certifies many entries would pay for it
+#: many times over.
+@functools.lru_cache(maxsize=4)
+def _standing_polarity_property(engine_tree_sha256: str) -> dict[str, Any]:
+    try:
+        return run_standing_property(project=project_acceptance)
+    except Exception as exc:  # noqa: BLE001 — a broken property is a FAIL
+        return {"property": "P-023 compensated polarity pair",
+                "verdict": "FAIL", "pairs": [], "controls": [],
+                "storage_agree_value": None,
+                "problems": [f"{type(exc).__name__}: {exc}"]}
+
+
 def run_battery(
     entries: list[BatteryEntry], *, root: Path | None = None, refresh_clj: bool = False,
     refresh_py: bool = False, ledger_path: str | Path | None = None, only: str | None = None,
@@ -1556,12 +1584,7 @@ def run_battery(
                 p.entry, CertifyError("inventory", "prefix diagnostic requires a full-stream companion"))
     standing: list[dict[str, Any]] = []
     if standing_properties:
-        try:
-            polarity = run_standing_property(project=project_acceptance)
-        except Exception as exc:  # noqa: BLE001 — a broken property is a FAIL
-            polarity = {"property": "P-023 compensated polarity pair",
-                        "verdict": "FAIL",
-                        "problems": [f"{type(exc).__name__}: {exc}"]}
+        polarity = _standing_polarity_property(_engine_tree_hash_cached())
         standing.append({
             "property": polarity["property"],
             "verdict": polarity["verdict"],

--- a/delphi/polismath/replay/fixture_bundle.py
+++ b/delphi/polismath/replay/fixture_bundle.py
@@ -76,6 +76,15 @@ from polismath.utils.vote_convention import (
 #: manifest carries an ``admission`` block stating the release policy that
 #: :func:`admit_manifest` enforces. A /1 or /2 manifest is NOT admissible.
 MANIFEST_SCHEMA_VERSION = "certify-fixture-manifest/3"
+#: The PREVIOUS closed manifest schema. It stays verifiable and admissible
+#: BYTE-FOR-BYTE (Astra review #2730 F-compat): a /2 manifest carries no
+#: ``transform`` key at all and its polarity block already spells out the -1 it
+#: was pinned to, so the /3 rules evaluate on it unchanged once the absent
+#: ``transform`` is read as the "original capture" declaration it is. New
+#: bundles are always written at /3; nothing re-issues an existing bundle.
+LEGACY_MANIFEST_SCHEMA_VERSION = "certify-fixture-manifest/2"
+ADMISSIBLE_MANIFEST_SCHEMA_VERSIONS = (
+    LEGACY_MANIFEST_SCHEMA_VERSION, MANIFEST_SCHEMA_VERSION)
 PROVENANCE_SCHEMA_VERSION = "certify-fixture-provenance/1"
 PINS_SCHEMA_VERSION = "certify-fixture-pins/1"
 #: Bumped to /2 by the r2 admission correction: the policy fields carry CLOSED
@@ -384,12 +393,25 @@ def build_transform_block(
     published first and is immutable — names nothing. A copied manifest with an
     edited sign and stale hashes is not an admitted pair, which is why the
     original's ``root_digest`` AND its ``manifest.json`` digest are both bound.
+
+    ``bijective_verified`` is NOT coerced (Astra review #2730 F3): ``bool("false")``
+    is ``True``, so coercion turned an unverified — or misspelled — declaration
+    into a verified one. It must already be a real boolean, and admission
+    requires it to be ``True``.
     """
+    if type(bijective_verified) is not bool:
+        raise BundleError(
+            f"bijective_verified must be a real boolean, got "
+            f"{type(bijective_verified).__name__} {bijective_verified!r}: a "
+            f"declaration in a closed admission contract is never coerced")
+    if not isinstance(notes, str):
+        raise BundleError(f"transform notes must be a string, got "
+                          f"{type(notes).__name__}")
     return {
         "schema_version": TRANSFORM_SCHEMA_VERSION,
         "transform_id": transform_id,
         "involution": True,
-        "bijective_verified": bool(bijective_verified),
+        "bijective_verified": bijective_verified,
         "source": {
             "bundle_id": source_bundle_id,
             "root_digest": source_root_digest,
@@ -416,6 +438,15 @@ def _validate_transform_shape(
         problems.append(f"transform.{missing} is missing")
     for unknown in sorted(keys - TRANSFORM_KEYS):
         problems.append(f"unknown transform field (nothing validates it): {unknown}")
+    if transform.get("schema_version") != TRANSFORM_SCHEMA_VERSION:
+        problems.append(
+            f"transform.schema_version is {transform.get('schema_version')!r}, "
+            f"expected {TRANSFORM_SCHEMA_VERSION!r}: an unreviewed transform "
+            f"schema validates nothing")
+    if not isinstance(transform.get("notes", ""), str):
+        problems.append(
+            f"transform.notes must be a string, got "
+            f"{type(transform.get('notes')).__name__}")
     if transform.get("transform_id") not in KNOWN_TRANSFORMS:
         problems.append(
             f"transform.transform_id is {transform.get('transform_id')!r}, not one "
@@ -423,7 +454,8 @@ def _validate_transform_shape(
     if transform.get("involution") is not True:
         problems.append("transform.involution must be True: the declared "
                         "polarity transform is its own inverse")
-    if transform.get("bijective_verified") is not True:
+    if type(transform.get("bijective_verified")) is not bool \
+            or transform.get("bijective_verified") is not True:
         problems.append(
             "transform.bijective_verified must be True: both directions are "
             "verified independently BEFORE any engine launch, and an "
@@ -444,12 +476,12 @@ def _validate_transform_shape(
             problems.append(
                 f"transform.source.{digest_field} must be a sha256 hex digest; a "
                 f"stale or absent digest binds nothing")
+    if not isinstance(source.get("bundle_id"), str) or not source["bundle_id"]:
+        problems.append("transform.source.bundle_id must be a non-empty string")
     if source.get("bundle_id") == bundle_id:
         problems.append(
             "transform.source.bundle_id is this bundle: the pair descriptor must "
             "be non-circular, and a bundle is not derived from itself")
-    if not source.get("bundle_id"):
-        problems.append("transform.source.bundle_id is missing")
     src_sign = source.get("storage_agree_value")
     if type(src_sign) is not int or src_sign not in ADMISSIBLE_STORAGE_AGREE_VALUES:
         problems.append(
@@ -488,6 +520,93 @@ def build_provenance(
             for s in selections
         ],
     }
+
+
+def derived_role(entry: dict[str, Any], *, source_bundle_id: str) -> dict[str, Any]:
+    """One role of a DERIVED bundle: the same role, same directory, same
+    measured metrics, with its source recorded as :data:`DERIVED_ROLE_SOURCE`
+    and the original role's own source RETAINED under ``derived_from``.
+
+    The involution changes raw vote signs and nothing else — not the
+    conversation a role was selected from, not the metrics it was selected
+    under, not its coverage. So the derived role keeps all of that and adds the
+    binding that says where it came from; it never claims to be a fresh
+    production extraction or an approved synthetic replacement.
+    """
+    original_source = entry.get("source")
+    if original_source not in ORIGINAL_ROLE_SOURCES:
+        raise BundleError(
+            f"role {entry.get('slug')!r} has source {original_source!r}; only "
+            f"{sorted(ORIGINAL_ROLE_SOURCES)} can be derived from (a derived "
+            f"bundle is not itself a derivation source)")
+    derived = dict(entry)
+    derived["source"] = DERIVED_ROLE_SOURCE
+    derived["derived_from"] = {
+        "bundle_id": source_bundle_id,
+        "slug": entry.get("slug"),
+        "source": original_source,
+    }
+    compat = derived.get("compat")
+    if isinstance(compat, dict) and "storage_agree_value" in compat:
+        compat = dict(compat)
+        compat["storage_agree_value"] = -compat["storage_agree_value"]
+        derived["compat"] = compat
+    return derived
+
+
+def build_derived_manifest(
+    source_manifest: dict[str, Any], *, bundle_id: str, payload_root: Path,
+    source_manifest_sha256: str, bijective_verified: bool,
+    owner: str | None = None, notes: str = "",
+) -> dict[str, Any]:
+    """The manifest of the FLIPPED side of a P-023 polarity pair.
+
+    This is the derived-source path admission needs to have something to
+    accept: it takes an ADMITTED original manifest and the derived payload tree
+    (the same fixtures with every non-null raw vote negated), and produces a
+    manifest that declares the opposite convention, re-scans the derived files,
+    binds the original through :func:`build_transform_block`, and re-labels
+    every role through :func:`derived_role`.
+
+    The original is never mutated and never learns about the derivative: the
+    pair descriptor points one way only. ``source_manifest_sha256`` is the
+    digest of the original's published ``manifest.json`` bytes, which is what
+    makes a stale or hand-edited source detectable rather than merely claimed.
+    """
+    if source_manifest.get("schema_version") not in ADMISSIBLE_MANIFEST_SCHEMA_VERSIONS:
+        raise BundleError(
+            f"cannot derive from schema_version "
+            f"{source_manifest.get('schema_version')!r}")
+    if source_manifest.get("transform") is not None:
+        raise BundleError(
+            "cannot derive from a bundle that is itself derived: the pair is "
+            "two sides, not a chain")
+    source_sign = validate_storage_agree_value(
+        source_manifest["polarity"]["storage_agree_value"],
+        field="source polarity.storage_agree_value")
+
+    files = scan_files(payload_root)
+    derived = dict(source_manifest)
+    derived.update(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        bundle_id=bundle_id,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        owner=owner or source_manifest["owner"],
+        files=files,
+        root_digest=root_digest(files),
+        polarity={**source_manifest["polarity"],
+                  "storage_agree_value": -source_sign},
+        roles=[derived_role(r, source_bundle_id=source_manifest["bundle_id"])
+               for r in source_manifest["roles"]],
+        transform=build_transform_block(
+            source_bundle_id=source_manifest["bundle_id"],
+            source_root_digest=source_manifest["root_digest"],
+            source_manifest_sha256=source_manifest_sha256,
+            source_storage_agree_value=source_sign,
+            bijective_verified=bijective_verified,
+            notes=notes),
+    )
+    return derived
 
 
 def canonical_json(obj: Any) -> bytes:
@@ -915,11 +1034,11 @@ def verify(payload_root: Path, manifest: dict[str, Any], *,
     if not isinstance(manifest, dict):
         raise VerificationError("manifest is not an object")
     version = manifest.get("schema_version")
-    if version != MANIFEST_SCHEMA_VERSION:
+    if version not in ADMISSIBLE_MANIFEST_SCHEMA_VERSIONS:
         raise VerificationError(
-            f"manifest schema_version is {version!r}, expected "
-            f"{MANIFEST_SCHEMA_VERSION!r}; an unversioned or foreign manifest is "
-            "not verifiable")
+            f"manifest schema_version is {version!r}, expected one of "
+            f"{list(ADMISSIBLE_MANIFEST_SCHEMA_VERSIONS)}; an unversioned or "
+            "foreign manifest is not verifiable")
     if not isinstance(manifest.get("bundle_id"), str) or not manifest["bundle_id"]:
         raise VerificationError("manifest has no bundle_id")
     if not isinstance(manifest.get("files"), list):
@@ -979,11 +1098,22 @@ MANIFEST_TOP_LEVEL_KEYS = frozenset({
     "schedules", "files", "root_digest", "archive", "redactions", "retention",
     "admission",
     # manifest/3 (P-023): the pair/transform provenance of a DERIVED fixture,
-    # explicitly null for an original capture. Required rather than optional —
-    # the set is closed in both directions, so "no transform block" has to be a
-    # stated fact, not an omission nobody noticed.
+    # explicitly null for an original capture. Required at /3 rather than
+    # optional — the set is closed in both directions, so "no transform block"
+    # has to be a stated fact, not an omission nobody noticed. A /2 manifest
+    # predates the field and is read with it ABSENT, which means the same
+    # thing: an original capture.
     "transform",
 })
+
+#: /3 fields the /2 schema did not have. Absent from a /2 manifest, and their
+#: /2 defaults are applied so an existing bundle admits on its original bytes.
+MANIFEST_KEYS_ADDED_IN_V3 = frozenset({"transform"})
+
+MANIFEST_TOP_LEVEL_KEYS_BY_VERSION: dict[str, frozenset[str]] = {
+    LEGACY_MANIFEST_SCHEMA_VERSION: MANIFEST_TOP_LEVEL_KEYS - MANIFEST_KEYS_ADDED_IN_V3,
+    MANIFEST_SCHEMA_VERSION: MANIFEST_TOP_LEVEL_KEYS,
+}
 
 #: Ordering guarantee -> the ONE tie-order policy token that guarantee permits.
 #: Admission compares the two: a manifest that declares ``frozen-extract-order``
@@ -996,7 +1126,27 @@ TIE_ORDER_POLICIES: dict[str, str] = {
 
 ORDERING_GUARANTEES = frozenset(TIE_ORDER_POLICIES)
 
-ROLE_SOURCES = frozenset({"production", "synthetic-replacement"})
+#: The role source of a DERIVED bundle: this role's fixture is the declared
+#: involution of an ADMITTED bundle's role, not a new production extraction and
+#: not an approved synthetic replacement (Astra review #2730 F1).
+#:
+#: Without it no flipped bundle could exist at all: 15 of the 17 required roles
+#: carry ``on_missing: fail``, so admission forbids substituting them, and the
+#: production release policy forbids a production-source role from declaring
+#: +1. Relabelling them "synthetic-replacement" only moves the failure. The
+#: derived source is the missing third case, and it is NOT a weakening: a
+#: derived role must name the transform's source bundle and RETAIN the original
+#: role's own source, so the provenance of the underlying capture survives the
+#: involution instead of being laundered by it.
+DERIVED_ROLE_SOURCE = "derived"
+
+#: What a derived role may have been derived FROM.
+ORIGINAL_ROLE_SOURCES = frozenset({"production", "synthetic-replacement"})
+
+ROLE_SOURCES = ORIGINAL_ROLE_SOURCES | frozenset({DERIVED_ROLE_SOURCE})
+
+#: Closed key set of a derived role's provenance binding.
+DERIVED_FROM_KEYS = frozenset({"bundle_id", "source", "slug"})
 
 #: The compatibility-CSV NULL-vote policy the extractor writes
 #: (``fixture_extract.COMPAT_NULL_VOTE_POLICY``). Restated here because
@@ -1151,13 +1301,19 @@ def admit_manifest(
     P = lambda cond, msg: _admission_problem(problems, cond, msg)  # noqa: E731
 
     # --- identity + closed field set -------------------------------------
-    P(manifest.get("schema_version") == MANIFEST_SCHEMA_VERSION,
-      f"schema_version is {manifest.get('schema_version')!r}, expected "
-      f"{MANIFEST_SCHEMA_VERSION!r}")
+    schema_version = manifest.get("schema_version")
+    P(schema_version in ADMISSIBLE_MANIFEST_SCHEMA_VERSIONS,
+      f"schema_version is {schema_version!r}, expected one of "
+      f"{list(ADMISSIBLE_MANIFEST_SCHEMA_VERSIONS)}")
+    # A /2 manifest is admitted on its ORIGINAL BYTES: its closed key set is the
+    # /2 one (no `transform`), and the /3 field it predates takes its /2 default
+    # below. Only /3 may carry a transform block at all.
+    expected_keys = MANIFEST_TOP_LEVEL_KEYS_BY_VERSION.get(
+        schema_version, MANIFEST_TOP_LEVEL_KEYS)
     keys = set(manifest)
-    for missing in sorted(MANIFEST_TOP_LEVEL_KEYS - keys):
+    for missing in sorted(expected_keys - keys):
         P(False, f"missing required manifest field: {missing}")
-    for unknown in sorted(keys - MANIFEST_TOP_LEVEL_KEYS):
+    for unknown in sorted(keys - expected_keys):
         P(False, f"unknown manifest field (nothing validates it): {unknown}")
     if problems:
         # Everything below indexes into fields whose presence is in doubt.
@@ -1272,13 +1428,17 @@ def admit_manifest(
     P(bool(polarity.get("boundaries")),
       "polarity.boundaries must name the storage/export/ingress sites")
 
-    # RELEASE POLICY, kept separate from the schema: a production capture must
+    # RELEASE POLICY, kept separate from the schema: a production CAPTURE must
     # still declare the production convention until the P-023 storage
-    # migration is separately approved. A derived pair fixture, which contains
-    # no production capture, is unaffected.
+    # migration is separately approved. A derived pair fixture, whose roles
+    # declare source "derived" and retain their original provenance, is not a
+    # capture and is unaffected.
     production_roles = sorted(
         str(r.get("slug")) for r in manifest["roles"]
         if isinstance(r, dict) and r.get("source") == "production")
+    derived_roles = sorted(
+        str(r.get("slug")) for r in manifest["roles"]
+        if isinstance(r, dict) and r.get("source") == DERIVED_ROLE_SOURCE)
     if production_roles and declared_sign in ADMISSIBLE_STORAGE_AGREE_VALUES:
         P(declared_sign == PRODUCTION_STORAGE_AGREE_VALUE,
           f"polarity.storage_agree_value is {declared_sign!r}, but this bundle "
@@ -1287,10 +1447,11 @@ def admit_manifest(
           f"capture may not declare the flipped convention before the storage "
           f"migration is approved (release policy, not schema)")
 
-    # manifest/3 pair provenance. `null` is the positive declaration that this
-    # is an ORIGINAL capture; a block must bind the original it was involuted
-    # from, with that original's final digests and the opposite convention.
-    transform = manifest["transform"]
+    # manifest/3 pair provenance. `null` — or, on a /2 manifest, the absent
+    # field — is the positive declaration that this is an ORIGINAL capture; a
+    # block must bind the original it was involuted from, with that original's
+    # final digests and the opposite convention.
+    transform = manifest.get("transform")
     if transform is not None:
         for problem in _validate_transform_shape(
                 transform,
@@ -1302,6 +1463,16 @@ def admit_manifest(
           f"this manifest declares a transform block AND production-source "
           f"role(s) {production_roles}: a derived fixture is built from an "
           f"admitted bundle's bytes, never re-extracted from production")
+        P(bool(derived_roles),
+          "this manifest declares a transform block but no role declares "
+          f"source {DERIVED_ROLE_SOURCE!r}: a derived bundle's roles are "
+          "derivations, and a transform nothing was derived under is not "
+          "provenance")
+    else:
+        P(not derived_roles,
+          f"role(s) {derived_roles} declare source {DERIVED_ROLE_SOURCE!r} but "
+          f"the manifest declares no transform block, so nothing says what they "
+          f"were derived from or under which transform")
 
     # --- declared release policy ------------------------------------------
     # Every policy is a CLOSED enum token, and the tie policy must agree with
@@ -1413,6 +1584,41 @@ def admit_manifest(
               f"role {slug!r} measured metrics do NOT satisfy the config "
               f"predicates it claims to have been selected under: "
               f"{_failed_predicates(metrics, rule['predicates'])}")
+        if source == DERIVED_ROLE_SOURCE:
+            # A derived role is admitted for ANY role, including the 15 whose
+            # rule says on_missing:fail — because nothing was substituted. It
+            # is the SAME fixture with its raw vote signs involuted, so its
+            # measured metrics (checked above, unchanged by a sign flip) still
+            # satisfy the rule it was selected under. What must be present is
+            # the binding that keeps the original provenance visible.
+            binding = entry.get("derived_from")
+            P(isinstance(binding, dict) and bool(binding),
+              f"derived role {slug!r} carries no derived_from binding: a role "
+              f"with no stated origin is an unprovenanced fixture, not a "
+              f"derivation")
+            if isinstance(binding, dict):
+                for unknown in sorted(set(binding) - DERIVED_FROM_KEYS):
+                    P(False, f"derived role {slug!r} derived_from carries "
+                             f"unknown field {unknown!r}")
+                for missing in sorted(DERIVED_FROM_KEYS - set(binding)):
+                    P(False, f"derived role {slug!r} derived_from is missing "
+                             f"{missing!r}")
+                P(binding.get("source") in ORIGINAL_ROLE_SOURCES,
+                  f"derived role {slug!r} derived_from.source is "
+                  f"{binding.get('source')!r}: it must RETAIN the original "
+                  f"role's own source, one of {sorted(ORIGINAL_ROLE_SOURCES)}")
+                P(binding.get("slug") == slug,
+                  f"derived role {slug!r} claims to derive from role "
+                  f"{binding.get('slug')!r}: the involution changes vote signs, "
+                  f"never which conversation filled a role")
+                if isinstance(transform, dict):
+                    expected_source = (transform.get("source") or {}).get(
+                        "bundle_id")
+                    P(binding.get("bundle_id") == expected_source,
+                      f"derived role {slug!r} names origin bundle "
+                      f"{binding.get('bundle_id')!r}, but the transform block "
+                      f"binds {expected_source!r}: one manifest cannot be "
+                      f"derived from two different bundles")
         if source == "synthetic-replacement":
             replacement = rule.get("synthetic_replacement")
             P(rule.get("on_missing") == "fail_with_synthetic_replacement_offer",
@@ -1451,6 +1657,15 @@ def admit_manifest(
               "is not a census of zero")
         if not isinstance(compat, dict):
             continue
+        # A sign-sensitive census is derived from the manifest's OWN declared
+        # sign (P-023 rev3). A role counted under -1 inside a bundle declaring
+        # +1 counted agreements as disagreements. Older censuses predate the
+        # field and are unaffected.
+        if "storage_agree_value" in compat:
+            P(compat.get("storage_agree_value") == declared_sign,
+              f"role {slug!r} compat census was counted under storage agree "
+              f"{compat.get('storage_agree_value')!r} but the manifest declares "
+              f"{declared_sign!r}")
         P(compat.get("null_vote_policy") == REQUIRED_COMPAT_NULL_VOTE_POLICY,
           f"role {slug!r} compat census declares NULL-vote policy "
           f"{compat.get('null_vote_policy')!r}, expected "

--- a/delphi/polismath/replay/fixture_bundle.py
+++ b/delphi/polismath/replay/fixture_bundle.py
@@ -74,7 +74,9 @@ from polismath.utils.vote_convention import (
 #: /2 was the lossless correction: NULL ``weight_x_32767`` and NULL
 #: ``votes.vote`` survive extraction as nulls instead of becoming 0, and the
 #: manifest carries an ``admission`` block stating the release policy that
-#: :func:`admit_manifest` enforces. A /1 or /2 manifest is NOT admissible.
+#: :func:`admit_manifest` enforces. A /1 manifest is NOT admissible; a /2
+#: manifest IS, unchanged, on its original bytes — see
+#: :data:`ADMISSIBLE_MANIFEST_SCHEMA_VERSIONS`.
 MANIFEST_SCHEMA_VERSION = "certify-fixture-manifest/3"
 #: The PREVIOUS closed manifest schema. It stays verifiable and admissible
 #: BYTE-FOR-BYTE (Astra review #2730 F-compat): a /2 manifest carries no
@@ -392,7 +394,10 @@ def build_transform_block(
     manifest names the original's final digests, and the original — which was
     published first and is immutable — names nothing. A copied manifest with an
     edited sign and stale hashes is not an admitted pair, which is why the
-    original's ``root_digest`` AND its ``manifest.json`` digest are both bound.
+    original's ``root_digest`` AND its ``manifest.json`` digest are both bound
+    — as DECLARATIONS. Neither is independently fetched and re-derived here;
+    see :func:`build_derived_manifest` for what that deferral does and does not
+    leave certified.
 
     ``bijective_verified`` is NOT coerced (Astra review #2730 F3): ``bool("false")``
     is ``True``, so coercion turned an unverified — or misspelled — declaration
@@ -570,8 +575,20 @@ def build_derived_manifest(
 
     The original is never mutated and never learns about the derivative: the
     pair descriptor points one way only. ``source_manifest_sha256`` is the
-    digest of the original's published ``manifest.json`` bytes, which is what
-    makes a stale or hand-edited source detectable rather than merely claimed.
+    digest of the original's published ``manifest.json`` bytes.
+
+    DEFERRED, and NOT claimed by this function or by any round-trip test built
+    on it: the source digests recorded here are DECLARATIONS. Nothing in this
+    slice fetches the original bundle's bytes and re-derives those digests, and
+    nothing independently verifies that this payload really is the bijective
+    involution of the source payload. Admission checks the block's shape and
+    its cross-field consistency — opposite conventions, a non-circular binding,
+    a known transform id, a strictly boolean verification flag, and the origin
+    rules each derived role inherits. A verify/admit/push/pull round trip of a
+    derived bundle therefore proves that it is internally consistent and
+    publishable, NOT that its stated source is real or that the transform was
+    performed correctly. The independent source-fetch and bijection gate
+    remains required before certifying an actual derived bundle.
     """
     if source_manifest.get("schema_version") not in ADMISSIBLE_MANIFEST_SCHEMA_VERSIONS:
         raise BundleError(
@@ -1584,6 +1601,17 @@ def admit_manifest(
               f"role {slug!r} measured metrics do NOT satisfy the config "
               f"predicates it claims to have been selected under: "
               f"{_failed_predicates(metrics, rule['predicates'])}")
+        # The EFFECTIVE source: for a derived role, the source of the role it
+        # was derived FROM. Every rule that governed the original governs the
+        # derivation too (Astra review #2730 R2-F1) — retaining a binding that
+        # NAMES a synthetic origin, while skipping the offer/approval/generator
+        # rules that make a synthetic role admissible, let a manifest claim an
+        # origin its own policy forbids, and the whole verify/admit/push/pull
+        # path accepted it.
+        binding = entry.get("derived_from")
+        effective_source = source
+        if source == DERIVED_ROLE_SOURCE and isinstance(binding, dict):
+            effective_source = binding.get("source")
         if source == DERIVED_ROLE_SOURCE:
             # A derived role is admitted for ANY role, including the 15 whose
             # rule says on_missing:fail — because nothing was substituted. It
@@ -1591,7 +1619,6 @@ def admit_manifest(
             # measured metrics (checked above, unchanged by a sign flip) still
             # satisfy the rule it was selected under. What must be present is
             # the binding that keeps the original provenance visible.
-            binding = entry.get("derived_from")
             P(isinstance(binding, dict) and bool(binding),
               f"derived role {slug!r} carries no derived_from binding: a role "
               f"with no stated origin is an unprovenanced fixture, not a "
@@ -1619,26 +1646,31 @@ def admit_manifest(
                       f"{binding.get('bundle_id')!r}, but the transform block "
                       f"binds {expected_source!r}: one manifest cannot be "
                       f"derived from two different bundles")
-        if source == "synthetic-replacement":
+        if effective_source == "synthetic-replacement":
+            # Applied to a fresh substitute AND to a derivation of one: the
+            # involution changes vote signs, never whether a substitution was
+            # offered, approved, materialised or pinned to a generator.
+            origin = ("derived synthetic role" if source == DERIVED_ROLE_SOURCE
+                      else "synthetic role")
             replacement = rule.get("synthetic_replacement")
             P(rule.get("on_missing") == "fail_with_synthetic_replacement_offer",
               f"role {slug!r} is a synthetic replacement but its rule does not "
               "offer one")
             P(bool(entry.get("approval")),
-              f"synthetic role {slug!r} carries no recorded operator approval")
+              f"{origin} {slug!r} carries no recorded operator approval")
             P(entry.get("synthetic_replacement") == replacement,
-              f"synthetic role {slug!r} names generator case "
+              f"{origin} {slug!r} names generator case "
               f"{entry.get('synthetic_replacement')!r}, config offers "
               f"{replacement!r}")
             P(str(entry.get("synthetic_replacement")) in materialised_case_ids
               or str(directory) in dirs_present,
-              f"synthetic role {slug!r} substitutes generator case "
+              f"{origin} {slug!r} substitutes generator case "
               f"{entry.get('synthetic_replacement')!r}, which is NOT materialised "
               "in this bundle")
             P(bool(entry.get("coverage_limits")),
-              f"synthetic role {slug!r} does not state its coverage limits")
+              f"{origin} {slug!r} does not state its coverage limits")
             P(bool((entry.get("generator") or {}).get("case_id")),
-              f"synthetic role {slug!r} does not pin the generator that produced it")
+              f"{origin} {slug!r} does not pin the generator that produced it")
         # The role's own extract meta must not contradict the manifest-level
         # ordering declaration it was published under.
         P(entry.get("ordering_guarantee") == guarantee,
@@ -1662,10 +1694,21 @@ def admit_manifest(
         # +1 counted agreements as disagreements. Older censuses predate the
         # field and are unaffected.
         if "storage_agree_value" in compat:
-            P(compat.get("storage_agree_value") == declared_sign,
-              f"role {slug!r} compat census was counted under storage agree "
-              f"{compat.get('storage_agree_value')!r} but the manifest declares "
-              f"{declared_sign!r}")
+            census_sign = compat.get("storage_agree_value")
+            # TYPE before equality (Astra review #2730 R2-F2), the same
+            # strictness the C9 ids get: `True == 1` and `1.0 == 1`, so an
+            # equality test alone admitted a bool and a float as a declared
+            # convention.
+            if type(census_sign) is not int \
+                    or census_sign not in ADMISSIBLE_STORAGE_AGREE_VALUES:
+                P(False,
+                  f"role {slug!r} compat census storage_agree_value must be "
+                  f"exactly the integer -1 or +1 (bool, float and str "
+                  f"excluded), got {type(census_sign).__name__} {census_sign!r}")
+            else:
+                P(census_sign == declared_sign,
+                  f"role {slug!r} compat census was counted under storage agree "
+                  f"{census_sign!r} but the manifest declares {declared_sign!r}")
         P(compat.get("null_vote_policy") == REQUIRED_COMPAT_NULL_VOTE_POLICY,
           f"role {slug!r} compat census declares NULL-vote policy "
           f"{compat.get('null_vote_policy')!r}, expected "

--- a/delphi/polismath/replay/fixture_bundle.py
+++ b/delphi/polismath/replay/fixture_bundle.py
@@ -57,11 +57,25 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
-#: Bumped to /2 by the lossless correction: NULL ``weight_x_32767`` and NULL
-#: ``votes.vote`` now survive extraction as nulls instead of becoming 0, and the
+from polismath.utils.vote_convention import (
+    ADMISSIBLE_STORAGE_AGREE_VALUES,
+    EXPORT_AGREE_VALUE,
+    STORAGE_AGREE_VALUE,
+    validate_storage_agree_value,
+)
+
+#: Bumped to /3 by P-023: ``polarity.storage_agree_value`` is now a DECLARED
+#: per-bundle value admitted for exactly -1 or +1 (it was hard-pinned to -1, so
+#: the flipped side of a compensated polarity pair was inadmissible by
+#: construction and could be neither pushed nor pulled), and the manifest
+#: carries a closed ``transform`` block binding a derived fixture to the
+#: original it was involuted from. Production-source bundles remain -1 by
+#: RELEASE POLICY — a separate predicate, not a schema pin.
+#: /2 was the lossless correction: NULL ``weight_x_32767`` and NULL
+#: ``votes.vote`` survive extraction as nulls instead of becoming 0, and the
 #: manifest carries an ``admission`` block stating the release policy that
-#: :func:`admit_manifest` enforces. A /1 manifest is NOT admissible.
-MANIFEST_SCHEMA_VERSION = "certify-fixture-manifest/2"
+#: :func:`admit_manifest` enforces. A /1 or /2 manifest is NOT admissible.
+MANIFEST_SCHEMA_VERSION = "certify-fixture-manifest/3"
 PROVENANCE_SCHEMA_VERSION = "certify-fixture-provenance/1"
 PINS_SCHEMA_VERSION = "certify-fixture-pins/1"
 #: Bumped to /2 by the r2 admission correction: the policy fields carry CLOSED
@@ -243,11 +257,26 @@ def build_manifest(
     source_commit: str | None = None, archive: dict[str, Any] | None = None,
     coverage_report: dict[str, Any] | None = None,
     accepted_null_vote_drops: bool = False,
+    storage_agree_value: int = STORAGE_AGREE_VALUE,
+    transform: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """The PRIVATE manifest. It records everything P-022 A lists EXCEPT the
     role -> zid mapping, which lives in the separate restricted provenance
     object (:func:`build_provenance`) because ordinary test execution does not
-    need identities."""
+    need identities.
+
+    ``storage_agree_value`` is the bundle's OWN declared raw storage sign of
+    agreement, -1 or +1 (P-023). It defaults to the authoritative production
+    value and is validated here, so a manifest can never carry a convention
+    nobody declared. ``transform`` is :func:`build_transform_block` for a
+    DERIVED pair fixture and ``None`` for an original capture; a derived bundle
+    binds the original's digests, never the other way round.
+    """
+    validate_storage_agree_value(storage_agree_value)
+    if transform is not None:
+        bad = _validate_transform_shape(transform, storage_agree_value, bundle_id)
+        if bad:
+            raise BundleError("; ".join(bad))
     files = scan_files(payload_root)
     return {
         "schema_version": MANIFEST_SCHEMA_VERSION,
@@ -278,14 +307,17 @@ def build_manifest(
             ordering_guarantee=tie_key["guarantee"],
             accepted_null_vote_drops=accepted_null_vote_drops),
         "polarity": {
-            "storage_agree_value": REQUIRED_STORAGE_AGREE_VALUE,
+            "storage_agree_value": storage_agree_value,
             "export_agree_value": REQUIRED_EXPORT_AGREE_VALUE,
             "boundaries": [
                 "storage: server/postgres/migrations/000000_initial.sql votes.vote",
-                "export: polismath/replay/prodclone.py format_votes_rows negates the sign",
+                "export: polismath/replay/prodclone.py format_votes_rows converts "
+                "raw x storage_agree_value",
                 "ingress: polismath/database/postgres.py conversion site",
+                "convention: polismath/utils/vote_convention.py STORAGE_AGREE_VALUE",
             ],
         },
+        "transform": transform,
         "roles": list(selections),
         "generated": {
             "generator_id": config["generated"]["generator_id"],
@@ -312,6 +344,123 @@ def build_manifest(
                      "Retirement requires an explicit privacy-approved decision, "
                      "never a short artifact TTL.",
     }
+
+
+# ---------------------------------------------------------------------------
+# manifest/3: the pair/transform block (P-023).
+# ---------------------------------------------------------------------------
+
+TRANSFORM_SCHEMA_VERSION = "certify-fixture-transform/1"
+
+#: The ONE declared transform: T(V, s) = (-V, -s), negating every non-null raw
+#: vote leaf and re-declaring the convention, changing nothing else. It is its
+#: own inverse, which is what "involution" asserts here.
+VOTE_POLARITY_TRANSFORM = "vote-polarity-involution/1"
+KNOWN_TRANSFORMS = frozenset({VOTE_POLARITY_TRANSFORM})
+
+#: Closed key sets. A transform block is evidence, so an unreviewed field in it
+#: is exactly as bad as an unreviewed top-level manifest field.
+TRANSFORM_KEYS = frozenset({
+    "schema_version", "transform_id", "involution", "bijective_verified",
+    "source", "notes",
+})
+TRANSFORM_SOURCE_KEYS = frozenset({
+    "bundle_id", "root_digest", "manifest_sha256", "storage_agree_value",
+})
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def build_transform_block(
+    *, transform_id: str = VOTE_POLARITY_TRANSFORM,
+    source_bundle_id: str, source_root_digest: str, source_manifest_sha256: str,
+    source_storage_agree_value: int, bijective_verified: bool,
+    notes: str = "",
+) -> dict[str, Any]:
+    """The derived fixture's binding to the fixture it was involuted from.
+
+    The binding is deliberately ONE-WAY and therefore non-circular: the derived
+    manifest names the original's final digests, and the original — which was
+    published first and is immutable — names nothing. A copied manifest with an
+    edited sign and stale hashes is not an admitted pair, which is why the
+    original's ``root_digest`` AND its ``manifest.json`` digest are both bound.
+    """
+    return {
+        "schema_version": TRANSFORM_SCHEMA_VERSION,
+        "transform_id": transform_id,
+        "involution": True,
+        "bijective_verified": bool(bijective_verified),
+        "source": {
+            "bundle_id": source_bundle_id,
+            "root_digest": source_root_digest,
+            "manifest_sha256": source_manifest_sha256,
+            "storage_agree_value": source_storage_agree_value,
+        },
+        "notes": notes,
+    }
+
+
+def _validate_transform_shape(
+    transform: Any, storage_agree_value: int, bundle_id: str,
+) -> list[str]:
+    """Structural + cross-field checks on a transform block. Returns the list
+    of problems (empty when the block is well formed) so both
+    :func:`build_manifest` (which raises) and :func:`admit_manifest` (which
+    collects) can use it."""
+    problems: list[str] = []
+    if not isinstance(transform, dict):
+        return [f"transform must be an object or null, got "
+                f"{type(transform).__name__}"]
+    keys = set(transform)
+    for missing in sorted(TRANSFORM_KEYS - keys - {"notes"}):
+        problems.append(f"transform.{missing} is missing")
+    for unknown in sorted(keys - TRANSFORM_KEYS):
+        problems.append(f"unknown transform field (nothing validates it): {unknown}")
+    if transform.get("transform_id") not in KNOWN_TRANSFORMS:
+        problems.append(
+            f"transform.transform_id is {transform.get('transform_id')!r}, not one "
+            f"of {sorted(KNOWN_TRANSFORMS)}")
+    if transform.get("involution") is not True:
+        problems.append("transform.involution must be True: the declared "
+                        "polarity transform is its own inverse")
+    if transform.get("bijective_verified") is not True:
+        problems.append(
+            "transform.bijective_verified must be True: both directions are "
+            "verified independently BEFORE any engine launch, and an "
+            "unverified transform is not a pair")
+    source = transform.get("source")
+    if not isinstance(source, dict):
+        problems.append("transform.source must be an object naming the original "
+                        "bundle and its final digests")
+        return problems
+    for missing in sorted(TRANSFORM_SOURCE_KEYS - set(source)):
+        problems.append(f"transform.source.{missing} is missing")
+    for unknown in sorted(set(source) - TRANSFORM_SOURCE_KEYS):
+        problems.append(
+            f"unknown transform.source field (nothing validates it): {unknown}")
+    for digest_field in ("root_digest", "manifest_sha256"):
+        value = source.get(digest_field)
+        if not isinstance(value, str) or not _SHA256_RE.match(value):
+            problems.append(
+                f"transform.source.{digest_field} must be a sha256 hex digest; a "
+                f"stale or absent digest binds nothing")
+    if source.get("bundle_id") == bundle_id:
+        problems.append(
+            "transform.source.bundle_id is this bundle: the pair descriptor must "
+            "be non-circular, and a bundle is not derived from itself")
+    if not source.get("bundle_id"):
+        problems.append("transform.source.bundle_id is missing")
+    src_sign = source.get("storage_agree_value")
+    if type(src_sign) is not int or src_sign not in ADMISSIBLE_STORAGE_AGREE_VALUES:
+        problems.append(
+            f"transform.source.storage_agree_value must be exactly the integer "
+            f"-1 or +1, got {type(src_sign).__name__} {src_sign!r}")
+    elif src_sign != -storage_agree_value:
+        problems.append(
+            f"transform.source.storage_agree_value is {src_sign!r} and this "
+            f"bundle declares {storage_agree_value!r}: the declared involution "
+            f"changes the convention, so the two must be opposite")
+    return problems
 
 
 def build_provenance(
@@ -829,6 +978,11 @@ MANIFEST_TOP_LEVEL_KEYS = frozenset({
     "roles", "generated", "workloads", "coverage_role_map", "coverage_report",
     "schedules", "files", "root_digest", "archive", "redactions", "retention",
     "admission",
+    # manifest/3 (P-023): the pair/transform provenance of a DERIVED fixture,
+    # explicitly null for an original capture. Required rather than optional —
+    # the set is closed in both directions, so "no transform block" has to be a
+    # stated fact, not an omission nobody noticed.
+    "transform",
 })
 
 #: Ordering guarantee -> the ONE tie-order policy token that guarantee permits.
@@ -869,11 +1023,23 @@ ADMISSION_POLICY_ENUMS: dict[str, frozenset[str]] = {
 #: census mandatory rather than optional.
 COMPAT_DROP_COUNTED_POLICY = "event-stream-nullable+compat-csv-drop-counted"
 
-#: Raw storage sign of AGREE and the export sign it becomes. Declaring these in
-#: the manifest is mandatory; admission checks the declaration matches the one
-#: definition the extractor uses.
-REQUIRED_STORAGE_AGREE_VALUE = -1
-REQUIRED_EXPORT_AGREE_VALUE = 1
+#: Raw storage sign of AGREE and the export sign it becomes.
+#:
+#: P-023 replaced the hard pin. ``storage_agree_value`` is now a DECLARED
+#: per-manifest value admitted for exactly the integer -1 or +1
+#: (``ADMISSIBLE_STORAGE_AGREE_VALUES``, bool excluded), because the flipped
+#: side of a compensated polarity pair is a legitimate fixture and the old
+#: ``== -1`` predicate made it inadmissible by construction: neither ``push``
+#: nor ``pull`` would accept it, so the pair could not be certified at all.
+#:
+#: What is NOT relaxed is the RELEASE POLICY: a bundle carrying a PRODUCTION
+#: capture must still declare -1 until the separately approved storage
+#: migration lands. That is a policy predicate over the declared roles, not a
+#: schema pin over every manifest — see :data:`PRODUCTION_STORAGE_AGREE_VALUE`.
+#: The export sign is unconditional: it is a separate tagged format and does
+#: not move with storage.
+PRODUCTION_STORAGE_AGREE_VALUE = STORAGE_AGREE_VALUE
+REQUIRED_EXPORT_AGREE_VALUE = EXPORT_AGREE_VALUE
 
 
 def _admission_block(*, ordering_guarantee: str,
@@ -1090,12 +1256,52 @@ def admit_manifest(
       "timestamp_precision must declare integer milliseconds")
 
     polarity = manifest["polarity"]
-    P(polarity.get("storage_agree_value") == REQUIRED_STORAGE_AGREE_VALUE,
-      f"polarity.storage_agree_value must be {REQUIRED_STORAGE_AGREE_VALUE}")
+    declared_sign = polarity.get("storage_agree_value")
+    # MATHEMATICAL admission: exactly the integer -1 or +1. `type(x) is int`
+    # rather than isinstance, because bool is an int subclass and `True == 1`
+    # would otherwise admit a convention nobody declared (P-023 control 7).
+    P(type(declared_sign) is int
+      and declared_sign in ADMISSIBLE_STORAGE_AGREE_VALUES,
+      f"polarity.storage_agree_value must be exactly the integer -1 or +1 "
+      f"(bool, float and str excluded), got "
+      f"{type(declared_sign).__name__} {declared_sign!r}")
     P(polarity.get("export_agree_value") == REQUIRED_EXPORT_AGREE_VALUE,
-      f"polarity.export_agree_value must be {REQUIRED_EXPORT_AGREE_VALUE}")
+      f"polarity.export_agree_value must be {REQUIRED_EXPORT_AGREE_VALUE}: the "
+      f"export is a separately tagged semantic format and does not move with "
+      f"storage")
     P(bool(polarity.get("boundaries")),
       "polarity.boundaries must name the storage/export/ingress sites")
+
+    # RELEASE POLICY, kept separate from the schema: a production capture must
+    # still declare the production convention until the P-023 storage
+    # migration is separately approved. A derived pair fixture, which contains
+    # no production capture, is unaffected.
+    production_roles = sorted(
+        str(r.get("slug")) for r in manifest["roles"]
+        if isinstance(r, dict) and r.get("source") == "production")
+    if production_roles and declared_sign in ADMISSIBLE_STORAGE_AGREE_VALUES:
+        P(declared_sign == PRODUCTION_STORAGE_AGREE_VALUE,
+          f"polarity.storage_agree_value is {declared_sign!r}, but this bundle "
+          f"carries production-source role(s) {production_roles} and production "
+          f"storage is still {PRODUCTION_STORAGE_AGREE_VALUE}: a production "
+          f"capture may not declare the flipped convention before the storage "
+          f"migration is approved (release policy, not schema)")
+
+    # manifest/3 pair provenance. `null` is the positive declaration that this
+    # is an ORIGINAL capture; a block must bind the original it was involuted
+    # from, with that original's final digests and the opposite convention.
+    transform = manifest["transform"]
+    if transform is not None:
+        for problem in _validate_transform_shape(
+                transform,
+                declared_sign if declared_sign in ADMISSIBLE_STORAGE_AGREE_VALUES
+                else PRODUCTION_STORAGE_AGREE_VALUE,
+                str(manifest["bundle_id"])):
+            P(False, problem)
+        P(not production_roles,
+          f"this manifest declares a transform block AND production-source "
+          f"role(s) {production_roles}: a derived fixture is built from an "
+          f"admitted bundle's bytes, never re-extracted from production")
 
     # --- declared release policy ------------------------------------------
     # Every policy is a CLOSED enum token, and the tie policy must agree with

--- a/delphi/polismath/replay/fixture_extract.py
+++ b/delphi/polismath/replay/fixture_extract.py
@@ -49,6 +49,11 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 from polismath.replay import prodclone as pc
+from polismath.utils.vote_convention import (
+    EXPORT_AGREE_VALUE,
+    STORAGE_AGREE_VALUE,
+    validate_storage_agree_value,
+)
 
 #: Bumped to /2 by the lossless correction: ``weight_x_32767`` and ``vote`` are
 #: NULLABLE in the stream. /1 coerced a NULL weight to 0, which silently
@@ -56,9 +61,12 @@ from polismath.replay import prodclone as pc
 EVENT_STREAM_SCHEMA_VERSION = "certify-events/2"
 
 #: Raw storage sign of an AGREE vote (``server/postgres/migrations/000000_initial.sql``:
-#: "-1 = Agree, 1 = Disagree, 0 = Pass/Unsure"). The export CSV negates it.
-STORAGE_AGREE_VALUE = -1
-EXPORT_AGREE_VALUE = 1
+#: "-1 = Agree, 1 = Disagree, 0 = Pass/Unsure"), and the export CSV's own
+#: (semantic) sign. Both are RE-EXPORTED from the ONE authoritative definition
+#: (``polismath.utils.vote_convention``) rather than restated as literals here
+#: — P-022-G rev4 allows exactly one Python definition, and every consumer
+#: takes the value through a validated argument. Production extraction remains
+#: -1 until the separately approved P-023 storage migration.
 
 _OPAQUE_PREFIX_BYTES = 8  # 16 hex characters
 
@@ -360,6 +368,7 @@ def logical_digest(events: Sequence[dict[str, Any]]) -> str:
 def stream_meta(
     *, slug: str, role: str, tie_key: dict[str, Any],
     events: Sequence[dict[str, Any]], n_participants: int,
+    storage_agree_value: int = STORAGE_AGREE_VALUE,
 ) -> dict[str, Any]:
     vote_events = [e for e in events if e["kind"] == "vote"]
     comment_events = [e for e in events if e["kind"] == "comment"]
@@ -380,10 +389,11 @@ def stream_meta(
             "note": tie_key["note"],
         },
         "polarity": {
-            "storage_agree_value": STORAGE_AGREE_VALUE,
+            "storage_agree_value": storage_agree_value,
             "export_agree_value": EXPORT_AGREE_VALUE,
             "events_carry": "raw storage sign, unmodified",
-            "compat_csv_carries": "negated sign, matching the production export",
+            "compat_csv_carries": "semantic sign (raw x storage_agree_value), "
+                                  "matching the production export",
         },
         "nullability": {
             "vote": "NULLABLE. votes.vote has no NOT NULL constraint; a NULL "
@@ -457,6 +467,7 @@ COMPAT_NULL_VOTE_POLICY = "drop-counted"
 
 def compat_rows_from_events(
     events: Sequence[dict[str, Any]],
+    *, storage_agree_value: int = STORAGE_AGREE_VALUE,
 ) -> tuple[list[dict[str, str]], list[dict[str, str]], dict[str, Any]]:
     """Derive the compatibility votes/comments CSV rows FROM the event stream
     (never from a second query), reusing the existing formatters so the export
@@ -485,13 +496,15 @@ def compat_rows_from_events(
     votable = [e for e in vote_events if e["vote"] is not None]
     null_vote_events = [e for e in vote_events if e["vote"] is None]
 
+    agree = validate_storage_agree_value(storage_agree_value)
     votes_rows = pc.format_votes_rows([
         {"tid": e["tid"], "pid": e["pid"], "vote": e["vote"], "created": e["created"]}
         for e in votable
-    ])
+    ], storage_agree_value=agree)
 
     compat_census = {
         "null_vote_policy": COMPAT_NULL_VOTE_POLICY,
+        "storage_agree_value": agree,
         "null_votes_dropped": len(null_vote_events),
         "null_vote_ordinals": [e["ord"] for e in null_vote_events[:64]],
         "null_vote_cells": sorted({(e["pid"], e["tid"]) for e in null_vote_events})[:64],
@@ -509,9 +522,9 @@ def compat_rows_from_events(
     counts: dict[int, list[int]] = {}
     for e in votable:
         entry = counts.setdefault(e["tid"], [0, 0])
-        if e["vote"] == STORAGE_AGREE_VALUE:
+        if e["vote"] == agree:
             entry[0] += 1
-        elif e["vote"] == -STORAGE_AGREE_VALUE:
+        elif e["vote"] == -agree:
             entry[1] += 1
     vote_counts = {tid: (a, d) for tid, (a, d) in counts.items()}
 
@@ -547,6 +560,7 @@ def fetch_conversation(conn, zid: int, tie_key: dict[str, Any]) -> dict[str, lis
 def extract_conversation(
     conn, *, zid: int, slug: str, role: str, payload_root: Path, guard_root: Path,
     dir_name: str, tie_key: dict[str, Any], measured: dict[str, Any] | None = None,
+    storage_agree_value: int = STORAGE_AGREE_VALUE,
 ) -> dict[str, Any]:
     """Extract ONE conversation into ``<payload_root>/<dir_name>/``.
 
@@ -558,7 +572,8 @@ def extract_conversation(
     raw = fetch_conversation(conn, zid, tie_key)
     events = build_events(raw["votes"], raw["comments"])
     meta = stream_meta(slug=slug, role=role, tie_key=tie_key, events=events,
-                       n_participants=len(raw["participants"]))
+                       n_participants=len(raw["participants"]),
+                       storage_agree_value=storage_agree_value)
 
     target.mkdir(parents=True, exist_ok=True)
     write_events_jsonl(target / "events.jsonl", events)
@@ -566,7 +581,8 @@ def extract_conversation(
         json.dumps(meta, indent=2, sort_keys=True) + "\n")
     write_participants_csv(target / "participants.csv", raw["participants"])
 
-    votes_rows, comments_rows, compat = compat_rows_from_events(events)
+    votes_rows, comments_rows, compat = compat_rows_from_events(
+        events, storage_agree_value=storage_agree_value)
     meta["compat_csv"] = compat
     (target / "events.meta.json").write_text(
         json.dumps(meta, indent=2, sort_keys=True) + "\n")

--- a/delphi/polismath/replay/polarity.py
+++ b/delphi/polismath/replay/polarity.py
@@ -1,0 +1,837 @@
+"""The standing POLARITY property: ``E(V, s) == E(-V, -s)`` through real ingress.
+
+P-023 (rev3, ACCEPTED) states the gate this module implements. Let an admitted
+vote stream ``V`` carry raw votes in ``{-1, 0, +1, NULL}`` with a declared
+storage convention ``s`` (exactly the integer -1 or +1; semantic vote is
+``v x s``). Define ``T(V, s) = (-V, -s)``, changing ONLY the non-null raw vote
+leaves and the convention declaration — every identity, ordinal, tie position,
+timestamp, weight and moderation event stays fixed. ``T`` is its own inverse
+and ``semantic(T(V, s)) == semantic(V, s)``. The property is then
+
+    canonical(E(V, s), output_profile) == canonical(E(-V, -s), output_profile)
+
+executed from FRESH STATE through the engine's actual ingress on both sides —
+never by transforming one already-computed output into the other, which would
+only prove the transformer.
+
+Three things this module keeps rigorously apart, because confusing them is how
+a wrong mean passes:
+
+1. **The storage convention `s`** — an input declaration
+   (``polismath.utils.vote_convention``). Changing it alone must change the
+   result; changing it together with the votes must not.
+2. **The vote-axis involution `N`** — an OUTPUT transform, defined strictly on
+   the *projected* ``PREP_MAIN_KEYS`` comparison view, applied only to
+   translate an explicitly different output convention into the common profile.
+   Rev3 is emphatic that N is NOT applied merely because ``s`` changed: this
+   engine ingests semantically and returns the same output profile on both
+   sides, so a compensated pair needs no N at all, and adding one would be the
+   double-negation gate the design forbids.
+3. **PCA eigenvector orientation** — a canonicalization step that flips a
+   component and its coupled projections, and NEVER touches ``pca.center``. N
+   leaves ``comps`` alone and moves the mean. They are different operations on
+   overlapping fields.
+
+What is deliberately NOT here: any raw-blob N, any extension of N to the
+``group_clusters`` twin or to ``proj``, and any change to C9's producer sign
+relation. Rev3 chose the post-projection definition of N precisely so that the
+raw blob is untouched — ``project_prep_main`` drops the snake twin (exact kebab
+wins) and drops ``proj`` (outside the whitelist) BEFORE N runs, so C9 is
+evaluated on untouched raw bytes and ``Conversation.from_dict`` never sees an
+N-translated blob. :func:`vote_axis_involution` enforces that by refusing to
+run on anything that still carries those raw extensions.
+"""
+
+from __future__ import annotations
+
+import copy
+import csv
+import hashlib
+import json
+import math
+import tempfile
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+from polismath.replay import driver as drv
+from polismath.replay import prodclone as pc
+from polismath.replay import real_data as rd
+from polismath.replay import schedule as sched
+from polismath.replay.crosslang import canonicalize_blob, project_prep_main
+from polismath.replay.types import ModEvent, ReplayDataset
+from polismath.utils.general import postgres_vote_to_delphi
+from polismath.utils.output_profile import (
+    OUTPUT_PROFILE_KEY,
+    PROJECTED_PROFILE,
+    VOTE_AXIS_AS_EMITTED,
+    VOTE_AXIS_NEGATED,
+    is_projected_view,
+    marker,
+    payload,
+    stamp,
+)
+from polismath.utils.vote_convention import (
+    STORAGE_AGREE_VALUE,
+    flipped,
+    semantic_vote,
+    validate_storage_agree_value,
+)
+
+
+class PolarityError(RuntimeError):
+    """The polarity property, or one of its transforms, was misused."""
+
+
+# ---------------------------------------------------------------------------
+# N — the vote-axis convention involution, on the PROJECTED view only.
+# ---------------------------------------------------------------------------
+
+#: Exactly the fields N negates (P-023 rev3, "Sign transformations" table).
+#: Anything not named here is invariant — N is not permission to negate
+#: arbitrary numeric fields.
+N_NEGATED_FIELDS: tuple[str, ...] = (
+    "pca.center",
+    "pca.comment-projection",
+    "base-clusters.x",
+    "base-clusters.y",
+    "group-clusters[].center",
+)
+
+#: Named INVARIANTS, checked by :func:`assert_n_invariants`. ``comps`` is
+#: covariance-derived and ``comment-extremity`` is a norm, so neither moves;
+#: ptptstats is invariant for the non-obvious reason recorded in the contract
+#: (extremeness is a dot product of ``(position - center)`` with the direction
+#: ``(center - global_center)/norm``, and BOTH vectors co-negate — a claim that
+#: would break if that direction were ever re-derived from ``comps``).
+N_INVARIANT_FIELDS: tuple[str, ...] = (
+    "pca.comps",
+    "pca.comment-extremity",
+    "n",
+    "n-cmts",
+    "tids",
+    "in-conv",
+    "repness",
+    "consensus",
+    "group-votes",
+    "votes-base",
+    "user-vote-counts",
+    "comment-priorities",
+    "group-aware-consensus",
+    "group-clusters[].id",
+    "group-clusters[].members",
+    "base-clusters.id",
+    "base-clusters.members",
+    "base-clusters.count",
+)
+
+#: Raw extensions that MUST already be gone when N runs. Their presence means
+#: the caller is holding a raw blob, not a projected comparison view — the
+#: exact mistake that would break C9's sign relation (the twin) or leave an
+#: internally inconsistent geometry (``proj`` un-negated beside a flipped PCA).
+N_FORBIDDEN_RAW_KEYS: tuple[str, ...] = ("group_clusters", "proj")
+
+
+def _negate_numbers(value: Any, where: str) -> Any:
+    """Negate every number under ``value``, preserving structure. Non-finite
+    and non-numeric leaves are a failure, not something to skip: N is defined
+    on finite coordinates only."""
+    if isinstance(value, bool):
+        raise PolarityError(f"N: {where} is a bool, not a coordinate")
+    if isinstance(value, (int, float)):
+        if not math.isfinite(value):
+            raise PolarityError(f"N: {where} is non-finite ({value!r})")
+        return -value
+    if isinstance(value, list):
+        return [_negate_numbers(v, f"{where}[{i}]") for i, v in enumerate(value)]
+    raise PolarityError(
+        f"N: {where} must be a number or a nested list of numbers, got "
+        f"{type(value).__name__}")
+
+
+def comparison_view(
+    blob: dict[str, Any], *,
+    project: Callable[[dict[str, Any]], dict[str, Any]] = project_prep_main,
+    canonicalize: Callable[[dict[str, Any]], dict[str, Any]] | None = canonicalize_blob,
+    vote_axis: str = VOTE_AXIS_AS_EMITTED,
+) -> dict[str, Any]:
+    """Project a RAW validated blob onto the comparison view and MARK it.
+
+    The ordering rev3 fixes is: raw validation (including C9 and the raw
+    extensions) -> project ``PREP_MAIN_KEYS`` -> optional declared N ->
+    independent PCA orientation/alignment -> compare. This is step two, and the
+    marker it stamps is what makes step three's misuse control non-vacuous: the
+    projected view is a *legal* kebab-only blob that the raw schema gate would
+    happily accept and ``from_dict`` would silently restore with no groups.
+
+    ``project`` is injectable so the certification battery can pass its own
+    acceptance projection (prep-main minus the dead subgroup-* trio) without
+    this module importing the battery.
+    """
+    view = project(blob)
+    if canonicalize is not None:
+        view = canonicalize(view)
+    return stamp(view, marker(profile=PROJECTED_PROFILE, vote_axis=vote_axis))
+
+
+def vote_axis_involution(view: dict[str, Any]) -> dict[str, Any]:
+    """N. Returns a NEW view with exactly :data:`N_NEGATED_FIELDS` negated.
+
+    Refuses anything but a marked projected view — N "is never a raw serializer
+    or restore transform" — and refuses a view that still carries a raw
+    extension from :data:`N_FORBIDDEN_RAW_KEYS`. Absent fields are skipped (an
+    empty checkpoint has no ``pca``), present-but-malformed fields fail.
+
+    The marker's ``vote_axis`` toggles, so ``N(N(view)) == view`` EXACTLY,
+    marker included: N is its own inverse, and the view always says which axis
+    it is currently on, independently of the input storage sign.
+    """
+    if not is_projected_view(view):
+        raise PolarityError(
+            "N is defined strictly on the validated, PROJECTED PREP_MAIN_KEYS "
+            "comparison view (P-023 rev3). This blob carries no output-profile "
+            f"marker ({OUTPUT_PROFILE_KEY!r}); build it with comparison_view() "
+            "first. Applying N to a raw blob would break C9's producer sign "
+            "relation on the group_clusters twin and corrupt the restore path.")
+    present = [k for k in N_FORBIDDEN_RAW_KEYS if k in view]
+    if present:
+        raise PolarityError(
+            f"N refuses a view still carrying the raw extension(s) {present}: "
+            "the projection must drop the group_clusters twin and proj BEFORE "
+            "N runs, which is exactly what keeps C9 and from_dict safe")
+
+    out = copy.deepcopy(view)
+
+    pca = out.get("pca")
+    if isinstance(pca, dict):
+        for key in ("center", "comment-projection"):
+            if key in pca:
+                pca[key] = _negate_numbers(pca[key], f"pca.{key}")
+    elif pca is not None:
+        raise PolarityError(f"N: 'pca' must be an object, got {type(pca).__name__}")
+
+    bc = out.get("base-clusters")
+    if isinstance(bc, dict):
+        for key in ("x", "y"):
+            if key in bc:
+                bc[key] = _negate_numbers(bc[key], f"base-clusters.{key}")
+    elif bc is not None:
+        raise PolarityError(
+            f"N: 'base-clusters' must be an object, got {type(bc).__name__}")
+
+    gc = out.get("group-clusters")
+    if isinstance(gc, list):
+        for i, group in enumerate(gc):
+            if not isinstance(group, dict):
+                raise PolarityError(
+                    f"N: group-clusters[{i}] must be an object, got "
+                    f"{type(group).__name__}")
+            if "center" in group:
+                group["center"] = _negate_numbers(
+                    group["center"], f"group-clusters[{i}].center")
+    elif gc is not None:
+        raise PolarityError(
+            f"N: 'group-clusters' must be an array, got {type(gc).__name__}")
+
+    old = out[OUTPUT_PROFILE_KEY]
+    transforms = list(old.get("transforms", []))
+    if transforms and transforms[-1] == "N":
+        transforms.pop()
+    else:
+        transforms.append("N")
+    out[OUTPUT_PROFILE_KEY] = marker(
+        profile=old.get("profile", PROJECTED_PROFILE),
+        vote_axis=(VOTE_AXIS_NEGATED if old.get("vote_axis") == VOTE_AXIS_AS_EMITTED
+                   else VOTE_AXIS_AS_EMITTED),
+        transforms=tuple(transforms),
+    )
+    return out
+
+
+def _dig(view: dict[str, Any], path: str) -> Any:
+    """Read one :data:`N_INVARIANT_FIELDS`-style path out of a view. ``[]``
+    marks a per-element read: ``group-clusters[].id`` -> the list of ids."""
+    if "[]" in path:
+        head, _, tail = path.partition("[].")
+        seq = view.get(head)
+        if not isinstance(seq, list):
+            return None
+        return [g.get(tail) if isinstance(g, dict) else None for g in seq]
+    node: Any = view
+    for part in path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def assert_n_invariants(view: dict[str, Any], n_view: dict[str, Any]) -> None:
+    """Every field N must NOT move is byte-equal across the pair. The
+    complementary direction (the negated set actually moved) is deliberately
+    NOT asserted here: an all-zero or empty geometry is a legitimate degenerate
+    checkpoint that no sign change can move, and ``-0.0 == 0.0``."""
+    for path in N_INVARIANT_FIELDS:
+        before, after = _dig(view, path), _dig(n_view, path)
+        if before != after:
+            raise PolarityError(
+                f"N changed the invariant field {path!r}: {before!r} -> {after!r}")
+
+
+# ---------------------------------------------------------------------------
+# Convention descriptors — what a run/cache entry declares about polarity.
+# ---------------------------------------------------------------------------
+
+#: What an export/replay votes CSV carries: SEMANTIC votes (agree = +1). It is
+#: a tagged format whose convention does not move with storage.
+INPUT_CONVENTION_EXPORT_SEMANTIC = "export-semantic/1"
+#: What a raw DB row carries: the declared storage sign.
+INPUT_CONVENTION_RAW_STORAGE = "raw-storage/1"
+#: The engine's own output vote axis, declared independently of the input sign.
+OUTPUT_CONVENTION_AS_EMITTED = "engine-as-emitted/1"
+
+PAIR_SIDE_ORIGINAL = "original"
+PAIR_SIDE_FLIPPED = "flipped"
+
+
+@dataclass(frozen=True)
+class ConventionDescriptor:
+    """The polarity identity of one execution. Every field belongs in the
+    recording-cache predicate: P-023's mandatory "change s without votes"
+    control is a CACHE HIT unless the declared convention is part of the key,
+    and a documentation-only key change is explicitly insufficient."""
+
+    storage_agree_value: int = STORAGE_AGREE_VALUE
+    input_convention: str = INPUT_CONVENTION_EXPORT_SEMANTIC
+    output_convention: str = OUTPUT_CONVENTION_AS_EMITTED
+    pair_side: str = PAIR_SIDE_ORIGINAL
+
+    def __post_init__(self) -> None:
+        validate_storage_agree_value(self.storage_agree_value)
+        if self.pair_side not in (PAIR_SIDE_ORIGINAL, PAIR_SIDE_FLIPPED):
+            raise PolarityError(f"unknown pair side {self.pair_side!r}")
+        if not self.input_convention or not self.output_convention:
+            raise PolarityError("input/output conventions must be declared; an "
+                                "unknown convention fails admission")
+
+    def cache_fields(self) -> dict[str, Any]:
+        return {
+            "storage_agree_value": self.storage_agree_value,
+            "input_convention": self.input_convention,
+            "output_convention": self.output_convention,
+            "pair_side": self.pair_side,
+        }
+
+    def flip(self) -> "ConventionDescriptor":
+        return ConventionDescriptor(
+            storage_agree_value=flipped(self.storage_agree_value),
+            input_convention=self.input_convention,
+            output_convention=self.output_convention,
+            pair_side=(PAIR_SIDE_FLIPPED if self.pair_side == PAIR_SIDE_ORIGINAL
+                       else PAIR_SIDE_ORIGINAL),
+        )
+
+
+DEFAULT_CONVENTIONS = ConventionDescriptor()
+
+
+# ---------------------------------------------------------------------------
+# T — the input transform, and the two real ingress paths.
+# ---------------------------------------------------------------------------
+
+#: A raw vote row, as extracted: everything but ``vote`` is identity/order.
+RAW_ROW_KEYS = ("tid", "pid", "vote", "created")
+
+INGRESS_EXPORT_CSV = "export-csv"
+INGRESS_DB_ROWS = "db-rows"
+INGRESS_PATHS = (INGRESS_EXPORT_CSV, INGRESS_DB_ROWS)
+
+
+def flip_raw_votes(rows: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    """``V -> -V``: negate every NON-NULL raw vote leaf and change nothing
+    else. NULL stays NULL (it is a distinct storage state, not a pass), ``0``
+    stays the literal ``0``, and identities, ordinals, timestamps and row order
+    are untouched — re-sorting by raw sign would change the winner at equal
+    timestamps, which is a negative control, not a transform."""
+    out = []
+    for row in rows:
+        new = dict(row)
+        if row.get("vote") is not None:
+            new["vote"] = -row["vote"]
+        out.append(new)
+    return out
+
+
+def _export_csv_ingress(
+    rows: Sequence[dict[str, Any]], s: int, *, workdir: Path,
+    mod_events: Sequence[ModEvent] = (), double_convert: bool = False,
+) -> tuple[ReplayDataset, str]:
+    """The REAL export-CSV ingress: raw rows -> ``prodclone.format_votes_rows``
+    (the one boundary that reads the declared ``s``) -> a votes CSV on disk ->
+    ``real_data.load_votes_csv``. Returns ``(dataset, csv_sha256)``.
+
+    ``double_convert=True`` is the "double-negate ingress" negative control: it
+    runs the storage->semantic conversion twice, exactly as a migration that
+    converted at two boundaries would.
+
+    NULL votes are dropped and COUNTED before formatting — the declared
+    ``drop-counted`` compatibility policy (``fixture_extract``), never a
+    coercion to pass — and the count is bound into the returned digest so a
+    NULL that silently became a row cannot hash equal to one that did not.
+    """
+    staged = [r for r in rows if r.get("vote") is not None]
+    null_dropped = len(rows) - len(staged)
+    if double_convert:
+        staged = [
+            {**r, "vote": (None if r.get("vote") is None
+                           else semantic_vote(r["vote"], s))}
+            for r in staged
+        ]
+    export_rows = pc.format_votes_rows(staged, storage_agree_value=s)
+    path = workdir / "votes.csv"
+    pc.write_votes_csv(path, export_rows)
+    dataset = rd.load_votes_csv(path, mod_events=list(mod_events))
+    digest = hashlib.sha256(
+        path.read_bytes() + f"\nnull_votes_dropped={null_dropped}".encode()
+    ).hexdigest()
+    return dataset, digest
+
+
+def _db_rows_ingress(
+    rows: Sequence[dict[str, Any]], s: int, *, workdir: Path,
+    mod_events: Sequence[ModEvent] = (), double_convert: bool = False,
+) -> tuple[ReplayDataset, str]:
+    """The REAL poller ingress: raw rows -> ``postgres_vote_to_delphi`` (the
+    converter ``database/postgres.py`` calls per row) -> the dataset the driver
+    folds. Deliberately a SECOND ingress path: a bug fixed at the CSV boundary
+    but not at the DB boundary must still fail the property."""
+    raw: list[tuple[int, int, int, int]] = []
+    for r in rows:
+        if r.get("vote") is None:
+            # G's v1 computing profile: reject NULL with INVALID_INPUT BEFORE
+            # any mutation. A paired rejection is an invalid-input control, not
+            # a successful math checkpoint.
+            raise PolarityError(
+                f"INVALID_INPUT: NULL vote at (pid={r.get('pid')}, "
+                f"tid={r.get('tid')}, created={r.get('created')}); the computing "
+                f"ingress rejects NULL before mutation and never reads it as pass")
+        vote = postgres_vote_to_delphi(int(r["vote"]), s)
+        if double_convert:
+            vote = postgres_vote_to_delphi(int(vote), s)
+        raw.append((int(r["created"]), int(r["pid"]), int(r["tid"]), int(vote)))
+    dataset = ReplayDataset.build(raw, mod_events=list(mod_events))
+    digest = hashlib.sha256(
+        json.dumps(raw, separators=(",", ":")).encode()).hexdigest()
+    return dataset, digest
+
+
+_INGRESS = {
+    INGRESS_EXPORT_CSV: _export_csv_ingress,
+    INGRESS_DB_ROWS: _db_rows_ingress,
+}
+
+
+# ---------------------------------------------------------------------------
+# The negative controls. Each one must reach the property's gate and FAIL for
+# its named reason — never fail setup and never collect zero comparisons.
+# ---------------------------------------------------------------------------
+
+CONTROL_NONE = "none"
+CONTROL_VOTES_ONLY = "negate-votes-without-s"
+CONTROL_CONVENTION_ONLY = "change-s-without-votes"
+CONTROL_DOUBLE_NEGATION = "double-negate-ingress"
+CONTROL_ONE_VOTE_UNCHANGED = "leave-one-vote-unchanged"
+CONTROL_NULL_TO_PASS = "null-becomes-pass"
+CONTROL_RESORT_BY_SIGN = "resort-equal-time-by-sign"
+
+CONTROLS: tuple[str, ...] = (
+    CONTROL_NONE, CONTROL_VOTES_ONLY, CONTROL_CONVENTION_ONLY,
+    CONTROL_DOUBLE_NEGATION, CONTROL_ONE_VOTE_UNCHANGED, CONTROL_NULL_TO_PASS,
+    CONTROL_RESORT_BY_SIGN,
+)
+
+#: Controls that MUST fail. ``CONTROL_NONE`` is the property itself.
+FAILING_CONTROLS: tuple[str, ...] = tuple(c for c in CONTROLS if c != CONTROL_NONE)
+
+
+def _apply_control(
+    rows: Sequence[dict[str, Any]], s: int, control: str,
+) -> tuple[list[dict[str, Any]], int, bool]:
+    """Build the FLIPPED side under ``control``. Returns
+    ``(rows_b, s_b, double_convert_original_side)``.
+
+    Note which side ``double-negate-ingress`` breaks: the ORIGINAL one. A
+    double conversion is arithmetically the identity (``s**2 == 1``), so
+    breaking the FLIPPED side would be indistinguishable from a correct pair at
+    ``s == -1`` — ``(-V)`` converted twice equals ``V x (-1)`` — and the
+    control would PASS while proving nothing. Breaking the original side gives
+    ``V`` against ``V x s``, which differs on every nonzero vote.
+    """
+    if control == CONTROL_NONE:
+        return flip_raw_votes(rows), flipped(s), False
+    if control == CONTROL_VOTES_ONLY:
+        # Votes negated, convention NOT re-declared: the semantic meaning of
+        # every nonzero vote inverts.
+        return flip_raw_votes(rows), s, False
+    if control == CONTROL_CONVENTION_ONLY:
+        # The convention alone changes. Same votes file — which is precisely
+        # why the recording cache must key on the declared convention, or this
+        # control silently reads a stale recording instead of executing.
+        return list(rows), flipped(s), False
+    if control == CONTROL_DOUBLE_NEGATION:
+        return flip_raw_votes(rows), flipped(s), True  # applied to side A
+    if control == CONTROL_ONE_VOTE_UNCHANGED:
+        out = flip_raw_votes(rows)
+        for i, row in enumerate(rows):
+            if row.get("vote"):
+                out[i] = dict(row)
+                break
+        else:
+            raise PolarityError(
+                f"control {control!r} needs at least one nonzero vote in the "
+                "fixture; it must reach the gate, not fail setup")
+        return out, flipped(s), False
+    if control == CONTROL_NULL_TO_PASS:
+        out = flip_raw_votes(rows)
+        for i, row in enumerate(rows):
+            if row.get("vote") is None:
+                out[i] = {**row, "vote": 0}
+                break
+        else:
+            raise PolarityError(
+                f"control {control!r} needs at least one NULL vote in the "
+                "fixture; it must reach the gate, not fail setup")
+        return out, flipped(s), False
+    if control == CONTROL_RESORT_BY_SIGN:
+        out = flip_raw_votes(rows)
+        # Re-sort by (created, raw sign) — the "improvement" P-023 forbids.
+        # With an equal-time opposing pair this changes the winning cell on one
+        # side only, because the raw signs are opposite across the pair.
+        out = sorted(out, key=lambda r: (r["created"], r["vote"] is None,
+                                         r["vote"] if r["vote"] is not None else 0))
+        return out, flipped(s), False
+    raise PolarityError(f"unknown control {control!r}")
+
+
+# ---------------------------------------------------------------------------
+# The property.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PolarityCase:
+    """One (fixture, schedule) the property must hold on."""
+
+    case_id: str
+    rows: tuple[dict[str, Any], ...]
+    cuts: dict[str, Any]
+    mod_events: tuple[ModEvent, ...] = ()
+    restart_after: int | None = None
+    notes: str = ""
+
+    def spec(self) -> sched.ScheduleSpec:
+        return sched.ScheduleSpec(
+            dataset=self.case_id,
+            schedule_id=f"{self.case_id}-polarity",
+            cuts=dict(self.cuts),
+            moderation=("none" if not self.mod_events else [
+                {"tid": m.tid, "is_meta": m.is_meta, "mod": m.mod,
+                 "t_ms": m.t_ms} for m in self.mod_events]),
+            restart_after=self.restart_after,
+            notes=self.notes,
+        )
+
+
+def _run_side(
+    case: PolarityCase, rows: Sequence[dict[str, Any]], s: int, *,
+    ingress: str, workdir: Path, double_convert: bool,
+    project: Callable[[dict[str, Any]], dict[str, Any]],
+) -> dict[str, Any]:
+    """Execute ONE side from fresh state and return its recorded identity plus
+    the marked comparison view of every checkpoint. Each side gets its own
+    working directory and its own run id: equal semantic inputs are not
+    permission to reuse the other side's artifact."""
+    ingest = _INGRESS[ingress]
+    dataset, input_digest = ingest(
+        rows, s, workdir=workdir, mod_events=case.mod_events,
+        double_convert=double_convert)
+    records = drv.run_replay(dataset, case.spec())
+    views = [comparison_view(r.blob, project=project) for r in records]
+    return {
+        "run_id": uuid.uuid4().hex,
+        "storage_agree_value": s,
+        "ingress": ingress,
+        "input_digest_sha256": input_digest,
+        "n_votes": dataset.n,
+        "views": views,
+        "view_digests": [
+            hashlib.sha256(json.dumps(payload(v), sort_keys=True,
+                                      separators=(",", ":")).encode()).hexdigest()
+            for v in views
+        ],
+    }
+
+
+def _first_difference(a: Any, b: Any, path: str = "") -> str | None:
+    """Dotted path of the first structural/value difference, or None."""
+    if isinstance(a, dict) and isinstance(b, dict):
+        for k in sorted(set(a) | set(b)):
+            if k not in a:
+                return f"{path}.{k} (missing on the original side)"
+            if k not in b:
+                return f"{path}.{k} (missing on the flipped side)"
+            found = _first_difference(a[k], b[k], f"{path}.{k}")
+            if found is not None:
+                return found
+        return None
+    if isinstance(a, list) and isinstance(b, list):
+        if len(a) != len(b):
+            return f"{path} (length {len(a)} vs {len(b)})"
+        for i, (x, y) in enumerate(zip(a, b)):
+            found = _first_difference(x, y, f"{path}[{i}]")
+            if found is not None:
+                return found
+        return None
+    if type(a) is not type(b) or a != b:
+        return f"{path} ({a!r} vs {b!r})"
+    return None
+
+
+def check_polarity_pair(
+    case: PolarityCase, *,
+    storage_agree_value: int = STORAGE_AGREE_VALUE,
+    ingress: str = INGRESS_EXPORT_CSV,
+    control: str = CONTROL_NONE,
+    project: Callable[[dict[str, Any]], dict[str, Any]] = project_prep_main,
+    workdir: Path | None = None,
+) -> dict[str, Any]:
+    """Execute the compensated pair for ONE case and return a verdict dict.
+
+    ``verdict`` is ``PASS`` when every checkpoint of ``E(V, s)`` equals the
+    corresponding checkpoint of ``E(-V, -s)`` under the projected comparison
+    profile, ``FAIL`` otherwise. A case that produced ZERO checkpoints is a
+    FAIL, never an empty PASS — an inventory that certifies nothing is the
+    failure mode the whole battery exists to prevent.
+
+    No N is applied: both sides declare the same output convention, so rev3
+    forbids an extra N here. ``control`` injects one of :data:`CONTROLS`; every
+    control but ``none`` must come back FAIL.
+    """
+    s = validate_storage_agree_value(storage_agree_value)
+    if ingress not in _INGRESS:
+        raise PolarityError(f"unknown ingress path {ingress!r}")
+    rows_b, s_b, double_convert_a = _apply_control(case.rows, s, control)
+
+    with tempfile.TemporaryDirectory(dir=workdir) as tmp:
+        root = Path(tmp)
+        (root / "a").mkdir()
+        (root / "b").mkdir()
+        side_a = _run_side(case, case.rows, s, ingress=ingress,
+                           workdir=root / "a", double_convert=double_convert_a,
+                           project=project)
+        side_b = _run_side(case, rows_b, s_b, ingress=ingress,
+                           workdir=root / "b", double_convert=False,
+                           project=project)
+
+    problems: list[str] = []
+    if not side_a["views"]:
+        problems.append("the original side produced NO checkpoint: an empty "
+                        "inventory is a blocking reason, never a PASS")
+    if len(side_a["views"]) != len(side_b["views"]):
+        problems.append(
+            f"the pair produced a different number of checkpoints "
+            f"({len(side_a['views'])} vs {len(side_b['views'])})")
+    if side_a["run_id"] == side_b["run_id"]:
+        problems.append("both sides report the same run identity: one side's "
+                        "artifact was reused instead of executed")
+    for i, (va, vb) in enumerate(zip(side_a["views"], side_b["views"])):
+        if va[OUTPUT_PROFILE_KEY]["vote_axis"] != vb[OUTPUT_PROFILE_KEY]["vote_axis"]:
+            problems.append(
+                f"step {i}: the two sides declare different output vote axes "
+                f"({va[OUTPUT_PROFILE_KEY]['vote_axis']} vs "
+                f"{vb[OUTPUT_PROFILE_KEY]['vote_axis']}); an unknown or "
+                f"mismatched output convention fails admission")
+            continue
+        diff = _first_difference(payload(va), payload(vb))
+        if diff is not None:
+            problems.append(f"step {i}: checkpoints differ at {diff.lstrip('.')}")
+
+    return {
+        "case_id": case.case_id,
+        "control": control,
+        "ingress": ingress,
+        "storage_agree_value": s,
+        "conventions": {
+            "original": ConventionDescriptor(
+                storage_agree_value=s,
+                input_convention=(INPUT_CONVENTION_EXPORT_SEMANTIC
+                                  if ingress == INGRESS_EXPORT_CSV
+                                  else INPUT_CONVENTION_RAW_STORAGE),
+            ).cache_fields(),
+            "flipped": ConventionDescriptor(
+                storage_agree_value=s_b,
+                input_convention=(INPUT_CONVENTION_EXPORT_SEMANTIC
+                                  if ingress == INGRESS_EXPORT_CSV
+                                  else INPUT_CONVENTION_RAW_STORAGE),
+                pair_side=PAIR_SIDE_FLIPPED,
+            ).cache_fields(),
+        },
+        "checkpoints": len(side_a["views"]),
+        "run_ids": [side_a["run_id"], side_b["run_id"]],
+        "input_digests": [side_a["input_digest_sha256"],
+                          side_b["input_digest_sha256"]],
+        "view_digests": [side_a["view_digests"], side_b["view_digests"]],
+        "verdict": "PASS" if not problems else "FAIL",
+        "problems": problems,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The standing case set. Small, synthetic, deterministic and cheap enough to
+# run on every certify invocation — the real-dataset pair lives in the test
+# suite, and a large fixture gets the same property, not an exemption.
+# ---------------------------------------------------------------------------
+
+
+def _row(created: int, pid: int, tid: int, vote: int | None) -> dict[str, Any]:
+    return {"created": created, "pid": pid, "tid": tid, "vote": vote}
+
+
+def _grid_rows(n_ptpt: int = 8, n_cmt: int = 6, t0: int = 1_600_000_000_000):
+    """A dense, deterministic agree/disagree/pass grid with revotes."""
+    rows = []
+    t = t0
+    for pid in range(n_ptpt):
+        for tid in range(n_cmt):
+            vote = (-1, 1, 0)[(pid + tid) % 3]
+            rows.append(_row(t, pid, tid, vote))
+            t += 1000
+    # revotes: the last three participants change their mind on comment 0
+    for pid in range(n_ptpt - 3, n_ptpt):
+        rows.append(_row(t, pid, 0, 1))
+        t += 1000
+    return rows
+
+
+def default_cases() -> list[PolarityCase]:
+    """The mandatory shapes: normal incremental ticks, all-pass, an equal-time
+    opposing pair, duplicates/revotes, and a real restart seam. Empty and
+    NULL-bearing streams are exercised by the controls and the harness suite,
+    where their declared rejection is the expected outcome."""
+    grid = _grid_rows()
+    all_pass = [_row(1_600_000_000_000 + i * 1000, i % 5, i % 4, 0)
+                for i in range(24)]
+    tied = []
+    t = 1_600_000_000_000
+    for pid in range(6):
+        for tid in range(4):
+            tied.append(_row(t + pid * 1000, pid, tid, (-1, 1)[(pid + tid) % 2]))
+    # the equal-time opposing pair: same cell, same millisecond, opposite signs
+    tied.append(_row(t + 6000, 0, 0, -1))
+    tied.append(_row(t + 6000, 0, 0, 1))
+    return [
+        PolarityCase("polarity-grid", tuple(grid),
+                     {"mode": "vote-count", "at": [12, 30, "end"]},
+                     notes="normal incremental ticks over a dense grid with revotes"),
+        PolarityCase("polarity-all-pass", tuple(all_pass),
+                     {"mode": "vote-count", "at": [12, "end"]},
+                     notes="every vote is a literal pass: invariant under T"),
+        PolarityCase("polarity-equal-time", tuple(tied),
+                     {"mode": "vote-count", "at": ["end"]},
+                     notes="opposite votes at an equal timestamp; the frozen "
+                           "order must be identical on both sides"),
+        PolarityCase("polarity-restart", tuple(grid),
+                     {"mode": "vote-count", "at": [12, 30, "end"]},
+                     restart_after=0,
+                     notes="real serialize -> from_dict -> continue seam"),
+    ]
+
+
+def run_standing_property(
+    *, storage_agree_value: int = STORAGE_AGREE_VALUE,
+    project: Callable[[dict[str, Any]], dict[str, Any]] = project_prep_main,
+    cases: Sequence[PolarityCase] | None = None,
+    ingress_paths: Sequence[str] = INGRESS_PATHS,
+    with_controls: bool = True,
+) -> dict[str, Any]:
+    """Run the standing polarity property: every case, on every ingress path,
+    plus every mandatory negative control on the first case of each path.
+
+    Returns a report dict with a terminal ``verdict``. FAIL if any pair
+    diverges, if any negative control PASSES (a control that does not reach its
+    gate is exactly as bad as a broken engine), or if no comparison ran at all.
+    """
+    s = validate_storage_agree_value(storage_agree_value)
+    cases = list(cases if cases is not None else default_cases())
+    results: list[dict[str, Any]] = []
+    control_results: list[dict[str, Any]] = []
+
+    for ingress in ingress_paths:
+        for case in cases:
+            results.append(check_polarity_pair(
+                case, storage_agree_value=s, ingress=ingress, project=project))
+        if with_controls:
+            for control in FAILING_CONTROLS:
+                case = control_case(control, cases)
+                if case is None:
+                    continue
+                if control == CONTROL_NULL_TO_PASS and ingress == INGRESS_DB_ROWS:
+                    # The computing ingress rejects NULL with INVALID_INPUT
+                    # before any mutation (G v1), so on this path the paired
+                    # rejection is an invalid-input control rather than a math
+                    # checkpoint. It is asserted as a rejection in the harness
+                    # suite instead of being run as a pair here.
+                    continue
+                control_results.append(check_polarity_pair(
+                    case, storage_agree_value=s, ingress=ingress,
+                    control=control, project=project))
+
+    problems = [
+        f"{r['ingress']}/{r['case_id']}: {'; '.join(r['problems'])}"
+        for r in results if r["verdict"] != "PASS"
+    ]
+    problems += [
+        f"{r['ingress']}/{r['case_id']}: negative control {r['control']!r} "
+        f"PASSED — it never reached its gate"
+        for r in control_results if r["verdict"] != "FAIL"
+    ]
+    if not results:
+        problems.append("no polarity pair executed: an empty inventory is a "
+                        "blocking reason, never a PASS")
+
+    return {
+        "property": "P-023 compensated polarity pair",
+        "storage_agree_value": s,
+        "pairs": results,
+        "controls": control_results,
+        "verdict": "PASS" if not problems else "FAIL",
+        "problems": problems,
+    }
+
+
+def control_case(
+    control: str, cases: Sequence[PolarityCase] | None = None,
+) -> PolarityCase | None:
+    """The fixture a given negative control needs in order to REACH its gate.
+
+    P-023: "Each control must reach the intended gate and fail for the named
+    reason, not fail setup or collect zero tests." Two controls need a specific
+    shape: ``null-becomes-pass`` needs a NULL vote leaf to convert, and
+    ``resort-equal-time-by-sign`` needs an opposing pair at an equal timestamp
+    (without one, re-sorting by sign is a no-op and the control would PASS
+    while proving nothing).
+    """
+    cases = list(cases if cases is not None else default_cases())
+    by_id = {c.case_id: c for c in cases}
+    base = by_id.get("polarity-grid", cases[0])
+    if control == CONTROL_NULL_TO_PASS:
+        rows = list(base.rows)
+        rows.append(_row(rows[-1]["created"] + 1000, 0, 0, None))
+        return PolarityCase(
+            f"{base.case_id}-null", tuple(rows), dict(base.cuts),
+            notes="control fixture: carries a NULL vote leaf, dropped-counted "
+                  "at the compatibility CSV and INVALID_INPUT at the computing "
+                  "ingress")
+    if control == CONTROL_RESORT_BY_SIGN:
+        return by_id.get("polarity-equal-time")
+    return base

--- a/delphi/polismath/replay/polarity.py
+++ b/delphi/polismath/replay/polarity.py
@@ -325,18 +325,19 @@ class ConventionDescriptor:
 
     def __post_init__(self) -> None:
         validate_storage_agree_value(self.storage_agree_value)
-        if self.pair_side not in PAIR_SIDES:
-            raise PolarityError(f"unknown pair side {self.pair_side!r}")
-        if self.input_convention not in INPUT_CONVENTIONS:
-            raise PolarityError(
-                f"input convention {self.input_convention!r} is not one of "
-                f"{sorted(INPUT_CONVENTIONS)}: an unknown convention fails "
-                f"admission")
-        if self.output_convention not in OUTPUT_CONVENTIONS:
-            raise PolarityError(
-                f"output convention {self.output_convention!r} is not one of "
-                f"{sorted(OUTPUT_CONVENTIONS)}: an unknown convention fails "
-                f"admission")
+        # TYPE before membership (Astra review #2730 R2-F2): a container-valued
+        # convention or side raised a raw `TypeError: unhashable type` out of
+        # the set test instead of the named PolarityError this contract
+        # promises. A container is not a convention token.
+        for field, value, allowed in (
+            ("pair side", self.pair_side, PAIR_SIDES),
+            ("input convention", self.input_convention, INPUT_CONVENTIONS),
+            ("output convention", self.output_convention, OUTPUT_CONVENTIONS),
+        ):
+            if not isinstance(value, str) or value not in allowed:
+                raise PolarityError(
+                    f"{field} {value!r} ({type(value).__name__}) is not one of "
+                    f"{sorted(allowed)}: an unknown convention fails admission")
 
     def cache_fields(self) -> dict[str, Any]:
         return {
@@ -480,7 +481,7 @@ FAILING_CONTROLS: tuple[str, ...] = tuple(c for c in CONTROLS if c != CONTROL_NO
 
 def _apply_control(
     rows: Sequence[dict[str, Any]], s: int, control: str,
-) -> tuple[list[dict[str, Any]], int, bool]:
+) -> tuple[list[dict[str, Any]], int, str | None]:
     """Build the FLIPPED side under ``control``. Returns
     ``(rows_b, s_b, double_convert_side)`` where the third element names the
     side whose ingress converts twice (``None`` for every other control).

--- a/delphi/polismath/replay/polarity.py
+++ b/delphi/polismath/replay/polarity.py
@@ -67,7 +67,9 @@ from polismath.utils.output_profile import (
     PROJECTED_PROFILE,
     VOTE_AXIS_AS_EMITTED,
     VOTE_AXIS_NEGATED,
-    is_projected_view,
+    OutputProfileError,
+    assert_valid_marker,
+    has_marker,
     marker,
     payload,
     stamp,
@@ -187,13 +189,20 @@ def vote_axis_involution(view: dict[str, Any]) -> dict[str, Any]:
     marker included: N is its own inverse, and the view always says which axis
     it is currently on, independently of the input storage sign.
     """
-    if not is_projected_view(view):
+    # The COMPARISON boundary validates the marker's own values, not merely its
+    # presence (Astra review #2730 F2): an unknown profile or axis is a
+    # corrupted view, and N must not translate one.
+    if not has_marker(view):
         raise PolarityError(
             "N is defined strictly on the validated, PROJECTED PREP_MAIN_KEYS "
             "comparison view (P-023 rev3). This blob carries no output-profile "
             f"marker ({OUTPUT_PROFILE_KEY!r}); build it with comparison_view() "
             "first. Applying N to a raw blob would break C9's producer sign "
             "relation on the group_clusters twin and corrupt the restore path.")
+    try:
+        assert_valid_marker(view, label="N")
+    except OutputProfileError as exc:
+        raise PolarityError(str(exc)) from exc
     present = [k for k in N_FORBIDDEN_RAW_KEYS if k in view]
     if present:
         raise PolarityError(
@@ -293,6 +302,14 @@ OUTPUT_CONVENTION_AS_EMITTED = "engine-as-emitted/1"
 PAIR_SIDE_ORIGINAL = "original"
 PAIR_SIDE_FLIPPED = "flipped"
 
+#: Closed enums. "Unknown convention fails admission" (P-023 rev3) is a
+#: predicate, not a sentiment: a truthiness check accepted `unknown-input/99`
+#: (Astra review #2730 F2).
+INPUT_CONVENTIONS: frozenset[str] = frozenset(
+    {INPUT_CONVENTION_EXPORT_SEMANTIC, INPUT_CONVENTION_RAW_STORAGE})
+OUTPUT_CONVENTIONS: frozenset[str] = frozenset({OUTPUT_CONVENTION_AS_EMITTED})
+PAIR_SIDES: frozenset[str] = frozenset({PAIR_SIDE_ORIGINAL, PAIR_SIDE_FLIPPED})
+
 
 @dataclass(frozen=True)
 class ConventionDescriptor:
@@ -308,11 +325,18 @@ class ConventionDescriptor:
 
     def __post_init__(self) -> None:
         validate_storage_agree_value(self.storage_agree_value)
-        if self.pair_side not in (PAIR_SIDE_ORIGINAL, PAIR_SIDE_FLIPPED):
+        if self.pair_side not in PAIR_SIDES:
             raise PolarityError(f"unknown pair side {self.pair_side!r}")
-        if not self.input_convention or not self.output_convention:
-            raise PolarityError("input/output conventions must be declared; an "
-                                "unknown convention fails admission")
+        if self.input_convention not in INPUT_CONVENTIONS:
+            raise PolarityError(
+                f"input convention {self.input_convention!r} is not one of "
+                f"{sorted(INPUT_CONVENTIONS)}: an unknown convention fails "
+                f"admission")
+        if self.output_convention not in OUTPUT_CONVENTIONS:
+            raise PolarityError(
+                f"output convention {self.output_convention!r} is not one of "
+                f"{sorted(OUTPUT_CONVENTIONS)}: an unknown convention fails "
+                f"admission")
 
     def cache_fields(self) -> dict[str, Any]:
         return {
@@ -458,28 +482,34 @@ def _apply_control(
     rows: Sequence[dict[str, Any]], s: int, control: str,
 ) -> tuple[list[dict[str, Any]], int, bool]:
     """Build the FLIPPED side under ``control``. Returns
-    ``(rows_b, s_b, double_convert_original_side)``.
+    ``(rows_b, s_b, double_convert_side)`` where the third element names the
+    side whose ingress converts twice (``None`` for every other control).
 
-    Note which side ``double-negate-ingress`` breaks: the ORIGINAL one. A
-    double conversion is arithmetically the identity (``s**2 == 1``), so
-    breaking the FLIPPED side would be indistinguishable from a correct pair at
-    ``s == -1`` — ``(-V)`` converted twice equals ``V x (-1)`` — and the
-    control would PASS while proving nothing. Breaking the original side gives
-    ``V`` against ``V x s``, which differs on every nonzero vote.
+    Which side ``double-negate-ingress`` must break depends on the DECLARED
+    convention, and getting it wrong makes the control vacuous (Astra review
+    #2730 F4). A double conversion is arithmetically the identity
+    (``s**2 == 1``), so a doubly-converted side emits raw ``V`` while the
+    correct side emits ``V x s``: the two differ only when ``s == -1``.
+    Breaking the side that declares ``-1`` is therefore the non-degenerate
+    choice under BOTH declarations — the original side at ``s == -1``, the
+    flipped side at ``s == +1`` — and it is the same fault either way: one
+    ingress converted twice.
     """
     if control == CONTROL_NONE:
-        return flip_raw_votes(rows), flipped(s), False
+        return flip_raw_votes(rows), flipped(s), None
     if control == CONTROL_VOTES_ONLY:
         # Votes negated, convention NOT re-declared: the semantic meaning of
         # every nonzero vote inverts.
-        return flip_raw_votes(rows), s, False
+        return flip_raw_votes(rows), s, None
     if control == CONTROL_CONVENTION_ONLY:
         # The convention alone changes. Same votes file — which is precisely
         # why the recording cache must key on the declared convention, or this
         # control silently reads a stale recording instead of executing.
-        return list(rows), flipped(s), False
+        return list(rows), flipped(s), None
     if control == CONTROL_DOUBLE_NEGATION:
-        return flip_raw_votes(rows), flipped(s), True  # applied to side A
+        # Break whichever side declares -1.
+        side = PAIR_SIDE_ORIGINAL if s == -1 else PAIR_SIDE_FLIPPED
+        return flip_raw_votes(rows), flipped(s), side
     if control == CONTROL_ONE_VOTE_UNCHANGED:
         out = flip_raw_votes(rows)
         for i, row in enumerate(rows):
@@ -490,7 +520,7 @@ def _apply_control(
             raise PolarityError(
                 f"control {control!r} needs at least one nonzero vote in the "
                 "fixture; it must reach the gate, not fail setup")
-        return out, flipped(s), False
+        return out, flipped(s), None
     if control == CONTROL_NULL_TO_PASS:
         out = flip_raw_votes(rows)
         for i, row in enumerate(rows):
@@ -501,7 +531,7 @@ def _apply_control(
             raise PolarityError(
                 f"control {control!r} needs at least one NULL vote in the "
                 "fixture; it must reach the gate, not fail setup")
-        return out, flipped(s), False
+        return out, flipped(s), None
     if control == CONTROL_RESORT_BY_SIGN:
         out = flip_raw_votes(rows)
         # Re-sort by (created, raw sign) — the "improvement" P-023 forbids.
@@ -509,7 +539,7 @@ def _apply_control(
         # side only, because the raw signs are opposite across the pair.
         out = sorted(out, key=lambda r: (r["created"], r["vote"] is None,
                                          r["vote"] if r["vote"] is not None else 0))
-        return out, flipped(s), False
+        return out, flipped(s), None
     raise PolarityError(f"unknown control {control!r}")
 
 
@@ -620,17 +650,19 @@ def check_polarity_pair(
     s = validate_storage_agree_value(storage_agree_value)
     if ingress not in _INGRESS:
         raise PolarityError(f"unknown ingress path {ingress!r}")
-    rows_b, s_b, double_convert_a = _apply_control(case.rows, s, control)
+    rows_b, s_b, double_side = _apply_control(case.rows, s, control)
 
     with tempfile.TemporaryDirectory(dir=workdir) as tmp:
         root = Path(tmp)
         (root / "a").mkdir()
         (root / "b").mkdir()
         side_a = _run_side(case, case.rows, s, ingress=ingress,
-                           workdir=root / "a", double_convert=double_convert_a,
+                           workdir=root / "a",
+                           double_convert=double_side == PAIR_SIDE_ORIGINAL,
                            project=project)
         side_b = _run_side(case, rows_b, s_b, ingress=ingress,
-                           workdir=root / "b", double_convert=False,
+                           workdir=root / "b",
+                           double_convert=double_side == PAIR_SIDE_FLIPPED,
                            project=project)
 
     problems: list[str] = []

--- a/delphi/polismath/replay/poller_equiv.py
+++ b/delphi/polismath/replay/poller_equiv.py
@@ -139,6 +139,7 @@ from polismath.replay.stepcompare import DEFAULT_TOLERANT_STAT_KEYS, StepCompare
 from polismath.replay.store import _safe_path_component
 from polismath.replay.types import ModEvent, ReplayDataset
 from polismath.utils.general import delphi_vote_to_postgres
+from polismath.utils.vote_convention import STORAGE_AGREE_VALUE
 
 # poller_equiv.py -> replay -> polismath -> delphi -> repo root (mirrors
 # certify.py / store.py).
@@ -507,14 +508,19 @@ def seed_conversation(conn: Any, dataset: ReplayDataset, zid: int = DEFAULT_ZID)
 
 
 def insert_votes(
-    conn: Any, dataset: ReplayDataset, from_slot: int, to_slot: int, zid: int = DEFAULT_ZID
+    conn: Any, dataset: ReplayDataset, from_slot: int, to_slot: int,
+    zid: int = DEFAULT_ZID, *, storage_agree_value: int = STORAGE_AGREE_VALUE,
 ) -> int:
     """Insert ``dataset.votes[from_slot:to_slot]`` (plain 0-based Python slice
     — consistent with :func:`polismath.replay.schedule.slice_schedule`'s own
     ``dataset.votes[prev:cut]`` use of 1-based cut slots as slice bounds),
     preserving ``pid``/``tid``/``created`` (``t_ms``) and flipping the vote
-    sign from the dataset's Delphi convention to RAW DB convention (module
-    docstring) via :func:`polismath.utils.general.delphi_vote_to_postgres`.
+    sign from the dataset's Delphi (semantic) convention to the DECLARED RAW DB
+    convention (module docstring) via
+    :func:`polismath.utils.general.delphi_vote_to_postgres` — which reads the
+    declared ``storage_agree_value`` (-1 or +1, defaulting to the one
+    authoritative constant), never a literal, so a seeded DB and the ingress
+    that reads it back cannot disagree about polarity.
 
     ATOMIC per batch — ONE multi-row ``INSERT ... VALUES (...), (...), ...``
     statement, never a per-row loop (ROOT CAUSE #5, 2026-07-24 live-debug
@@ -555,7 +561,7 @@ def insert_votes(
         value_clauses.append(f"(:zid, :pid{i}, :tid{i}, :vote{i}, :created{i})")
         params[f"pid{i}"] = v.pid
         params[f"tid{i}"] = v.tid
-        params[f"vote{i}"] = delphi_vote_to_postgres(v.sign)
+        params[f"vote{i}"] = delphi_vote_to_postgres(v.sign, storage_agree_value)
         params[f"created{i}"] = v.t_ms
     stmt = (
         "INSERT INTO votes (zid, pid, tid, vote, created) VALUES "

--- a/delphi/polismath/replay/prodclone.py
+++ b/delphi/polismath/replay/prodclone.py
@@ -33,6 +33,12 @@ import re
 from pathlib import Path
 from typing import Any, Iterable
 
+from polismath.utils.vote_convention import (
+    STORAGE_AGREE_VALUE,
+    semantic_vote,
+    validate_storage_agree_value,
+)
+
 
 class NullVoteError(ValueError):
     """A raw ``votes.vote`` was NULL where an export row was being formatted.
@@ -167,14 +173,23 @@ def sql_comments_export() -> str:
     """
 
 
-def sql_comment_vote_counts() -> str:
+def sql_comment_vote_counts(
+    storage_agree_value: int = STORAGE_AGREE_VALUE,
+) -> str:
     """Agrees/disagrees per comment, counted over ALL vote rows (including
     revotes) — mirrors server/src/report.ts's sendCommentSummary, which
-    increments per raw vote row with no dedup."""
-    return """
+    increments per raw vote row with no dedup.
+
+    The two predicates are RAW-STORAGE sign tests, so they are derived from the
+    declared convention (``storage_agree_value``, -1 or +1) rather than written
+    as literals: under a flipped storage convention the same SQL with a bare
+    ``vote = -1`` would silently count disagreements as agreements.
+    """
+    agree = validate_storage_agree_value(storage_agree_value)
+    return f"""
         SELECT tid,
-               COUNT(*) FILTER (WHERE vote = -1) AS agrees,
-               COUNT(*) FILTER (WHERE vote = 1) AS disagrees
+               COUNT(*) FILTER (WHERE vote = {agree}) AS agrees,
+               COUNT(*) FILTER (WHERE vote = {-agree}) AS disagrees
         FROM votes
         WHERE zid = %s
         GROUP BY tid
@@ -365,12 +380,22 @@ def format_export_datetime(created_ms: int) -> str:
     )
 
 
-def format_votes_rows(raw_rows: Iterable[dict[str, Any]]) -> list[dict[str, str]]:
+def format_votes_rows(
+    raw_rows: Iterable[dict[str, Any]],
+    *, storage_agree_value: int = STORAGE_AGREE_VALUE,
+) -> list[dict[str, str]]:
     """``raw_rows``: dicts with keys tid, pid, vote (RAW db sign), created (ms).
     Returns export-format row dicts, one per input row, in the SAME order —
-    no sorting, no dedup (full revote history survives verbatim). The vote
-    sign is flipped (raw AGREE=-1 -> export +1), mirroring the production
-    export's ``String(-row.vote)``."""
+    no sorting, no dedup (full revote history survives verbatim).
+
+    The vote column is converted from the DECLARED raw storage convention to
+    the export/semantic one (``raw × storage_agree_value``: AGREE -> +1),
+    mirroring the production export's ``String(-row.vote)`` at the default
+    ``storage_agree_value = -1``. The export convention itself is FIXED
+    (agree = +1) and does not move with storage — an export row is already
+    semantic input and must never be negated a second time.
+    """
+    agree = validate_storage_agree_value(storage_agree_value)
     out = []
     for row in raw_rows:
         if row["vote"] is None:
@@ -392,7 +417,7 @@ def format_votes_rows(raw_rows: Iterable[dict[str, Any]]) -> list[dict[str, str]
             "datetime": format_export_datetime(created),
             "comment-id": str(row["tid"]),
             "voter-id": str(row["pid"]),
-            "vote": str(-row["vote"]),
+            "vote": str(semantic_vote(row["vote"], agree)),
         })
     return out
 

--- a/delphi/polismath/replay/real_data.py
+++ b/delphi/polismath/replay/real_data.py
@@ -113,8 +113,26 @@ def load_export_votes(slug: str) -> ReplayDataset:
     votes_csvs = sorted(d.glob("*-votes.csv"))
     if not votes_csvs:
         raise FileNotFoundError(f"no *-votes.csv in {d.name}")
+
+    mod_events: list[ModEvent] = []
+    mod_events_skipped = 0
+    comments_csvs = sorted(d.glob("*-comments.csv"))
+    if comments_csvs:
+        mod_events, mod_events_skipped = _load_mod_events(comments_csvs[0])
+
+    dataset = load_votes_csv(votes_csvs[0], mod_events=mod_events)
+    dataset.mod_events_skipped = mod_events_skipped
+    return dataset
+
+
+def read_export_vote_rows(path: str | Path) -> list[tuple[int, int, int, int]]:
+    """Parse ONE export votes CSV into the raw ``(t_ms, pid, tid, sign)`` rows
+    :meth:`ReplayDataset.build` consumes. Second-resolution timestamps are
+    widened to milliseconds; the vote column is taken VERBATIM, because the
+    export format is already semantic (agree = +1) and negating it here would
+    be the double flip P-023 forbids."""
     raw: list[tuple[int, int, int, int]] = []
-    with open(votes_csvs[0], newline="") as fh:
+    with open(path, newline="") as fh:
         for row in csv.DictReader(fh):
             raw.append(
                 (
@@ -124,13 +142,16 @@ def load_export_votes(slug: str) -> ReplayDataset:
                     int(row["vote"]),
                 )
             )
+    return raw
 
-    mod_events: list[ModEvent] = []
-    mod_events_skipped = 0
-    comments_csvs = sorted(d.glob("*-comments.csv"))
-    if comments_csvs:
-        mod_events, mod_events_skipped = _load_mod_events(comments_csvs[0])
 
-    dataset = ReplayDataset.build(raw, mod_events=mod_events)
-    dataset.mod_events_skipped = mod_events_skipped
-    return dataset
+def load_votes_csv(
+    path: str | Path, *, mod_events: list[ModEvent] | None = None,
+) -> ReplayDataset:
+    """Load ONE export votes CSV (by path) into a ReplayDataset — the ingress
+    :func:`load_export_votes` performs, factored out so a caller holding a
+    freshly written CSV (e.g. the P-023 polarity pair, which formats raw rows
+    through ``prodclone.format_votes_rows`` under a declared storage
+    convention) runs the SAME parse rather than a copy of it."""
+    return ReplayDataset.build(read_export_vote_rows(path),
+                               mod_events=list(mod_events or []))

--- a/delphi/polismath/run_math_pipeline.py
+++ b/delphi/polismath/run_math_pipeline.py
@@ -13,6 +13,7 @@ import decimal
 from datetime import datetime
 
 from polismath.utils.general import postgres_vote_to_delphi
+from polismath.utils.vote_convention import STORAGE_AGREE_VALUE
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -76,13 +77,16 @@ def connect_to_db():
         return None
 
 
-def fetch_votes(conn, conversation_id):
+def fetch_votes(conn, conversation_id, storage_agree_value=STORAGE_AGREE_VALUE):
     """
     Fetch votes for a specific conversation from PostgreSQL.
     Returns a dictionary containing votes in the format expected by Conversation.
 
-    Vote signs are flipped at this PostgreSQL boundary:
-    - PostgreSQL stores: AGREE=-1, DISAGREE=+1
+    Vote signs are converted at this PostgreSQL boundary, through the DECLARED
+    storage convention (``storage_agree_value``, -1 or +1 — the one
+    authoritative definition in polismath.utils.vote_convention), never a
+    literal:
+    - PostgreSQL stores: AGREE=storage_agree_value (today -1)
     - Delphi expects:    AGREE=+1, DISAGREE=-1
     """
     import time
@@ -117,8 +121,8 @@ def fetch_votes(conn, conversation_id):
                 "pid": str(vote["voter_id"]),
                 "tid": str(vote["comment_id"]),
                 "vote": postgres_vote_to_delphi(
-                    float(vote["vote"])
-                ),  # Flip at boundary
+                    float(vote["vote"]), storage_agree_value
+                ),  # Declared-convention conversion at the boundary
                 "created": created_time,
             }
         )

--- a/delphi/polismath/utils/general.py
+++ b/delphi/polismath/utils/general.py
@@ -8,52 +8,76 @@ from the original Clojure codebase.
 import numpy as np
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
 
+from polismath.utils.vote_convention import (
+    STORAGE_AGREE_VALUE,
+    semantic_vote,
+    storage_vote,
+)
+
 T = TypeVar('T')
 U = TypeVar('U')
 
+#: SEMANTIC vote meaning (Delphi's internal convention), not the configurable
+#: storage convention. These stay fixed through any storage flip; the sign that
+#: moves is polismath.utils.vote_convention.STORAGE_AGREE_VALUE.
 AGREE = 1
 DISAGREE = -1
 PASS = 0
 
 
-def postgres_vote_to_delphi(pg_vote: Union[int, float]) -> Union[int, float]:
+def postgres_vote_to_delphi(
+    pg_vote: Union[int, float],
+    storage_agree_value: int = STORAGE_AGREE_VALUE,
+) -> Union[int, float]:
     """
-    Convert PostgreSQL vote convention to Delphi convention.
+    Convert a RAW PostgreSQL vote to the Delphi (semantic) convention.
 
-    PostgreSQL/Server/Client use: AGREE=-1, DISAGREE=+1, PASS=0
+    PostgreSQL/Server/Client use: AGREE=storage_agree_value (today -1)
     Delphi uses:                  AGREE=+1, DISAGREE=-1, PASS=0
 
     This function should be called at every PostgreSQL data ingress boundary
     to ensure Delphi code receives votes in the expected convention.
 
-    The sign flip is: vote * -1
-    - PostgreSQL AGREE (-1) → Delphi AGREE (+1)
-    - PostgreSQL DISAGREE (+1) → Delphi DISAGREE (-1)
+    The conversion is ``pg_vote * storage_agree_value`` — the single formula
+    P-022-G rev4 pins, read from the one authoritative definition
+    (``polismath.utils.vote_convention``) rather than restating a literal:
+    - PostgreSQL AGREE (s) → Delphi AGREE (+1)
+    - PostgreSQL DISAGREE (-s) → Delphi DISAGREE (-1)
     - PostgreSQL PASS (0) → Delphi PASS (0) [unchanged]
 
     Args:
-        pg_vote: Vote value from PostgreSQL (-1=agree, +1=disagree, 0=pass)
+        pg_vote: Raw vote value from PostgreSQL
+        storage_agree_value: the DECLARED raw storage sign of AGREE, -1 or +1.
+            Defaults to the authoritative constant; a caller replaying a
+            derived paired fixture declares the other one. NULL is refused,
+            never coerced to pass.
 
     Returns:
         Vote value in Delphi convention (+1=agree, -1=disagree, 0=pass)
     """
-    return pg_vote * -1
+    return semantic_vote(pg_vote, storage_agree_value)
 
 
-def delphi_vote_to_postgres(delphi_vote: Union[int, float]) -> Union[int, float]:
+def delphi_vote_to_postgres(
+    delphi_vote: Union[int, float],
+    storage_agree_value: int = STORAGE_AGREE_VALUE,
+) -> Union[int, float]:
     """
-    Convert Delphi vote convention to PostgreSQL convention.
+    Convert a Delphi (semantic) vote to the RAW PostgreSQL convention.
 
     This is the inverse of postgres_vote_to_delphi() and should be used
-    if Delphi ever needs to write vote data back to PostgreSQL.
+    if Delphi ever needs to write vote data back to PostgreSQL. Multiplication
+    by ``storage_agree_value`` is its own inverse, so the two directions share
+    one formula and differ only in what they mean at the boundary.
 
     Args:
         delphi_vote: Vote value in Delphi convention (+1=agree, -1=disagree, 0=pass)
+        storage_agree_value: the DECLARED raw storage sign of AGREE, -1 or +1.
 
     Returns:
-        Vote value for PostgreSQL (-1=agree, +1=disagree, 0=pass)
+        Raw vote value for PostgreSQL (AGREE=storage_agree_value)
     """
-    return delphi_vote * -1
+    return storage_vote(delphi_vote, storage_agree_value)
 
 
 def xor(a: bool, b: bool) -> bool:

--- a/delphi/polismath/utils/output_profile.py
+++ b/delphi/polismath/utils/output_profile.py
@@ -116,14 +116,20 @@ def marker_problems(value: Any) -> list[str]:
         problems.append(f"marker is missing {missing!r}")
     for unknown in sorted(set(value) - MARKER_KEYS):
         problems.append(f"marker carries unknown field {unknown!r}")
-    if value.get("profile") not in PROFILES:
+    # TYPE before membership at every lookup (Astra review #2730 R2-F2): an
+    # unhashable value (`profile: []`, `vote_axis: {}`) raised a raw
+    # `TypeError: unhashable type` out of the set test, escaping every gate
+    # that promised a named, graded failure. A container is simply not a token.
+    profile = value.get("profile")
+    if not isinstance(profile, str) or profile not in PROFILES:
         problems.append(
-            f"marker profile {value.get('profile')!r} is not one of "
-            f"{sorted(PROFILES)}")
-    if value.get("vote_axis") not in VOTE_AXES:
+            f"marker profile {profile!r} ({type(profile).__name__}) is not one "
+            f"of {sorted(PROFILES)}")
+    vote_axis = value.get("vote_axis")
+    if not isinstance(vote_axis, str) or vote_axis not in VOTE_AXES:
         problems.append(
-            f"marker vote_axis {value.get('vote_axis')!r} is not one of "
-            f"{sorted(VOTE_AXES)}")
+            f"marker vote_axis {vote_axis!r} ({type(vote_axis).__name__}) is "
+            f"not one of {sorted(VOTE_AXES)}")
     restorable = value.get("restorable")
     if type(restorable) is not bool or restorable is not False:
         problems.append(
@@ -136,10 +142,10 @@ def marker_problems(value: Any) -> list[str]:
             f"{type(transforms).__name__}")
     else:
         for i, name in enumerate(transforms):
-            if name not in TRANSFORMS:
+            if not isinstance(name, str) or name not in TRANSFORMS:
                 problems.append(
-                    f"marker transforms[{i}] is {name!r}, not one of "
-                    f"{sorted(TRANSFORMS)}")
+                    f"marker transforms[{i}] is {name!r} "
+                    f"({type(name).__name__}), not one of {sorted(TRANSFORMS)}")
     return problems
 
 

--- a/delphi/polismath/utils/output_profile.py
+++ b/delphi/polismath/utils/output_profile.py
@@ -54,6 +54,17 @@ PROJECTED_PROFILE = "polis-prep-main-projected/1"
 VOTE_AXIS_AS_EMITTED = "as-emitted"
 VOTE_AXIS_NEGATED = "negated"
 
+#: Closed enums. A marker is a DECLARATION inside a gate, so every value is
+#: checked against the set of reviewed tokens; an unknown profile, axis or
+#: transform name is a malformed marker, not a new feature.
+PROFILES: frozenset[str] = frozenset({PROJECTED_PROFILE})
+VOTE_AXES: frozenset[str] = frozenset({VOTE_AXIS_AS_EMITTED, VOTE_AXIS_NEGATED})
+TRANSFORMS: frozenset[str] = frozenset({"project_prep_main", "N"})
+
+#: Closed key set of the marker value itself.
+MARKER_KEYS: frozenset[str] = frozenset(
+    {"profile", "restorable", "vote_axis", "transforms"})
+
 
 class OutputProfileError(ValueError):
     """A marked (projected/N-translated) view reached a boundary that requires
@@ -81,18 +92,89 @@ def stamp(view: dict[str, Any], marker_value: dict[str, Any]) -> dict[str, Any]:
     return view
 
 
+def has_marker(blob: Any) -> bool:
+    """True iff the reserved key is PRESENT, whatever its value.
+
+    The distinction matters at a gate (Astra review #2730 F2): a guard that
+    only reacts to a well-formed dict treats ``{"__output_profile__": null}``,
+    ``false``, a string or an array as unmarked raw data — so replacing a valid
+    marker with any garbage walked a projected view straight through both
+    restore boundaries. Malformed provenance is not the absence of provenance.
+    """
+    return isinstance(blob, dict) and OUTPUT_PROFILE_KEY in blob
+
+
+def marker_problems(value: Any) -> list[str]:
+    """Everything wrong with a marker VALUE, or an empty list. Closed schema:
+    a dict with exactly :data:`MARKER_KEYS`, a reviewed profile token, a
+    reviewed vote axis, ``restorable`` the literal boolean ``False``, and a
+    list of reviewed transform names."""
+    if not isinstance(value, dict):
+        return [f"marker must be a JSON object, got {type(value).__name__}"]
+    problems: list[str] = []
+    for missing in sorted(MARKER_KEYS - set(value)):
+        problems.append(f"marker is missing {missing!r}")
+    for unknown in sorted(set(value) - MARKER_KEYS):
+        problems.append(f"marker carries unknown field {unknown!r}")
+    if value.get("profile") not in PROFILES:
+        problems.append(
+            f"marker profile {value.get('profile')!r} is not one of "
+            f"{sorted(PROFILES)}")
+    if value.get("vote_axis") not in VOTE_AXES:
+        problems.append(
+            f"marker vote_axis {value.get('vote_axis')!r} is not one of "
+            f"{sorted(VOTE_AXES)}")
+    restorable = value.get("restorable")
+    if type(restorable) is not bool or restorable is not False:
+        problems.append(
+            f"marker restorable must be the boolean False, got "
+            f"{type(restorable).__name__} {restorable!r}")
+    transforms = value.get("transforms")
+    if not isinstance(transforms, list) or not transforms:
+        problems.append(
+            f"marker transforms must be a non-empty array, got "
+            f"{type(transforms).__name__}")
+    else:
+        for i, name in enumerate(transforms):
+            if name not in TRANSFORMS:
+                problems.append(
+                    f"marker transforms[{i}] is {name!r}, not one of "
+                    f"{sorted(TRANSFORMS)}")
+    return problems
+
+
 def profile_of(blob: Any) -> dict[str, Any] | None:
-    """The marker on ``blob``, or ``None`` for an unmarked (raw) blob."""
-    if isinstance(blob, dict):
-        found = blob.get(OUTPUT_PROFILE_KEY)
-        if isinstance(found, dict):
-            return found
-    return None
+    """The VALID marker on ``blob``, or ``None``.
+
+    ``None`` here means "no well-formed marker" and covers both an unmarked raw
+    blob and a corrupted one, so it is never the right thing for a gate to key
+    on by itself — use :func:`has_marker` for presence and
+    :func:`marker_problems` for validity.
+    """
+    if not has_marker(blob):
+        return None
+    found = blob[OUTPUT_PROFILE_KEY]
+    return found if not marker_problems(found) else None
 
 
 def is_projected_view(blob: Any) -> bool:
-    """True iff ``blob`` declares itself a projected (non-restorable) view."""
+    """True iff ``blob`` carries a WELL-FORMED projected-view marker."""
     return profile_of(blob) is not None
+
+
+def assert_valid_marker(blob: Any, *, label: str = "comparison view") -> dict[str, Any]:
+    """The COMPARISON-boundary check: the view must carry a marker and that
+    marker must satisfy the closed schema. Returns it."""
+    if not has_marker(blob):
+        raise OutputProfileError(
+            f"{label}: no {OUTPUT_PROFILE_KEY!r} marker; a projected view must "
+            f"declare its output profile and vote axis")
+    problems = marker_problems(blob[OUTPUT_PROFILE_KEY])
+    if problems:
+        raise OutputProfileError(
+            f"{label}: malformed {OUTPUT_PROFILE_KEY!r} marker — "
+            + "; ".join(problems))
+    return blob[OUTPUT_PROFILE_KEY]
 
 
 def payload(view: dict[str, Any]) -> dict[str, Any]:
@@ -109,12 +191,22 @@ def assert_restorable(blob: Any, *, label: str = "restore") -> None:
     a path that must consume the original complete, validated raw engine
     serialization.
 
-    Cheap and total: an unmarked raw blob — every blob any producer actually
-    emits — passes without inspection.
+    Fails closed on PRESENCE, not on validity: a malformed marker value is a
+    corrupted or hand-edited projected view, which is exactly the thing that
+    must not be restored (Astra review #2730 F2). An unmarked raw blob — every
+    blob any producer actually emits — passes without inspection.
     """
-    found = profile_of(blob)
-    if found is None:
+    if not has_marker(blob):
         return
+    found = blob[OUTPUT_PROFILE_KEY]
+    problems = marker_problems(found)
+    if problems:
+        raise OutputProfileError(
+            f"{label}: this blob carries a MALFORMED output-profile marker "
+            f"{OUTPUT_PROFILE_KEY!r} ({'; '.join(problems)}). The reserved key "
+            f"is rejected whenever it is present: malformed provenance is not "
+            f"the absence of provenance, and restore consumes only an original "
+            f"complete raw engine serialization.")
     raise OutputProfileError(
         f"{label}: this blob carries the output-profile marker "
         f"{OUTPUT_PROFILE_KEY!r} ({found.get('profile')!r}, vote_axis "

--- a/delphi/polismath/utils/output_profile.py
+++ b/delphi/polismath/utils/output_profile.py
@@ -1,0 +1,126 @@
+"""Output-profile / provenance marker for a PROJECTED engine view.
+
+P-023 rev3 ("Sign transformations are explicit and distinct", and R3-1 in the
+round-3 disposition):
+
+    Do not feed this projected/N-translated view to ``from_dict``, save it as a
+    raw snapshot, or run C9 on it. […] Enforce misuse rejection with an
+    explicit output-profile/provenance marker at the restore boundary:
+    raw-schema validation alone accepts a projected kebab-only view and can
+    silently restore an empty underscore group list.
+
+The reason a marker is REQUIRED, and a stronger raw schema is not enough: a
+projected ``PREP_MAIN_KEYS`` view is a *legal* kebab-only blob. It carries no
+snake/kebab alias pair, so the declared-alias check never fires and C9 never
+runs; every remaining field is well typed and finite. It passes the raw
+checkpoint gate — and then ``Conversation.from_dict``'s
+``data.get('group_clusters', [])`` quietly restores a conversation with NO
+groups and no error anywhere. The control that "attempts the projected-to-
+restore misuse" passes vacuously unless the view SAYS what it is.
+
+So every projected view carries :data:`OUTPUT_PROFILE_KEY`, and every restore
+boundary refuses a blob that carries it. The marker also states the view's
+**vote-axis convention independently of the input storage sign** (rev3: "Every
+descriptor must identify that output convention independently from the input
+storage sign. Unknown convention fails admission"), which is what lets a
+harness tell "this side needed N to reach the common profile" from "this side
+was already in it" without inferring anything from ``storage_agree_value``.
+
+The marker is deliberately NOT a kebab/snake alias of anything and never
+collides with a prep-main key, so stamping it cannot shadow engine output.
+
+This module imports nothing from ``polismath``: both the engine
+(``conversation.py``, at the restore boundary) and the harness
+(``replay/polarity.py``, which stamps) depend on it, and neither may depend on
+the other.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: The one marker key. Double-underscored so it can never be mistaken for an
+#: engine field, and outside ``PREP_MAIN_KEYS`` so the projection would drop it
+#: rather than carry it into a raw comparison by accident.
+OUTPUT_PROFILE_KEY = "__output_profile__"
+
+#: The projected comparison view: ``project_prep_main`` (+ the acceptance
+#: exclusions) applied to a validated raw blob. NOT a serialization.
+PROJECTED_PROFILE = "polis-prep-main-projected/1"
+
+#: Vote-axis convention of a view. ``as-emitted`` is the producer's own axis;
+#: ``negated`` is that axis after the declared involution N. These name the
+#: OUTPUT convention; they say nothing about the input storage sign.
+VOTE_AXIS_AS_EMITTED = "as-emitted"
+VOTE_AXIS_NEGATED = "negated"
+
+
+class OutputProfileError(ValueError):
+    """A marked (projected/N-translated) view reached a boundary that requires
+    a complete raw engine serialization."""
+
+
+def marker(
+    *, profile: str = PROJECTED_PROFILE, vote_axis: str = VOTE_AXIS_AS_EMITTED,
+    transforms: tuple[str, ...] = ("project_prep_main",),
+) -> dict[str, Any]:
+    """The marker value: what this view IS, how it got here, and the one fact
+    every boundary reads — ``restorable: False``."""
+    return {
+        "profile": profile,
+        "restorable": False,
+        "vote_axis": vote_axis,
+        "transforms": list(transforms),
+    }
+
+
+def stamp(view: dict[str, Any], marker_value: dict[str, Any]) -> dict[str, Any]:
+    """Return ``view`` with the marker attached (mutates and returns, so a
+    caller cannot accidentally publish the unmarked copy it just built)."""
+    view[OUTPUT_PROFILE_KEY] = marker_value
+    return view
+
+
+def profile_of(blob: Any) -> dict[str, Any] | None:
+    """The marker on ``blob``, or ``None`` for an unmarked (raw) blob."""
+    if isinstance(blob, dict):
+        found = blob.get(OUTPUT_PROFILE_KEY)
+        if isinstance(found, dict):
+            return found
+    return None
+
+
+def is_projected_view(blob: Any) -> bool:
+    """True iff ``blob`` declares itself a projected (non-restorable) view."""
+    return profile_of(blob) is not None
+
+
+def payload(view: dict[str, Any]) -> dict[str, Any]:
+    """The view WITHOUT its marker — what an equality comparison runs on. The
+    marker is provenance about the view, not a computed engine value, so it is
+    compared separately (both sides must declare the same vote axis) rather
+    than folded into the payload hash."""
+    return {k: v for k, v in view.items() if k != OUTPUT_PROFILE_KEY}
+
+
+def assert_restorable(blob: Any, *, label: str = "restore") -> None:
+    """The RESTORE-BOUNDARY guard (P-023 rev3 R3-1). Raises
+    :class:`OutputProfileError` when a projected/N-translated view is handed to
+    a path that must consume the original complete, validated raw engine
+    serialization.
+
+    Cheap and total: an unmarked raw blob — every blob any producer actually
+    emits — passes without inspection.
+    """
+    found = profile_of(blob)
+    if found is None:
+        return
+    raise OutputProfileError(
+        f"{label}: this blob carries the output-profile marker "
+        f"{OUTPUT_PROFILE_KEY!r} ({found.get('profile')!r}, vote_axis "
+        f"{found.get('vote_axis')!r}, transforms {found.get('transforms')!r}): "
+        f"it is a PROJECTED comparison view, not a restorable engine "
+        f"serialization. Restore consumes the original complete raw blob plus "
+        f"its declared input convention/epoch; a projected view has already "
+        f"lost the raw extensions (group_clusters, proj) that restore reads, "
+        f"and would silently rebuild an empty group list.")

--- a/delphi/polismath/utils/vote_convention.py
+++ b/delphi/polismath/utils/vote_convention.py
@@ -1,0 +1,134 @@
+"""The ONE authoritative Python definition of the raw vote-storage convention.
+
+P-022-G rev4 ("Input contract", the polarity paragraph) requires exactly one
+Python definition of the raw storage sign of AGREE, living at
+``polismath/utils/vote_convention.py::STORAGE_AGREE_VALUE``, with every
+extractor, manifest, converter and ingress consuming it through a *validated
+configuration argument* rather than restating the literal. P-023's first slice
+lands that definition, because until a configurable ``s`` exists the compensated
+polarity pair ``E(V, s) == E(-V, -s)`` cannot even be EXPRESSED: no code path
+reads anything but a hard-coded ``-1``.
+
+Three distinct conventions live in this codebase and they must never be
+conflated:
+
+- **storage** — the raw ``votes.vote`` column. Today AGREE is ``-1``
+  (``server/postgres/migrations/000000_initial.sql``: "-1 = Agree, 1 =
+  Disagree, 0 = Pass/Unsure"). :data:`STORAGE_AGREE_VALUE` is the authoritative
+  default and it stays ``-1`` until a separately approved DB migration; a
+  caller may nonetheless *declare* ``+1`` for a derived paired fixture, which is
+  exactly what makes the polarity property testable ahead of the migration.
+- **semantic** — what a vote MEANS: ``+1`` agree, ``-1`` disagree, ``0`` pass.
+  This is NOT configurable; it is the fixed meaning both engines compute on
+  (Delphi's internal convention) and the convention the export CSV carries.
+  ``semantic = raw_vote × storage_agree_value``.
+- **export** — the tagged CSV format (``report.ts``'s ``String(-row.vote)``).
+  It is semantic by construction and :data:`EXPORT_AGREE_VALUE` stays ``+1``
+  through any storage flip. Never negate twice: an export row is already
+  semantic input, never raw storage input.
+
+NULL is a fourth storage state, neither pass nor missing, and it is NOT
+convertible: :func:`semantic_vote` refuses it loudly rather than letting
+``None * -1`` raise ``TypeError`` from somewhere deeper, and never turns it
+into ``0``.
+
+This module deliberately has no imports from the rest of ``polismath``: the
+independent reference fold, the manifest gate and the extractor all read it
+without dragging in the candidate converter.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Union
+
+Number = Union[int, float]
+
+#: Raw storage sign of an AGREE vote — the authoritative default and the only
+#: value production extraction may declare before the P-023 storage migration.
+STORAGE_AGREE_VALUE: int = -1
+
+#: The two admissible storage conventions. Exactly the integers -1 and +1:
+#: ``bool`` is excluded (``True == 1`` in Python, and a convention carrying
+#: ``True`` is a typing accident, not a declaration), and so are ``0``, floats,
+#: strings and ``None``.
+ADMISSIBLE_STORAGE_AGREE_VALUES: tuple[int, int] = (-1, 1)
+
+#: Semantic vote meaning. FIXED — not a convention a manifest may declare.
+SEMANTIC_AGREE: int = 1
+SEMANTIC_DISAGREE: int = -1
+SEMANTIC_PASS: int = 0
+
+#: Sign of AGREE in the export CSV format. A separate, tagged format whose
+#: convention is independent of storage and unchanged by a storage flip.
+EXPORT_AGREE_VALUE: int = 1
+
+
+class VoteConventionError(ValueError):
+    """A declared convention or a raw vote value is not admissible."""
+
+
+def validate_storage_agree_value(
+    value: Any, *, field: str = "storage_agree_value",
+) -> int:
+    """Return ``value`` iff it is exactly the integer ``-1`` or ``+1``.
+
+    ``type(value) is int`` rather than ``isinstance``: ``bool`` is a subclass of
+    ``int``, so ``isinstance(True, int)`` admits ``True`` as ``+1`` — a
+    convention that was never declared. A float ``-1.0``, the string ``"-1"``,
+    ``0`` and ``None`` are all refused for the same reason: the convention is a
+    declaration, not a value to coerce.
+    """
+    if type(value) is not int:
+        raise VoteConventionError(
+            f"{field} must be the integer -1 or +1, got "
+            f"{type(value).__name__} {value!r} (bool, float, str and None are "
+            f"not conventions)")
+    if value not in ADMISSIBLE_STORAGE_AGREE_VALUES:
+        raise VoteConventionError(
+            f"{field} must be -1 or +1, got {value!r}")
+    return value
+
+
+def flipped(storage_agree_value: int) -> int:
+    """The other convention. ``T(V, s) = (-V, -s)`` is its own inverse, so this
+    is too: ``flipped(flipped(s)) == s``."""
+    return -validate_storage_agree_value(storage_agree_value)
+
+
+def semantic_vote(
+    raw_vote: Number, storage_agree_value: int = STORAGE_AGREE_VALUE,
+) -> Number:
+    """``raw_vote × storage_agree_value`` — the ONE formula.
+
+    ``+1`` agree, ``-1`` disagree, ``0`` pass, independent of which storage
+    convention produced it. ``0`` (pass) is invariant: it is the literal zero on
+    both sides of the involution, never a sign to flip.
+
+    NULL (``None``) is refused: it is a distinct storage state, not a pass, and
+    silently mapping it onto ``0`` would fabricate a vote. ``bool`` is refused
+    for the same reason :func:`validate_storage_agree_value` refuses it.
+    """
+    s = validate_storage_agree_value(storage_agree_value)
+    if raw_vote is None:
+        raise VoteConventionError(
+            "votes.vote is NULL: NULL is a distinct storage state, neither "
+            "pass nor missing, and has no semantic vote. Apply an explicit "
+            "declared NULL policy before conversion; never coerce it to 0.")
+    if isinstance(raw_vote, bool):
+        raise VoteConventionError(
+            f"raw vote must be a number, got bool {raw_vote!r}")
+    if not isinstance(raw_vote, (int, float)):
+        raise VoteConventionError(
+            f"raw vote must be a number, got {type(raw_vote).__name__} "
+            f"{raw_vote!r}")
+    return raw_vote * s
+
+
+def storage_vote(
+    semantic: Number, storage_agree_value: int = STORAGE_AGREE_VALUE,
+) -> Number:
+    """The inverse of :func:`semantic_vote`. Multiplication by ``s`` is its own
+    inverse (``s² == 1``), so this is the same arithmetic — spelled separately
+    because the two directions mean different things at a boundary, and a
+    reader must never have to work out which way a bare ``* -1`` points."""
+    return semantic_vote(semantic, storage_agree_value)

--- a/delphi/tests/replay_harness/test_polarity_property.py
+++ b/delphi/tests/replay_harness/test_polarity_property.py
@@ -354,6 +354,62 @@ def test_control_17_the_projected_view_is_refused_at_both_restore_boundaries(
         Conversation.from_dict(view)
 
 
+MALFORMED_MARKERS = [
+    None, False, True, 0, "projected", [], {},
+    {"profile": "made-up/9", "restorable": False,
+     "vote_axis": op.VOTE_AXIS_AS_EMITTED, "transforms": ["project_prep_main"]},
+    {"profile": op.PROJECTED_PROFILE, "restorable": False,
+     "vote_axis": "sideways", "transforms": ["project_prep_main"]},
+    {"profile": op.PROJECTED_PROFILE, "restorable": "false",
+     "vote_axis": op.VOTE_AXIS_AS_EMITTED, "transforms": ["project_prep_main"]},
+    {"profile": op.PROJECTED_PROFILE, "restorable": False,
+     "vote_axis": op.VOTE_AXIS_AS_EMITTED, "transforms": ["hand-rolled"]},
+    {"profile": op.PROJECTED_PROFILE, "restorable": False,
+     "vote_axis": op.VOTE_AXIS_AS_EMITTED, "transforms": []},
+    {"profile": op.PROJECTED_PROFILE, "restorable": False,
+     "vote_axis": op.VOTE_AXIS_AS_EMITTED, "transforms": ["project_prep_main"],
+     "surprise": 1},
+    {"profile": op.PROJECTED_PROFILE, "restorable": False,
+     "vote_axis": op.VOTE_AXIS_AS_EMITTED},
+]
+
+
+@pytest.mark.parametrize("malformed", MALFORMED_MARKERS)
+def test_control_17b_a_malformed_marker_does_not_bypass_either_boundary(
+        real_driver_blob, malformed):
+    """Astra #2730 F2. Both guards keyed on a well-formed dict, so replacing the
+    marker value with null, false, a string or an array made the projected view
+    read as unmarked RAW data: it passed the checkpoint gate and restored a
+    conversation with zero groups. Malformed provenance is not the absence of
+    provenance — the reserved key is refused whenever it is present."""
+    view = pol.payload(pol.vote_axis_involution(_projected(real_driver_blob)))
+    view[op.OUTPUT_PROFILE_KEY] = malformed
+
+    with pytest.raises(cert.CertifyError, match="output-profile marker"):
+        cert.validate_checkpoint_blob(view, "malformed marker")
+    with pytest.raises(op.OutputProfileError):
+        Conversation.from_dict(view)
+
+
+@pytest.mark.parametrize("malformed", MALFORMED_MARKERS)
+def test_N_refuses_a_malformed_marker_at_the_comparison_boundary(malformed):
+    """The comparison boundary validates the marker's VALUES, not just its
+    presence: N must not translate a view whose declared output convention is
+    unreviewed or corrupted."""
+    view = _projected(GEOMETRY_BLOB)
+    view[op.OUTPUT_PROFILE_KEY] = malformed
+    with pytest.raises(pol.PolarityError):
+        pol.vote_axis_involution(view)
+
+
+def test_a_well_formed_marker_round_trips_through_the_validator():
+    view = _projected(GEOMETRY_BLOB)
+    assert op.marker_problems(view[op.OUTPUT_PROFILE_KEY]) == []
+    assert op.assert_valid_marker(view)["profile"] == op.PROJECTED_PROFILE
+    assert op.has_marker(view) and op.is_projected_view(view)
+    assert not op.has_marker(pol.payload(view))
+
+
 def test_control_18_the_marker_is_what_prevents_the_silent_empty_restore(
         real_driver_blob):
     """Control 18 — the hazard the marker prevents, demonstrated. Strip the
@@ -383,14 +439,20 @@ def test_the_compensated_pair_holds_on_every_case_and_ingress(ingress, case_inde
     assert result["run_ids"][0] != result["run_ids"][1]
 
 
+@pytest.mark.parametrize("declared", [-1, 1])
 @pytest.mark.parametrize("ingress", pol.INGRESS_PATHS)
 @pytest.mark.parametrize("control", pol.FAILING_CONTROLS)
-def test_every_negative_control_reaches_its_gate_and_fails(ingress, control):
+def test_every_negative_control_reaches_its_gate_and_fails(ingress, control, declared):
+    """Under BOTH declarations (Astra #2730 F4). The double-conversion control
+    was injected unconditionally on the original side, which is the identity
+    at s = +1: the "broken" pair passed on both ingress paths and the mandatory
+    control proved nothing."""
     if control == pol.CONTROL_NULL_TO_PASS and ingress == pol.INGRESS_DB_ROWS:
         pytest.skip("NULL is INVALID_INPUT at the computing ingress; see the "
                     "rejection test below")
     case = pol.control_case(control)
-    result = pol.check_polarity_pair(case, ingress=ingress, control=control)
+    result = pol.check_polarity_pair(case, ingress=ingress, control=control,
+                                     storage_agree_value=declared)
     assert result["verdict"] == "FAIL", result
     assert result["problems"], "a control must fail for a NAMED reason"
     assert result["checkpoints"] > 0, (
@@ -413,9 +475,11 @@ def test_the_pair_runs_from_a_declared_plus_one_convention_too():
     assert result["conventions"]["flipped"]["storage_agree_value"] == -1
 
 
-def test_the_standing_property_passes_and_carries_its_controls():
-    report = pol.run_standing_property()
+@pytest.mark.parametrize("declared", [-1, 1])
+def test_the_standing_property_passes_and_carries_its_controls(declared):
+    report = pol.run_standing_property(storage_agree_value=declared)
     assert report["verdict"] == "PASS", report["problems"]
+    assert report["storage_agree_value"] == declared
     assert len(report["pairs"]) == 8
     assert len(report["controls"]) == 11
     assert all(r["verdict"] == "FAIL" for r in report["controls"])
@@ -436,13 +500,22 @@ def test_a_broken_ingress_conversion_fails_the_standing_property(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_the_convention_descriptor_refuses_an_undeclared_convention():
-    with pytest.raises(vc.VoteConventionError):
-        pol.ConventionDescriptor(storage_agree_value=True)
-    with pytest.raises(pol.PolarityError):
-        pol.ConventionDescriptor(pair_side="whichever")
-    with pytest.raises(pol.PolarityError):
-        pol.ConventionDescriptor(output_convention="")
+@pytest.mark.parametrize("kwargs", [
+    {"storage_agree_value": True},
+    {"pair_side": "whichever"},
+    {"output_convention": ""},
+    {"input_convention": ""},
+    # "Unknown convention fails admission" is a predicate, not a sentiment:
+    # a truthiness check accepted these (Astra #2730 F2).
+    {"input_convention": "unknown-input/99"},
+    {"output_convention": "unknown-output/99"},
+])
+def test_the_convention_descriptor_refuses_an_undeclared_convention(kwargs):
+    with pytest.raises((pol.PolarityError, vc.VoteConventionError)):
+        pol.ConventionDescriptor(**kwargs)
+
+
+def test_the_convention_descriptor_flip_is_an_involution():
     assert pol.DEFAULT_CONVENTIONS.flip().flip() == pol.DEFAULT_CONVENTIONS
 
 

--- a/delphi/tests/replay_harness/test_polarity_property.py
+++ b/delphi/tests/replay_harness/test_polarity_property.py
@@ -1,0 +1,553 @@
+"""P-023 polarity: the algebra controls, N, the marker, and the real pair.
+
+The plan's ten algebra controls and the review's nine composition/misuse
+controls, executed here as pytest rather than as a scratch script — against the
+REAL ``project_prep_main``, the REAL ``certify.validate_checkpoint_blob``, the
+REAL ``Conversation.from_dict`` and a REAL Python-driver blob replayed from the
+committed biodiversity dataset (the one that carries both group-cluster
+spellings and ``proj``, which is what makes controls 13-18 evidence rather than
+restatement).
+
+Numbering follows the review so a reader can line each test up with the control
+it discharges:
+
+  1-9   the algebra of ``semantic = v x s`` and of ``T(V, s) = (-V, -s)``
+  10-12 N: involution, invariants, and its distinction from PCA orientation
+  13-16 N composed with the shipped raw gate on a real driver blob
+  17-18 the projected-to-restore misuse, which rev3 R3-1 requires a MARKER to
+        catch (the raw schema alone cannot: control 18 shows what the marker
+        prevents)
+"""
+
+import copy
+import csv
+import json
+import math
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from polismath.conversation.conversation import Conversation
+from polismath.replay import certify as cert
+from polismath.replay import polarity as pol
+from polismath.replay import prodclone as pc
+from polismath.replay import real_data as rd
+from polismath.replay import schedule as sched
+from polismath.replay.crosslang import PREP_MAIN_KEYS, project_prep_main
+from polismath.replay.driver import run_replay
+from polismath.replay.types import ReplayDataset
+from polismath.utils import output_profile as op
+from polismath.utils import vote_convention as vc
+from polismath.utils.general import postgres_vote_to_delphi
+
+RAW_DOMAIN = (-1, 0, 1)
+SIGNS = (-1, 1)
+
+
+# ---------------------------------------------------------------------------
+# 1-9 — the algebra of the storage convention and of T.
+# ---------------------------------------------------------------------------
+
+
+def test_control_01_semantic_is_v_times_s_over_the_whole_domain():
+    """Control 1. agree = +1, disagree = -1, pass = 0, for both conventions."""
+    for s in SIGNS:
+        assert vc.semantic_vote(s, s) == vc.SEMANTIC_AGREE
+        assert vc.semantic_vote(-s, s) == vc.SEMANTIC_DISAGREE
+        assert vc.semantic_vote(0, s) == vc.SEMANTIC_PASS
+        for v in RAW_DOMAIN:
+            assert vc.semantic_vote(v, s) == v * s
+
+
+def test_control_02_T_preserves_semantics_for_every_raw_value():
+    """Control 2. semantic(T(V, s)) == semantic(V, s)."""
+    for s in SIGNS:
+        for v in RAW_DOMAIN:
+            assert vc.semantic_vote(-v, vc.flipped(s)) == vc.semantic_vote(v, s)
+
+
+def test_control_03_T_is_its_own_inverse():
+    """Control 3. On the votes and on the constant."""
+    rows = [{"created": 1, "pid": 0, "tid": 0, "vote": -1},
+            {"created": 2, "pid": 1, "tid": 0, "vote": 1},
+            {"created": 3, "pid": 2, "tid": 0, "vote": 0},
+            {"created": 4, "pid": 3, "tid": 0, "vote": None}]
+    assert pol.flip_raw_votes(pol.flip_raw_votes(rows)) == rows
+    for s in SIGNS:
+        assert vc.flipped(vc.flipped(s)) == s
+
+
+def test_control_04_pass_stays_the_literal_zero_on_both_sides():
+    """Control 4."""
+    rows = [{"created": 1, "pid": 0, "tid": 0, "vote": 0}]
+    flipped = pol.flip_raw_votes(rows)
+    assert flipped[0]["vote"] == 0
+    assert type(flipped[0]["vote"]) is int
+
+
+def test_control_05_null_is_preserved_by_T_and_is_not_pass():
+    """Control 5. NULL is a distinct storage state; the converter refuses it
+    rather than reading it as a pass."""
+    rows = [{"created": 1, "pid": 0, "tid": 0, "vote": None}]
+    assert pol.flip_raw_votes(rows)[0]["vote"] is None
+    with pytest.raises(vc.VoteConventionError, match="NULL"):
+        vc.semantic_vote(None, -1)
+
+
+def test_control_06_a_missing_cell_stays_absent_under_T():
+    """Control 6. T touches vote leaves; it never materialises a cell."""
+    rows = [{"created": 1, "pid": 0, "tid": 0, "vote": -1},
+            {"created": 2, "pid": 0, "tid": 1, "vote": 1}]
+    flipped = pol.flip_raw_votes(rows)
+    assert [(r["pid"], r["tid"]) for r in flipped] == [(0, 0), (0, 1)]
+    assert len(flipped) == len(rows)
+
+
+@pytest.mark.parametrize(
+    "bad", [True, False, None, 0, -1.0, 1.0, "-1", "+1", [-1], 2, -2])
+def test_control_07_storage_agree_value_rejects_everything_but_int_pm1(bad):
+    """Control 7. bool included: True == 1 would otherwise declare +1."""
+    with pytest.raises(vc.VoteConventionError):
+        vc.validate_storage_agree_value(bad)
+
+
+def test_control_08_the_frozen_order_gives_the_same_semantic_winner():
+    """Control 8. Later (created_ms, source_ordinal) wins, and the winner's
+    MEANING is identical across the pair when the frozen order is kept."""
+    rows = [{"created": 1000, "pid": 0, "tid": 0, "vote": -1},
+            {"created": 1000, "pid": 0, "tid": 0, "vote": 1}]
+    s = -1
+    winner_a = vc.semantic_vote(rows[-1]["vote"], s)
+    flipped_rows = pol.flip_raw_votes(rows)
+    winner_b = vc.semantic_vote(flipped_rows[-1]["vote"], vc.flipped(s))
+    assert winner_a == winner_b
+
+
+def test_control_09_negative_resorting_by_raw_sign_changes_the_winner():
+    """Control 9 (NEGATIVE). The load-bearing one: re-sorting by raw sign
+    picks a DIFFERENT equal-time winner on the two sides, which is why 'use
+    exactly the same frozen tie order on both sides' is a requirement and not
+    defensive prose."""
+    rows = [{"created": 1000, "pid": 0, "tid": 0, "vote": -1},
+            {"created": 1000, "pid": 0, "tid": 0, "vote": 1}]
+    s = -1
+    by_sign_a = sorted(rows, key=lambda r: (r["created"], r["vote"]))
+    by_sign_b = sorted(pol.flip_raw_votes(rows),
+                       key=lambda r: (r["created"], r["vote"]))
+    assert (vc.semantic_vote(by_sign_a[-1]["vote"], s)
+            != vc.semantic_vote(by_sign_b[-1]["vote"], vc.flipped(s)))
+
+
+# ---------------------------------------------------------------------------
+# 10-12 — N itself.
+# ---------------------------------------------------------------------------
+
+
+def _projected(blob):
+    return pol.comparison_view(blob, project=project_prep_main)
+
+
+GEOMETRY_BLOB = {
+    "zid": "t", "n": 4, "n-cmts": 2, "tids": [0, 1], "in-conv": [0, 1, 2, 3],
+    "pca": {
+        "center": [0.5, -0.25],
+        "comps": [[1.0, 0.0], [0.0, 1.0]],
+        "comment-projection": [[0.3, -0.4], [0.1, 0.2]],
+        "comment-extremity": [0.5, 0.22],
+    },
+    "base-clusters": {"id": [0, 1], "members": [[0, 1], [2, 3]],
+                      "x": [1.5, -2.5], "y": [-0.5, 0.25], "count": [2, 2]},
+    "group-clusters": [{"id": 0, "members": [0], "center": [1.5, -0.5]},
+                       {"id": 1, "members": [1], "center": [-2.5, 0.25]}],
+    "repness": {}, "consensus": {}, "group-votes": {}, "votes-base": {},
+    "user-vote-counts": {}, "comment-priorities": {},
+    "group-aware-consensus": {},
+}
+
+
+def test_control_10_N_is_an_involution_on_the_declared_field_set():
+    """Control 10. N(N(view)) == view exactly, marker included."""
+    view = _projected(GEOMETRY_BLOB)
+    once = pol.vote_axis_involution(view)
+    twice = pol.vote_axis_involution(once)
+    assert twice == view
+    assert once != view
+    assert once[op.OUTPUT_PROFILE_KEY]["vote_axis"] == op.VOTE_AXIS_NEGATED
+    assert twice[op.OUTPUT_PROFILE_KEY]["vote_axis"] == op.VOTE_AXIS_AS_EMITTED
+
+
+def test_control_10b_N_negates_exactly_the_declared_fields():
+    view = _projected(GEOMETRY_BLOB)
+    n_view = pol.vote_axis_involution(view)
+    assert n_view["pca"]["center"] == [-0.5, 0.25]
+    assert n_view["pca"]["comment-projection"] == [[-0.3, 0.4], [-0.1, -0.2]]
+    assert n_view["base-clusters"]["x"] == [-1.5, 2.5]
+    assert n_view["base-clusters"]["y"] == [0.5, -0.25]
+    assert [g["center"] for g in n_view["group-clusters"]] == [
+        [-1.5, 0.5], [2.5, -0.25]]
+
+
+def test_control_11_N_leaves_comps_extremity_counts_and_ids_invariant():
+    """Control 11, and the plan's 'apply N to comps or extremity' control:
+    those fields must NOT move."""
+    view = _projected(GEOMETRY_BLOB)
+    n_view = pol.vote_axis_involution(view)
+    pol.assert_n_invariants(view, n_view)
+    assert n_view["pca"]["comps"] == view["pca"]["comps"]
+    assert n_view["pca"]["comment-extremity"] == view["pca"]["comment-extremity"]
+    assert n_view["base-clusters"]["members"] == view["base-clusters"]["members"]
+    assert [g["members"] for g in n_view["group-clusters"]] == [
+        g["members"] for g in view["group-clusters"]]
+
+
+def test_control_11b_a_partial_N_is_caught_by_the_invariant_check():
+    """The plan's 'flip only one coupled output field' control. A hand-rolled
+    partial N leaves comps alone (fine) but also changes an invariant when the
+    implementer negates the wrong family — assert_n_invariants names it."""
+    view = _projected(GEOMETRY_BLOB)
+    bad = copy.deepcopy(view)
+    bad["pca"]["comps"] = [[-c for c in row] for row in bad["pca"]["comps"]]
+    with pytest.raises(pol.PolarityError, match="pca.comps"):
+        pol.assert_n_invariants(view, bad)
+
+
+def test_control_12_N_changes_the_mean_pca_orientation_never_does():
+    """Control 12. Orientation flips a component AND its coupled projections
+    and leaves pca.center alone; N moves the mean and leaves comps alone. The
+    two operations must never be confused — that is how a wrong mean passes."""
+    view = _projected(GEOMETRY_BLOB)
+    n_view = pol.vote_axis_involution(view)
+    assert n_view["pca"]["center"] != view["pca"]["center"]
+    assert n_view["pca"]["comps"] == view["pca"]["comps"]
+
+    # An orientation flip, spelled out here as the contrast case.
+    oriented = copy.deepcopy(view)
+    oriented["pca"]["comps"][0] = [-c for c in oriented["pca"]["comps"][0]]
+    oriented["pca"]["comment-projection"][0] = [
+        -c for c in oriented["pca"]["comment-projection"][0]]
+    assert oriented["pca"]["center"] == view["pca"]["center"]
+    assert oriented["pca"]["comps"] != view["pca"]["comps"]
+
+
+def test_N_refuses_a_raw_blob_and_a_view_carrying_raw_extensions():
+    """N 'is never a raw serializer or restore transform'."""
+    with pytest.raises(pol.PolarityError, match="PROJECTED"):
+        pol.vote_axis_involution(dict(GEOMETRY_BLOB))
+    smuggled = _projected(GEOMETRY_BLOB)
+    smuggled["group_clusters"] = [{"id": 0, "members": [0], "center": [1.0, 1.0]}]
+    with pytest.raises(pol.PolarityError, match="group_clusters"):
+        pol.vote_axis_involution(smuggled)
+
+
+# ---------------------------------------------------------------------------
+# 13-18 — the real driver blob: N composed with the shipped gate, and the
+# projected-to-restore misuse.
+# ---------------------------------------------------------------------------
+
+BIODIVERSITY = "biodiversity"
+
+
+@pytest.fixture(scope="module")
+def real_driver_blob():
+    """A REAL ``Conversation.to_dict()`` blob from the committed biodiversity
+    dataset, replayed through the real Python driver. It carries both
+    group-cluster spellings and ``proj`` — the raw extensions the whole
+    post-projection argument turns on — so these controls are evidence rather
+    than a restatement of the design."""
+    directory = rd.dataset_dir(BIODIVERSITY)
+    if directory is None:
+        pytest.skip("biodiversity dataset not present")
+    votes_csv = sorted(directory.glob("*-votes.csv"))[0]
+    raw = rd.read_export_vote_rows(votes_csv)[:1200]
+    dataset = ReplayDataset.build(raw)
+    spec = sched.ScheduleSpec(dataset=BIODIVERSITY, schedule_id="polarity-real",
+                              cuts={"mode": "vote-count", "at": ["end"]})
+    records = run_replay(dataset, spec)
+    blob = records[-1].blob
+    assert "group-clusters" in blob and "group_clusters" in blob, (
+        "the real driver blob must carry BOTH spellings, or controls 13-18 "
+        "prove nothing")
+    assert "proj" in blob
+    assert blob["group-clusters"], "the fixture must have at least one group"
+    return blob
+
+
+def _gate_verdict(blob):
+    """The shipped raw gate's verdict, as data. Deliberately NOT asserted to be
+    'accepted': the alias policy's treatment of the real twin pair is the
+    subject of a separate campaign (#2725). What these controls assert is that
+    N does not CHANGE this verdict, because it never touches the raw blob."""
+    try:
+        cert.validate_checkpoint_blob(blob, "real: step-000")
+        return "accepted"
+    except cert.CertifyError as exc:
+        return f"rejected:{exc.args[0]}"
+
+
+def test_control_13_15_N_leaves_the_raw_blob_and_its_gate_verdict_untouched(
+        real_driver_blob):
+    """Controls 13 and 15. The raw blob is byte-identical before and after N
+    runs on its projected view, so its verdict under the shipped gate cannot
+    move — which is exactly what makes ``from_dict`` safe."""
+    before = json.dumps(real_driver_blob, sort_keys=True)
+    verdict_before = _gate_verdict(real_driver_blob)
+
+    view = _projected(real_driver_blob)
+    pol.vote_axis_involution(view)
+
+    assert json.dumps(real_driver_blob, sort_keys=True) == before
+    assert _gate_verdict(real_driver_blob) == verdict_before
+
+
+def test_control_14a_the_projected_view_carries_no_twin_and_no_proj(
+        real_driver_blob):
+    """Control 14a — the round-1 defect, closed by rev2/rev3's post-projection
+    N. ``project_prep_main`` drops ``group_clusters`` (exact kebab wins) and
+    ``proj`` (outside the whitelist) BEFORE N runs, so post-projection N cannot
+    violate the C9 sign relation: the relation is never evaluated on anything N
+    has touched."""
+    view = pol.payload(_projected(real_driver_blob))
+    assert "group_clusters" not in view
+    assert "proj" not in view
+    assert set(view) <= PREP_MAIN_KEYS
+
+
+def test_control_14b_from_dict_still_restores_the_twin_in_internal_sign(
+        real_driver_blob):
+    """Control 14b. The raw blob is unmodified, so ``from_dict``'s
+    ``data.get('group_clusters')`` still reads the producer's internal sign —
+    no double-negation path exists, and the C9 relation could not have seen one
+    if it did (both twins would have flipped consistently)."""
+    view = _projected(real_driver_blob)
+    pol.vote_axis_involution(view)
+    restored = Conversation.from_dict(real_driver_blob)
+    assert restored.group_clusters == real_driver_blob["group_clusters"]
+    assert restored.group_clusters, "the twin must restore a nonempty group set"
+
+
+def test_control_16_N_is_an_involution_on_the_real_view_and_stays_in_prep_main(
+        real_driver_blob):
+    """Control 16."""
+    view = _projected(real_driver_blob)
+    once = pol.vote_axis_involution(view)
+    assert pol.vote_axis_involution(once) == view
+    changed = [k for k in pol.payload(view)
+               if pol.payload(once)[k] != pol.payload(view)[k]]
+    assert set(changed) <= {"pca", "base-clusters", "group-clusters"}
+    assert set(pol.payload(once)) <= PREP_MAIN_KEYS
+
+
+def test_control_17_the_projected_view_is_refused_at_both_restore_boundaries(
+        real_driver_blob):
+    """Control 17 — the round-3 P3, now CLOSED. On the reviewed baseline the
+    gate did NOT reject a projected+N view fed back as raw: it is a legal
+    kebab-only blob, no alias pair exists, so C9 never runs. The
+    output-profile marker is what makes the control fire, at both boundaries."""
+    view = pol.vote_axis_involution(_projected(real_driver_blob))
+
+    with pytest.raises(cert.CertifyError, match="output-profile marker"):
+        cert.validate_checkpoint_blob(view, "misuse: projected view as raw")
+
+    with pytest.raises(op.OutputProfileError, match="PROJECTED"):
+        Conversation.from_dict(view)
+
+
+def test_control_18_the_marker_is_what_prevents_the_silent_empty_restore(
+        real_driver_blob):
+    """Control 18 — the hazard the marker prevents, demonstrated. Strip the
+    marker and the projected view restores a conversation that has LOST every
+    group, with no error anywhere: ``data.get('group_clusters', [])``."""
+    view = pol.payload(pol.vote_axis_involution(_projected(real_driver_blob)))
+    assert op.OUTPUT_PROFILE_KEY not in view
+
+    cert.validate_checkpoint_blob(view, "unmarked projected view")  # no error
+    restored = Conversation.from_dict(view)
+    assert restored.group_clusters == []
+    assert real_driver_blob["group_clusters"] != []
+
+
+# ---------------------------------------------------------------------------
+# The property itself: the compensated pair through both real ingress paths.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ingress", pol.INGRESS_PATHS)
+@pytest.mark.parametrize("case_index", range(4))
+def test_the_compensated_pair_holds_on_every_case_and_ingress(ingress, case_index):
+    case = pol.default_cases()[case_index]
+    result = pol.check_polarity_pair(case, ingress=ingress)
+    assert result["verdict"] == "PASS", result["problems"]
+    assert result["checkpoints"] > 0
+    assert result["run_ids"][0] != result["run_ids"][1]
+
+
+@pytest.mark.parametrize("ingress", pol.INGRESS_PATHS)
+@pytest.mark.parametrize("control", pol.FAILING_CONTROLS)
+def test_every_negative_control_reaches_its_gate_and_fails(ingress, control):
+    if control == pol.CONTROL_NULL_TO_PASS and ingress == pol.INGRESS_DB_ROWS:
+        pytest.skip("NULL is INVALID_INPUT at the computing ingress; see the "
+                    "rejection test below")
+    case = pol.control_case(control)
+    result = pol.check_polarity_pair(case, ingress=ingress, control=control)
+    assert result["verdict"] == "FAIL", result
+    assert result["problems"], "a control must fail for a NAMED reason"
+    assert result["checkpoints"] > 0, (
+        "a control that collected zero comparisons failed setup, not its gate")
+
+
+def test_the_computing_ingress_rejects_null_before_any_mutation():
+    """G's v1 computing profile: INVALID_INPUT before mutation, never NULL->0."""
+    case = pol.control_case(pol.CONTROL_NULL_TO_PASS)
+    with pytest.raises(pol.PolarityError, match="INVALID_INPUT"):
+        pol.check_polarity_pair(case, ingress=pol.INGRESS_DB_ROWS)
+
+
+def test_the_pair_runs_from_a_declared_plus_one_convention_too():
+    """The property is about the DECLARED convention, not about -1: it must
+    hold with s = +1 declared on the original side as well."""
+    result = pol.check_polarity_pair(pol.default_cases()[0], storage_agree_value=1)
+    assert result["verdict"] == "PASS", result["problems"]
+    assert result["conventions"]["original"]["storage_agree_value"] == 1
+    assert result["conventions"]["flipped"]["storage_agree_value"] == -1
+
+
+def test_the_standing_property_passes_and_carries_its_controls():
+    report = pol.run_standing_property()
+    assert report["verdict"] == "PASS", report["problems"]
+    assert len(report["pairs"]) == 8
+    assert len(report["controls"]) == 11
+    assert all(r["verdict"] == "FAIL" for r in report["controls"])
+
+
+def test_a_broken_ingress_conversion_fails_the_standing_property(monkeypatch):
+    """The property must be SENSITIVE: break the one conversion the ingress
+    performs and the gate has to go red, or it is decoration."""
+    monkeypatch.setattr(pol, "semantic_vote", lambda v, s: v)
+    monkeypatch.setattr(pc, "semantic_vote", lambda v, s: v)
+    result = pol.check_polarity_pair(pol.default_cases()[0],
+                                     ingress=pol.INGRESS_EXPORT_CSV)
+    assert result["verdict"] == "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# Descriptors, the recording cache, and the fixture manifest pin.
+# ---------------------------------------------------------------------------
+
+
+def test_the_convention_descriptor_refuses_an_undeclared_convention():
+    with pytest.raises(vc.VoteConventionError):
+        pol.ConventionDescriptor(storage_agree_value=True)
+    with pytest.raises(pol.PolarityError):
+        pol.ConventionDescriptor(pair_side="whichever")
+    with pytest.raises(pol.PolarityError):
+        pol.ConventionDescriptor(output_convention="")
+    assert pol.DEFAULT_CONVENTIONS.flip().flip() == pol.DEFAULT_CONVENTIONS
+
+
+def test_changing_s_alone_forces_execution_rather_than_a_cache_hit(tmp_path):
+    """Correction 7. Same votes file, same schedule, same engine tree — the
+    ONLY difference is the declared convention. Under manifest/3 that was a
+    cache hit and the control never reached its gate."""
+    manifest_path = tmp_path / "cache_manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "step-000.json").write_text("{}")
+    base = {
+        "manifest_version": cert._RECORDING_MANIFEST_VERSION,
+        "votes_sha256": "v", "schedule_hash": "s", "engine_tree_sha256": "e",
+        **pol.DEFAULT_CONVENTIONS.cache_fields(),
+    }
+    cert._write_manifest(manifest_path, base)
+    assert cert._manifest_matches(manifest_path, base)
+
+    # Only the declared convention differs. The cached recording must NOT be
+    # reused: _manifest_matches returns False, which is the "re-run the
+    # producer" path, so the control executes instead of reading a stale run.
+    other = dict(base, **pol.DEFAULT_CONVENTIONS.flip().cache_fields())
+    assert other["storage_agree_value"] != base["storage_agree_value"]
+    assert cert._manifest_matches(manifest_path, other) is False
+
+
+def test_an_older_recording_manifest_is_never_reused(tmp_path):
+    manifest_path = tmp_path / "cache_manifest.json"
+    (tmp_path / "step-000.json").write_text("{}")
+    for old in (1, 2, 3):
+        cert._write_manifest(manifest_path, {"manifest_version": old})
+        assert cert._manifest_matches(manifest_path, {"manifest_version": old}) is False
+
+
+# ---------------------------------------------------------------------------
+# Optional: the REAL Clojure driver on both sides of the pair.
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(
+    shutil.which("clojure") is None or os.environ.get("RUN_CLJ_INTEGRATION") != "1",
+    reason="opt-in: needs the clojure CLI on PATH and RUN_CLJ_INTEGRATION=1 "
+           "(runs the REAL clojure driver on both sides of the pair)",
+)
+def test_the_pair_holds_through_the_real_clojure_driver(tmp_path):
+    """The property on the OTHER engine, with its repeatability precondition.
+
+    Two facts, in order:
+
+    1. The compensated pair CONVERGES AT THE EXPORT BOUNDARY: side A formats
+       raw ``V`` under ``s = -1`` and side B formats ``-V`` under ``s = +1``,
+       and the two CSVs are byte-identical. That is the property's real content
+       for a semantic-ingress engine — everything downstream is then a question
+       about the engine's determinism, not its polarity.
+    2. Whether the engine reproduces its own output. P-023: "Nondeterministic
+       repeatability outside the pinned profile is INCONCLUSIVE until
+       separately characterized, not a reason to weaken this invariant." So
+       side A is replayed TWICE first. If those two runs of one identical input
+       disagree, this profile cannot certify anything about polarity and the
+       test reports INCONCLUSIVE rather than a PASS or a false FAIL.
+
+    Observed while writing this (2026-09-08, local clojure CLI): on the small
+    synthetic grid the Clojure driver's step 0 is stable (the pinned cold-start
+    PCA) but its warm ticks are NOT bit-repeatable across runs of identical
+    input, so this test reports INCONCLUSIVE there. The Python side of the
+    property, which is deterministic, is certified by the tests above.
+    """
+    case = pol.default_cases()[0]
+    spec_path = tmp_path / "schedule.json"
+    spec_path.write_text(json.dumps(case.spec().to_dict()))
+
+    def write_side(name, rows, s):
+        side = tmp_path / name
+        side.mkdir()
+        votes_csv = side / "votes.csv"
+        pc.write_votes_csv(
+            votes_csv, pc.format_votes_rows(rows, storage_agree_value=s))
+        return votes_csv
+
+    csv_a = write_side("a", list(case.rows), -1)
+    csv_b = write_side("b", pol.flip_raw_votes(case.rows), 1)
+    assert csv_a.read_bytes() == csv_b.read_bytes(), (
+        "the compensated pair must converge to identical SEMANTIC input at the "
+        "export boundary; if it does not, the declared convention is not being "
+        "read at that boundary")
+
+    def replay(tag, votes_csv):
+        out = tmp_path / f"out-{tag}"
+        out.mkdir()
+        result = cert.run_clj_driver(spec_path, votes_csv, out_dir=out)
+        assert result.returncode == 0, (result.stderr or result.stdout)[:2000]
+        blobs = sorted(out.rglob("step-*.blob.json"))
+        assert blobs, "the clojure driver recorded no checkpoint"
+        return [pol.payload(pol.comparison_view(json.loads(p.read_text())))
+                for p in blobs]
+
+    first = replay("a1", csv_a)
+    repeat = replay("a2", csv_a)
+    if first != repeat:
+        pytest.skip(
+            "INCONCLUSIVE: the Clojure driver is not bit-repeatable on this "
+            "profile — two replays of one identical input disagree, so a "
+            "polarity pair here would measure nondeterminism, not polarity. "
+            "Characterize repeatability separately (P-023); this is never a "
+            "reason to weaken the invariant.")
+
+    other = replay("b1", csv_b)
+    assert len(other) == len(first) > 0
+    for i, (a, b) in enumerate(zip(first, other)):
+        assert a == b, f"clojure pair diverged at step {i}"

--- a/delphi/tests/replay_harness/test_polarity_property.py
+++ b/delphi/tests/replay_harness/test_polarity_property.py
@@ -402,6 +402,43 @@ def test_N_refuses_a_malformed_marker_at_the_comparison_boundary(malformed):
         pol.vote_axis_involution(view)
 
 
+#: Marker values whose fields are CONTAINERS. These hashed before they were
+#: typed, so each raised a raw ``TypeError: unhashable type`` out of the set
+#: membership test — an ungraded crash at a gate that promises a named failure
+#: (Astra review #2730 R2-F2).
+NESTED_MARKER_VALUES = [
+    ("profile", []), ("profile", {}), ("vote_axis", {}), ("vote_axis", set()),
+    ("transforms", [[]]), ("transforms", [{}]),
+]
+
+
+@pytest.mark.parametrize("field,value", NESTED_MARKER_VALUES)
+def test_a_container_valued_marker_field_is_a_graded_failure(field, value):
+    """Every malformed shape is a NAMED gate failure, never an exception: the
+    three boundaries must grade it, not crash through it."""
+    bad = op.marker()
+    bad[field] = value
+    blob = {op.OUTPUT_PROFILE_KEY: bad}
+
+    with pytest.raises(op.OutputProfileError, match=field):
+        Conversation.from_dict(blob)
+    with pytest.raises(cert.CertifyError, match=field) as raised:
+        cert.validate_checkpoint_blob(blob, "nested marker")
+    assert raised.value.stage == "checkpoint-schema"
+    with pytest.raises(pol.PolarityError, match=field):
+        pol.vote_axis_involution(dict(_projected(GEOMETRY_BLOB),
+                                      **{op.OUTPUT_PROFILE_KEY: bad}))
+    assert any(field in problem for problem in op.marker_problems(bad))
+
+
+@pytest.mark.parametrize("field", ["input_convention", "output_convention",
+                                   "pair_side"])
+@pytest.mark.parametrize("value", [[], {}, set(), 1, None])
+def test_a_container_valued_convention_is_a_graded_failure(field, value):
+    with pytest.raises(pol.PolarityError, match="is not one of"):
+        pol.ConventionDescriptor(**{field: value})
+
+
 def test_a_well_formed_marker_round_trips_through_the_validator():
     view = _projected(GEOMETRY_BLOB)
     assert op.marker_problems(view[op.OUTPUT_PROFILE_KEY]) == []

--- a/delphi/tests/test_certify_bundle.py
+++ b/delphi/tests/test_certify_bundle.py
@@ -1554,3 +1554,139 @@ def test_generated_case_metrics_use_latest_distinct_cells_not_revote_rows():
     assert metrics["P"] == 2 and metrics["C"] == 2
     assert metrics["matrix_area"] == 4
     assert metrics["density"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# P-023: manifest/3 — a DECLARED +-1 storage convention and the pair/transform
+# block. The old gate hard-pinned -1 (`REQUIRED_STORAGE_AGREE_VALUE`, checked
+# against a module constant rather than the bundle's own declaration), so the
+# flipped side of a compensated polarity pair was inadmissible by construction
+# and could be neither pushed nor pulled.
+# ---------------------------------------------------------------------------
+
+def _polarity_problems(manifest, config):
+    """Only the polarity/transform lines of the admission report. The shared
+    reference bundle carries an unrelated pre-existing defect, so these tests
+    assert on the predicates they are about rather than on overall success."""
+    try:
+        fb.admit_manifest(manifest, config=config,
+                          config_bytes=fc.DEFAULT_CONFIG_PATH.read_bytes())
+    except fb.AdmissionError as exc:
+        return [line.strip(" -") for line in str(exc).splitlines()
+                if "polarity" in line or "transform" in line]
+    return []
+
+
+def _as_derived(manifest, sign):
+    """A copy of the reference manifest re-declared as a DERIVED pair fixture:
+    the flipped convention and no production-source role."""
+    derived = copy.deepcopy(manifest)
+    derived["polarity"]["storage_agree_value"] = sign
+    for role in derived["roles"]:
+        role["source"] = "synthetic-replacement"
+    return derived
+
+
+def test_an_original_capture_declares_minus_one_and_no_transform(bundle, config):
+    _, manifest, _, _ = bundle
+    assert manifest["schema_version"] == "certify-fixture-manifest/3"
+    assert manifest["polarity"]["storage_agree_value"] == -1
+    assert manifest["transform"] is None
+    assert _polarity_problems(manifest, config) == []
+
+
+def test_a_derived_fixture_may_declare_the_flipped_convention(bundle, config):
+    """The whole point of the bump: +1 is admissible when it is DECLARED and
+    the bundle carries no production capture."""
+    _, manifest, _, _ = bundle
+    assert _polarity_problems(_as_derived(manifest, 1), config) == []
+
+
+def test_a_production_capture_may_not_declare_the_flipped_convention(bundle, config):
+    """The release policy, kept separate from the schema."""
+    _, manifest, _, _ = bundle
+    broken = copy.deepcopy(manifest)
+    broken["polarity"]["storage_agree_value"] = 1
+    problems = _polarity_problems(broken, config)
+    assert any("production" in p and "storage_agree_value" in p for p in problems), \
+        problems
+
+
+@pytest.mark.parametrize("bad", [True, False, 0, -1.0, "-1", None, 2])
+def test_a_convention_that_is_not_exactly_int_pm1_is_refused(bundle, config, bad):
+    _, manifest, _, _ = bundle
+    broken = copy.deepcopy(manifest)
+    broken["polarity"]["storage_agree_value"] = bad
+    problems = _polarity_problems(broken, config)
+    assert any("exactly the integer -1 or +1" in p for p in problems), problems
+
+
+def _transform(**overrides):
+    kwargs = dict(
+        source_bundle_id="pcb-test-0000",
+        source_root_digest="a" * 64,
+        source_manifest_sha256="b" * 64,
+        source_storage_agree_value=-1,
+        bijective_verified=True,
+        notes="P-023 compensated pair",
+    )
+    kwargs.update(overrides)
+    return fb.build_transform_block(**kwargs)
+
+
+def test_a_derived_manifest_binds_the_original_non_circularly(bundle, config):
+    _, manifest, _, _ = bundle
+    derived = _as_derived(manifest, 1)
+    derived["transform"] = _transform()
+    assert _polarity_problems(derived, config) == []
+    assert derived["transform"]["source"]["bundle_id"] != derived["bundle_id"]
+
+
+@pytest.mark.parametrize("mutate,needle", [
+    (lambda t, m: t.update(transform_id="hand-edited/9"), "transform_id"),
+    (lambda t, m: t.update(involution=False), "involution"),
+    (lambda t, m: t.update(bijective_verified=False), "bijective_verified"),
+    (lambda t, m: t.update(surprise="unreviewed"), "unknown transform field"),
+    (lambda t, m: t["source"].update(bundle_id=m["bundle_id"]), "non-circular"),
+    (lambda t, m: t["source"].update(storage_agree_value=1), "must be opposite"),
+    (lambda t, m: t["source"].update(root_digest="stale"), "sha256 hex digest"),
+    (lambda t, m: t["source"].pop("manifest_sha256"), "manifest_sha256 is missing"),
+    (lambda t, m: t["source"].update(extra="unreviewed"),
+     "unknown transform.source field"),
+])
+def test_a_malformed_pair_descriptor_is_refused(bundle, config, mutate, needle):
+    _, manifest, _, _ = bundle
+    derived = _as_derived(manifest, 1)
+    derived["transform"] = _transform()
+    mutate(derived["transform"], derived)
+    problems = _polarity_problems(derived, config)
+    assert any(needle in p for p in problems), problems
+
+
+def test_a_derived_fixture_may_not_also_claim_a_production_role(bundle, config):
+    _, manifest, _, _ = bundle
+    derived = copy.deepcopy(manifest)
+    derived["polarity"]["storage_agree_value"] = 1
+    derived["transform"] = _transform()
+    problems = _polarity_problems(derived, config)
+    assert any("never re-extracted from production" in p for p in problems), problems
+
+
+def test_build_manifest_refuses_an_undeclarable_convention(config, tmp_path):
+    payload, summaries = _generate(config, tmp_path)
+    with pytest.raises(Exception):
+        _manifest(config, payload, generated_summaries=summaries,
+                  storage_agree_value=True)
+    with pytest.raises(fb.BundleError, match="must be opposite"):
+        _manifest(config, payload, generated_summaries=summaries,
+                  storage_agree_value=1,
+                  transform=_transform(source_storage_agree_value=1))
+
+
+def test_build_manifest_writes_the_declared_convention(config, tmp_path):
+    payload, summaries = _generate(config, tmp_path)
+    flipped = _manifest(config, payload, generated_summaries=summaries,
+                        storage_agree_value=1, transform=_transform())
+    assert flipped["polarity"]["storage_agree_value"] == 1
+    assert flipped["polarity"]["export_agree_value"] == 1
+    assert flipped["transform"]["source"]["storage_agree_value"] == -1

--- a/delphi/tests/test_certify_bundle.py
+++ b/delphi/tests/test_certify_bundle.py
@@ -1834,3 +1834,114 @@ def test_a_v3_manifest_must_state_the_transform_field(admitted, config):
     with pytest.raises(fb.AdmissionError,
                        match="missing required manifest field: transform"):
         _admit(broken, config)
+
+
+# --- round 3: the origin's rules travel with the derivation -----------------
+# Astra review #2730 R2-F1. A derived role RETAINED a binding naming a
+# synthetic origin while skipping every rule that makes a synthetic role
+# admissible — offer, approval, generator, coverage — so a manifest could claim
+# an origin its own policy forbids and still verify, admit, push and pull.
+
+def _synthetic_offer_rule(config):
+    """The one config role whose rule offers a synthetic replacement."""
+    return next(r for r in config["roles"]
+                if r["on_missing"] == "fail_with_synthetic_replacement_offer")
+
+
+def _fail_rule(config):
+    """A required role whose rule offers NO synthetic replacement."""
+    return next(r for r in config["roles"] if r["on_missing"] == "fail")
+
+
+def _make_synthetic(manifest, rule, *, approved=True):
+    """Turn one role of an ORIGINAL manifest into a valid approved synthetic
+    replacement, exactly as an operator-approved substitution records it."""
+    entry = next(r for r in manifest["roles"] if r["slug"] == rule["slug"])
+    entry["source"] = "synthetic-replacement"
+    entry["synthetic_replacement"] = rule["synthetic_replacement"]
+    entry["coverage_limits"] = "synthetic: generated boundary case, no real ptpts"
+    entry["generator"] = {"case_id": rule["synthetic_replacement"]}
+    if approved:
+        entry["approval"] = "operator: --accept-synthetic (test)"
+    return entry
+
+
+def test_an_approved_synthetic_role_derives_and_still_admits(
+        admitted, config, tmp_path):
+    """The positive: a legitimately approved synthetic origin keeps its
+    approval and generator through the involution, and admits on both sides."""
+    payload, manifest = admitted
+    original = copy.deepcopy(manifest)
+    _make_synthetic(original, _synthetic_offer_rule(config))
+    _admit(original, config)
+
+    derived_payload = _flip_payload(payload, tmp_path / "derived-payload")
+    derived = _derived_manifest(original, derived_payload)
+    entry = next(r for r in derived["roles"]
+                 if r["slug"] == _synthetic_offer_rule(config)["slug"])
+    assert entry["source"] == fb.DERIVED_ROLE_SOURCE
+    assert entry["derived_from"]["source"] == "synthetic-replacement"
+    assert entry["approval"] and entry["generator"]["case_id"]
+
+    fb.verify(derived_payload, derived)
+    _admit(derived, config)
+
+
+@pytest.mark.parametrize("break_it,needle", [
+    (lambda e: e.pop("approval"), "carries no recorded operator approval"),
+    (lambda e: e.pop("generator"), "does not pin the generator"),
+    (lambda e: e.pop("coverage_limits"), "does not state its coverage limits"),
+    (lambda e: e.update(synthetic_replacement="gen-v1-something-else"),
+     "names generator case"),
+])
+def test_a_derived_synthetic_origin_must_satisfy_the_origin_rules(
+        admitted, config, tmp_path, break_it, needle):
+    payload, manifest = admitted
+    original = copy.deepcopy(manifest)
+    _make_synthetic(original, _synthetic_offer_rule(config))
+    _admit(original, config)
+
+    derived = _derived_manifest(
+        original, _flip_payload(payload, tmp_path / "derived-payload"))
+    entry = next(r for r in derived["roles"]
+                 if r["slug"] == _synthetic_offer_rule(config)["slug"])
+    break_it(entry)
+    with pytest.raises(fb.AdmissionError, match=needle):
+        _admit(derived, config)
+
+
+def test_a_derived_role_cannot_claim_an_origin_its_rule_forbids(
+        derived_pair, config):
+    """Astra's witness, failing closed. Relabelling only the BINDING to a
+    synthetic origin, on a role whose rule offers no replacement and with no
+    approval or generator anywhere, previously passed the whole
+    verify/admit/push/pull path."""
+    _, derived = derived_pair
+    slug = _fail_rule(config)["slug"]
+    broken = copy.deepcopy(derived)
+    entry = next(r for r in broken["roles"] if r["slug"] == slug)
+    entry["derived_from"]["source"] = "synthetic-replacement"
+    assert not entry.get("approval") and not entry.get("generator")
+    with pytest.raises(fb.AdmissionError, match="rule does not offer one"):
+        _admit(broken, config)
+
+
+@pytest.mark.parametrize("bad", [True, False, 1.0, -1.0, "1", None, 0])
+def test_the_compat_census_sign_is_a_strict_integer(derived_pair, config, bad):
+    """R2-F2: `True == 1` and `1.0 == 1`, so an equality test alone admitted a
+    bool and a float as a declared convention."""
+    _, derived = derived_pair
+    broken = copy.deepcopy(derived)
+    broken["roles"][0]["compat"]["storage_agree_value"] = bad
+    with pytest.raises(fb.AdmissionError,
+                       match="compat census storage_agree_value must be"):
+        _admit(broken, config)
+
+
+def test_the_transform_block_states_what_it_does_not_verify():
+    """The digests are declarations. Independent source-fetch and bijection
+    verification are DEFERRED and are not claimed by the round trip."""
+    doc = fb.build_derived_manifest.__doc__
+    assert "DEFERRED" in doc
+    assert "NOT that its stated source is real" in doc
+    assert "DECLARATIONS" in fb.build_transform_block.__doc__

--- a/delphi/tests/test_certify_bundle.py
+++ b/delphi/tests/test_certify_bundle.py
@@ -1557,136 +1557,280 @@ def test_generated_case_metrics_use_latest_distinct_cells_not_revote_rows():
 
 
 # ---------------------------------------------------------------------------
-# P-023: manifest/3 — a DECLARED +-1 storage convention and the pair/transform
-# block. The old gate hard-pinned -1 (`REQUIRED_STORAGE_AGREE_VALUE`, checked
-# against a module constant rather than the bundle's own declaration), so the
-# flipped side of a compensated polarity pair was inadmissible by construction
-# and could be neither pushed nor pulled.
+# P-023: manifest/3 — a DECLARED +-1 storage convention, the pair/transform
+# block, and the DERIVED role source that makes a flipped bundle admissible.
+#
+# Every test here runs the REAL admission gate end to end: no filtered problem
+# list (Astra review #2730 F1 — filtering hid the fact that no role source
+# existed under which a flipped bundle could be admitted at all), so an
+# unrelated admission error fails the test rather than being discarded.
+#
+# The shared `bundle` fixture pins the committed `schedules/` directory, which
+# contains an independently pre-existing zero-cut schedule that admission
+# rejects. These tests therefore pin the valid subset explicitly: the defect is
+# real and untouched, but it is not what they are about.
 # ---------------------------------------------------------------------------
 
-def _polarity_problems(manifest, config):
-    """Only the polarity/transform lines of the admission report. The shared
-    reference bundle carries an unrelated pre-existing defect, so these tests
-    assert on the predicates they are about rather than on overall success."""
-    try:
-        fb.admit_manifest(manifest, config=config,
-                          config_bytes=fc.DEFAULT_CONFIG_PATH.read_bytes())
-    except fb.AdmissionError as exc:
-        return [line.strip(" -") for line in str(exc).splitlines()
-                if "polarity" in line or "transform" in line]
-    return []
+import shutil
 
 
-def _as_derived(manifest, sign):
-    """A copy of the reference manifest re-declared as a DERIVED pair fixture:
-    the flipped convention and no production-source role."""
-    derived = copy.deepcopy(manifest)
-    derived["polarity"]["storage_agree_value"] = sign
-    for role in derived["roles"]:
-        role["source"] = "synthetic-replacement"
-    return derived
+def _valid_schedules():
+    return [s for s in fb.collect_schedule_hashes(fc.SCRIPTS_DIR / "schedules")
+            if s["n_cuts"] > 0]
 
 
-def test_an_original_capture_declares_minus_one_and_no_transform(bundle, config):
-    _, manifest, _, _ = bundle
+def _admit(manifest, config):
+    fb.admit_manifest(manifest, config=config,
+                      config_bytes=fc.DEFAULT_CONFIG_PATH.read_bytes())
+
+
+@pytest.fixture
+def admitted(config, tmp_path):
+    """A COMPLETELY admitted original manifest/3 bundle: -1, transform null."""
+    payload, summaries = _generate(config, tmp_path)
+    manifest = _manifest(config, payload, generated_summaries=summaries,
+                         schedules=_valid_schedules())
+    _admit(manifest, config)
+    return payload, manifest
+
+
+def _flip_payload(src: Path, dest: Path) -> Path:
+    """The derived side's payload: every non-null RAW vote leaf negated in the
+    authoritative event stream, written back through the extractor's own
+    serializer, and the compatibility CSVs regenerated under the flipped
+    declared convention. Identities, ordinals, timestamps and order are
+    untouched."""
+    shutil.copytree(src, dest)
+    for events_path in sorted(dest.rglob("events.jsonl")):
+        events = [json.loads(line) for line
+                  in events_path.read_text().splitlines() if line.strip()]
+        for event in events:
+            if event.get("kind") == "vote" and event.get("vote") is not None:
+                event["vote"] = -event["vote"]
+        fx.write_events_jsonl(events_path, events)
+        votes_rows, comments_rows, _ = fx.compat_rows_from_events(
+            events, storage_agree_value=1)
+        stem = events_path.parent.name
+        pc.write_votes_csv(events_path.parent / f"{stem}-votes.csv", votes_rows)
+        pc.write_comments_csv(
+            events_path.parent / f"{stem}-comments.csv", comments_rows)
+    return dest
+
+
+def test_an_original_capture_declares_minus_one_and_no_transform(admitted, config):
+    _, manifest = admitted
     assert manifest["schema_version"] == "certify-fixture-manifest/3"
     assert manifest["polarity"]["storage_agree_value"] == -1
     assert manifest["transform"] is None
-    assert _polarity_problems(manifest, config) == []
+    assert {r["source"] for r in manifest["roles"]} <= fb.ORIGINAL_ROLE_SOURCES
 
 
-def test_a_derived_fixture_may_declare_the_flipped_convention(bundle, config):
-    """The whole point of the bump: +1 is admissible when it is DECLARED and
-    the bundle carries no production capture."""
-    _, manifest, _, _ = bundle
-    assert _polarity_problems(_as_derived(manifest, 1), config) == []
+def test_the_flipped_side_of_a_pair_verifies_admits_pushes_and_pulls(
+        admitted, config, tmp_path):
+    """F1, end to end and unfiltered. The whole point of the schema bump: the
+    +1 side of the compensated pair must be publishable, and it was not — 15 of
+    the 17 required roles carry on_missing:fail, so they can be neither
+    substituted nor (under +1) production."""
+    payload, manifest = admitted
+    derived_payload = _flip_payload(payload, tmp_path / "derived-payload")
+
+    # The involution is visible in the RAW stream and invisible in the
+    # compatibility export: the export is semantic, so raw x s is unchanged.
+    # That is the pair's convergence, asserted on real bytes.
+    for original_csv in sorted(payload.rglob("*-votes.csv")):
+        mirror = derived_payload / original_csv.relative_to(payload)
+        assert mirror.read_bytes() == original_csv.read_bytes()
+    raw_changed = [p for p in sorted(payload.rglob("events.jsonl"))
+                   if (derived_payload / p.relative_to(payload)).read_bytes()
+                   != p.read_bytes()]
+    assert raw_changed, "the derived payload must actually differ in raw votes"
+
+    derived = fb.build_derived_manifest(
+        manifest, bundle_id="pcb-test-0001-flipped",
+        payload_root=derived_payload,
+        source_manifest_sha256=fb.sha256_bytes(fb.canonical_json(manifest)),
+        bijective_verified=True,
+        notes="P-023 compensated pair, flipped side")
+
+    assert derived["polarity"]["storage_agree_value"] == 1
+    assert all(r["source"] == fb.DERIVED_ROLE_SOURCE for r in derived["roles"])
+    assert all(r["derived_from"]["bundle_id"] == manifest["bundle_id"]
+               for r in derived["roles"])
+    assert derived["transform"]["source"]["root_digest"] == manifest["root_digest"]
+
+    fb.verify(derived_payload, derived)
+    _admit(derived, config)
+
+    store = fb.LocalStore(tmp_path / "store")
+    provenance = fb.build_provenance(
+        bundle_id=derived["bundle_id"], root_digest_value=derived["root_digest"],
+        selections=[{"role": "one", "slug": "pc-v1-one", "dir": "gen-v1-one-voter",
+                     "zid": 987654321}],
+        owner="test-owner")
+    pins = fb.push(store, bundle_id=derived["bundle_id"],
+                   payload_root=derived_payload, manifest=derived,
+                   provenance=provenance, config=config,
+                   config_bytes=fc.DEFAULT_CONFIG_PATH.read_bytes())
+    assert pins["root_digest"] == derived["root_digest"]
+
+    dest = tmp_path / "pulled"
+    result = fb.pull(store, bundle_id=derived["bundle_id"], dest=dest)
+    assert result["n_files"] == len(derived["files"])
+    assert fb.root_digest(fb.scan_files(dest / "payload")) == derived["root_digest"]
 
 
-def test_a_production_capture_may_not_declare_the_flipped_convention(bundle, config):
-    """The release policy, kept separate from the schema."""
-    _, manifest, _, _ = bundle
+def test_a_production_capture_may_not_declare_the_flipped_convention(
+        admitted, config):
+    _, manifest = admitted
     broken = copy.deepcopy(manifest)
     broken["polarity"]["storage_agree_value"] = 1
-    problems = _polarity_problems(broken, config)
-    assert any("production" in p and "storage_agree_value" in p for p in problems), \
-        problems
+    with pytest.raises(fb.AdmissionError, match="production storage is still -1"):
+        _admit(broken, config)
 
 
 @pytest.mark.parametrize("bad", [True, False, 0, -1.0, "-1", None, 2])
-def test_a_convention_that_is_not_exactly_int_pm1_is_refused(bundle, config, bad):
-    _, manifest, _, _ = bundle
+def test_a_convention_that_is_not_exactly_int_pm1_is_refused(admitted, config, bad):
+    _, manifest = admitted
     broken = copy.deepcopy(manifest)
     broken["polarity"]["storage_agree_value"] = bad
-    problems = _polarity_problems(broken, config)
-    assert any("exactly the integer -1 or +1" in p for p in problems), problems
+    with pytest.raises(fb.AdmissionError, match="exactly the integer -1 or \\+1"):
+        _admit(broken, config)
 
 
-def _transform(**overrides):
+def _derived_manifest(manifest, payload_root, **overrides):
     kwargs = dict(
-        source_bundle_id="pcb-test-0000",
-        source_root_digest="a" * 64,
-        source_manifest_sha256="b" * 64,
-        source_storage_agree_value=-1,
-        bijective_verified=True,
-        notes="P-023 compensated pair",
-    )
+        bundle_id="pcb-test-0001-flipped", payload_root=payload_root,
+        source_manifest_sha256=fb.sha256_bytes(fb.canonical_json(manifest)),
+        bijective_verified=True)
     kwargs.update(overrides)
-    return fb.build_transform_block(**kwargs)
+    return fb.build_derived_manifest(manifest, **kwargs)
 
 
-def test_a_derived_manifest_binds_the_original_non_circularly(bundle, config):
-    _, manifest, _, _ = bundle
-    derived = _as_derived(manifest, 1)
-    derived["transform"] = _transform()
-    assert _polarity_problems(derived, config) == []
-    assert derived["transform"]["source"]["bundle_id"] != derived["bundle_id"]
+@pytest.fixture
+def derived_pair(admitted, tmp_path):
+    payload, manifest = admitted
+    derived_payload = _flip_payload(payload, tmp_path / "derived-payload")
+    return manifest, _derived_manifest(manifest, derived_payload)
 
 
 @pytest.mark.parametrize("mutate,needle", [
-    (lambda t, m: t.update(transform_id="hand-edited/9"), "transform_id"),
-    (lambda t, m: t.update(involution=False), "involution"),
-    (lambda t, m: t.update(bijective_verified=False), "bijective_verified"),
-    (lambda t, m: t.update(surprise="unreviewed"), "unknown transform field"),
-    (lambda t, m: t["source"].update(bundle_id=m["bundle_id"]), "non-circular"),
-    (lambda t, m: t["source"].update(storage_agree_value=1), "must be opposite"),
-    (lambda t, m: t["source"].update(root_digest="stale"), "sha256 hex digest"),
-    (lambda t, m: t["source"].pop("manifest_sha256"), "manifest_sha256 is missing"),
-    (lambda t, m: t["source"].update(extra="unreviewed"),
+    (lambda m: m["transform"].update(schema_version="unreviewed-transform/999"),
+     "transform.schema_version"),
+    (lambda m: m["transform"].update(transform_id="hand-edited/9"), "transform_id"),
+    (lambda m: m["transform"].update(involution=False), "involution"),
+    (lambda m: m["transform"].update(bijective_verified=False), "bijective_verified"),
+    (lambda m: m["transform"].update(surprise="unreviewed"), "unknown transform field"),
+    (lambda m: m["transform"]["source"].update(bundle_id=m["bundle_id"]),
+     "non-circular"),
+    (lambda m: m["transform"]["source"].update(storage_agree_value=1),
+     "must be opposite"),
+    (lambda m: m["transform"]["source"].update(root_digest="stale"),
+     "sha256 hex digest"),
+    (lambda m: m["transform"]["source"].pop("manifest_sha256"),
+     "manifest_sha256 is missing"),
+    (lambda m: m["transform"]["source"].update(extra="unreviewed"),
      "unknown transform.source field"),
+    (lambda m: m.update(transform=None), "declares no transform block"),
+    (lambda m: [r.pop("derived_from") for r in m["roles"]],
+     "no derived_from binding"),
+    (lambda m: [r["derived_from"].update(source="derived") for r in m["roles"]],
+     "RETAIN the original"),
+    (lambda m: [r["derived_from"].update(bundle_id="some-other-bundle")
+                for r in m["roles"]], "derived from two different bundles"),
+    (lambda m: [r["derived_from"].update(slug="pc-v1-elsewhere") for r in m["roles"]],
+     "never which conversation filled a role"),
+    (lambda m: [r["derived_from"].update(surprise=1) for r in m["roles"]],
+     "unknown field"),
+    (lambda m: [r.update(source="production") for r in m["roles"]],
+     "never re-extracted from production"),
+    (lambda m: [r["compat"].update(storage_agree_value=-1) for r in m["roles"]
+                if isinstance(r.get("compat"), dict)],
+     "counted under storage agree"),
 ])
-def test_a_malformed_pair_descriptor_is_refused(bundle, config, mutate, needle):
-    _, manifest, _, _ = bundle
-    derived = _as_derived(manifest, 1)
-    derived["transform"] = _transform()
-    mutate(derived["transform"], derived)
-    problems = _polarity_problems(derived, config)
-    assert any(needle in p for p in problems), problems
+def test_a_malformed_derived_manifest_is_refused(derived_pair, config, mutate, needle):
+    _, derived = derived_pair
+    broken = copy.deepcopy(derived)
+    mutate(broken)
+    with pytest.raises(fb.AdmissionError, match=needle):
+        _admit(broken, config)
 
 
-def test_a_derived_fixture_may_not_also_claim_a_production_role(bundle, config):
-    _, manifest, _, _ = bundle
-    derived = copy.deepcopy(manifest)
-    derived["polarity"]["storage_agree_value"] = 1
-    derived["transform"] = _transform()
-    problems = _polarity_problems(derived, config)
-    assert any("never re-extracted from production" in p for p in problems), problems
+def test_a_derived_role_needs_its_transform_block(admitted, config, tmp_path):
+    payload, manifest = admitted
+    broken = copy.deepcopy(manifest)
+    broken["roles"] = [fb.derived_role(r, source_bundle_id="pcb-test-0000")
+                       for r in broken["roles"]]
+    with pytest.raises(fb.AdmissionError, match="declares no transform block"):
+        _admit(broken, config)
 
 
-def test_build_manifest_refuses_an_undeclarable_convention(config, tmp_path):
-    payload, summaries = _generate(config, tmp_path)
-    with pytest.raises(Exception):
-        _manifest(config, payload, generated_summaries=summaries,
-                  storage_agree_value=True)
-    with pytest.raises(fb.BundleError, match="must be opposite"):
-        _manifest(config, payload, generated_summaries=summaries,
-                  storage_agree_value=1,
-                  transform=_transform(source_storage_agree_value=1))
+def test_a_transform_block_needs_derived_roles(derived_pair, config):
+    _, derived = derived_pair
+    broken = copy.deepcopy(derived)
+    for role, original in zip(broken["roles"], derived["roles"]):
+        role["source"] = original["derived_from"]["source"]
+        role.pop("derived_from")
+    with pytest.raises(fb.AdmissionError, match="no role declares source"):
+        _admit(broken, config)
 
 
-def test_build_manifest_writes_the_declared_convention(config, tmp_path):
-    payload, summaries = _generate(config, tmp_path)
-    flipped = _manifest(config, payload, generated_summaries=summaries,
-                        storage_agree_value=1, transform=_transform())
-    assert flipped["polarity"]["storage_agree_value"] == 1
-    assert flipped["polarity"]["export_agree_value"] == 1
-    assert flipped["transform"]["source"]["storage_agree_value"] == -1
+def test_a_pair_is_two_sides_not_a_chain(derived_pair, tmp_path):
+    _, derived = derived_pair
+    with pytest.raises(fb.BundleError, match="not a chain"):
+        fb.build_derived_manifest(
+            derived, bundle_id="pcb-test-0001-flipped-again",
+            payload_root=tmp_path / "derived-payload",
+            source_manifest_sha256="c" * 64, bijective_verified=True)
+
+
+def test_bijective_verified_is_never_coerced():
+    """F3: bool("false") is True, so coercion turned an unverified declaration
+    into a verified one."""
+    with pytest.raises(fb.BundleError, match="never coerced"):
+        fb.build_transform_block(
+            source_bundle_id="pcb-test-0000", source_root_digest="a" * 64,
+            source_manifest_sha256="b" * 64, source_storage_agree_value=-1,
+            bijective_verified="false")
+
+
+# --- manifest/2 stays admissible on its original bytes ----------------------
+
+def _as_legacy_v2(manifest):
+    """Exactly what the parent implementation wrote: no transform key, and the
+    /2 schema version."""
+    legacy = copy.deepcopy(manifest)
+    legacy.pop("transform")
+    legacy["schema_version"] = fb.LEGACY_MANIFEST_SCHEMA_VERSION
+    return legacy
+
+
+def test_an_existing_manifest_v2_still_verifies_and_admits_unchanged(
+        admitted, config):
+    """Astra #2730: a /2 manifest that verified and admitted under the parent
+    implementation must not be invalidated by this bump. Its absent transform
+    field IS the 'original capture' declaration, and its bytes are untouched."""
+    payload, manifest = admitted
+    legacy = _as_legacy_v2(manifest)
+    before = fb.canonical_json(legacy)
+
+    fb.verify(payload, legacy)
+    _admit(legacy, config)
+    assert fb.canonical_json(legacy) == before
+
+
+def test_a_v2_manifest_may_not_carry_a_v3_field(admitted, config, tmp_path):
+    payload, manifest = admitted
+    legacy = _as_legacy_v2(manifest)
+    legacy["transform"] = _derived_manifest(
+        manifest, payload)["transform"]
+    with pytest.raises(fb.AdmissionError, match="unknown manifest field"):
+        _admit(legacy, config)
+
+
+def test_a_v3_manifest_must_state_the_transform_field(admitted, config):
+    _, manifest = admitted
+    broken = copy.deepcopy(manifest)
+    broken.pop("transform")
+    with pytest.raises(fb.AdmissionError,
+                       match="missing required manifest field: transform"):
+        _admit(broken, config)


### PR DESCRIPTION
First slice of P-023. Votes are stored with agree = −1 today; Colin wants a future DB flip to be a boring, provable no-op. This slice makes the property checkable without changing storage, the engine's outputs, the schema, or any client.

1. `STORAGE_AGREE_VALUE` in `delphi/polismath/utils/vote_convention.py`, threaded through all nine engine-ingest sites that hard-coded agree (general, postgres, run_math_pipeline, prodclone, fixture_extract, poller_equiv, fixture_bundle). Server and clients untouched; two import-free standalone converters left alone by design.
2. A standing polarity property in the certification gate (`replay/polarity.py`): the compensated pair (data under the declared convention vs the flipped one) is run through both real ingress paths from fresh state, including a real restart seam; the negation set is applied post-projection exactly as the accepted plan defines it; mandatory negative controls (a missing or doubled negation fails). An output-profile marker is enforced at both restore boundaries so a projected view can never be restored as a blob (without it, the unmarked view silently restores zero groups).
3. Fixture manifest schema `/3`: `storage_agree_value` admitted for ±1 (replacing the hard pin), a closed `transform` block for pair provenance, defaults unchanged so every existing bundle admits as before.

Tests: new `test_polarity_property.py` 57 passed / 2 skipped (same with the Clojure integration flag); replay harness 568 / 6 unchanged; 25 manifest/3 admission tests; the delphi suite's remaining failures are the pre-existing edge set. One honest limit: the Clojure pair is INCONCLUSIVE rather than PASS, because two Clojure replays of one identical input disagree on warm ticks (the known non-determinism), so that test skips with the reason.

Reviewed design: P-023 rev3 (Astra), accepted after two Opus rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s