### PR TITLE
fix(poller): publish math_tick + all three math tables in one transaction (R05/R09)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ test-recovery-races: ## Re-run the deterministic race schedules 20x (P-022 accep
 				tests/poller/recovery/test_r04_park_unpark_races.py \
 				tests/poller/recovery/test_r06_lru_in_flight.py \
 				tests/poller/recovery/test_r09_partial_tables_readers.py \
+				tests/poller/recovery/test_atomic_publish.py::test_blocked_zid_does_not_block_other_zid_transactions \
 				tests/poller/recovery/test_r12_publication_cursor.py \
 				tests/poller/test_park_rebuild_recovery.py \
 				-q ) || exit 1; \

--- a/delphi/Makefile
+++ b/delphi/Makefile
@@ -5,6 +5,10 @@ help: ## Show this help message
 	@echo "Available commands:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: test-recovery test-recovery-races
+test-recovery test-recovery-races: ## Run the root recovery target with isolated Postgres
+	$(MAKE) -C .. $@
+
 install: ## Install production dependencies
 	pip install -e .
 

--- a/delphi/polismath/database/postgres.py
+++ b/delphi/polismath/database/postgres.py
@@ -429,26 +429,34 @@ class PostgresClient:
             result = conn.execute(text(sql), params or {})
             return result.rowcount
 
-    def _write_returning(
-        self, sql: str, params: Optional[Dict[str, Any]] = None
-    ) -> List[Dict[str, Any]]:
-        """Execute a writing statement inside a COMMITTED transaction and return
-        any RETURNING rows.
+    @contextmanager
+    def transaction(self):
+        """One commit/rollback boundary; the connection belongs to the caller.
 
-        ``query()`` uses ``engine.connect()`` (SQLAlchemy 2.0 "commit as you go"),
-        which rolls back on close — fine for SELECTs but it silently discards
-        INSERT/UPDATEs.  The upsert writers (math_main / math_ticks / math_bidtopid
-        / math_ptptstats) MUST persist, so they route through here:
-        ``engine.begin()`` commits on successful exit.
+        Never store it on this shared client: different zid workers must use
+        independent connections and transactions.
         """
         if not self._initialized:
             self.initialize()
-
         with self.engine.begin() as conn:
-            result = conn.execute(text(sql), params or {})
-            if result.returns_rows:
-                return [dict(row) for row in result.mappings().all()]
-            return []
+            yield conn
+
+    def _write_returning(
+        self, sql: str, params: Optional[Dict[str, Any]] = None,
+        *, connection: Optional[sa.Connection] = None,
+    ) -> List[Dict[str, Any]]:
+        """Write within the supplied transaction, or commit a standalone call.
+
+        Only the owner of ``connection`` commits or rolls back. This lets the
+        poller publish a complete snapshot while retaining per-table callers.
+        """
+        if connection is None:
+            with self.transaction() as conn:
+                return self._write_returning(sql, params, connection=conn)
+        result = connection.execute(text(sql), params or {})
+        if result.returns_rows:
+            return [dict(row) for row in result.mappings().all()]
+        return []
 
     def get_zinvite_from_zid(self, zid: int) -> Optional[str]:
         """
@@ -778,36 +786,51 @@ class PostgresClient:
         }
 
     def load_math_main(self, zid: int) -> Optional[Dict[str, Any]]:
+        """Load main plus generation completeness in ONE statement snapshot.
+
+        Separate SELECTs at READ COMMITTED could straddle a successful publish
+        and falsely diagnose a mixed generation. Missing companions and NULL
+        ticks are incomplete, even if both companions are missing/NULL alike.
         """
-        Load math results for a conversation.
+        rows = self.query(
+            """
+            SELECT m.*, COALESCE(
+                m.math_tick = b.math_tick AND m.math_tick = p.math_tick,
+                false) AS snapshot_complete
+            FROM math_main m
+            LEFT JOIN math_bidtopid b USING (zid, math_env)
+            LEFT JOIN math_ptptstats p USING (zid, math_env)
+            WHERE m.zid = :zid AND m.math_env = :math_env
+            """,
+            {"zid": zid, "math_env": self.config.math_env},
+        )
+        return rows[0] if rows else None
 
-        Args:
-            zid: Conversation ID
+    def find_incomplete_math_snapshots(self) -> List[int]:
+        """Find legacy partial publications, including dormant/orphan rows.
 
-        Returns:
-            Math data, or None if not found
+        Run once at startup, independent of vote/moderation lookback. FULL
+        JOINs include companion-only remnants; namespace predicates are applied
+        before joining so another engine's rows cannot complete this snapshot.
         """
-        with self.session() as session:
-            # Query for math main data
-            math_main = (
-                session.query(MathMain)
-                .filter_by(zid=zid, math_env=self.config.math_env)
-                .first()
-            )
-
-            if not math_main:
-                return None
-
-            # Return data with all fields
-            return {
-                "zid": math_main.zid,
-                "math_env": math_main.math_env,
-                "data": math_main.data,
-                "last_vote_timestamp": math_main.last_vote_timestamp,
-                "caching_tick": math_main.caching_tick,
-                "math_tick": math_main.math_tick,
-                "modified": math_main.modified,
-            }
+        rows = self.query(
+            """
+            SELECT zid FROM
+                (SELECT zid, math_tick AS main_tick FROM math_main
+                 WHERE math_env = :math_env) m
+            FULL JOIN
+                (SELECT zid, math_tick AS bid_tick FROM math_bidtopid
+                 WHERE math_env = :math_env) b USING (zid)
+            FULL JOIN
+                (SELECT zid, math_tick AS stats_tick FROM math_ptptstats
+                 WHERE math_env = :math_env) p USING (zid)
+            WHERE main_tick IS NULL OR bid_tick IS NULL OR stats_tick IS NULL
+               OR main_tick <> bid_tick OR main_tick <> stats_tick
+            ORDER BY zid
+            """,
+            {"math_env": self.config.math_env},
+        )
+        return [row["zid"] for row in rows]
 
     def write_math_main(
         self,
@@ -816,6 +839,7 @@ class PostgresClient:
         last_vote_timestamp: Optional[int] = None,
         caching_tick: Optional[int] = None,
         math_tick: Optional[int] = None,
+        *, connection: Optional[sa.Connection] = None,
     ) -> None:
         """
         Write math results for a conversation (Clojure upload-math-main parity).
@@ -827,9 +851,10 @@ class PostgresClient:
                 (SELECT max(caching_tick) + 1 FROM math_main WHERE math_env = ?),
                 1)
 
-        so the TS server's prefetch (pca.ts:84-151 polls caching_tick > last) sees
-        a strictly increasing, per-math_env cursor.  The `caching_tick` parameter
-        is accepted for signature compatibility but ignored.
+        Allocation happens inside the publication transaction. MAX+1 still
+        races across different zids (R12); it is not a commit-order guarantee.
+        The `caching_tick` parameter is accepted for signature compatibility
+        but ignored.
 
         Args:
             zid: Conversation ID
@@ -869,10 +894,12 @@ class PostgresClient:
                 "math_tick": math_tick if math_tick is not None else -1,
                 "data": json.dumps(data, default=convert_numpy_types),
             },
+            connection=connection,
         )
 
     def write_math_bidtopid(
-        self, zid: int, data: Dict[str, Any], math_tick: Optional[int] = None
+        self, zid: int, data: Dict[str, Any], math_tick: Optional[int] = None,
+        *, connection: Optional[sa.Connection] = None,
     ) -> None:
         """
         Write the bid -> participant-id mapping (Clojure upload-math-bidtopid,
@@ -900,10 +927,12 @@ class PostgresClient:
                 "math_tick": math_tick if math_tick is not None else -1,
                 "data": json.dumps(data, default=convert_numpy_types),
             },
+            connection=connection,
         )
 
     def write_participant_stats(
-        self, zid: int, data: Dict[str, Any], math_tick: Optional[int] = None
+        self, zid: int, data: Dict[str, Any], math_tick: Optional[int] = None,
+        *, connection: Optional[sa.Connection] = None,
     ) -> None:
         """
         Write participant statistics (Clojure upload-math-ptptstats parity,
@@ -931,6 +960,7 @@ class PostgresClient:
                 "math_tick": math_tick if math_tick is not None else -1,
                 "data": json.dumps(data, default=convert_numpy_types),
             },
+            connection=connection,
         )
 
     def write_correlation_matrix(self, rid: int, data: Dict[str, Any]) -> None:
@@ -962,7 +992,9 @@ class PostgresClient:
                 )
                 session.add(corr_matrix)
 
-    def increment_math_tick(self, zid: int) -> int:
+    def increment_math_tick(
+        self, zid: int, *, connection: Optional[sa.Connection] = None,
+    ) -> int:
         """
         Atomically increment the math tick counter for a conversation.
 
@@ -990,6 +1022,7 @@ class PostgresClient:
             returning math_tick;
             """,
             {"zid": zid, "math_env": self.config.math_env},
+            connection=connection,
         )
         return rows[0]["math_tick"]
 

--- a/delphi/polismath/database/postgres.py
+++ b/delphi/polismath/database/postgres.py
@@ -35,6 +35,21 @@ from polismath.utils.vote_convention import (
 logger = logging.getLogger(__name__)
 
 
+def encode_math_blob(data: Any) -> str:
+    """Encode a math blob for a ``jsonb`` parameter, or pass one through.
+
+    The poller pre-encodes all three blobs BEFORE opening the publication
+    transaction (``math_writer.write_conv_updates``) so that ``json.dumps`` of a
+    large ``math_main`` blob does not run while the ``(zid, math_env)`` row
+    locks are held — it lengthens both the lock hold and the
+    caching_tick allocate -> commit window (R12). Every other caller still
+    hands these writers a dict.
+    """
+    if isinstance(data, str):
+        return data
+    return json.dumps(data, default=convert_numpy_types)
+
+
 # Base class for SQLAlchemy models
 class Base(DeclarativeBase):
     """Base class for all SQLAlchemy models."""
@@ -892,7 +907,7 @@ class PostgresClient:
                 "math_env": self.config.math_env,
                 "last_vote_timestamp": last_vote_timestamp,
                 "math_tick": math_tick if math_tick is not None else -1,
-                "data": json.dumps(data, default=convert_numpy_types),
+                "data": encode_math_blob(data),
             },
             connection=connection,
         )
@@ -925,7 +940,7 @@ class PostgresClient:
                 "zid": zid,
                 "math_env": self.config.math_env,
                 "math_tick": math_tick if math_tick is not None else -1,
-                "data": json.dumps(data, default=convert_numpy_types),
+                "data": encode_math_blob(data),
             },
             connection=connection,
         )
@@ -958,7 +973,7 @@ class PostgresClient:
                 "zid": zid,
                 "math_env": self.config.math_env,
                 "math_tick": math_tick if math_tick is not None else -1,
-                "data": json.dumps(data, default=convert_numpy_types),
+                "data": encode_math_blob(data),
             },
             connection=connection,
         )

--- a/delphi/polismath/poller/math_writer.py
+++ b/delphi/polismath/poller/math_writer.py
@@ -11,7 +11,8 @@ write-conv-updates! (conv_man.clj:158-169):
 
 The Clojure-exact SQL (caching_tick = MAX+1 subquery, atomic tick upsert) lives
 in polismath.database.postgres.PostgresClient; this module orchestrates the
-per-cycle write and derives the bidToPid blob.
+per-cycle write and derives the bidToPid blob. Python publishes the tick and
+all three tables in ONE transaction so readers never see a partial commit.
 """
 
 import json
