### PR TITLE
test(e2e): wait on the real precondition in the visualization spec (P-039)

### DIFF
--- a/e2e/cypress/e2e/client-participation/visualization.cy.js
+++ b/e2e/cypress/e2e/client-participation/visualization.cy.js
@@ -1,14 +1,71 @@
 /**
  * Visualization tests
- * Verifies that the PCA visualization appears after sufficient participants vote
- * Note: This test is flaky because it depends on an external math service.
- * It might fail intermittently even when the code is working correctly.
+ * Verifies that the PCA visualization appears after sufficient participants vote.
+ *
+ * The client only un-hides #vis_section once a math (PCA) result served by
+ * /api/v3/math/pca2 reports at least MIN_PTPTS participants -- see
+ * onPersonUpdate() in client-participation/js/views/participation.js, which
+ * derives its count from sum(pca['base-clusters'].count), not from the
+ * conversation's participant_count. The conversation's participant_count is
+ * updated the moment people vote, but the Clojure math service publishes on
+ * its own poll cycle and the API server caches/prefetches those results, so
+ * "everyone has voted" is NOT the same precondition as "the visualization can
+ * be drawn". This spec therefore polls the math endpoint for the real
+ * precondition before loading the page under test; otherwise a slow math cycle
+ * shows up as a bogus "#vis_section should be visible" timeout.
  */
 
 describe('Visualization', function () {
   let conversationId
   const participationView = '[data-view-name="participationView"]'
   const timeout = { timeout: 30000 }
+
+  // Keep in sync with MIN_PTPTS in client-participation/js/views/participation.js
+  const MIN_PTPTS = 7
+  // Bounded but generous: the math service polls votes on an interval and the
+  // API server prefetches/caches its output, so give it real room under CI load.
+  const MATH_POLL_INTERVAL_MS = 2000
+  const MATH_POLL_MAX_ATTEMPTS = 60
+
+  // Counts exactly what onPersonUpdate() counts.
+  const mathParticipantCount = (body) => {
+    const counts = (body && body['base-clusters'] && body['base-clusters'].count) || []
+    return counts.reduce((total, n) => total + n, 0)
+  }
+
+  const mathGroupCount = (body) => ((body && body['group-clusters']) || []).length
+
+  // Poll the served math blob until it carries the participant and group counts
+  // the client needs in order to render the visualization.
+  const waitForMathResult = (attempt) => {
+    return cy
+      .request({
+        method: 'GET',
+        url: `/api/v3/math/pca2?conversation_id=${conversationId}&cacheBust=${attempt}`,
+        failOnStatusCode: false,
+      })
+      .then((mathResponse) => {
+        const participants = mathParticipantCount(mathResponse.body)
+        const groups = mathGroupCount(mathResponse.body)
+
+        if (participants >= MIN_PTPTS && groups > 0) {
+          cy.log(`📊 Math ready: ${participants} participants in ${groups} groups`)
+          return cy.wrap(participants)
+        }
+
+        if (attempt >= MATH_POLL_MAX_ATTEMPTS) {
+          throw new Error(
+            `Math service never published a PCA result with ${MIN_PTPTS}+ participants ` +
+              `and at least one group for conversation ${conversationId}. ` +
+              `Last seen: ${participants} participants, ${groups} groups after ` +
+              `${MATH_POLL_MAX_ATTEMPTS} attempts (~${(MATH_POLL_MAX_ATTEMPTS * MATH_POLL_INTERVAL_MS) / 1000}s).`,
+          )
+        }
+
+        cy.wait(MATH_POLL_INTERVAL_MS)
+        return waitForMathResult(attempt + 1)
+      })
+  }
 
   it('creates conversation and shows visualization with 7 participants', function () {
     cy.log('🚀 Setting up visualization test with clean auth')
@@ -238,6 +295,12 @@ describe('Visualization', function () {
           cy.log(`📊 Final participant count: ${count}`)
           expect(count).to.be.at.least(7, 'Should have at least 7 participants')
         })
+
+        // Step 3b: Wait for the actual precondition the client gates on -- a
+        // published math result carrying MIN_PTPTS participants and >=1 group.
+        // Without this the assertions below race the math service's poll cycle.
+        cy.log('⏳ Waiting for math to publish a result the visualization can use')
+        waitForMathResult(1)
 
         // Step 4: Check visualization
         cy.log('🔍 Checking visualization')


### PR DESCRIPTION
The cypress spec `client-participation/visualization.cy.js` failed on three unrelated PRs tonight (CDK- and delphi-only changes) with `expected '<div#vis_section.displayNone>' to be 'visible'` after all three CI attempts, and passed on re-run.

Root cause: the spec waited on `participant_count` from `/api/v3/conversations`, but the client only removes `displayNone` when the `pca2` blob's base clusters count at least seven participants (`participation.js:544`). Between the Clojure poller and recompute, the server's prefetch/cache window and the browser's PCA poll, that chain can exceed the 30 s assertion timeout on a loaded runner. Reproduced deterministically by raising the math service's polling interval.

Fix, spec only: a bounded poll of `pca2` for the real precondition (at least seven participants counted exactly as the client counts them, plus one group cluster) before `cy.visit`; on exhaustion it fails naming the math service. Assertions and their timeout are unchanged. No new env knob.

Runs in an isolated stack: original spec 0/1 under a 45 s math lag; fixed spec 9/9 normal, 2/2 under lag, 2/2 with two concurrent workers. eslint and prettier clean.

Secondary finding, documented in the private notes and not fixed here: the Clojure poller's `where created > watermark` with the watermark advanced to the batch maximum permanently drops a vote committed after the query snapshot with an equal-or-lower `created`; observed under concurrency as a conversation with 24 votes in Postgres while math stayed at three forever. That is a math-service change (overlap window, or `>=` plus dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s