### PR TITLE
alpha: read math_tick (not mathTick) so the pca2 poll guard fires; declare all 17 pca2 fields; astro check

### DIFF
--- a/.github/workflows/client-participation-alpha-ci.yml
+++ b/.github/workflows/client-participation-alpha-ci.yml
@@ -48,6 +48,17 @@ jobs:
         run: npm run build
         working-directory: client-participation-alpha
 
+      # tsconfig.json extends astro/tsconfigs/strict, but `astro build` only
+      # transpiles — nothing has ever enforced that strictness. `astro check`
+      # does. It currently reports 34 pre-existing errors (28 of them one
+      # missing @testing-library/jest-dom type augmentation), so this step
+      # reports rather than blocks; flip continue-on-error off once they are
+      # triaged. See cost-reduction/04-plans/P-046-alpha-pca-type-notes.md.
+      - name: Typecheck (reporting only until pre-existing errors are triaged)
+        run: npm run typecheck
+        working-directory: client-participation-alpha
+        continue-on-error: true
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/client-participation-alpha-ci.yml
+++ b/.github/workflows/client-participation-alpha-ci.yml
@@ -53,7 +53,10 @@ jobs:
       # does. It currently reports 34 pre-existing errors (28 of them one
       # missing @testing-library/jest-dom type augmentation), so this step
       # reports rather than blocks; flip continue-on-error off once they are
-      # triaged. See cost-reduction/04-plans/P-046-alpha-pca-type-notes.md.
+      # triaged. Note the asymmetry: CI stays green on those 34, but local
+      # `npm run verify` runs the same command without this escape hatch and
+      # therefore exits nonzero until they are cleared.
+      # See cost-reduction/04-plans/P-046-alpha-pca-type-notes.md.
       - name: Typecheck (reporting only until pre-existing errors are triaged)
         run: npm run typecheck
         working-directory: client-participation-alpha

--- a/client-participation-alpha/.astro/types.d.ts
+++ b/client-participation-alpha/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/client-participation-alpha/package-lock.json
+++ b/client-participation-alpha/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "^19.2.1"
       },
       "devDependencies": {
+        "@astrojs/check": "^0.9.10",
         "@eslint/js": "^9.39.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -84,10 +85,89 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@astrojs/check": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.10.tgz",
+      "integrity": "sha512-zgx/UQMozdjOa3bOxjgeCFdtpE3c9rRX6xHwa+2QXvy8z8Akifu2AtubHyv/zzC2znO8dl8fFWL4K+Ba9kS8HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/language-server": "^2.16.7",
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "astro-check": "bin/astro-check.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/yargs/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@astrojs/compiler": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.0.tgz",
-      "integrity": "sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
@@ -95,6 +175,48 @@
       "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.5.tgz",
       "integrity": "sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==",
       "license": "MIT"
+    },
+    "node_modules/@astrojs/language-server": {
+      "version": "2.16.16",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.16.tgz",
+      "integrity": "sha512-KuS17AOOqH/M5mHXPmKvtp8L+NNteARC7Xjf395+9R9dtJOBndqdStwU4V+OKzYZpgZ+hliV13knzx/oMtFl7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.13.1",
+        "@astrojs/yaml2ts": "^0.2.4",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@volar/kit": "~2.4.28",
+        "@volar/language-core": "~2.4.28",
+        "@volar/language-server": "~2.4.28",
+        "@volar/language-service": "~2.4.28",
+        "muggle-string": "^0.4.1",
+        "tinyglobby": "^0.2.16",
+        "volar-service-css": "0.0.71",
+        "volar-service-emmet": "0.0.71",
+        "volar-service-html": "0.0.71",
+        "volar-service-prettier": "0.0.71",
+        "volar-service-typescript": "0.0.71",
+        "volar-service-typescript-twoslash-queries": "0.0.71",
+        "volar-service-yaml": "0.0.71",
+        "vscode-html-languageservice": "^5.6.2",
+        "vscode-uri": "^3.1.0"
+      },
+      "bin": {
+        "astro-ls": "bin/nodeServer.js"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "prettier-plugin-astro": ">=0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "6.3.9",
@@ -187,6 +309,16 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
+      "integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -858,6 +990,68 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@emmetio/abbreviation": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-abbreviation": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.7.1",
@@ -4613,6 +4807,104 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@volar/kit": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "typesafe-path": "^0.2.2",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/language-server": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "request-light": "^0.7.0",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/language-service": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emmet": "^2.4.3",
+        "jsonc-parser": "^2.3.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -6743,6 +7035,23 @@
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
+    "node_modules/emmet": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "./packages/scanner",
+        "./packages/abbreviation",
+        "./packages/css-abbreviation",
+        "./"
+      ],
+      "dependencies": {
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
@@ -7517,6 +7826,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -7815,9 +8141,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10824,6 +11150,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -10857,6 +11190,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -12072,6 +12415,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -12602,6 +12952,13 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12676,9 +13033,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12835,9 +13192,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -13343,10 +13700,27 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/request-light": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14483,13 +14857,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -14871,6 +15245,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typesafe-path": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -14882,6 +15263,29 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-auto-import-cache": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.8"
+      }
+    },
+    "node_modules/typescript-auto-import-cache/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/typescript-eslint": {
@@ -15377,6 +15781,309 @@
         }
       }
     },