@@ -224,36 +225,32 @@ class MathWriter:
         self._pg = pg_client
 
     def write_conv_updates(self, zid: int, conv: Any) -> int:
-        """Mint one math_tick and write all three data tables with it.
+        """Atomically mint one math_tick and publish all three data tables.
 
         Returns the math_tick used (handy for logging / tests).
         """
-        math_tick = self._pg.increment_math_tick(zid)
-
         data = conv.to_dict()
         last_vote_timestamp = data.get("lastVoteTimestamp")
         if last_vote_timestamp is None:
             last_vote_timestamp = getattr(conv, "last_updated", None)
 
-        # 1. math_main — client-facing PCA/cluster/repness blob (fidelity-critical)
-        self._pg.write_math_main(
-            zid,
-            data,
-            last_vote_timestamp=last_vote_timestamp,
-            math_tick=math_tick,
-        )
-        # 2. math_bidtopid — server bid->pid mapping (fidelity-critical)
-        self._pg.write_math_bidtopid(
-            zid, data=derive_bidtopid(conv, zid), math_tick=math_tick
-        )
-        # 3. math_ptptstats — participant stats (clj-shaped, 2026-07-24 fix).
-        # Reuses data["user-vote-counts"] (already computed above for
-        # math_main) rather than recomputing it a second time.
-        self._pg.write_participant_stats(
-            zid,
-            data=derive_ptptstats(conv, zid, data.get("user-vote-counts", {})),
-            math_tick=math_tick,
-        )
+        # Derive blobs before opening the transaction/holding any row locks.
+        bidtopid = derive_bidtopid(conv, zid)
+        ptptstats = derive_ptptstats(conv, zid, data.get("user-vote-counts", {}))
+        with self._pg.transaction() as connection:
+            # The tick upsert locks this (zid, math_env) until all three writes
+            # commit. Other zids use independent connections on the shared client.
+            math_tick = self._pg.increment_math_tick(zid, connection=connection)
+            self._pg.write_math_main(
+                zid, data, last_vote_timestamp=last_vote_timestamp,
+                math_tick=math_tick, connection=connection,
+            )
+            self._pg.write_math_bidtopid(
+                zid, data=bidtopid, math_tick=math_tick, connection=connection,
+            )
+            self._pg.write_participant_stats(
+                zid, data=ptptstats, math_tick=math_tick, connection=connection,
+            )
 
         logger.info(
             "Wrote math results for zid=%s math_tick=%s (main+bidtopid+ptptstats)",

--- a/delphi/polismath/poller/math_writer.py
+++ b/delphi/polismath/poller/math_writer.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
+from polismath.database.postgres import encode_math_blob
 from polismath.utils.clj_hash import clojure_hash_map_key_order
 
 logger = logging.getLogger(__name__)
@@ -234,22 +235,33 @@ class MathWriter:
         if last_vote_timestamp is None:
             last_vote_timestamp = getattr(conv, "last_updated", None)
 
-        # Derive blobs before opening the transaction/holding any row locks.
+        # Derive AND encode all three blobs before opening the transaction, so
+        # neither derivation nor json.dumps of the (large) math_main blob runs
+        # while the (zid, math_env) row locks are held.
         bidtopid = derive_bidtopid(conv, zid)
         ptptstats = derive_ptptstats(conv, zid, data.get("user-vote-counts", {}))
+        main_json = encode_math_blob(data)
+        bidtopid_json = encode_math_blob(bidtopid)
+        ptptstats_json = encode_math_blob(ptptstats)
         with self._pg.transaction() as connection:
             # The tick upsert locks this (zid, math_env) until all three writes
             # commit. Other zids use independent connections on the shared client.
             math_tick = self._pg.increment_math_tick(zid, connection=connection)
-            self._pg.write_math_main(
-                zid, data, last_vote_timestamp=last_vote_timestamp,
-                math_tick=math_tick, connection=connection,
-            )
+            # math_main is written LAST, and deliberately so: it is the statement
+            # that allocates caching_tick with MAX(caching_tick)+1, and that
+            # allocation is not serializable (R12). Keeping it adjacent to the
+            # COMMIT keeps the allocate -> commit window as short as it was when
+            # each write autocommitted; the companions carry only the tick that
+            # was already minted above, so moving them earlier is free.
             self._pg.write_math_bidtopid(
-                zid, data=bidtopid, math_tick=math_tick, connection=connection,
+                zid, data=bidtopid_json, math_tick=math_tick, connection=connection,
             )
             self._pg.write_participant_stats(
-                zid, data=ptptstats, math_tick=math_tick, connection=connection,
+                zid, data=ptptstats_json, math_tick=math_tick, connection=connection,
+            )
+            self._pg.write_math_main(
+                zid, main_json, last_vote_timestamp=last_vote_timestamp,
+                math_tick=math_tick, connection=connection,
             )
 
         logger.info(

--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -282,7 +282,12 @@ class MathPollerService:
         self._stop = threading.Event()
         self._vote_wm: Optional[int] = None
         self._mod_wm: Optional[int] = None
+        # Set ONLY on a scan that completed without raising. Until then the
+        # parked-zid reconciler retries it every cycle (see _reconcile_once);
+        # the lock serialises start()/poll_once()/reconciler so a retry cannot
+        # run concurrently with the scan it is retrying and double-submit.
         self._startup_repair_done = False
+        self._startup_repair_lock = threading.Lock()
 
     @property
     def _parked(self) -> set:
@@ -316,9 +321,13 @@ class MathPollerService:
         # A boot-time database blip must not abort startup. Before the startup
         # scan existed, start() touched no database at all and a blip was
         # absorbed by the poll loops' own try/except; keep that property. The
-        # scan leaves _startup_repair_done False on failure, so the first poll
-        # cycle retries it. poll_once() deliberately still propagates — the
-        # --once contract and test_startup_scan_failure_is_retried depend on it.
+        # scan leaves _startup_repair_done False on failure, and the parked-zid
+        # reconciler thread started just below retries it every cycle until it
+        # succeeds — swallowing the error here must NOT strand dormant mixed
+        # generations for the process lifetime, and no vote/moderation traffic
+        # is required to trigger the retry. poll_once() deliberately still
+        # propagates — the --once contract and
+        # test_startup_scan_failure_is_retried depend on it.
         try:
             self._repair_incomplete_snapshots()
         except Exception:
@@ -382,10 +391,16 @@ class MathPollerService:
     def _repair_incomplete_snapshots(self) -> None:
         """Schedule legacy partial generations even outside the boot lookback.
 
-        A scan failure must propagate, leaving the scan pending for the next
-        poll_once/start attempt. Once submitted, ordinary worker retry/park
+        IDEMPOTENT and re-entrant-safe: it is a no-op once it has completed
+        successfully, and the flag is set ONLY after the whole scan+submit pass
+        returns. A scan failure must propagate, leaving the scan pending; the
+        caller decides. ``start()`` catches it so a boot-time blip cannot abort
+        startup, and ``_reconcile_once`` — the one daemon path that runs
+        without any vote/moderation traffic — retries it every cycle until it
+        succeeds. ``poll_once`` still propagates. The lock serialises those
+        three entry points so a retry cannot overlap the scan it is retrying
+        and submit each zid twice. Once submitted, ordinary worker retry/park
         reconciliation owns recovery, including a failed rebuild with no votes.
-        start() catches it so a boot-time blip cannot abort startup.
 
         TODO(review E4 - startup REBUILD burst cap): this submits an UNBOUNDED
         number of REBUILDs (each a full vote-history recompute), logs one
@@ -408,18 +423,21 @@ class MathPollerService:
         if self._startup_repair_done:
             return
         assert self._pool is not None
-        for zid in self._pg.find_incomplete_math_snapshots():
-            if should_process_zid(
-                zid, self.config.allowlist, self.config.blocklist,
-                self.config.shard_index, self.config.shard_count,
-            ):
-                logger.warning(
-                    "Startup repair: incomplete math snapshot for zid=%s "
-                    "math_env=%s (missing rows or mismatched math_tick); "
-                    "scheduling full rebuild", zid, self.config.math_env,
-                )
-                self._pool.submit(zid, REBUILD, [])
-        self._startup_repair_done = True
+        with self._startup_repair_lock:
+            if self._startup_repair_done:  # won by another entry point
+                return
+            for zid in self._pg.find_incomplete_math_snapshots():
+                if should_process_zid(
+                    zid, self.config.allowlist, self.config.blocklist,
+                    self.config.shard_index, self.config.shard_count,
+                ):
+                    logger.warning(
+                        "Startup repair: incomplete math snapshot for zid=%s "
+                        "math_env=%s (missing rows or mismatched math_tick); "
+                        "scheduling full rebuild", zid, self.config.math_env,
+                    )
+                    self._pool.submit(zid, REBUILD, [])
+            self._startup_repair_done = True
 
     def _vote_loop(self) -> None:
         while not self._stop.is_set():
@@ -457,8 +475,33 @@ class MathPollerService:
         unparks each parked zid (which invalidates its cache) and enqueues a
         REBUILD so the worker reloads the full vote history from Postgres and
         re-persists — reprocessing the interval that was skipped when the global
-        watermark advanced past the failure."""
+        watermark advanced past the failure.
+
+        It ALSO retries the startup repair scan until that has completed
+        successfully once. This is the only daemon path that runs without new
+        votes or moderation, so it is the only place a dormant zid with mixed
+        math_tick generations can be rediscovered after a boot-time DB error;
+        without it, swallowing that error in start() would strand the zid for
+        the process lifetime (start() runs no other scan, and the vote/mod
+        loops never look outside the watermark lookback). The retry is bounded
+        by the reconciler's own cadence, so a persistently failing scan retries
+        once per interval rather than hot-looping."""
         assert self._pool is not None
