### PR TITLE
ci: stop building the math image for server-integration; retry the Maven classpath fetch

### DIFF
--- a/.github/workflows/jest-server-test.yml
+++ b/.github/workflows/jest-server-test.yml
@@ -75,15 +75,20 @@ jobs:
 
     - name: Build Docker images
       run: |
-        # Build all services except server (tests run on host)
+        # Build only the services these tests need (tests run on host).
+        # The math (Clojure) service is intentionally excluded: the server
+        # integration tests insert math_* rows directly and gate all live-math
+        # assertions behind a hasMathData flag, so they pass with or without it.
+        # Excluding it also avoids the flaky Maven Central classpath fetch in
+        # math/Dockerfile from failing this job before any test runs.
         docker compose -f docker-compose.test.yml --env-file test.env build \
-          math postgres file-server ses-local oidc-simulator dynamodb
+          postgres file-server ses-local oidc-simulator dynamodb
 
     - name: Start services
       run: |
-        # Start only required services in detached mode (exclude server)
+        # Start only required services in detached mode (exclude server + math)
         docker compose -f docker-compose.test.yml --env-file test.env up -d \
-          math postgres file-server ses-local oidc-simulator dynamodb
+          postgres file-server ses-local oidc-simulator dynamodb
         
         # Wait for services to be ready
         echo "Waiting for services to start..."
@@ -151,10 +156,7 @@ jobs:
         
         echo "=== Postgres logs ==="
         docker compose -f docker-compose.test.yml logs postgres | tail -100
-        
-        echo "=== Math logs ==="
-        docker compose -f docker-compose.test.yml logs math | tail -50
-        
+
         echo "=== DynamoDB logs ==="
         docker compose -f docker-compose.test.yml logs dynamodb | tail -100
 

--- a/math/Dockerfile
+++ b/math/Dockerfile
@@ -3,7 +3,17 @@ FROM docker.io/clojure:temurin-17-tools-deps
 WORKDIR /app
 COPY . .
 
-# Install clojure and fetch dependencies
-RUN clojure -A:dev -P
+# Install clojure and fetch dependencies.
+# Retry the Maven Central classpath fetch: it intermittently fails with
+# "Premature end of Content-Length delimited message body" on large jars
+# (e.g. org.apache.poi:poi), which would otherwise abort the whole build.
+RUN for attempt in 1 2 3; do \
+      echo "clojure -A:dev -P (attempt $attempt/3)"; \
+      clojure -A:dev -P && break; \
+      if [ "$attempt" = "3" ]; then \
+        echo "dependency fetch failed after 3 attempts" >&2; exit 1; \
+      fi; \
+      echo "retrying in 5s..."; sleep 5; \
+    done
 
 CMD ["./bin/run"]


### PR DESCRIPTION
The `server-integration-tests` job built the Clojure `math` image it does not require; a transient Maven Central truncation (`Premature end of Content-Length` on `org.apache.poi:poi:5.2.3`) killed #2719's run before any test ran. `server/__tests__/integration/math.test.ts` gates every live-math assertion behind `hasMathData`, and `data-export.test.ts` accepts synthesized PCA, so the service is not required there (removing it does drop opportunistic live-math coverage that the job picked up when the service happened to be healthy).

- `.github/workflows/jest-server-test.yml`: drop `math` from the build and `up -d` service lists (service stays defined in `docker-compose.test.yml` for the jobs that still build it).
- `math/Dockerfile`: wrap `clojure -A:dev -P` in a 3-attempt retry with backoff, for `cypress-run` and the Delphi job, which still build the image via a bare `docker compose build`.

No Maven cache added: none of the three test workflows use buildx cache or `actions/cache`, and adding one would be restructuring.

Verified locally: workflow YAML parses; `docker compose -f docker-compose.test.yml --env-file test.env config -q` passes with the reduced list; Dockerfile RUN block passes `sh -n`, retry control flow simulated both ways. CI on this PR: `server-integration-tests` passes with no math container. Cross-reviewed by Astra (accept). Notes: `cost-reduction/02-findings/ci-maven-flake.md` (not in repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s