+    "node_modules/volar-service-css": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.71.tgz",
+      "integrity": "sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-css-languageservice": "^6.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-emmet": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.71.tgz",
+      "integrity": "sha512-zqjzt6bN95e3CUstBm0PBFAJnrfz0ZAARka87fart46/gNCLLuP3Vujy8V/J8HEziTFLnfkgIASLFYPUhonJcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/css-parser": "^0.4.1",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.3",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-html": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.71.tgz",
+      "integrity": "sha512-e8tHPhgQ7ooLfudAEIku+kgd9pWkq3SSz8RbnQDI1+Eb8wbenkLGHqoirLqz5ORLV6wIMr2Iv08RWBG5eOcgpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-html-languageservice": "^5.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-prettier": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.71.tgz",
+      "integrity": "sha512-Rz7JVH3qD108UCdmIEiZvOBNljMt2nLFdbN8AXcDfn7xD9F5I2aCIsDVqBbXw21PsnxG0b7MfwtNF+zPS/NKUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0",
+        "prettier": "^2.2 || ^3.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.71.tgz",
+      "integrity": "sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-browserify": "^1.0.1",
+        "semver": "^7.6.2",
+        "typescript-auto-import-cache": "^0.3.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-nls": "^5.2.0",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript-twoslash-queries": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.71.tgz",
+      "integrity": "sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/volar-service-yaml": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.71.tgz",
+      "integrity": "sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8",
+        "yaml-language-server": "~1.23.0"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-css-languageservice/node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-html-languageservice": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.2.tgz",
+      "integrity": "sha512-SbQSV9yRemARxeXw6LU5sS6Zq0e9/DgCCX5yelH263ZQWukbTk8EF8fjTrr1dziasf4GwlJbvTwFnTrnQFWZXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.3.tgz",
+      "integrity": "sha512-DF49+WeV5py4zO5hhobp60jjsDSK0lAqA0OuKBLBvp423HPWQcCbhZz3JgyfIewsEz2f8U+X75xNIFHdiXZm2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.2",
+        "vscode-languageserver-types": "3.18.3"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.14.tgz",
+      "integrity": "sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.3.tgz",
+      "integrity": "sha512-XIlzJ7Qp/jzSI1ds7/FwPAWrPeTZA7pAtlW4hdJ1J6xXWJL6dR9QYnDhJOdLzdKhUQ5Mm6mvUMw+3DcOQQasPw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.2.0.tgz",
+      "integrity": "sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -15781,6 +16488,118 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.23.0.tgz",
+      "integrity": "sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-i18n": "^4.2.0",
+        "prettier": "^3.8.1",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.8.3"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/ajv-i18n": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
+      "integrity": "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.0-beta.0"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/client-participation-alpha/package.json
+++ b/client-participation-alpha/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "verify": "npm run format && npm run lint && npm run test && npm run build"
+    "typecheck": "astro check",
+    "verify": "npm run format && npm run lint && npm run test && npm run build && npm run typecheck"
   },
   "dependencies": {
     "@astrojs/node": "9.5.1",
@@ -37,6 +38,7 @@
     "react-dom": "^19.2.1"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.10",
     "@eslint/js": "^9.39.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",

--- a/client-participation-alpha/src/api/__tests__/pca.test.ts
+++ b/client-participation-alpha/src/api/__tests__/pca.test.ts
@@ -1,0 +1,87 @@
+import { fetchPCAData, PCA2_WIRE_FIELDS, PCA_VISUALIZATION_KEYS } from '../pca'
+import PolisNet from '../../lib/net'
+
+jest.mock('../../lib/net')
+
+const mockedPolisNet = PolisNet as jest.Mocked<typeof PolisNet>
+
+/**
+ * The 17 field names of the decoded pca2 body, transcribed from the `required`
+ * list of cost-reduction/04-plans/p032-slice1/decoded-empty.schema.json (a
+ * closed Draft-07 schema: `additionalProperties: false`), in the wire order
+ * quoted in cost-reduction/04-plans/P-032-slice1-pca2.md.
+ *
+ * Duplicated literally here rather than imported so the test fails if the
+ * production list drifts from the contract.
+ */
+const CONTRACT_FIELDS = [
+  'group-clusters',
+  'base-clusters',
+  'group-votes',
+  'group-aware-consensus',
+  'user-vote-counts',
+  'in-conv',
+  'n-cmts',
+  'pca',
+  'tids',
+  'n',
+  'repness',
+  'consensus',
+  'votes-base',
+  'lastModTimestamp',
+  'lastVoteTimestamp',
+  'comment-priorities',
+  'math_tick'
+]
+
+describe('pca2 wire field names', () => {
+  it('PCA2_WIRE_FIELDS matches the P-032 slice-1 contract exactly, in wire order', () => {
+    expect([...PCA2_WIRE_FIELDS]).toEqual(CONTRACT_FIELDS)
+    expect(PCA2_WIRE_FIELDS).toHaveLength(17)
+  })
+
+  it('requested keys are all real wire field names', () => {
+    // The server picks with `_.pick` and silently drops unknown keys, so an
+    // unknown key here is not an error at runtime — it is a field that never
+    // arrives. This is the check that caught `mathTick`.
+    for (const key of PCA_VISUALIZATION_KEYS) {
+      expect(CONTRACT_FIELDS).toContain(key)
+    }
+  })
+
+  it('requests the tick under its wire name, not a camelCased one', () => {
+    expect(PCA_VISUALIZATION_KEYS).toContain('math_tick')
+    expect(PCA_VISUALIZATION_KEYS).not.toContain('mathTick')
+  })
+
+  it('requests no key twice', () => {
+    expect(new Set(PCA_VISUALIZATION_KEYS).size).toBe(PCA_VISUALIZATION_KEYS.length)
+  })
+})
+
+describe('fetchPCAData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('sends no keys param in full mode', async () => {
+    mockedPolisNet.polisGet.mockResolvedValue({})
+
+    await fetchPCAData('conv123')
+
+    expect(mockedPolisNet.polisGet).toHaveBeenCalledWith('/math/pca2', {
+      conversation_id: 'conv123'
+    })
+  })
+
+  it('sends the requested keys as a comma list in subset mode', async () => {
+    mockedPolisNet.polisGet.mockResolvedValue({})
+
+    await fetchPCAData('conv123', PCA_VISUALIZATION_KEYS)
+
+    expect(mockedPolisNet.polisGet).toHaveBeenCalledWith('/math/pca2', {
+      conversation_id: 'conv123',
+      keys: 'base-clusters,group-clusters,group-aware-consensus,group-votes,repness,math_tick'
+    })
+  })
+})

--- a/client-participation-alpha/src/api/pca.ts
+++ b/client-participation-alpha/src/api/pca.ts
@@ -1,5 +1,5 @@
 import PolisNet from '../lib/net'