+        if not self._startup_repair_done:
+            logger.warning(
+                "Startup repair scan still pending; retrying it from the "
+                "parked-zid reconciler"
+            )
+            # Swallowed like the parked-zid work below: a still-broken database
+            # must not kill the reconciler thread, and the flag stays False so
+            # the next cycle retries again.
+            try:
+                self._repair_incomplete_snapshots()
+            except Exception:
+                logger.exception(
+                    "Startup repair scan retry failed; the next reconcile "
+                    "cycle retries"
+                )
         for zid in sorted(self._pool.parked_zids()):
             logger.info("Reconciler recovering parked zid=%s (M1)", zid)
             self._unpark(zid)  # clears park + invalidates cache

--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -313,7 +313,19 @@ class MathPollerService:
 
     def start(self) -> None:
         self._ensure_runtime()
-        self._repair_incomplete_snapshots()
+        # A boot-time database blip must not abort startup. Before the startup
+        # scan existed, start() touched no database at all and a blip was
+        # absorbed by the poll loops' own try/except; keep that property. The
+        # scan leaves _startup_repair_done False on failure, so the first poll
+        # cycle retries it. poll_once() deliberately still propagates — the
+        # --once contract and test_startup_scan_failure_is_retried depend on it.
+        try:
+            self._repair_incomplete_snapshots()
+        except Exception:
+            logger.exception(
+                "Startup repair scan failed; continuing without it "
+                "(the next poll cycle retries)"
+            )
         self._stop.clear()
         self._threads = [
             threading.Thread(target=self._vote_loop, name="vote-poller", daemon=True),
@@ -373,6 +385,25 @@ class MathPollerService:
         A scan failure must propagate, leaving the scan pending for the next
         poll_once/start attempt. Once submitted, ordinary worker retry/park
         reconciliation owns recovery, including a failed rebuild with no votes.
+        start() catches it so a boot-time blip cannot abort startup.
+
+        TODO(review E4 - startup REBUILD burst cap): this submits an UNBOUNDED
+        number of REBUILDs (each a full vote-history recompute), logs one
+        WARNING per zid, and runs before the poll threads start. The scan is
+        three seq scans (math_env is unindexed on all three tables) and the
+        burst on a large production namespace has not been benchmarked. Wants a
+        cap, a summary count log instead of per-zid warnings, an env kill
+        switch, and a benchmark. Note R10: poll_once's join(timeout=120)
+        result is discarded, so with a backlog `--once` reports success with
+        work still pending.
+
+        TODO(review E5 - rebuild-thrash metering): _load_or_init's mismatch
+        path discards warm state and re-reads full vote history every time it
+        fires, unthrottled. A second writer (Clojure during dual-run) holding
+        one table at a different tick would make that zid full-rebuild every
+        cycle. Wants a counter/metric so it is visible.
+
+        Both are deliberate follow-ups, not part of this change.
         """
         if self._startup_repair_done:
             return

--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -282,6 +282,7 @@ class MathPollerService:
         self._stop = threading.Event()
         self._vote_wm: Optional[int] = None
         self._mod_wm: Optional[int] = None
+        self._startup_repair_done = False
 
     @property
     def _parked(self) -> set:
@@ -312,6 +313,7 @@ class MathPollerService:
 
     def start(self) -> None:
         self._ensure_runtime()
+        self._repair_incomplete_snapshots()
         self._stop.clear()
         self._threads = [
             threading.Thread(target=self._vote_loop, name="vote-poller", daemon=True),
@@ -357,12 +359,36 @@ class MathPollerService:
         Used by ``--once`` and the integration test.
         """
         self._ensure_runtime()
+        self._repair_incomplete_snapshots()
         self._poll_votes_once()
         self._poll_moderation_once()
         # Recover any zids parked in earlier cycles even if they got no new votes.
         self._reconcile_once()
         assert self._pool is not None
         self._pool.join(timeout=120.0)
+
+    def _repair_incomplete_snapshots(self) -> None:
+        """Schedule legacy partial generations even outside the boot lookback.
+
+        A scan failure must propagate, leaving the scan pending for the next
+        poll_once/start attempt. Once submitted, ordinary worker retry/park
+        reconciliation owns recovery, including a failed rebuild with no votes.
+        """
+        if self._startup_repair_done:
+            return
+        assert self._pool is not None
+        for zid in self._pg.find_incomplete_math_snapshots():
+            if should_process_zid(
+                zid, self.config.allowlist, self.config.blocklist,
+                self.config.shard_index, self.config.shard_count,
+            ):
+                logger.warning(
+                    "Startup repair: incomplete math snapshot for zid=%s "
+                    "math_env=%s (missing rows or mismatched math_tick); "
+                    "scheduling full rebuild", zid, self.config.math_env,
+                )
+                self._pool.submit(zid, REBUILD, [])
+        self._startup_repair_done = True
 
     def _vote_loop(self) -> None:
         while not self._stop.is_set():
@@ -569,6 +595,14 @@ class MathPollerService:
             row = self._pg.load_math_main(zid)
         except Exception:
             logger.exception("load_math_main failed for zid=%s; cold start", zid)
+            row = None
+
+        if row and row.get("snapshot_complete") is False:
+            logger.warning(
+                "load-or-init: incomplete math snapshot for zid=%s math_env=%s "
+                "(missing rows or mismatched math_tick); discarding persisted "
+                "state and rebuilding full history", zid, self.config.math_env,
+            )
             row = None
 
         if row and row.get("data"):

--- a/delphi/tests/poller/recovery/restart_child.py
+++ b/delphi/tests/poller/recovery/restart_child.py
@@ -16,10 +16,10 @@ Stages (the P-022 §C R05 list):
     :func:`_install_after_poll_latch`.
 ``during_compute``
     inside ``Conversation.recompute``
-``after_main_commit``
-    after ``write_math_main`` committed, before the other two tables
-``before_final_table_commit``
-    after main+bidtopid committed, before ``write_participant_stats``
+``after_main_write``
+    after ``write_math_main`` executed, before the other two tables (uncommitted)
+``before_final_table_write``
+    after main+bidtopid executed, before ``write_participant_stats`` (uncommitted)
 ``after_all_writes_before_cache``
     after all three writes committed, before the conversation is cached
 ``none``
@@ -171,6 +171,8 @@ def _hold_ownership(latch_dir: str) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--legacy-writes", action="store_true",
+                        help="Test-only negative control: commit each write separately")
     parser.add_argument("--pg-url", required=True)
     parser.add_argument("--math-env", required=True)
     parser.add_argument("--kill-stage", default="none")
@@ -203,6 +205,21 @@ def main() -> int:
                            ssl_mode="disable")
         )
         pg.initialize()
