### PR TITLE
fix(server): make globalErrorHandler reachable, behind a default-off flag (P-038)

### DIFF
--- a/server/__tests__/unit/global-error-handler.test.ts
+++ b/server/__tests__/unit/global-error-handler.test.ts
@@ -59,7 +59,12 @@ function loadExpress(nodeEnv: string) {
  * ("after-router", the mounting `POLIS_REACHABLE_ERROR_HANDLER` adds).
  *
  * `/param-400` reproduces `src/utils/parameter.ts:146-149`, which sets the
- * status and hands a bare *string* to `next` without ever writing a body.
+ * status and hands a bare *string* to `next` without ever writing a body. That
+ * string carries no `.name`, `.stack`, `.message`, `.code` or `.constraint`, so
+ * enabling the flag recovers the `polis_err_*` identity neither in the response
+ * body nor in `globalErrorHandler`'s own structured log record — every field it
+ * logs about the error is `undefined`. Any `polis_err_*` text in the logs comes
+ * from `parameter.ts`'s separate `logger.error(s)`, not from this handler.
  */
 function buildApp(express: any, mounting: Mounting, handler: any) {
   const app = express();

--- a/server/__tests__/unit/global-error-handler.test.ts
+++ b/server/__tests__/unit/global-error-handler.test.ts
@@ -1,0 +1,230 @@
+/**
+ * P-038 — `globalErrorHandler` reachability under Express 3.
+ *
+ * `app.ts` mounts `globalErrorHandler` during module evaluation, while every
+ * route is registered later inside the async `helpersInitialized` callback.
+ * Express 3 appends `app.router` to the app stack at the first route
+ * registration (`express/lib/application.js:464`,
+ * `if (!this._usedRouter) this.use(this.router)`), and `next(err)` walks the
+ * stack forward only — so an error middleware mounted before the router can
+ * never see a route's error. The error falls through to connect's
+ * `finalhandler`, which in production serves `http.STATUS_CODES[status]`
+ * (`finalhandler@0.4.0 index.js:83-86`).
+ *
+ * These tests pin both halves of that: the current (unreachable) mounting, and
+ * what the `POLIS_REACHABLE_ERROR_HANDLER` mounting would serve instead. The
+ * two are NOT byte-equivalent, which is why the flag defaults to off.
+ */
+import { describe, test, expect, jest } from "@jest/globals";
+import http from "node:http";
+import Config from "../../src/config";
+import { globalErrorHandler } from "../../src/server-middleware";
+
+type Mounting = "before-router" | "after-router";
+
+interface Served {
+  handlerCalls: number;
+  status: number;
+  contentType: string | undefined;
+  contentTypeOptions: string | undefined;
+  body: string;
+  byteLength: number;
+}
+
+/**
+ * connect reads its environment once, at module load
+ * (`connect/lib/proto.js:23`, `var env = process.env.NODE_ENV || 'development'`),
+ * and hands it to `finalhandler`. `app.set('env', ...)` does not reach it. So
+ * to exercise the production branch we must load a fresh copy of express with
+ * NODE_ENV already set.
+ */
+function loadExpress(nodeEnv: string) {
+  const previous = process.env.NODE_ENV;
+  process.env.NODE_ENV = nodeEnv;
+  let express: any;
+  try {
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      express = require("express");
+    });
+  } finally {
+    process.env.NODE_ENV = previous;
+  }
+  return express;
+}
+
+/**
+ * Mirrors the shape of `app.ts`: an error middleware mounted before any route
+ * ("before-router", today's production mounting) or after every route
+ * ("after-router", the mounting `POLIS_REACHABLE_ERROR_HANDLER` adds).
+ *
+ * `/param-400` reproduces `src/utils/parameter.ts:146-149`, which sets the
+ * status and hands a bare *string* to `next` without ever writing a body.
+ */
+function buildApp(express: any, mounting: Mounting, handler: any) {
+  const app = express();
+  if (mounting === "before-router") {
+    app.use(handler);
+  }
+  app.get("/param-400", (_req: any, res: any, next: any) => {
+    res.status(400);
+    next("polis_err_param_missing_conversation_id");
+  });
+  app.get("/throw-500", (_req: any, _res: any, next: any) => {
+    next(new Error("boom"));
+  });
+  if (mounting === "after-router") {
+    app.use(handler);
+  }
+  return app;
+}
+
+function serve(app: any, path: string, calls: { n: number }): Promise<Served> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      http
+        .get({ port, path }, (res) => {
+          let body = "";
+          res.setEncoding("utf8");
+          res.on("data", (chunk) => (body += chunk));
+          res.on("end", () => {
+            server.close();
+            resolve({
+              handlerCalls: calls.n,
+              status: res.statusCode as number,
+              contentType: res.headers["content-type"],
+              contentTypeOptions: res.headers["x-content-type-options"],
+              body,
+              byteLength: Buffer.byteLength(body, "utf8"),
+            });
+          });
+        })
+        .on("error", (err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+async function request(
+  mounting: Mounting,
+  path: string,
+  nodeEnv = "production"
+): Promise<Served> {
+  const express = loadExpress(nodeEnv);
+  const calls = { n: 0 };
+  const spy = (err: any, req: any, res: any, next: any) => {
+    calls.n += 1;
+    return globalErrorHandler(err, req, res, next);
+  };
+  return serve(buildApp(express, mounting, spy), path, calls);
+}
+
+describe("P-038 globalErrorHandler reachability", () => {
+  describe("the mechanism: mounted before the router, it never runs", () => {
+    test("a route's next(string) does not reach it; finalhandler answers", async () => {
+      const served = await request("before-router", "/param-400");
+
+      expect(served.handlerCalls).toBe(0);
+      // finalhandler's production branch, verbatim.
+      expect(served.status).toBe(400);
+      expect(served.body).toBe("Bad Request\n");
+      expect(served.contentType).toBe("text/html; charset=utf-8");
+      expect(served.contentTypeOptions).toBe("nosniff");
+      expect(served.byteLength).toBe(12);
+    });
+
+    test("a route's next(new Error()) does not reach it either", async () => {
+      const served = await request("before-router", "/throw-500");
+
+      expect(served.handlerCalls).toBe(0);
+      expect(served.status).toBe(500);
+      expect(served.body).toBe("Internal Server Error\n");
+      expect(served.contentType).toBe("text/html; charset=utf-8");
+      expect(served.contentTypeOptions).toBe("nosniff");
+      expect(served.byteLength).toBe(22);
+    });
+
+    test("outside production finalhandler leaks the error instead", async () => {
+      const served = await request(
+        "before-router",
+        "/param-400",
+        "development"
+      );
+
+      expect(served.handlerCalls).toBe(0);
+      expect(served.status).toBe(400);
+      // This development-only body is what the characterization harness saw
+      // before it switched to a production profile.
+      expect(served.body).toBe("polis_err_param_missing_conversation_id\n");
+    });
+  });
+
+  describe("mounted after the router it runs — and changes served bytes", () => {
+    test("the 400 parameter failure becomes a 500 JSON envelope", async () => {
+      const served = await request("after-router", "/param-400");
+
+      expect(served.handlerCalls).toBe(1);
+      expect(served.status).toBe(500);
+      expect(served.contentType).toBe("application/json; charset=utf-8");
+      expect(served.contentTypeOptions).toBeUndefined();
+      expect(JSON.parse(served.body).error).toBe("internal_server_error");
+    });
+
+    test("the 500 error becomes the same JSON envelope", async () => {
+      const served = await request("after-router", "/throw-500");
+
+      expect(served.handlerCalls).toBe(1);
+      expect(served.status).toBe(500);
+      expect(served.contentType).toBe("application/json; charset=utf-8");
+      expect(JSON.parse(served.body).error).toBe("internal_server_error");
+    });
+  });
+
+  describe("served-bytes difference, measured", () => {
+    test.each([
+      ["/param-400", 400],
+      ["/throw-500", 500],
+    ])(
+      "%s: status, Content-Type and body all differ between the two mountings",
+      async (path, currentStatus) => {
+        const current = await request("before-router", path as string);
+        const reachable = await request("after-router", path as string);
+
+        expect(current.status).toBe(currentStatus);
+        expect(reachable.status).toBe(500);
+        expect(reachable.contentType).not.toBe(current.contentType);
+        expect(reachable.body).not.toBe(current.body);
+        expect(reachable.byteLength).toBeGreaterThan(current.byteLength);
+      }
+    );
+  });
+
+  test("the flag is off by default, so production behaviour is unchanged", () => {
+    expect(process.env.POLIS_REACHABLE_ERROR_HANDLER).toBeUndefined();
+    expect(Config.reachableErrorHandler).toBe(false);
+  });
+
+  test("the flag is read from POLIS_REACHABLE_ERROR_HANDLER", () => {
+    const previous = process.env.POLIS_REACHABLE_ERROR_HANDLER;
+    process.env.POLIS_REACHABLE_ERROR_HANDLER = "true";
+    let reloaded: any;
+    try {
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        reloaded = require("../../src/config").default;
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.POLIS_REACHABLE_ERROR_HANDLER;
+      } else {
+        process.env.POLIS_REACHABLE_ERROR_HANDLER = previous;
+      }
+    }
+    expect(reloaded.reachableErrorHandler).toBe(true);
+  });
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -2223,7 +2223,10 @@ helpersInitialized.then(
     //
     // Mounting it here is NOT behaviour-preserving: finalhandler currently
     // serves `400 text/html "Bad Request\n"` where `globalErrorHandler` would
-    // serve `500 application/json {"error":"internal_server_error",...}`. It is
+    // serve `500 application/json {"error":"internal_server_error",...}`. Note
+    // that the generic branch's status stays 500 either way — what the flag
+    // changes on an already-500 path is the Content-Type and body, and only the
+    // 400 paths (and the typed 23505/JWT/timeout branches) change status. It is
     // therefore off by default and gated so the change can be recorded and
     // approved before it ships. See
     // cost-reduction/04-plans/P-038-global-error-handler-notes.md.

--- a/server/app.ts
+++ b/server/app.ts
@@ -2212,6 +2212,25 @@ helpersInitialized.then(
       app.get(/^\/[^(api\/)]?.*/, proxy);
     }
 
+    // P-038. This is the only position from which `globalErrorHandler` can see
+    // errors that a route hands to `next(err)`: Express 3 inserts `app.router`
+    // into the app stack at the first route registration (express
+    // `lib/application.js:464`) and `next(err)` walks the stack forward from
+    // there, so any error middleware mounted earlier — including the
+    // module-level `app.use(globalErrorHandler)` below and
+    // `middleware_log_middleware_errors` above — is never reached and the error
+    // falls through to connect's finalhandler.
+    //
+    // Mounting it here is NOT behaviour-preserving: finalhandler currently
+    // serves `400 text/html "Bad Request\n"` where `globalErrorHandler` would
+    // serve `500 application/json {"error":"internal_server_error",...}`. It is
+    // therefore off by default and gated so the change can be recorded and
+    // approved before it ships. See
+    // cost-reduction/04-plans/P-038-global-error-handler-notes.md.
+    if (Config.reachableErrorHandler) {
+      app.use(globalErrorHandler);
+    }
+
     // move app.listen to index.ts
   },
 
@@ -2220,7 +2239,15 @@ helpersInitialized.then(
   }
 );
 
-// Setup global error handling
+// Setup global error handling.
+//
+// P-038: this mount runs during module evaluation, i.e. before the async
+// `helpersInitialized` callback above registers any route, so it sits ahead of
+// `app.router` in the app stack and is unreachable for route errors. It is kept
+// because it is the current production behaviour and it still covers errors
+// raised by the two middlewares registered above it (morgan /
+// `middleware_http_json_logger`). The reachable mount is inside the callback,
+// behind `POLIS_REACHABLE_ERROR_HANDLER`.
 app.use(globalErrorHandler);
 
 // Initialize global process-level error handlers

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -13,6 +13,17 @@ const serverPort: number = parseInt(
 const shouldUseTranslationAPI: boolean = isTrue(
   process.env.SHOULD_USE_TRANSLATION_API
 );
+// P-038. When true, `globalErrorHandler` is additionally mounted AFTER the
+// router, which is the only position from which it can see errors handed to
+// `next(err)` by a route (Express 3 walks the app stack forward only).
+// Default OFF: turning it on changes served bytes on every error that reaches
+// finalhandler today (status, Content-Type and body all change) — see
+// cost-reduction/04-plans/P-038-global-error-handler-notes.md. The flag exists
+// so the characterization harness can re-record the difference before anyone
+// decides to adopt it.
+const reachableErrorHandler: boolean = isTrue(
+  process.env.POLIS_REACHABLE_ERROR_HANDLER
+);
 
 import("source-map-support").then((sourceMapSupport) => {
   sourceMapSupport.install();
@@ -21,6 +32,7 @@ import("source-map-support").then((sourceMapSupport) => {
 export default {
   domainOverride,
   isDevMode: devMode,
+  reachableErrorHandler,
   serverPort,
 
   getServerNameWithProtocol: (req: any): string => {


### PR DESCRIPTION
Found by the API characterization harness review: `globalErrorHandler` in `server/app.ts` is mounted at module scope, but Express 3 appends the router at the first route registration, and routes are registered inside the async `helpersInitialized.then(...)` callback. So the error handler sits before the router and `next(err)` (forward-only) never reaches it; the same applies to the error-logging middleware and even body-parser errors. A spy records zero calls; `finalhandler` answers instead.

Making it reachable is not behaviour-preserving, measured over a socket at `NODE_ENV=production`: `res.status(400); next("polis_err_…")` serves `400 text/html "Bad Request\n"` today versus `500 application/json {"error":"internal_server_error",…}` with different headers if the handler is reachable. That would change status, content type, two headers and body on all 307 recorded cases. So the reachable mounting ships behind `POLIS_REACHABLE_ERROR_HANDLER` (default off); with the flag unset the served bytes are unchanged, proven by tests over both mountings, a 400 and a 500 path, and the dev-vs-prod finalhandler branch (9 unit tests).

Before anyone enables the flag, two defects in the handler itself need fixing (documented in the private notes): it logs a 400 and then serves a 500, and the `polis_err_*` identity still never reaches the body. Enabling is therefore a follow-up with a re-recorded harness baseline and Colin's approval of the served-bytes change.

Suite: 323 passing on the branch vs 314 on `edge` (+9 new), with the identical 36 pre-existing failures in the same 14 suites (OIDC and emulated SES on this host). tsc, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s