### PR TITLE
projgate: re-record the reviewed exemption's module digest after the vote-convention change

### DIFF
--- a/delphi/scripts/projection_inventory.py
+++ b/delphi/scripts/projection_inventory.py
@@ -344,9 +344,12 @@ CLEARED_UNRESOLVED: tuple[ClearedUnresolved, ...] = (
         guard_var="EQUIV_TABLES",
         forbidden_tables=frozenset({"votes", "votes_latest_unique"}),
         function_digest="048839c8fbbec1950c585b88303aace14c0daacac943f33e016e37d0168b3fbc",
-        module_digest="0cdb947d5fa50988f7abd46894defa376c9118e2a394c0143f358032d283f479",
+        module_digest="2d86223bdaedb284250ff7598ddfdc16bd94d034624384aa97674b8010461f19",
         note="replay harness fetch_math_row; {table} guarded by `table not in "
-        "EQUIV_TABLES` (math_main/bidtopid/ptptstats) — never a vote table",
+        "EQUIV_TABLES` (math_main/bidtopid/ptptstats) — never a vote table. "
+        "Module digest re-recorded after edge commit e307602fa (P-023 slice 1, "
+        "vote-convention constant) edited insert_votes/imports — NOT fetch_math_row "
+        "or EQUIV_TABLES; function digest unchanged, structural re-review passed.",
     ),
 )
 


### PR DESCRIPTION
Edge's Delphi job is red since #2736 merged: the reviewed wildcard exemption for `delphi/polismath/replay/poller_equiv.py` is pinned to two structural digests, and edge commit e307602fa (vote convention constant, P-023 slice 1) changed that module after #2736's last rebase — it added an import and changed `insert_votes`, and did not touch the guard function `fetch_math_row` or the `EQUIV_TABLES` guard set (function digest unchanged at every revision; module digest moved from 0cdb947d… to 2d86223b…). The design's re-review was performed (all four structural checks pass on current edge) and the module digest re-recorded. One-line change in `delphi/scripts/projection_inventory.py`.

Verified in the CI image layout: `tests/projgate/` + `tests/topic_naming/test_job_routing.py` → 37 passed / 13 docker-skipped (the green shape); normal layout 33 passed / 13 skipped.

Follow-up (not here): bind the exemption to a reduced node (guard function + every module-level statement binding `EQUIV_TABLES`) so unrelated edits to the module no longer redden edge; proposal in the notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s