+        if args.legacy_writes:
+            # None tells each table writer to own/commit its transaction. Only
+            # the victim uses this: survivors always run the production
+            # atomic writer.
+            from contextlib import nullcontext
+            pg.transaction = lambda: nullcontext(None)
+            # Standalone _write_returning also uses transaction(), so provide
+            # its original implementation bound to the engine rather than
+            # recurse.
+            def legacy_returning(sql, params=None, *, connection=None):
+                from sqlalchemy import text
+                with pg.engine.begin() as conn:
+                    result = conn.execute(text(sql), params or {})
+                    return [dict(row) for row in result.mappings().all()]
+            pg._write_returning = legacy_returning
         svc = MathPollerService(
             pg,
             PollerConfig(
@@ -244,7 +261,7 @@ def main() -> int:
 
         Conversation.recompute = hooked_recompute
 
-    elif stage == "after_main_commit":
+    elif stage == "after_main_write":
         real_main = pg.write_math_main
 
         def hooked_main(*a, **kw):
@@ -254,7 +271,7 @@ def main() -> int:
 
         pg.write_math_main = hooked_main
 
-    elif stage == "before_final_table_commit":
+    elif stage == "before_final_table_write":
         real_stats = pg.write_participant_stats
 
         def hooked_stats(*a, **kw):

--- a/delphi/tests/poller/recovery/restart_child.py
+++ b/delphi/tests/poller/recovery/restart_child.py
@@ -16,10 +16,15 @@ Stages (the P-022 §C R05 list):
     :func:`_install_after_poll_latch`.
 ``during_compute``
     inside ``Conversation.recompute``
-``after_main_write``
-    after ``write_math_main`` executed, before the other two tables (uncommitted)
+``after_first_table_write``
+    after the FIRST of the three table writes (``write_math_bidtopid``)
+    executed, before the other two.  Under the production writer nothing is
+    committed yet; under ``--legacy-writes`` that first table committed alone,
+    which is the mixed generation the old writer could leave behind.
 ``before_final_table_write``
-    after main+bidtopid executed, before ``write_participant_stats`` (uncommitted)
+    after tick+bidtopid+ptptstats executed, before ``write_math_main`` — which
+    is deliberately the LAST statement in the publication transaction, so this
+    is the widest uncommitted window the writer ever has
 ``after_all_writes_before_cache``
     after all three writes committed, before the conversation is cached
 ``none``
@@ -218,6 +223,12 @@ def main() -> int:
                 from sqlalchemy import text
                 with pg.engine.begin() as conn:
                     result = conn.execute(text(sql), params or {})
+                    # Mirror the real _write_returning: .mappings() on a
+                    # statement with no result set raises. Every writer uses
+                    # RETURNING today, so this only keeps the stand-in from
+                    # drifting.
+                    if not result.returns_rows:
+                        return []
                     return [dict(row) for row in result.mappings().all()]
             pg._write_returning = legacy_returning
         svc = MathPollerService(
@@ -261,24 +272,24 @@ def main() -> int:
 
         Conversation.recompute = hooked_recompute
 
-    elif stage == "after_main_write":
+    elif stage == "after_first_table_write":
+        real_bidtopid = pg.write_math_bidtopid
+
+        def hooked_bidtopid(*a, **kw):
+            result = real_bidtopid(*a, **kw)
+            _emit(stage)
+            _block_forever()
+
+        pg.write_math_bidtopid = hooked_bidtopid
+
+    elif stage == "before_final_table_write":
         real_main = pg.write_math_main
 
         def hooked_main(*a, **kw):
-            result = real_main(*a, **kw)
             _emit(stage)
             _block_forever()
 
         pg.write_math_main = hooked_main
-
-    elif stage == "before_final_table_write":
-        real_stats = pg.write_participant_stats
-
-        def hooked_stats(*a, **kw):
-            _emit(stage)
-            _block_forever()
-
-        pg.write_participant_stats = hooked_stats
 
     elif stage == "after_all_writes_before_cache":
         real_remember = svc._remember

--- a/delphi/tests/poller/recovery/test_atomic_publish.py
+++ b/delphi/tests/poller/recovery/test_atomic_publish.py
@@ -128,6 +128,28 @@ def test_startup_scan_failure_is_retried(pg_url, make_service):
     assert svc._startup_repair_done
 
 
+def test_start_survives_a_boot_time_scan_failure(pg_url, make_service, caplog):
+    """A database blip at boot must not abort startup. Before the startup scan
+    existed, start() touched no database at all; a scan failure now has to be
+    logged and swallowed there (poll_once still propagates, above), leaving the
+    scan pending so the first poll cycle retries it."""
+    svc = make_service(pg_url, math_env=MATH_ENV)
+    scan = svc._pg.find_incomplete_math_snapshots
+    with patch.object(svc._pg, "find_incomplete_math_snapshots",
+                      side_effect=RuntimeError("boot scan failed")):
+        svc.start()
+    try:
+        assert not svc._startup_repair_done
+        assert "Startup repair scan failed" in caplog.text
+        assert svc._threads and all(t.is_alive() for t in svc._threads)
+    finally:
+        svc.stop()
+    with patch.object(svc._pg, "find_incomplete_math_snapshots", wraps=scan) as called:
+        svc.poll_once()
+        called.assert_called_once_with()
+    assert svc._startup_repair_done
+
+
 def test_blocked_zid_does_not_block_other_zid_transactions(
     engine, pg_url, make_service, monkeypatch
 ):

--- a/delphi/tests/poller/recovery/test_atomic_publish.py
+++ b/delphi/tests/poller/recovery/test_atomic_publish.py
@@ -2,6 +2,7 @@
 
 from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
+import threading
 import time
 
 import pytest
@@ -9,8 +10,8 @@ import sqlalchemy as sa
 
 from polismath.conversation.conversation import Conversation
 from .conftest import (
-    FaultInjector, Latch, fail_stage, read_math_tables, read_vote_events,
-    seed_conversation, tables_are_coherent,
+    FaultInjector, Latch, drain, eventually, fail_stage, read_math_tables,
+    read_vote_events, seed_conversation, tables_are_coherent,
 )
 from . import fold as F
 
@@ -148,6 +149,88 @@ def test_start_survives_a_boot_time_scan_failure(pg_url, make_service, caplog):
         svc.poll_once()
         called.assert_called_once_with()
     assert svc._startup_repair_done
+
+
+def test_running_daemon_retries_a_failed_boot_scan_and_repairs_a_dormant_zid(
+    engine, pg_url, make_service, caplog
+):
+    """The daemon itself must recover from a boot-time scan failure.
+
+    ``test_start_survives_a_boot_time_scan_failure`` only proves start() does not
+    abort; it then stops the daemon and drives ``poll_once`` by hand, which the
+    long-running ``start``/``run_forever`` path never calls.  Nothing there shows
+    a RUNNING process ever retrying.  This test never calls ``poll_once``: it
+    starts the real threads, fails exactly the boot scan, heals the database, and
+    requires the daemon's own reconciler loop to rediscover a DORMANT zid whose
+    math_tick generations are mixed — a zid no vote or moderation cycle can ever
+    reach, because it is 10 days old and the lookback is 1 day.  Without the
+    reconciler retry the scan is never re-run and the zid stays broken for the
+    process lifetime.
+    """
+    old = int(time.time() * 1000) - 10 * 24 * 60 * 60 * 1000
+    seed_conversation(engine, zid=2, n_ptpts=6, n_cmts=4, base_created=old)
+    # Publish one real coherent generation (no poll cycle involved), then damage
+    # it into UNEQUAL generations across the three tables.
+    setup = make_service(pg_url, math_env=MATH_ENV, poll_from_days_ago=30)
+    setup._writer.write_conv_updates(2, setup._load_or_init(2))
+    assert tables_are_coherent(read_math_tables(engine, 2, MATH_ENV)) == []
+    with engine.begin() as conn:
+        conn.execute(sa.text("UPDATE math_ptptstats SET math_tick = math_tick + 7 "
+                             "WHERE zid=2 AND math_env=:e"), {"e": MATH_ENV})
+        # A mixed main must not seed an incorrect watermark into the rebuild.
+        conn.execute(sa.text("UPDATE math_main SET last_vote_timestamp=:t "
+                             "WHERE zid=2 AND math_env=:e"),
+                     {"t": old + 99999999, "e": MATH_ENV})
+    assert setup._pg.find_incomplete_math_snapshots() == [2]
+    before = read_math_tables(engine, 2, MATH_ENV)
+
+    svc = make_service(
+        pg_url, math_env=MATH_ENV, poll_from_days_ago=1, worker_pool_size=1,
+        vote_interval_ms=50, mod_interval_ms=50, reconcile_interval_ms=25,
+    )
+    real_scan = svc._pg.find_incomplete_math_snapshots
+    calls = []
+    lock = threading.Lock()
+    boot_scan_failed = threading.Event()
+
+    def scan():
+        """Fail exactly the first scan (the boot one), then the database is healthy."""
+        with lock:
+            calls.append(1)
+            first = len(calls) == 1
+        if first:
+            boot_scan_failed.set()
+            raise RuntimeError("boot scan failed")
+        return real_scan()
+
+    with patch.object(svc._pg, "find_incomplete_math_snapshots", side_effect=scan):
+        svc.start()
+        try:
+            # start() ran the scan synchronously before spawning the threads, so
+            # this is deterministic rather than a race with the reconciler.
+            assert boot_scan_failed.is_set()
+            assert "Startup repair scan failed" in caplog.text
+            assert svc._threads and all(t.is_alive() for t in svc._threads)
+            # The ONLY thing that can flip this now is a daemon loop.
+            eventually(
+                lambda: svc._startup_repair_done,
+                message="no daemon loop ever retried the failed startup scan",
+            )
+            assert len(calls) >= 2, "the scan was never re-run"
+            drain(svc)
+        finally:
+            svc.stop()
+
+    assert "retrying it from the parked-zid reconciler" in caplog.text
+    assert "Startup repair: incomplete math snapshot for zid=2" in caplog.text
+    # Rebuilt from authoritative history, not restored from the mixed state.
+    assert "discarding persisted state and rebuilding full history" in caplog.text
+    tables = read_math_tables(engine, 2, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    assert tables["main"]["math_tick"] > before["main"]["math_tick"]
+    fold = F.fold_votes(read_vote_events(engine, 2))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    assert svc._pg.find_incomplete_math_snapshots() == []
 
 
 def test_blocked_zid_does_not_block_other_zid_transactions(

--- a/delphi/tests/poller/recovery/test_atomic_publish.py
+++ b/delphi/tests/poller/recovery/test_atomic_publish.py
@@ -1,0 +1,196 @@
+"""R05/R09: transaction rollback, legacy repair and concurrent zid isolation."""
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+import time
+
+import pytest
+import sqlalchemy as sa
+
+from polismath.conversation.conversation import Conversation
+from .conftest import (
+    FaultInjector, Latch, fail_stage, read_math_tables, read_vote_events,
+    seed_conversation, tables_are_coherent,
+)
+from . import fold as F
+
+pytestmark = pytest.mark.recovery
+MATH_ENV = "recovery"
+
+
+@pytest.mark.parametrize("published_before", [False, True])
+@pytest.mark.parametrize("stage", [
+    "increment_math_tick", "write_math_main", "write_math_bidtopid",
+    "write_participant_stats",
+])
+@pytest.mark.parametrize("after", [False, True])
+def test_failure_rolls_back_whole_snapshot(
+    engine, pg_url, make_service, stage, after, published_before
+):
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV)
+    conv = svc._load_or_init(1)
+    if published_before:
+        svc._writer.write_conv_updates(1, conv)
+    before = read_math_tables(engine, 1, MATH_ENV)
+    fault = FaultInjector(name=stage, mode="once")
+    undo = fail_stage(svc._pg, stage, fault, after=after)
+    try:
+        with pytest.raises(RuntimeError):
+            svc._writer.write_conv_updates(1, conv)
+    finally:
+        undo()
+    assert fault.fired == 1
+    # This includes the allocation row, not only the three published blobs.
+    assert read_math_tables(engine, 1, MATH_ENV) == before
+    svc._writer.write_conv_updates(1, conv)
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    expected = before["main"]["math_tick"] + 1 if published_before else 0
+    assert tables["main"]["math_tick"] == expected
+    assert tables["main"]["caching_tick"] == (2 if published_before else 1)
+
+
+@pytest.mark.parametrize("table", ["math_main", "math_bidtopid", "math_ptptstats"])
+@pytest.mark.parametrize("damage", ["missing", "different_tick"])
+def test_dormant_partial_snapshot_rebuilds_without_restoring_mixed_state(
+    engine, pg_url, make_service, caplog, table, damage
+):
+    old = int(time.time() * 1000) - 10 * 24 * 60 * 60 * 1000
+    seed_conversation(engine, zid=2, n_ptpts=6, n_cmts=4, base_created=old)
+    svc = make_service(pg_url, math_env=MATH_ENV, poll_from_days_ago=30)
+    svc.poll_once()
+    with engine.begin() as conn:
+        if damage == "missing":
+            conn.execute(sa.text(f"DELETE FROM {table} WHERE zid=2 AND math_env=:e"),
+                         {"e": MATH_ENV})
+        else:
+            conn.execute(sa.text(f"UPDATE {table} SET math_tick=math_tick + 7 "
+                                 "WHERE zid=2 AND math_env=:e"), {"e": MATH_ENV})
+        # A mixed main must not seed an incorrect watermark into the rebuild.
+        conn.execute(sa.text("UPDATE math_main SET last_vote_timestamp=:t "
+                             "WHERE zid=2 AND math_env=:e"),
+                     {"t": old + 99999999, "e": MATH_ENV})
+    assert svc._pg.find_incomplete_math_snapshots() == [2]
+    fresh = make_service(pg_url, math_env=MATH_ENV, poll_from_days_ago=1)
+    with patch.object(Conversation, "from_dict", wraps=Conversation.from_dict) as restore:
+        fresh.poll_once()
+        restore.assert_not_called()
+    tables = read_math_tables(engine, 2, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    fold = F.fold_votes(read_vote_events(engine, 2))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    assert fresh._pg.find_incomplete_math_snapshots() == []
+    assert "Startup repair: incomplete math snapshot for zid=2" in caplog.text
+    if table != "math_main" or damage != "missing":
+        assert "discarding persisted state and rebuilding full history" in caplog.text
+
+
+@pytest.mark.parametrize("config,expected", [
+    ({"allowlist": [1, 2], "shard_index": 0, "shard_count": 2}, [2]),
+    ({"blocklist": [2, 3]}, [1]),
+    ({"allowlist": [3], "blocklist": [3]}, [3]),
+])
+def test_startup_repair_obeys_namespace_and_routing(
+    engine, pg_url, make_service, config, expected
+):
+    old = int(time.time() * 1000) - 10 * 24 * 60 * 60 * 1000
+    for zid in (1, 2, 3, 4):
+        seed_conversation(engine, zid=zid, n_ptpts=4, n_cmts=3, base_created=old)
+        with engine.begin() as conn:
+            conn.execute(sa.text("INSERT INTO math_main "
+                                 "(zid, math_env, data, math_tick, last_vote_timestamp) "
+                                 "VALUES (:z, :e, '{}'::jsonb, 7, 0)"),
+                         {"z": zid, "e": "other" if zid == 4 else MATH_ENV})
+    other_before = read_math_tables(engine, 4, "other")
+    svc = make_service(pg_url, math_env=MATH_ENV, **config)
+    assert svc._pg.find_incomplete_math_snapshots() == [1, 2, 3]
+    svc.poll_once()
+    for zid in (1, 2, 3):
+        tables = read_math_tables(engine, zid, MATH_ENV)
+        assert (tables_are_coherent(tables) == []) == (zid in expected)
+    assert read_math_tables(engine, 4, "other") == other_before
+    assert read_math_tables(engine, 4, MATH_ENV)["main"] is None
+
+
+def test_startup_scan_failure_is_retried(pg_url, make_service):
+    svc = make_service(pg_url, math_env=MATH_ENV)
+    scan = svc._pg.find_incomplete_math_snapshots
+    with patch.object(svc._pg, "find_incomplete_math_snapshots",
+                      side_effect=RuntimeError("scan failed")):
+        with pytest.raises(RuntimeError, match="scan failed"):
+            svc.poll_once()
+    assert not svc._startup_repair_done
+    with patch.object(svc._pg, "find_incomplete_math_snapshots", wraps=scan) as called:
+        svc.poll_once()
+        svc.poll_once()
+        called.assert_called_once_with()
+    assert svc._startup_repair_done
+
+
+def test_blocked_zid_does_not_block_other_zid_transactions(
+    engine, pg_url, make_service, monkeypatch
+):
+    for zid in (1, 2, 3, 4):
+        seed_conversation(engine, zid=zid, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=4)
+    svc.poll_once()
+    before = read_math_tables(engine, 1, MATH_ENV)
+    latch = Latch("zid 1 before bidtopid")
+    real = svc._pg.write_math_bidtopid
+
+    def blocked(zid, *args, **kwargs):
+        if zid == 1:
+            latch.block()
+        return real(zid, *args, **kwargs)
+
+    monkeypatch.setattr(svc._pg, "write_math_bidtopid", blocked)
+    # Same client, four explicit connections. Holding zid 1's transaction open
+    # must neither commit its main/tick nor stop the other three transactions.
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        first = pool.submit(svc._writer.write_conv_updates, 1, svc._convs[1])
+        try:
+            latch.wait_arrival()
+            others = [pool.submit(svc._writer.write_conv_updates, z, svc._convs[z])
+                      for z in (2, 3, 4)]
+            for future in others:
+                future.result(timeout=20)
+            assert not first.done()
+            assert read_math_tables(engine, 1, MATH_ENV) == before
+            for zid in (2, 3, 4):
+                tables = read_math_tables(engine, zid, MATH_ENV)
+                assert tables_are_coherent(tables) == []
+                assert tables["main"]["math_tick"] == 1
+        finally:
+            latch.let_go()
+        first.result(timeout=20)
+    assert tables_are_coherent(read_math_tables(engine, 1, MATH_ENV)) == []
+
+
+def test_lost_ack_after_snapshot_commit_recovers(engine, pg_url, make_service):
+    """The commit succeeded, but the worker sees failure before caching. Retry
+    must preserve all inputs and coherence even though a generation committed."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=1, worker_pool_size=1)
+    committed = []
+    real = svc._writer.write_conv_updates
+
+    def lose_first_ack(zid, conv):
+        tick = real(zid, conv)
+        if not committed:
+            tables = read_math_tables(engine, zid, MATH_ENV)
+            assert tables_are_coherent(tables) == []
+            assert tables["main"]["math_tick"] == tick
+            committed.append(tables)
+            raise RuntimeError("lost acknowledgement after commit")
+        return tick
+
+    with patch.object(svc._writer, "write_conv_updates", side_effect=lose_first_ack):
+        svc.poll_once()
+    assert len(committed) == 1
+    tables = read_math_tables(engine, 1, MATH_ENV)
+    assert tables_are_coherent(tables) == []
+    assert tables["main"]["math_tick"] == committed[0]["main"]["math_tick"] + 1
+    fold = F.fold_votes(read_vote_events(engine, 1))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
+    assert 1 not in svc._parked

--- a/delphi/tests/poller/recovery/test_r01_stage_failures.py
+++ b/delphi/tests/poller/recovery/test_r01_stage_failures.py
@@ -10,10 +10,11 @@ P-022 §C required matrix:
     gaps are not lost votes.
 
 Every failure is injected at the ``PostgresClient`` boundary that
-``MathWriter.write_conv_updates`` calls (``math_writer.py:238`` — three separate
-calls, each committing on its own ``engine.begin()``), so the code under test is
-the deployed code.  Three of the failures are genuine Postgres failures, not
-Python stand-ins:
+``MathWriter.write_conv_updates`` calls (``math_writer.py:227`` — the tick
+allocation and all three table writes now share ONE ``engine.begin()``, so a
+failure at any stage rolls the whole snapshot back, including the tick), so the
+code under test is the deployed code.  Three of the failures are genuine
+Postgres failures, not Python stand-ins:
 
 * **DB rollback** — a real ``NOT NULL`` violation inside the real upsert.
 * **connection loss** — ``pg_terminate_backend`` on the poller's own backend.
@@ -68,14 +69,15 @@ def _publish_and_check(engine, svc, zid=1):
 @pytest.mark.parametrize(
     "stage,after",
     [
+        # Writer order is tick -> bidtopid -> ptptstats -> main -> COMMIT.
         ("increment_math_tick", False),   # before tick allocation
         ("increment_math_tick", True),    # after tick allocation
-        ("write_math_main", False),       # before the main write
-        ("write_math_main", True),        # after the main write (lost ack)
         ("write_math_bidtopid", False),   # before the bidtopid write
         ("write_math_bidtopid", True),    # after the bidtopid write
         ("write_participant_stats", False),   # before the ptptstats write
-        ("write_participant_stats", True),    # after all three writes
+        ("write_participant_stats", True),    # after the ptptstats write
+        ("write_math_main", False),       # before the main write
+        ("write_math_main", True),        # after all three writes (lost ack)
     ],
 )
 def test_one_shot_stage_failure_recovers(engine, pg_url, make_service, stage, after):

--- a/delphi/tests/poller/recovery/test_r01_stage_failures.py
+++ b/delphi/tests/poller/recovery/test_r01_stage_failures.py
@@ -568,14 +568,17 @@ def test_recovered_state_matches_a_clean_reference_computation(engine, pg_url,
 
 
 def test_tick_gap_is_allowed_but_votes_are_not_lost(engine, pg_url, make_service):
-    """A failure AFTER tick allocation burns a math_tick.  P-022: "Tick gaps may
-    occur; gaps are not lost votes." — assert the gap AND the intact input."""
+    """A legacy standalone allocation can leave a tick gap. Atomic publication
+    must tolerate that existing gap and preserve the final authoritative input.
+    New transaction rollback is checked separately in test_atomic_publish."""
     from .conftest import commit_vote
 
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=0)
     svc.poll_once()
     first = read_math_tables(engine, 1, MATH_ENV)["main"]["math_tick"]
+    # Explicit legacy negative control: commit an allocation without a snapshot.
+    assert svc._pg.increment_math_tick(1) == first + 1
 
     injector = FaultInjector(name="write_math_main", mode="once")
     undo = fail_stage(svc._pg, "write_math_main", injector)

--- a/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
+++ b/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
@@ -16,6 +16,12 @@ The production writer now commits all three rows together. The legacy-writes
 child option intentionally restores separate commits ONLY for negative controls
 and the dormant-zid repair regression: old partial rows still need repair even
 though new publications can no longer produce them.
+
+P-022's "after main commit / before final table commit" stages are expressed as
+``after_first_table_write`` and ``before_final_table_write``, because the writer
+now emits ``math_main`` LAST (it is the statement that allocates caching_tick,
+so it is kept adjacent to the COMMIT — see math_writer.py). The two stages still
+bracket the same seam: one table written, and all-but-the-last written.
 """
 
 import os
@@ -49,7 +55,7 @@ _MS_PER_DAY = 24 * 60 * 60 * 1000
 STAGES = [
     "after_poll",
     "during_compute",
-    "after_main_write",
+    "after_first_table_write",
     "before_final_table_write",
     "after_all_writes_before_cache",
 ]
@@ -269,23 +275,23 @@ def test_after_poll_kill_point_is_latched_after_the_watermark_advance(
     assert F.check_published_against_fold(tables["main"]["data"], fold) == []
 
 
-def test_legacy_kill_after_main_write_leaves_a_mixed_generation(
+def test_legacy_kill_after_first_table_write_leaves_a_mixed_generation(
     engine, pg_url, children, tmp_path
 ):
     """The seam itself, asserted directly: a kill between the three writes DOES
-    leave math_main ahead of the other two tables.  (Recovery is the test
+    leave the first table ahead of the other two.  (Recovery is the test
     above; this one pins the intermediate state so the defect is documented
     rather than inferred.)"""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
 
-    victim = _spawn(children, pg_url, "after_main_write", tmp_path=tmp_path,
+    victim = _spawn(children, pg_url, "after_first_table_write", tmp_path=tmp_path,
                     legacy_writes=True)
-    victim.await_stage("after_main_write")
+    victim.await_stage("after_first_table_write")
     victim.kill()
 
     tables = read_math_tables(engine, 1, MATH_ENV)
-    assert tables["main"] is not None, "math_main committed on its own"
-    assert tables["bidtopid"] is None and tables["ptptstats"] is None, (
+    assert tables["bidtopid"] is not None, "math_bidtopid committed on its own"
+    assert tables["main"] is None and tables["ptptstats"] is None, (
         "the other two tables must not exist yet — that is the non-atomic "
         "three-table write (math_writer.py:238)"
     )
@@ -321,17 +327,18 @@ def test_dormant_zid_is_outside_the_lookback(engine, pg_url, children,
 def test_dormant_zid_partial_write_is_repaired_after_restart(
     engine, pg_url, children, tmp_path
 ):
-    """Kill the process after the main commit for a DORMANT conversation using the legacy writer, then
-    restart the production writer with no new votes. It must discover and repair
-    the preexisting mixed generation outside its lookback."""
+    """Kill the process after the first table commit for a DORMANT conversation
+    using the legacy writer, then restart the production writer with no new
+    votes. It must discover and repair the preexisting mixed generation outside
+    its lookback."""
     _seed_dormant(engine, zid=2)
 
     # The conversation was active when the poller last ran (wide lookback).
-    victim = _spawn(children, pg_url, "after_main_write", days=30.0,
+    victim = _spawn(children, pg_url, "after_first_table_write", days=30.0,
                     tmp_path=tmp_path, legacy_writes=True)
-    victim.await_stage("after_main_write")
+    victim.await_stage("after_first_table_write")
     victim.kill()
-    assert read_math_tables(engine, 2, MATH_ENV)["main"] is not None
+    assert read_math_tables(engine, 2, MATH_ENV)["bidtopid"] is not None
 
     # It has since gone quiet for longer than the boot lookback.
     survivor = _spawn(children, pg_url, "none", days=1.0, tmp_path=tmp_path)
@@ -351,9 +358,9 @@ def test_dormant_zid_partial_write_is_repaired_with_a_wide_lookback(
     durable repair path rather than to the write seam alone."""
     _seed_dormant(engine, zid=2)
 
-    victim = _spawn(children, pg_url, "after_main_write", days=30.0,
+    victim = _spawn(children, pg_url, "after_first_table_write", days=30.0,
                     tmp_path=tmp_path, legacy_writes=True)
-    victim.await_stage("after_main_write")
+    victim.await_stage("after_first_table_write")
     victim.kill()
 
     survivor = _spawn(children, pg_url, "none", days=30.0, tmp_path=tmp_path)
@@ -377,7 +384,7 @@ class TestNegativeControl:
         seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
         child = _spawn(children, pg_url, "none", tmp_path=tmp_path)
         with pytest.raises(AssertionError):
-            child.await_stage("after_main_write", timeout=5.0)
+            child.await_stage("after_first_table_write", timeout=5.0)
 
     def test_the_after_poll_latch_refuses_to_claim_an_unadvanced_watermark(
         self, engine, pg_url, children, tmp_path
@@ -417,7 +424,7 @@ class TestNegativeControl:
         )
 
 
-@pytest.mark.parametrize("stage", ["after_main_write", "before_final_table_write"])
+@pytest.mark.parametrize("stage", ["after_first_table_write", "before_final_table_write"])
 @pytest.mark.parametrize("published_before", [False, True])
 def test_atomic_publish_kill_rolls_back_every_table(
     engine, pg_url, children, tmp_path, stage, published_before

--- a/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
+++ b/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
@@ -12,14 +12,10 @@ The subject is ``restart_child.py``: a real ``MathPollerService`` in a real
 subprocess, which announces the named stage on stdout and then blocks so the
 TEST delivers ``SIGKILL``.  Nothing is simulated in-process.
 
-Two of these scenarios expose the seam P-022 predicted
-(``math_writer.py:238`` issues three separate calls, each committing on its own
-``engine.begin()`` — ``database/postgres.py:413``, ``:432``): a process killed
-between them leaves math_main published at a generation the other two tables
-never reach, and there is no parked marker to reconcile because the marker only
-ever lived in the dead process's memory.  With a recent conversation the next
-poll happens to repair it; with a DORMANT one (older than the boot lookback) it
-never does.
+The production writer now commits all three rows together. The legacy-writes
+child option intentionally restores separate commits ONLY for negative controls
+and the dormant-zid repair regression: old partial rows still need repair even
+though new publications can no longer produce them.
 """
 
 import os
@@ -53,8 +49,8 @@ _MS_PER_DAY = 24 * 60 * 60 * 1000
 STAGES = [
     "after_poll",
     "during_compute",
-    "after_main_commit",
-    "before_final_table_commit",
+    "after_main_write",
+    "before_final_table_write",
     "after_all_writes_before_cache",
 ]
 
@@ -68,7 +64,8 @@ class Child:
     """
 
     def __init__(self, pg_url, stage, days=1.0, tmp_path=None,
-                 ownership_latch_dir=None, math_env=MATH_ENV):
+                 ownership_latch_dir=None, math_env=MATH_ENV,
+                 legacy_writes=False):
         env = dict(os.environ)
         env["PYTHONPATH"] = _DELPHI_ROOT + os.pathsep + env.get("PYTHONPATH", "")
         if tmp_path is not None:
@@ -78,6 +75,8 @@ class Child:
                 "--poll-from-days-ago", str(days)]
         if ownership_latch_dir is not None:
             argv += ["--ownership-latch-dir", str(ownership_latch_dir)]
+        if legacy_writes:
+            argv += ["--legacy-writes"]
         self.proc = subprocess.Popen(
             argv,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
@@ -270,7 +269,7 @@ def test_after_poll_kill_point_is_latched_after_the_watermark_advance(
     assert F.check_published_against_fold(tables["main"]["data"], fold) == []
 
 
-def test_kill_after_main_commit_leaves_a_mixed_generation_before_restart(
+def test_legacy_kill_after_main_write_leaves_a_mixed_generation(
     engine, pg_url, children, tmp_path
 ):
     """The seam itself, asserted directly: a kill between the three writes DOES
@@ -279,8 +278,9 @@ def test_kill_after_main_commit_leaves_a_mixed_generation_before_restart(
     rather than inferred.)"""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
 
-    victim = _spawn(children, pg_url, "after_main_commit", tmp_path=tmp_path)
-    victim.await_stage("after_main_commit")
+    victim = _spawn(children, pg_url, "after_main_write", tmp_path=tmp_path,
+                    legacy_writes=True)
+    victim.await_stage("after_main_write")
     victim.kill()
 
     tables = read_math_tables(engine, 1, MATH_ENV)
@@ -308,7 +308,7 @@ def _seed_dormant(engine, zid=2):
 def test_dormant_zid_is_outside_the_lookback(engine, pg_url, children,
                                              tmp_path):
     """Control: with a 1-day lookback a dormant conversation is genuinely never
-    polled, so the xfail below is about repair and not about a mis-seeded
+    polled, so the regression below is about repair and not about a mis-seeded
     fixture."""
     _seed_dormant(engine, zid=2)
     child = _spawn(children, pg_url, "none", days=1.0, tmp_path=tmp_path)
@@ -318,38 +318,18 @@ def test_dormant_zid_is_outside_the_lookback(engine, pg_url, children,
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "DEFECT (predicted by P-022 §C): a process killed between the three "
-        "non-atomic table writes leaves a permanently mixed generation for a "
-        "DORMANT conversation. polismath/poller/math_writer.py:238 issues "
-        "write_math_main / write_math_bidtopid / write_participant_stats as "
-        "three separate calls, each committing on its own engine.begin() "
-        "(polismath/database/postgres.py:413, :432), so a main-row watermark "
-        "is not proof of all-table completion. The only repair path is the "
-        "parked-zid reconciler (polismath/poller/service.py:393), which "
-        "iterates the pool's in-memory parked set — that set died with the "
-        "process, and the conversation's newest vote is older than the boot "
-        "lookback (service.py:55 initial_watermark), so nothing ever revisits "
-        "it. math_main stays published at math_tick N while math_bidtopid and "
-        "math_ptptstats are absent, indefinitely. Fixing this needs either a "
-        "transaction spanning all three writes or a durable "
-        "table-generation-completeness scan; both are a separate decision."
-    ),
-)
 def test_dormant_zid_partial_write_is_repaired_after_restart(
     engine, pg_url, children, tmp_path
 ):
-    """Kill the process after the main commit for a DORMANT conversation, then
-    restart with the production-like lookback and no new votes.  A correct
-    system repairs the mixed generation; this one cannot."""
+    """Kill the process after the main commit for a DORMANT conversation using the legacy writer, then
+    restart the production writer with no new votes. It must discover and repair
+    the preexisting mixed generation outside its lookback."""
     _seed_dormant(engine, zid=2)
 
     # The conversation was active when the poller last ran (wide lookback).
-    victim = _spawn(children, pg_url, "after_main_commit", days=30.0,
-                    tmp_path=tmp_path)
-    victim.await_stage("after_main_commit")
+    victim = _spawn(children, pg_url, "after_main_write", days=30.0,
+                    tmp_path=tmp_path, legacy_writes=True)
+    victim.await_stage("after_main_write")
     victim.kill()
     assert read_math_tables(engine, 2, MATH_ENV)["main"] is not None
 
@@ -359,6 +339,8 @@ def test_dormant_zid_partial_write_is_repaired_after_restart(
 
     tables = read_math_tables(engine, 2, MATH_ENV)
     assert tables_are_coherent(tables) == [], tables_are_coherent(tables)
+    fold = F.fold_votes(read_vote_events(engine, 2))
+    assert F.check_published_against_fold(tables["main"]["data"], fold) == []
 
 
 def test_dormant_zid_partial_write_is_repaired_with_a_wide_lookback(
@@ -369,9 +351,9 @@ def test_dormant_zid_partial_write_is_repaired_with_a_wide_lookback(
     durable repair path rather than to the write seam alone."""
     _seed_dormant(engine, zid=2)
 
-    victim = _spawn(children, pg_url, "after_main_commit", days=30.0,
-                    tmp_path=tmp_path)
-    victim.await_stage("after_main_commit")
+    victim = _spawn(children, pg_url, "after_main_write", days=30.0,
+                    tmp_path=tmp_path, legacy_writes=True)
+    victim.await_stage("after_main_write")
     victim.kill()
 
     survivor = _spawn(children, pg_url, "none", days=30.0, tmp_path=tmp_path)
@@ -395,7 +377,7 @@ class TestNegativeControl:
         seed_conversation(engine, zid=1, n_ptpts=4, n_cmts=3)
         child = _spawn(children, pg_url, "none", tmp_path=tmp_path)
         with pytest.raises(AssertionError):
-            child.await_stage("after_main_commit", timeout=5.0)
+            child.await_stage("after_main_write", timeout=5.0)
 
     def test_the_after_poll_latch_refuses_to_claim_an_unadvanced_watermark(
         self, engine, pg_url, children, tmp_path
@@ -433,3 +415,23 @@ class TestNegativeControl:
             "NEGATIVE CONTROL FAILED: the victim completed its poll cycle, so "
             "the kill did not interrupt anything"
         )
+
+
+@pytest.mark.parametrize("stage", ["after_main_write", "before_final_table_write"])
+@pytest.mark.parametrize("published_before", [False, True])
+def test_atomic_publish_kill_rolls_back_every_table(
+    engine, pg_url, children, tmp_path, stage, published_before
+):
+    """SIGKILL inside the shared transaction preserves ALL prior rows, including
+    both ticks; a first publication leaves no partial rows at all."""
+    seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
+    if published_before:
+        initial = _spawn(children, pg_url, "none", tmp_path=tmp_path)
+        initial.wait_done()
+    before = read_math_tables(engine, 1, MATH_ENV)
+    victim = _spawn(children, pg_url, stage, tmp_path=tmp_path)
+    victim.await_stage(stage)
+    # Uncommitted writes are invisible even before the backend notices the kill.
+    assert read_math_tables(engine, 1, MATH_ENV) == before
+    victim.kill()
+    assert read_math_tables(engine, 1, MATH_ENV) == before

--- a/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
+++ b/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
@@ -427,34 +427,17 @@ class ContinuousReader(threading.Thread):
                 if s[0] is not None and response_problems(*s)]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "DEFECT (predicted by P-022 §C): the three tables are published "
-        "NON-ATOMICALLY, so a reader can observe math_main at generation N "
-        "together with math_bidtopid/math_ptptstats at N-1 or absent. "
-        "polismath/poller/math_writer.py:238 makes three separate client "
-        "calls and each commits on its own engine.begin() "
-        "(polismath/database/postgres.py:413, :432). The consumer joins the "
-        "two blobs POSITIONALLY — server/src/utils/participants.ts:33-51 maps "
-        "base-clusters.id -> index -> bidToPid[index] — so a mixed pair is a "
-        "wrong participant mapping, not merely a stale one. P-022 §C: 'No "
-        "response may combine incompatible generations... Eventual repair "
-        "alone does not make a mixed mapping safe.' The fix is a transaction "
-        "spanning all three writes, or a reader-visible completed-generation "
-        "marker; that is a separate decision."
-    ),
-)
 @pytest.mark.parametrize("mode", READER_MODES)
 def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service,
                                               mode):
-    """Pause the writer after the main commit and before the bidtopid commit,
+    """Pause the writer after the main write and before the bidtopid write,
     while a reader polls continuously.
 
     Run in BOTH observer modes: the REPEATABLE READ observer (writer-isolation
     evidence, stronger than the server) and the separate-autocommit-statement
     observer (what Node's two independent ``queryP_readOnly`` calls actually
-    do).  Both see the window, because the window is the writer's."""
+    do). Neither sees a mixed generation, because the three tables are now
+    published inside a single transaction."""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
     svc.poll_once()          # generation 1: complete
@@ -472,7 +455,7 @@ def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service,
     worker = threading.Thread(target=svc.poll_once, daemon=True)
     worker.start()
     latch.wait_arrival()
-    # The reader is running while math_main is committed and bidtopid is not.
+    # Main has executed, but the full snapshot is still uncommitted.
     eventually(lambda: len(reader.snapshots) > 3, timeout=10,
                message="the reader took no snapshots during the pause")
     latch.let_go()
@@ -487,13 +470,25 @@ def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service,
     )
 
 
-def test_the_mixed_window_is_real_and_observable(engine, pg_url, make_service):
-    """Companion to the xfail: assert the incoherent window EXISTS, so the
-    defect is documented directly rather than only as a failing expectation."""
+def test_legacy_mixed_window_is_real_and_observable(engine, pg_url, make_service,
+                                                    monkeypatch):
+    """Negative control: the intentionally non-atomic legacy writer MUST expose
+    a mixed window. Keep the original defect assertions load-bearing."""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
     svc.poll_once()
     first_tick = read_math_tables(engine, 1, MATH_ENV)["main"]["math_tick"]
+
+    from contextlib import nullcontext
+    real_transaction = svc._pg.transaction
+    real_returning = svc._pg._write_returning
+
+    def legacy_returning(sql, params=None, *, connection=None):
+        with real_transaction() as conn:
+            return real_returning(sql, params, connection=conn)
+
+    monkeypatch.setattr(svc._pg, "transaction", lambda: nullcontext(None))
+    monkeypatch.setattr(svc._pg, "_write_returning", legacy_returning)
 
     latch = Latch("write_math_bidtopid")
     undo = latch_method(svc._pg, "write_math_bidtopid", latch)
@@ -796,8 +791,8 @@ class TestNegativeControl:
         """Intentionally 'fixed' variant: write all three rows inside ONE
         transaction and show the SNAPSHOT reader never observes a split.  This
         proves the ``repeatable_read`` observer can distinguish atomic from
-        non-atomic publication — the xfail is about the WRITER, not about the
-        check.
+        non-atomic publication — the regression is about the WRITER, not
+        about the check.
 
         Scope, stated exactly (astra review finding 2): this is
         writer-isolation evidence only.  It does NOT show that an atomic writer

--- a/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
+++ b/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
@@ -430,8 +430,10 @@ class ContinuousReader(threading.Thread):
 @pytest.mark.parametrize("mode", READER_MODES)
 def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service,
                                               mode):
-    """Pause the writer after the main write and before the bidtopid write,
-    while a reader polls continuously.
+    """Pause the writer between the table writes — after bidtopid and ptptstats
+    have executed and before math_main, which the writer now emits last — while
+    a reader polls continuously. That is the widest window in which a reader
+    could observe a mixed generation.
 
     Run in BOTH observer modes: the REPEATABLE READ observer (writer-isolation
     evidence, stronger than the server) and the separate-autocommit-statement
@@ -445,8 +447,8 @@ def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service,
     reader = ContinuousReader(engine, 1, MATH_ENV, mode=mode)
     reader.start()
 
-    latch = Latch("write_math_bidtopid")
-    undo = latch_method(svc._pg, "write_math_bidtopid", latch)
+    latch = Latch("write_math_main")
+    undo = latch_method(svc._pg, "write_math_main", latch)
     from .conftest import commit_vote
     base = max(e["created"] for e in read_vote_events(engine, 1))
     commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
@@ -455,7 +457,7 @@ def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service,
     worker = threading.Thread(target=svc.poll_once, daemon=True)
     worker.start()
     latch.wait_arrival()
-    # Main has executed, but the full snapshot is still uncommitted.
+    # Both companions have executed, but the full snapshot is still uncommitted.
     eventually(lambda: len(reader.snapshots) > 3, timeout=10,
                message="the reader took no snapshots during the pause")
     latch.let_go()
@@ -490,8 +492,10 @@ def test_legacy_mixed_window_is_real_and_observable(engine, pg_url, make_service
     monkeypatch.setattr(svc._pg, "transaction", lambda: nullcontext(None))
     monkeypatch.setattr(svc._pg, "_write_returning", legacy_returning)
 
-    latch = Latch("write_math_bidtopid")
-    undo = latch_method(svc._pg, "write_math_bidtopid", latch)
+    # Pause after the FIRST table write commits on its own: with separate
+    # commits, whichever table goes first is a generation ahead of the rest.
+    latch = Latch("write_participant_stats")
+    undo = latch_method(svc._pg, "write_participant_stats", latch)
     from .conftest import commit_vote
     base = max(e["created"] for e in read_vote_events(engine, 1))
     commit_vote(engine, 1, 0, 0, F.RAW_DISAGREE, base + 1000)
@@ -501,8 +505,8 @@ def test_legacy_mixed_window_is_real_and_observable(engine, pg_url, make_service
     latch.wait_arrival()
 
     main, bid, pts = read_generation(engine, 1, MATH_ENV)
-    assert main["math_tick"] > first_tick, "math_main advanced on its own"
-    assert bid["math_tick"] == first_tick, "math_bidtopid is a generation behind"
+    assert bid["math_tick"] > first_tick, "math_bidtopid advanced on its own"
+    assert main["math_tick"] == first_tick, "math_main is a generation behind"
     assert pts["math_tick"] == first_tick
     problems = response_problems(main, bid, pts)
     assert any("MIXED GENERATIONS" in p for p in problems), problems

--- a/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
+++ b/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
@@ -37,12 +37,15 @@ What this module does and does NOT prove (astra review finding 2)
 
 So:
 
-* **Proved here.** The three tables are published NON-ATOMICALLY, and a reader
-  can observe math_main at generation N with the other two at N-1 or absent —
-  in both observer modes, because the window is the writer's.  A writer that
-  commits all three in ONE transaction closes that window *for the snapshot
-  observer* (``TestNegativeControl``), so the observer can tell atomic from
-  non-atomic publication.  That is WRITER-ISOLATION evidence and nothing more.
+* **Proved here.** The writer now publishes all three tables in ONE
+  transaction (#2704), so a snapshot observer (``repeatable_read``) never
+  observes math_main at generation N paired with the other two at N-1 or
+  absent — the publication window is closed *for that observer*
+  (``test_reader_never_sees_a_mixed_generation``, ``TestNegativeControl``).
+  The legacy, deliberately non-atomic writer still exposes that window
+  (``test_legacy_mixed_window_is_real_and_observable``), so the snapshot
+  observer can tell atomic from non-atomic publication.  That is
+  WRITER-ISOLATION evidence and nothing more.
 * **NOT proved here.** That an atomic writer makes the *Node* reader safe.  Two
   tests demonstrate the opposite, deterministically and without any race:
 
@@ -427,7 +430,19 @@ class ContinuousReader(threading.Thread):
                 if s[0] is not None and response_problems(*s)]
 
 
-@pytest.mark.parametrize("mode", READER_MODES)
+# Collected for the snapshot observer only.  ``#2704`` publishes all three
+# tables in ONE transaction, which guarantees a coherent generation *to a
+# snapshot reader* (``repeatable_read``) — and that is the only always-coherent
+# publication guarantee this atomic writer makes (astra review finding 1).  The
+# ``separate_statements`` observer is deliberately NOT collected here: a writer
+# commit can land BETWEEN its two independent autocommit SELECTs no matter how
+# atomically the writer publishes, so it MAY observe a mixed generation.  That
+# reader-side hazard is retained as its own deterministic witnesses below
+# (``test_an_atomic_write_is_still_observed_mixed_by_a_node_shaped_reader`` and
+# ``test_a_cached_main_blob_can_pair_with_a_newer_mapping_even_when_the_writer_is_atomic``);
+# the review's scheduling witness drives THIS function in ``separate_statements``
+# mode to reproduce the same mixed observation under a pinned interleaving.
+@pytest.mark.parametrize("mode", ["repeatable_read"])
 def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service,
                                               mode):
     """Pause the writer between the table writes — after bidtopid and ptptstats
@@ -435,11 +450,18 @@ def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service,
     a reader polls continuously. That is the widest window in which a reader
     could observe a mixed generation.
 
-    Run in BOTH observer modes: the REPEATABLE READ observer (writer-isolation
-    evidence, stronger than the server) and the separate-autocommit-statement
-    observer (what Node's two independent ``queryP_readOnly`` calls actually
-    do). Neither sees a mixed generation, because the three tables are now
-    published inside a single transaction."""
+    Asserted for the REPEATABLE READ (snapshot) observer only: because the
+    writer commits all three tables in one transaction (#2704), that observer
+    never sees a mixed generation, and any incoherence it did report would be
+    the WRITER's, never a torn read of the test's own making. The
+    separate-autocommit-statement observer — what Node's two independent
+    ``queryP_readOnly`` calls actually do — is NOT asserted coherent, because a
+    commit can land between its two statements even under atomic publication;
+    that hazard is witnessed deterministically by the two node-shaped-reader
+    tests below (see the module header, astra review finding 1). The body still
+    runs the coherence check for whatever ``mode`` it is CALLED with, so the
+    review's scheduling witness can drive ``separate_statements`` directly and
+    observe the mixed generation it must."""
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
     svc.poll_once()          # generation 1: complete

--- a/delphi/tests/poller/recovery/test_r12_publication_cursor.py
+++ b/delphi/tests/poller/recovery/test_r12_publication_cursor.py
@@ -10,9 +10,18 @@ P-022 §C required matrix:
 
 Two halves, both real:
 
-* the WRITER's cursor allocation — ``polismath/database/postgres.py:838``'s
-  ``COALESCE((select max(caching_tick) + 1 from math_main where math_env = ?), 1)``,
-  evaluated inside each write's own transaction;
+* the WRITER's cursor allocation — ``polismath/database/postgres.py:878``'s
+  ``COALESCE((select max(caching_tick) + 1 from math_main where math_env = ?), 1)``.
+  It is now evaluated inside the ONE publication transaction that also mints the
+  math_tick and writes all three tables (``math_writer.py:227``), not inside a
+  per-table transaction — the R05/R09 fix.  That makes the snapshot atomic but
+  changes nothing here: the allocation is still a non-serializable read at READ
+  COMMITTED with no uniqueness constraint on ``caching_tick``, so two zids
+  publishing concurrently can still allocate the same value and still commit out
+  of cursor order.  ``write_math_main`` is deliberately the last statement
+  before the COMMIT so the allocate -> commit window stays as short as it was
+  when each write autocommitted;
+
 * the READER's cursor consumption — ``server/src/utils/pca.ts:98``'s
   ``select * from math_main where caching_tick > ($1) order by caching_tick
   limit 10``, with ``lastPrefetchedMathTick`` advanced to the largest
@@ -151,10 +160,15 @@ def test_two_concurrent_publications_allocate_the_SAME_cursor(engine, pg_url):
     strict=True,
     reason=(
         "DEFECT (predicted by P-022 §C): MAX(caching_tick)+1 is not a safe "
-        "global change cursor. polismath/database/postgres.py:838 allocates "
+        "global change cursor. polismath/database/postgres.py:878 allocates "
         "`COALESCE((select max(caching_tick)+1 from math_main where math_env = "
-        "?), 1)` INSIDE each write's own transaction, so two conversations "
-        "publishing concurrently allocate the SAME value; the consumer "
+        "?), 1)` inside the single publication transaction that mints the "
+        "math_tick and writes all three tables (math_writer.py:227). That "
+        "transaction made the SNAPSHOT atomic (R05/R09) but does not serialize "
+        "the allocation: it is still a plain read at READ COMMITTED with no "
+        "predicate lock and no uniqueness constraint on caching_tick, so two "
+        "conversations publishing concurrently allocate the SAME value; the "
+        "consumer "
         "(server/src/utils/pca.ts:98, :130-132) polls `caching_tick > "
         "lastPrefetchedMathTick` and advances the cursor to the largest value "
         "it saw. If the reader advances past a value between the two commits, "

--- a/delphi/tests/poller/test_math_writer.py
+++ b/delphi/tests/poller/test_math_writer.py
@@ -38,6 +38,13 @@ def _fake_conv(zid=42, base_clusters=None, last_updated=1234567,
     return conv
 
 
+def _decoded(data):
+    """``write_conv_updates`` pre-encodes each blob before opening the
+    transaction (so json.dumps never runs under the row locks), so the writers
+    receive a JSON string from the poller and a dict from every other caller."""
+    return json.loads(data) if isinstance(data, str) else data
+
+
 class TestDeriveBidToPid:
     def test_shape_is_list_of_member_lists_sorted_by_id(self):
         # base_clusters intentionally out of id order to prove sorting.
@@ -298,13 +305,14 @@ class TestMathWriterSharedTick:
         conv = _fake_conv(zid=42, base_clusters=[{"id": 0, "members": ["1", "2"]}])
         MathWriter(client).write_conv_updates(42, conv)
 
-        # Find the data dict passed to write_math_bidtopid.
+        # Find the data blob passed to write_math_bidtopid.
         call = client.write_math_bidtopid.call_args
         data = call.kwargs.get("data")
         if data is None:
             # positional: (zid, data, math_tick)
             data = call.args[1]
-        assert data["bidToPid"] == [["1", "2"]]
+        # The writer pre-encodes the blob before opening the transaction.
+        assert _decoded(data)["bidToPid"] == [["1", "2"]]
 
     def test_ptptstats_written_uses_user_vote_counts_from_to_dict(self):
         """write_conv_updates must thread data["user-vote-counts"] (already
@@ -329,7 +337,7 @@ class TestMathWriterSharedTick:
         data = call.kwargs.get("data")
         if data is None:
             data = call.args[1]
-        assert data["ptptstats"]["n-votes"] == [42]
+        assert _decoded(data)["ptptstats"]["n-votes"] == [42]
 
 
 class TestWriterSQLFidelity:

--- a/delphi/tests/poller/test_math_writer.py
+++ b/delphi/tests/poller/test_math_writer.py
@@ -277,7 +277,12 @@ class TestMathWriterSharedTick:
         writer.write_conv_updates(42, conv)
 
         # tick incremented exactly once for the zid
-        client.increment_math_tick.assert_called_once_with(42)
+        connection = client.transaction.return_value.__enter__.return_value
+        client.increment_math_tick.assert_called_once_with(42, connection=connection)
+        client.transaction.assert_called_once_with()
+        for method in (client.write_math_main, client.write_math_bidtopid,
+                       client.write_participant_stats):
+            assert method.call_args.kwargs["connection"] is connection
 
         # all three data writes carry the SAME tick value returned above
         assert client.write_math_main.call_args.kwargs.get("math_tick") == 77 \
@@ -338,7 +343,7 @@ class TestWriterSQLFidelity:
         client = PostgresClient(cfg)
         calls = []
 
-        def recorder(sql, params=None):
+        def recorder(sql, params=None, *, connection=None):
             calls.append((sql, params or {}))
             # increment_math_tick reads [0]["math_tick"] off the result
             return [{"math_tick": 5, "zid": 1}]

--- a/delphi/tests/poller/test_recovery.py
+++ b/delphi/tests/poller/test_recovery.py
@@ -83,6 +83,9 @@ class FakePg:
     def poll_moderation(self, zid, since):
         return []
 
+    def find_incomplete_math_snapshots(self):
+        return []
+
     def load_math_main(self, zid):
         return None
 

--- a/delphi/tests/test_math_writer_numpy_serialization.py
+++ b/delphi/tests/test_math_writer_numpy_serialization.py
@@ -61,7 +61,7 @@ def _client_capturing():
     client = PostgresClient(PostgresConfig(url="postgresql://ignored/db", math_env="t3"))
     captured = {}
 
-    def _fake_write_returning(sql, params=None):
+    def _fake_write_returning(sql, params=None, *, connection=None):
         captured["params"] = params
         return []
 


### PR DESCRIPTION
Reopened against edge after #2702 merged and its branch was deleted; supersedes #2704. Rebased onto edge: only this PR's three commits remain; test-file conflicts with the merged harness were resolved additively (no production-code conflicts).

## Why
The Python poller published a conversation's results as three separate transactions (`math_main`, `math_bidtopid`, `math_ptptstats`), so a crash between them left mixed generations, permanently for a conversation that then went quiet. Recovery scenarios R05 and R09, previously pinned as strict xfails, now pass. Inherited from Clojure's design (`conv_man.clj:158-169`, which is worse: its writes run outside any error handling).

## What
- `database/postgres.py`, `poller/math_writer.py`: tick allocation + all three upserts in ONE `engine.begin()`; fixed lock order (`math_ticks` → bidtopid → ptptstats → main), per-zid rows so two zids cannot deadlock; `write_math_main` is the last statement so a reader never sees `math_main` ahead of its companions; blobs pre-encoded outside the transaction (`encode_math_blob`).
- `poller/service.py`: on load-or-init, unequal `math_tick` across the three rows triggers a full rebuild with a clear log line; a boot-time DB error in that scan is logged and survived (`start()` only; `poll_once` still propagates).
- Tests: R05/R09 xfails removed; R01/R05/R09 negative controls re-pointed for the new write order (assertions preserved); new `test_atomic_publish.py`; `test_start_survives_a_boot_time_scan_failure`.

Not fixed here, tracked: the `max(caching_tick)+1` cursor is still racy under READ COMMITTED (R12 stays xfail; this change shrinks but does not close the window). Follow-ups noted in code: cap the startup REBUILD burst; meter rebuild thrash during a dual-run.

## Verification
`make test-recovery` → 244 passed, 1 skipped, 9 xfailed. `uv run pytest tests/poller -q` → same. `make test-recovery-races` → 20/20 iterations, 40 passed + 3 xfailed each. Implemented by a headless worker; independently reviewed (verdict: merge with edits E1/E2/E3/E6, all applied); rebuilt on the #2702 base with duplicated prerequisites dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s