-import type { PCAData } from './types'
+import type { PCA2FullResponse, PCAData } from './types'
 
 /**
  * Field names of the decoded `GET /api/v3/math/pca2` body, in the wire order
@@ -33,7 +33,7 @@ export const PCA2_WIRE_FIELDS = [
   'lastVoteTimestamp',
   'comment-priorities',
   'math_tick'
-] as const
+] as const satisfies ReadonlyArray<keyof PCA2FullResponse>
 
 /**
  * The subset of pca2 fields the participation visualization needs.

--- a/client-participation-alpha/src/api/pca.ts
+++ b/client-participation-alpha/src/api/pca.ts
@@ -1,6 +1,54 @@
 import PolisNet from '../lib/net'
 import type { PCAData } from './types'
 
+/**
+ * Field names of the decoded `GET /api/v3/math/pca2` body, in the wire order
+ * pinned by the P-032 slice-1 contract.
+ *
+ * Source of truth: cost-reduction/04-plans/P-032-slice1-pca2.md ("Decoded
+ * schemas and exact order") and the `required` list of
+ * cost-reduction/04-plans/p032-slice1/decoded-empty.schema.json, which is a
+ * closed Draft-07 schema naming all 17 full properties.
+ *
+ * Anything sent in `keys=` that is not in this list is silently dropped by the
+ * server's `_.pick` (server/src/routes/math.ts:106) — see the `keys-unknown`
+ * cell recorded by slice 1. So an unknown key is not an error, it is a value
+ * that never arrives.
+ */
+export const PCA2_WIRE_FIELDS = [
+  'group-clusters',
+  'base-clusters',
+  'group-votes',
+  'group-aware-consensus',
+  'user-vote-counts',
+  'in-conv',
+  'n-cmts',
+  'pca',
+  'tids',
+  'n',
+  'repness',
+  'consensus',
+  'votes-base',
+  'lastModTimestamp',
+  'lastVoteTimestamp',
+  'comment-priorities',
+  'math_tick'
+] as const
+
+/**
+ * The subset of pca2 fields the participation visualization needs.
+ * `math_tick` is required for the unchanged-tick short circuit in
+ * VisualizationContainer; it must be spelled exactly as it is on the wire.
+ */
+export const PCA_VISUALIZATION_KEYS: Array<keyof PCAData> = [
+  'base-clusters',
+  'group-clusters',
+  'group-aware-consensus',
+  'group-votes',
+  'repness',
+  'math_tick'
+]
+
 export async function fetchPCAData(
   conversationId: string,
   keys?: Array<keyof PCAData>

--- a/client-participation-alpha/src/api/types.ts
+++ b/client-participation-alpha/src/api/types.ts
@@ -20,7 +20,41 @@ export interface BaseClusters {
   y: number[]
   id: number[]
   count: number[]
+  // All five are `required` in the closed empty schema; `members` is not
+  // optional on the wire (existing callers still guard it defensively).
   members?: number[][]
+}
+
+/**
+ * `pca` sub-object. Empty-branch shapes are pinned by the closed schema:
+ * `comps` is `[[], []]`, `center` is `[0, 0]`, `comment-extremity` is zeros of
+ * `tids.length`, and `comment-projection` is the empty object `{}`.
+ *
+ * Populated element types are NOT established by that schema — P-032-slice1
+ * says so explicitly ("Empty collections do not establish populated element
+ * types", "null, absence, empty arrays and empty objects remain distinct").
+ * The populated arms below are read off real math output
+ * (delphi/real_data/*_math_blob.json), where `comment-projection` is a
+ * 2 x n array of numbers rather than a map — the empty `{}` and the populated
+ * array really are different JSON types, so both arms are declared.
+ */
+export interface PCAComponents {
+  comps: number[][]
+  center: number[]
+  'comment-extremity': number[]
+  'comment-projection': number[][] | Record<string, never>
+}
+
+export interface ConsensusGroups {
+  agree: ConsensusItem[]
+  disagree: ConsensusItem[]
+}
+
+/** Per-base-cluster vote tallies for one statement. */
+export interface VotesBaseEntry {
+  A: number[] // Agree, one entry per base cluster
+  D: number[] // Disagree
+  S: number[] // Skip
 }
 
 export interface ConsensusItem {
@@ -55,21 +89,78 @@ export interface RepnessItem {
   'best-agree'?: boolean
 }
 
-export interface PCAData {
-  'base-clusters': BaseClusters
+/**
+ * The full decoded body of `GET /api/v3/math/pca2`.
+ *
+ * Field set and empty-branch types come from the P-032 slice-1 contract:
+ * cost-reduction/04-plans/p032-slice1/decoded-empty.schema.json is a closed
+ * Draft-07 schema (`additionalProperties: false`) whose `required` list names
+ * all seventeen properties, and cost-reduction/04-plans/P-032-slice1-pca2.md
+ * quotes the same seventeen in wire order. In full mode (no `keys` parameter)
+ * every one of them is present, so every property here is required.
+ *
+ * Caveat carried from the contract: that schema pins the *empty-math* cell
+ * only, and populated schemas "need review before a general generated client
+ * type is approved". Where the schema shows only an empty collection, the
+ * element types below are read off real math output
+ * (delphi/real_data/*_math_blob.json) and are the client's best current belief,
+ * not admitted contract.
+ */
+export interface PCA2FullResponse {
   'group-clusters': GroupCluster[]
-  'group-aware-consensus'?: {
-    [tid: string]: number
-  }
-  'group-votes'?: {
+  'base-clusters': BaseClusters
+  /** group id -> that group's vote tallies */
+  'group-votes': {
     [groupId: string]: GroupVotes
   }
-  repness?: {
+  /** tid -> group-aware consensus score */
+  'group-aware-consensus': {
+    [tid: string]: number
+  }
+  /** pid -> number of votes cast */
+  'user-vote-counts': {
+    [pid: string]: number
+  }
+  /** pids counted as in-conversation */
+  'in-conv': number[]
+  'n-cmts': number
+  pca: PCAComponents
+  tids: number[]
+  n: number
+  /** group id -> representative statements for that group */
+  repness: {
     [groupId: string]: RepnessItem[]
   }
-  // Wire field name is `math_tick` (P-032 slice-1 decoded contract,
-  // cost-reduction/04-plans/p032-slice1/decoded-empty.schema.json).
-  math_tick?: number
+  consensus: ConsensusGroups
+  /** tid -> per-base-cluster tallies */
+  'votes-base': {
+    [tid: string]: VotesBaseEntry
+  }
+  /** null in the recorded empty branch; a ms epoch when moderation has run */
+  lastModTimestamp: number | null
+  lastVoteTimestamp: number
+  /** tid -> priority weight */
+  'comment-priorities': {
+    [tid: string]: number
+  }
+  /** Integer per the schema. The wire name is `math_tick`, never `mathTick`. */
+  math_tick: number
+}
+
+/**
+ * Subset mode: when `keys=` is sent, the server returns `_.pick(body, keys)`,
+ * so nothing is guaranteed and unknown keys are dropped silently.
+ */
+export type PCA2SubsetResponse = Partial<PCA2FullResponse>
+
+/**
+ * What the participation visualization consumes. It is a subset response —
+ * VisualizationContainer always sends `keys` — narrowed by the two fields it
+ * asks for and then dereferences without a guard.
+ */
+export interface PCAData extends PCA2SubsetResponse {
+  'base-clusters': BaseClusters
+  'group-clusters': GroupCluster[]
 }
 
 export interface Topic {

--- a/client-participation-alpha/src/api/types.ts
+++ b/client-participation-alpha/src/api/types.ts
@@ -20,8 +20,11 @@ export interface BaseClusters {
   y: number[]
   id: number[]
   count: number[]
-  // All five are `required` in the closed empty schema; `members` is not
-  // optional on the wire (existing callers still guard it defensively).
+  // All five are `required` in the empty-cell schema, so the contract does not
+  // sanction an absent `members`. It stays optional here as *compatibility
+  // typing* — existing callers guard it, and tightening it would be a
+  // behaviour question, not a typing one. Do not read this `?` as evidence
+  // that the field may be missing on the wire.
   members?: number[][]
 }
 
@@ -99,12 +102,18 @@ export interface RepnessItem {
  * quotes the same seventeen in wire order. In full mode (no `keys` parameter)
  * every one of them is present, so every property here is required.
  *
- * Caveat carried from the contract: that schema pins the *empty-math* cell
- * only, and populated schemas "need review before a general generated client
- * type is approved". Where the schema shows only an empty collection, the
- * element types below are read off real math output
- * (delphi/real_data/*_math_blob.json) and are the client's best current belief,
- * not admitted contract.
+ * Caveat carried from the contract, and it applies to the field *set* as well
+ * as the field types: that schema pins the **empty-math cell only**
+ * (MATH_ENV=p027, math_tick=0, n=0). Seventeen is what that cell is closed
+ * over; it is not proof that every production full-mode blob carries exactly
+ * these seventeen and no others. Populated schemas "need review before a
+ * general generated client type is approved", so this interface is a
+ * contract-derived belief about full mode, not an admitted full-mode contract.
+ * Where the schema shows only an empty collection, the element types below are
+ * read off real math output (delphi/real_data/*_math_blob.json) and are the
+ * client's best current belief.
+ *
+ * This interface is erased at runtime: nothing here validates a response.
  */
 export interface PCA2FullResponse {
   'group-clusters': GroupCluster[]

--- a/client-participation-alpha/src/api/types.ts
+++ b/client-participation-alpha/src/api/types.ts
@@ -67,7 +67,9 @@ export interface PCAData {
   repness?: {
     [groupId: string]: RepnessItem[]
   }
-  mathTick?: number
+  // Wire field name is `math_tick` (P-032 slice-1 decoded contract,
+  // cost-reduction/04-plans/p032-slice1/decoded-empty.schema.json).
+  math_tick?: number
 }
 
 export interface Topic {

--- a/client-participation-alpha/src/components/Statement.tsx
+++ b/client-participation-alpha/src/components/Statement.tsx
@@ -86,11 +86,7 @@ export function Statement({
             {s.anonPerson} {s.x_wrote}
           </span>
         </div>
-        {remainingText && (
-          <span className="statement-remaining">
-            {remainingText}
-          </span>
-        )}
+        {remainingText && <span className="statement-remaining">{remainingText}</span>}
       </div>
 
       {/* Show official translation (replaces original) or original text */}

--- a/client-participation-alpha/src/components/VisualizationContainer.tsx
+++ b/client-participation-alpha/src/components/VisualizationContainer.tsx
@@ -89,9 +89,13 @@ export default function VisualizationContainer({
         setError(err instanceof Error ? err.message : 'Failed to fetch data')
         console.error('Error fetching data:', err)
       } finally {
-        // A stale request must not clear the loading state a newer, still
-        // pending request is showing.
-        if (showLoadingState && requestGeneration.current === generation) {
+        // The spinner belongs to the in-flight sequence, not to the request
+        // that turned it on. Whichever request is current when it finishes
+        // settles it — including a background poll (showLoadingState false)
+        // that superseded a pending initial load, which would otherwise leave
+        // the spinner up with no request left to take it down. A stale request
+        // still clears nothing.
+        if (requestGeneration.current === generation) {
           setLoading(false)
         }
       }

--- a/client-participation-alpha/src/components/VisualizationContainer.tsx
+++ b/client-participation-alpha/src/components/VisualizationContainer.tsx
@@ -19,16 +19,28 @@ export default function VisualizationContainer({
   const [comments, setComments] = useState<Comment[] | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const currentMathTick = useRef<number | undefined>(undefined)
+  // The last math tick we applied, together with the conversation it came
+  // from. A tick is a per-conversation generation counter, so conversation B's
+  // tick 7 says nothing about conversation A's tick 7 — comparing them across
+  // a switch would leave A's math on screen under B's id.
+  const lastMathTick = useRef<{ conversationId: string; tick: number | undefined } | null>(null)
+  // The conversation whose in-flight responses we are still willing to apply.
+  const activeConversationId = useRef<string>(conversation_id)
   const refetchTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   const loadData = useCallback(
     async (showLoadingState = true) => {
-      if (!conversation_id) {
+      const conversationId = conversation_id
+
+      if (!conversationId) {
         setLoading(false)
         setError('No conversation ID provided')
         return
       }
+
+      // Claim this conversation before awaiting: any response that arrives for
+      // a conversation we have since navigated away from is dropped below.
+      activeConversationId.current = conversationId
 
       try {
         if (showLoadingState) {
@@ -38,27 +50,42 @@ export default function VisualizationContainer({
 
         // Fetch both PCA data and comments in parallel
         const [pcaDataResult, commentsResult] = await Promise.all([
-          fetchPCAData(conversation_id, PCA_VISUALIZATION_KEYS),
-          fetchComments(conversation_id)
+          fetchPCAData(conversationId, PCA_VISUALIZATION_KEYS),
+          fetchComments(conversationId)
         ])
 
-        // Check if math_tick has changed (skip update if unchanged)
-        if (
-          pcaDataResult.math_tick !== undefined &&
-          pcaDataResult.math_tick === currentMathTick.current
-        ) {
-          // Math hasn't been recalculated yet, data is the same
+        if (activeConversationId.current !== conversationId) {
+          // A newer conversation is loading; this response is stale.
           return
         }
 
-        currentMathTick.current = pcaDataResult.math_tick
-        setPcaData(pcaDataResult)
+        // Comments do not depend on the math tick: submitting or editing a
+        // statement changes this response while the tick stands still, so
+        // they are applied unconditionally. Only the PCA state is guarded.
         setComments(commentsResult)
+
+        const tick = pcaDataResult.math_tick
+        const applied = lastMathTick.current
+        if (
+          tick !== undefined &&
+          applied !== null &&
+          applied.conversationId === conversationId &&
+          applied.tick === tick
+        ) {
+          // Math hasn't been recalculated yet, the PCA data is the same
+          return
+        }
+
+        lastMathTick.current = { conversationId, tick }
+        setPcaData(pcaDataResult)
       } catch (err) {
+        if (activeConversationId.current !== conversationId) {
+          return
+        }
         setError(err instanceof Error ? err.message : 'Failed to fetch data')
         console.error('Error fetching data:', err)
       } finally {
-        if (showLoadingState) {
+        if (showLoadingState && activeConversationId.current === conversationId) {
           setLoading(false)
         }
       }

--- a/client-participation-alpha/src/components/VisualizationContainer.tsx
+++ b/client-participation-alpha/src/components/VisualizationContainer.tsx
@@ -24,12 +24,19 @@ export default function VisualizationContainer({
   // tick 7 says nothing about conversation A's tick 7 — comparing them across
   // a switch would leave A's math on screen under B's id.
   const lastMathTick = useRef<{ conversationId: string; tick: number | undefined } | null>(null)
-  // The conversation whose in-flight responses we are still willing to apply.
-  const activeConversationId = useRef<string>(conversation_id)
+  // Monotonically increasing request generation. Every call to loadData takes
+  // the next one and is only allowed to touch state while it still holds the
+  // current one. Conversation identity is NOT sufficient for this: A -> B -> A
+  // returns to the same id, so an id check would let the first A's late
+  // response through to overwrite the second A's. Generations never repeat.
+  const requestGeneration = useRef(0)
   const refetchTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   const loadData = useCallback(
     async (showLoadingState = true) => {
+      // Taken before anything else, so even the empty-id early return
+      // invalidates whatever was in flight.
+      const generation = ++requestGeneration.current
       const conversationId = conversation_id
 
       if (!conversationId) {
@@ -37,10 +44,6 @@ export default function VisualizationContainer({
         setError('No conversation ID provided')
         return
       }
-
-      // Claim this conversation before awaiting: any response that arrives for
-      // a conversation we have since navigated away from is dropped below.
-      activeConversationId.current = conversationId
 
       try {
         if (showLoadingState) {
@@ -54,8 +57,8 @@ export default function VisualizationContainer({
           fetchComments(conversationId)
         ])
 
-        if (activeConversationId.current !== conversationId) {
-          // A newer conversation is loading; this response is stale.
+        if (requestGeneration.current !== generation) {
+          // A newer request has been started since; this response is stale.
           return
         }
 
@@ -79,13 +82,16 @@ export default function VisualizationContainer({
         lastMathTick.current = { conversationId, tick }
         setPcaData(pcaDataResult)
       } catch (err) {
-        if (activeConversationId.current !== conversationId) {
+        if (requestGeneration.current !== generation) {
+          // A stale failure must not surface over a newer successful visit.
           return
         }
         setError(err instanceof Error ? err.message : 'Failed to fetch data')
         console.error('Error fetching data:', err)
       } finally {
-        if (showLoadingState && activeConversationId.current === conversationId) {
+        // A stale request must not clear the loading state a newer, still
+        // pending request is showing.
+        if (showLoadingState && requestGeneration.current === generation) {
           setLoading(false)
         }
       }
@@ -96,6 +102,11 @@ export default function VisualizationContainer({
   // Initial load
   useEffect(() => {
     loadData()
+    return () => {
+      // Conversation change or unmount: whatever is in flight belongs to a
+      // visit we have left, so retire its generation.
+      requestGeneration.current += 1
+    }
   }, [loadData])
 
   // Listen for vote/comment submissions and refetch after delay

--- a/client-participation-alpha/src/components/VisualizationContainer.tsx
+++ b/client-participation-alpha/src/components/VisualizationContainer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { fetchComments } from '../api/comments'
-import { fetchPCAData } from '../api/pca'
+import { fetchPCAData, PCA_VISUALIZATION_KEYS } from '../api/pca'
 import type { Comment, PCAData } from '../api/types'
 import type { Translations } from '../strings/types'
 import { PCAVisualization } from './visualization'
@@ -36,31 +36,22 @@ export default function VisualizationContainer({
         }
         setError(null)
 
-        const pcaKeys: Array<keyof PCAData> = [
-          'base-clusters',
-          'group-clusters',
-          'group-aware-consensus',
-          'group-votes',
-          'repness',
-          'mathTick'
-        ]
-
         // Fetch both PCA data and comments in parallel
         const [pcaDataResult, commentsResult] = await Promise.all([
-          fetchPCAData(conversation_id, pcaKeys),
+          fetchPCAData(conversation_id, PCA_VISUALIZATION_KEYS),
           fetchComments(conversation_id)
         ])
 
-        // Check if mathTick has changed (skip update if unchanged)
+        // Check if math_tick has changed (skip update if unchanged)
         if (
-          pcaDataResult.mathTick !== undefined &&
-          pcaDataResult.mathTick === currentMathTick.current
+          pcaDataResult.math_tick !== undefined &&
+          pcaDataResult.math_tick === currentMathTick.current
         ) {
           // Math hasn't been recalculated yet, data is the same
           return
         }
 
-        currentMathTick.current = pcaDataResult.mathTick
+        currentMathTick.current = pcaDataResult.math_tick
         setPcaData(pcaDataResult)
         setComments(commentsResult)
       } catch (err) {

--- a/client-participation-alpha/src/components/__tests__/VisualizationContainer.test.tsx
+++ b/client-participation-alpha/src/components/__tests__/VisualizationContainer.test.tsx
@@ -211,4 +211,98 @@ describe('VisualizationContainer math_tick guard', () => {
     expect(received).not.toContain(staleA)
     expect(received[received.length - 1]).toBe(conversationB)
   })
+
+  // A -> B -> A returns to the same conversation id, so an id-equality guard
+  // lets the FIRST A's late response through. These three follow the schedules
+  // in cost-reduction/scripts/p046-r2-astra-review.cjs.
+  describe('A -> B -> A', () => {
+    function deferred<T>() {
+      let resolve: (value: T) => void = () => {}
+      let reject: (reason: unknown) => void = () => {}
+      const promise = new Promise<T>((res, rej) => {
+        resolve = res
+        reject = rej
+      })
+      // Nothing awaits a rejection until the component does.
+      promise.catch(() => {})
+      return { promise, resolve, reject }
+    }
+
+    async function goAthenBthenA(slowA: Promise<PCAData>, secondA: PCAData | Promise<PCAData>) {
+      const conversationB = pcaBody(7)
+      mockedFetchPCAData
+        .mockReturnValueOnce(slowA)
+        .mockResolvedValueOnce(conversationB)
+        .mockReturnValueOnce(
+          secondA instanceof Promise ? secondA : (Promise.resolve(secondA) as Promise<PCAData>)
+        )
+      mockedFetchComments
+        .mockResolvedValueOnce([comment(1)])
+        .mockResolvedValueOnce([comment(2)])
+        .mockResolvedValueOnce([comment(3)])
+
+      const view = render(<VisualizationContainer conversation_id="convA" s={{} as Translations} />)
+      await act(async () => {
+        view.rerender(<VisualizationContainer conversation_id="convB" s={{} as Translations} />)
+      })
+      await act(async () => {
+        view.rerender(<VisualizationContainer conversation_id="convA" s={{} as Translations} />)
+      })
+      return view
+    }
+
+    it('does not let the first visit resurrect old math and comments', async () => {
+      const slowA = deferred<PCAData>()
+      const secondA = pcaBody(9)
+      const staleA = pcaBody(3)
+
+      await goAthenBthenA(slowA.promise, secondA)
+      await waitFor(() => expect(received[received.length - 1]).toBe(secondA))
+
+      await act(async () => {
+        slowA.resolve(staleA)
+      })
+
+      expect(received).not.toContain(staleA)
+      expect(received[received.length - 1]).toBe(secondA)
+      // The stale visit's comments must not come back either.
+      expect(receivedComments[receivedComments.length - 1]).toEqual([comment(3)])
+    })
+
+    it('does not let the first visit surface an obsolete error', async () => {
+      const slowA = deferred<PCAData>()
+      const secondA = pcaBody(9)
+
+      const view = await goAthenBthenA(slowA.promise, secondA)
+      await waitFor(() => expect(received[received.length - 1]).toBe(secondA))
+
+      await act(async () => {
+        slowA.reject(new Error('obsolete A failure'))
+      })
+
+      expect(view.queryByText('Visualization unavailable')).toBeNull()
+      expect(view.queryByTestId('viz')).not.toBeNull()
+    })
+
+    it('does not let the first visit clear the current loading state', async () => {
+      const slowA = deferred<PCAData>()
+      const stillLoadingA = deferred<PCAData>()
+
+      const view = await goAthenBthenA(slowA.promise, stillLoadingA.promise)
+      // The second visit to A is still in flight, so the spinner is up.
+      expect(view.queryByText('Loading visualization data...')).not.toBeNull()
+
+      await act(async () => {
+        slowA.resolve(pcaBody(3))
+      })
+
+      // ...and the first visit finishing must not take it down.
+      expect(view.queryByText('Loading visualization data...')).not.toBeNull()
+
+      await act(async () => {
+        stillLoadingA.resolve(pcaBody(9))
+      })
+      expect(view.queryByText('Loading visualization data...')).toBeNull()
+    })
+  })
 })

--- a/client-participation-alpha/src/components/__tests__/VisualizationContainer.test.tsx
+++ b/client-participation-alpha/src/components/__tests__/VisualizationContainer.test.tsx
@@ -1,0 +1,122 @@
+import { act, render, waitFor } from '@testing-library/react'
+import VisualizationContainer from '../VisualizationContainer'
+import { fetchPCAData, PCA_VISUALIZATION_KEYS } from '../../api/pca'
+import { fetchComments } from '../../api/comments'
+import { REFRESH_DELAY_MS } from '../visualization/constants'
+import type { PCAData } from '../../api/types'
+import type { Translations } from '../../strings/types'
+
+jest.mock('../../lib/net')
+jest.mock('../../lib/lang')
+jest.mock('../../api/pca', () => {
+  const actual = jest.requireActual('../../api/pca')
+  return { ...actual, fetchPCAData: jest.fn() }
+})
+jest.mock('../../api/comments')
+
+// Record every `data` object the visualization is handed, so we can tell a
+// short-circuited poll (no new object) from an applied one.
+const received: PCAData[] = []
+jest.mock('../visualization', () => ({
+  PCAVisualization: (props: { data: PCAData }) => {
+    received.push(props.data)
+    return <div data-testid="viz">tick:{String(props.data.math_tick)}</div>
+  }
+}))
+
+const mockedFetchPCAData = fetchPCAData as jest.MockedFunction<typeof fetchPCAData>
+const mockedFetchComments = fetchComments as jest.MockedFunction<typeof fetchComments>
+
+const CONVERSATION_ID = 'conv123'
+
+function pcaBody(math_tick: number): PCAData {
+  return {
+    'base-clusters': { x: [], y: [], id: [], count: [], members: [] },
+    'group-clusters': [],
+    math_tick
+  } as PCAData
+}
+
+async function triggerPoll() {
+  await act(async () => {
+    window.dispatchEvent(
+      new CustomEvent('polis-vote-submitted', {
+        detail: { conversation_id: CONVERSATION_ID }
+      })
+    )
+    jest.advanceTimersByTime(REFRESH_DELAY_MS)
+  })
+}
+
+describe('VisualizationContainer math_tick guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    received.length = 0
+    jest.useFakeTimers()
+    mockedFetchComments.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('requests math_tick under its wire name', async () => {
+    mockedFetchPCAData.mockResolvedValue(pcaBody(7))
+
+    render(<VisualizationContainer conversation_id={CONVERSATION_ID} s={{} as Translations} />)
+
+    await waitFor(() => expect(mockedFetchPCAData).toHaveBeenCalled())
+    expect(mockedFetchPCAData).toHaveBeenCalledWith(CONVERSATION_ID, PCA_VISUALIZATION_KEYS)
+    expect(PCA_VISUALIZATION_KEYS).toContain('math_tick')
+  })
+
+  it('short-circuits when the tick is unchanged', async () => {
+    const first = pcaBody(7)
+    const unchanged = pcaBody(7)
+    mockedFetchPCAData.mockResolvedValueOnce(first).mockResolvedValueOnce(unchanged)
+
+    render(<VisualizationContainer conversation_id={CONVERSATION_ID} s={{} as Translations} />)
+
+    await waitFor(() => expect(received.length).toBeGreaterThan(0))
+    expect(received[received.length - 1]).toBe(first)
+
+    await triggerPoll()
+
+    expect(mockedFetchPCAData).toHaveBeenCalledTimes(2)
+    // The second body never reached the visualization: state was not replaced.
+    expect(received).not.toContain(unchanged)
+    expect(new Set(received).size).toBe(1)
+  })
+
+  it('updates when the tick advances', async () => {
+    const first = pcaBody(7)
+    const advanced = pcaBody(8)
+    mockedFetchPCAData.mockResolvedValueOnce(first).mockResolvedValueOnce(advanced)
+
+    render(<VisualizationContainer conversation_id={CONVERSATION_ID} s={{} as Translations} />)
+
+    await waitFor(() => expect(received.length).toBeGreaterThan(0))
+
+    await triggerPoll()
+
+    expect(mockedFetchPCAData).toHaveBeenCalledTimes(2)
+    expect(received).toContain(advanced)
+    expect(received[received.length - 1]).toBe(advanced)
+  })
+
+  it('always updates when the server omits the tick', async () => {
+    // Subset mode may legitimately omit a key; an absent tick must not be
+    // mistaken for an unchanged one.
+    const first = pcaBody(7)
+    const untracked = { 'base-clusters': first['base-clusters'], 'group-clusters': [] } as PCAData
+    mockedFetchPCAData.mockResolvedValueOnce(first).mockResolvedValueOnce(untracked)
+
+    render(<VisualizationContainer conversation_id={CONVERSATION_ID} s={{} as Translations} />)
+
+    await waitFor(() => expect(received.length).toBeGreaterThan(0))
+
+    await triggerPoll()
+
+    expect(received).toContain(untracked)
+  })
+})

--- a/client-participation-alpha/src/components/__tests__/VisualizationContainer.test.tsx
+++ b/client-participation-alpha/src/components/__tests__/VisualizationContainer.test.tsx
@@ -3,7 +3,7 @@ import VisualizationContainer from '../VisualizationContainer'
 import { fetchPCAData, PCA_VISUALIZATION_KEYS } from '../../api/pca'
 import { fetchComments } from '../../api/comments'
 import { REFRESH_DELAY_MS } from '../visualization/constants'
-import type { PCAData } from '../../api/types'
+import type { Comment, PCAData } from '../../api/types'
 import type { Translations } from '../../strings/types'
 
 jest.mock('../../lib/net')
@@ -14,12 +14,15 @@ jest.mock('../../api/pca', () => {
 })
 jest.mock('../../api/comments')
 
-// Record every `data` object the visualization is handed, so we can tell a
-// short-circuited poll (no new object) from an applied one.
+// Record every (data, comments) pair the visualization is handed, so we can
+// tell a short-circuited poll (no new object) from an applied one, and so the
+// two states can be checked independently of each other.
 const received: PCAData[] = []
+const receivedComments: (Comment[] | null)[] = []
 jest.mock('../visualization', () => ({
-  PCAVisualization: (props: { data: PCAData }) => {
+  PCAVisualization: (props: { data: PCAData; comments: Comment[] | null }) => {
     received.push(props.data)
+    receivedComments.push(props.comments)
     return <div data-testid="viz">tick:{String(props.data.math_tick)}</div>
   }
 }))
@@ -37,11 +40,24 @@ function pcaBody(math_tick: number): PCAData {
   } as PCAData
 }
 
-async function triggerPoll() {
+function comment(tid: number): Comment {
+  return {
+    txt: `statement ${tid}`,
+    tid,
+    created: 0,
+    quote_src_url: null,
+    is_seed: false,
+    is_meta: false,
+    lang: 'en',
+    pid: 0
+  }
+}
+
+async function triggerPoll(conversationId = CONVERSATION_ID) {
   await act(async () => {
     window.dispatchEvent(
       new CustomEvent('polis-vote-submitted', {
-        detail: { conversation_id: CONVERSATION_ID }
+        detail: { conversation_id: conversationId }
       })
     )
     jest.advanceTimersByTime(REFRESH_DELAY_MS)
@@ -52,6 +68,7 @@ describe('VisualizationContainer math_tick guard', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     received.length = 0
+    receivedComments.length = 0
     jest.useFakeTimers()
     mockedFetchComments.mockResolvedValue([])
   })
@@ -118,5 +135,80 @@ describe('VisualizationContainer math_tick guard', () => {
     await triggerPoll()
 
     expect(received).toContain(untracked)
+  })
+
+  it('applies changed comments even when the tick is unchanged', async () => {
+    // A statement can be submitted or moderated between polls while the math
+    // tick stands still. The short circuit must skip only the PCA state.
+    const first = pcaBody(7)
+    const unchanged = pcaBody(7)
+    const before = [comment(1)]
+    const after = [comment(1), comment(2)]
+    mockedFetchPCAData.mockResolvedValueOnce(first).mockResolvedValueOnce(unchanged)
+    mockedFetchComments.mockResolvedValueOnce(before).mockResolvedValueOnce(after)
+
+    render(<VisualizationContainer conversation_id={CONVERSATION_ID} s={{} as Translations} />)
+
+    await waitFor(() => expect(received.length).toBeGreaterThan(0))
+    expect(receivedComments[receivedComments.length - 1]).toBe(before)
+
+    await triggerPoll()
+
+    // PCA state still short-circuited...
+    expect(received).not.toContain(unchanged)
+    expect(new Set(received).size).toBe(1)
+    // ...but the newer comments were applied.
+    expect(receivedComments).toContain(after)
+    expect(receivedComments[receivedComments.length - 1]).toBe(after)
+  })
+
+  it('re-applies math when the conversation changes at an equal tick', async () => {
+    // Ticks are per-conversation generations: conversation B's tick 7 is not
+    // conversation A's tick 7, so a switch must not short-circuit and leave
+    // A's math on screen under B's id.
+    const conversationA = pcaBody(7)
+    const conversationB = pcaBody(7)
+    mockedFetchPCAData.mockResolvedValueOnce(conversationA).mockResolvedValueOnce(conversationB)
+
+    const { rerender } = render(
+      <VisualizationContainer conversation_id="convA" s={{} as Translations} />
+    )
+
+    await waitFor(() => expect(received.length).toBeGreaterThan(0))
+    expect(received[received.length - 1]).toBe(conversationA)
+
+    await act(async () => {
+      rerender(<VisualizationContainer conversation_id="convB" s={{} as Translations} />)
+    })
+
+    await waitFor(() => expect(received[received.length - 1]).toBe(conversationB))
+    expect(mockedFetchPCAData).toHaveBeenNthCalledWith(2, 'convB', PCA_VISUALIZATION_KEYS)
+  })
+
+  it('drops a response for a conversation that has already been left', async () => {
+    // A slow response for conversation A must not land on conversation B.
+    let resolveA: (value: PCAData) => void = () => {}
+    const slowA = new Promise<PCAData>((resolve) => {
+      resolveA = resolve
+    })
+    const staleA = pcaBody(3)
+    const conversationB = pcaBody(4)
+    mockedFetchPCAData.mockReturnValueOnce(slowA).mockResolvedValueOnce(conversationB)
+
+    const { rerender } = render(
+      <VisualizationContainer conversation_id="convA" s={{} as Translations} />
+    )
+
+    await act(async () => {
+      rerender(<VisualizationContainer conversation_id="convB" s={{} as Translations} />)
+    })
+    await waitFor(() => expect(received[received.length - 1]).toBe(conversationB))
+
+    await act(async () => {
+      resolveA(staleA)
+    })
+
+    expect(received).not.toContain(staleA)
+    expect(received[received.length - 1]).toBe(conversationB)
   })
 })

--- a/client-participation-alpha/src/components/__tests__/VisualizationContainer.test.tsx
+++ b/client-participation-alpha/src/components/__tests__/VisualizationContainer.test.tsx
@@ -53,6 +53,20 @@ function comment(tid: number): Comment {
   }
 }
 
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {}
+  let reject: (reason: unknown) => void = () => {}
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  // Nothing awaits a rejection until the component does.
+  promise.catch(() => {})
+  return { promise, resolve, reject }
+}
+
+const LOADING_TEXT = 'Loading visualization data...'
+
 async function triggerPoll(conversationId = CONVERSATION_ID) {
   await act(async () => {
     window.dispatchEvent(
@@ -216,18 +230,6 @@ describe('VisualizationContainer math_tick guard', () => {
   // lets the FIRST A's late response through. These three follow the schedules
   // in cost-reduction/scripts/p046-r2-astra-review.cjs.
   describe('A -> B -> A', () => {
-    function deferred<T>() {
-      let resolve: (value: T) => void = () => {}
-      let reject: (reason: unknown) => void = () => {}
-      const promise = new Promise<T>((res, rej) => {
-        resolve = res
-        reject = rej
-      })
-      // Nothing awaits a rejection until the component does.
-      promise.catch(() => {})
-      return { promise, resolve, reject }
-    }
-
     async function goAthenBthenA(slowA: Promise<PCAData>, secondA: PCAData | Promise<PCAData>) {
       const conversationB = pcaBody(7)
       mockedFetchPCAData
@@ -290,19 +292,99 @@ describe('VisualizationContainer math_tick guard', () => {
 
       const view = await goAthenBthenA(slowA.promise, stillLoadingA.promise)
       // The second visit to A is still in flight, so the spinner is up.
-      expect(view.queryByText('Loading visualization data...')).not.toBeNull()
+      expect(view.queryByText(LOADING_TEXT)).not.toBeNull()
 
       await act(async () => {
         slowA.resolve(pcaBody(3))
       })
 
       // ...and the first visit finishing must not take it down.
-      expect(view.queryByText('Loading visualization data...')).not.toBeNull()
+      expect(view.queryByText(LOADING_TEXT)).not.toBeNull()
 
       await act(async () => {
         stillLoadingA.resolve(pcaBody(9))
       })
-      expect(view.queryByText('Loading visualization data...')).toBeNull()
+      expect(view.queryByText(LOADING_TEXT)).toBeNull()
+    })
+  })
+
+  // The vote/comment event effect calls loadData(false). If it supersedes a
+  // still-pending initial loadData(true), the spinner has to be settled by the
+  // background request even though it never asked for one — nothing else is
+  // left to take it down.
+  describe('background poll overlapping the initial load', () => {
+    it('settles the spinner when a background poll supersedes a pending initial load', async () => {
+      const slowInitial = deferred<PCAData>()
+      const refreshed = pcaBody(10)
+      mockedFetchPCAData.mockReturnValueOnce(slowInitial.promise).mockResolvedValueOnce(refreshed)
+
+      const view = render(
+        <VisualizationContainer conversation_id={CONVERSATION_ID} s={{} as Translations} />
+      )
+      expect(view.queryByText(LOADING_TEXT)).not.toBeNull()
+
+      await triggerPoll()
+      await act(async () => {
+        slowInitial.resolve(pcaBody(9))
+      })
+
+      // No request left in flight, so the spinner must be down.
+      expect(view.queryByText(LOADING_TEXT)).toBeNull()
+      expect(received[received.length - 1]).toBe(refreshed)
+    })
+
+    it('settles the spinner when the superseding background poll fails', async () => {
+      const slowInitial = deferred<PCAData>()
+      mockedFetchPCAData
+        .mockReturnValueOnce(slowInitial.promise)
+        .mockRejectedValueOnce(new Error('refresh failed'))
+
+      const view = render(
+        <VisualizationContainer conversation_id={CONVERSATION_ID} s={{} as Translations} />
+      )
+      expect(view.queryByText(LOADING_TEXT)).not.toBeNull()
+
+      await triggerPoll()
+      await act(async () => {
+        slowInitial.resolve(pcaBody(9))
+      })
+
+      // Stuck on the spinner would hide the failure entirely.
+      expect(view.queryByText(LOADING_TEXT)).toBeNull()
+      expect(view.queryByText('Visualization unavailable')).not.toBeNull()
+    })
+
+    it('still does not let a superseded background poll clear a newer spinner', async () => {
+      // The stale-finally protection has to survive the relaxation above.
+      const first = pcaBody(1)
+      const slowPoll = deferred<PCAData>()
+      const pendingB = deferred<PCAData>()
+      mockedFetchPCAData
+        .mockResolvedValueOnce(first)
+        .mockReturnValueOnce(slowPoll.promise)
+        .mockReturnValueOnce(pendingB.promise)
+
+      const view = render(<VisualizationContainer conversation_id="convA" s={{} as Translations} />)
+      await waitFor(() => expect(view.queryByText(LOADING_TEXT)).toBeNull())
+
+      // Background poll on A, left in flight.
+      await triggerPoll('convA')
+
+      // Navigate to B: its initial load shows the spinner.
+      await act(async () => {
+        view.rerender(<VisualizationContainer conversation_id="convB" s={{} as Translations} />)
+      })
+      expect(view.queryByText(LOADING_TEXT)).not.toBeNull()
+
+      await act(async () => {
+        slowPoll.resolve(pcaBody(2))
+      })
+      expect(view.queryByText(LOADING_TEXT)).not.toBeNull()
+
+      await act(async () => {
+        pendingB.resolve(pcaBody(3))
+      })
+      expect(view.queryByText(LOADING_TEXT)).toBeNull()
     })
   })
 })


### PR DESCRIPTION
P-046 (from the P-041 client-typing review). Three commits:

1. The alpha client requested and read `mathTick`, but the pca2 wire field is `math_tick` (closed schema `p032-slice1/decoded-empty.schema.json`, 17 required names). `_.pick` in `server/src/routes/math.ts` silently drops unknown keys, so the tick was always `undefined` and the poll guard never short-circuited: `VisualizationContainer` re-set state on every poll. Fixed; keys list moved to `src/api/pca.ts` as `PCA_VISUALIZATION_KEYS` beside `PCA2_WIRE_FIELDS`. 10 new tests (short-circuit on unchanged tick, update on advance, update when tick absent, keys ⊆ contract names).
2. `PCA2FullResponse` (17 required) / `PCA2SubsetResponse = Partial<…>` / `PCAData` narrowed to the two fields consumers dereference. No runtime change.
3. `@astrojs/check` + `npm run typecheck`, last in `verify` and a non-blocking CI step (`continue-on-error: true`, per P-041's non-blocking-first order). Current baseline: 34 errors in untouched files, 28 of them one root cause (jest-dom matcher augmentation not in the TS program). Incidental: `@astrojs/check` lifted prettier 3.7.4→3.9.6, which reformats one JSX conditional in `Statement.tsx`; `astro sync` regenerated tracked `.astro/types.d.ts`.

Verify: format clean, eslint 0, jest 9 suites / 98 tests, `astro build` OK.

Second review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s