### PR TITLE
fix(poller): surface a pool join timeout from poll_once instead of returning success (R10)

### DIFF
--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -34,6 +34,17 @@ logger = logging.getLogger(__name__)
 _MS_PER_DAY = 24 * 60 * 60 * 1000
 
 
+class PoolDrainTimeout(TimeoutError):
+    """``poll_once``'s worker pool did not drain within its join bound.
+
+    A ``TimeoutError`` subclass so existing ``except TimeoutError`` / ``except
+    Exception`` handlers (the daemon loops, the ``--once`` CLI) keep matching,
+    but distinguishable by type from the socket and database timeouts that
+    share the builtin — ``TimeoutError`` is an ``OSError``, so catching the
+    builtin alone would also swallow those.
+    """
+
+
 # --------------------------------------------------------------------------- #
 # Pure poll-loop helpers (unit-tested in isolation)
 # --------------------------------------------------------------------------- #
@@ -377,9 +388,10 @@ class MathPollerService:
     def poll_once(self) -> None:
         """Run one vote + one moderation cycle, blocking until processed.
 
-        Used by ``--once`` and the integration test. Raises ``TimeoutError``
-        if the worker pool has not drained within 120 seconds. A timeout does
-        not cancel in-flight work; callers must not treat it as completion.
+        Used by ``--once`` and the integration test. Raises
+        ``PoolDrainTimeout`` (a ``TimeoutError``) if the worker pool has not
+        drained within 120 seconds. A timeout does not cancel in-flight work;
+        callers must not treat it as completion.
         """
         self._ensure_runtime()
         self._repair_incomplete_snapshots()
@@ -389,7 +401,9 @@ class MathPollerService:
         self._reconcile_once()
         assert self._pool is not None
         if not self._pool.join(timeout=120.0):
-            raise TimeoutError("Poll cycle worker pool did not drain within 120 seconds")
+            raise PoolDrainTimeout(
+                "Poll cycle worker pool did not drain within 120 seconds"
+            )
 
     def _repair_incomplete_snapshots(self) -> None:
         """Schedule legacy partial generations even outside the boot lookback.

--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -377,7 +377,9 @@ class MathPollerService:
     def poll_once(self) -> None:
         """Run one vote + one moderation cycle, blocking until processed.
 
-        Used by ``--once`` and the integration test.
+        Used by ``--once`` and the integration test. Raises ``TimeoutError``
+        if the worker pool has not drained within 120 seconds. A timeout does
+        not cancel in-flight work; callers must not treat it as completion.
         """
         self._ensure_runtime()
         self._repair_incomplete_snapshots()
@@ -386,7 +388,8 @@ class MathPollerService:
         # Recover any zids parked in earlier cycles even if they got no new votes.
         self._reconcile_once()
         assert self._pool is not None
-        self._pool.join(timeout=120.0)
+        if not self._pool.join(timeout=120.0):
+            raise TimeoutError("Poll cycle worker pool did not drain within 120 seconds")
 
     def _repair_incomplete_snapshots(self) -> None:
         """Schedule legacy partial generations even outside the boot lookback.
@@ -408,9 +411,10 @@ class MathPollerService:
         three seq scans (math_env is unindexed on all three tables) and the
         burst on a large production namespace has not been benchmarked. Wants a
         cap, a summary count log instead of per-zid warnings, an env kill
-        switch, and a benchmark. Note R10: poll_once's join(timeout=120)
-        result is discarded, so with a backlog `--once` reports success with
-        work still pending.
+        switch, and a benchmark. Note R10: poll_once now raises when its
+        join(timeout=120) bound is exhausted, so a startup burst that outruns
+        that bound fails `--once` rather than reporting success with work
+        still pending.
 
         TODO(review E5 - rebuild-thrash metering): _load_or_init's mismatch
         path discards warm state and re-reads full vote history every time it

--- a/delphi/scripts/math_poller.py
+++ b/delphi/scripts/math_poller.py
@@ -18,7 +18,7 @@ import signal
 import sys
 
 from polismath.database.postgres import PostgresClient, PostgresConfig
-from polismath.poller.service import MathPollerService, PollerConfig
+from polismath.poller.service import MathPollerService, PollerConfig, PoolDrainTimeout
 
 
 def _configure_logging() -> None:
@@ -55,7 +55,20 @@ def main(argv=None) -> int:
 
     if args.once:
         log.info("Running a single poll cycle (--once)")
-        service.poll_once()
+        try:
+            service.poll_once()
+        except PoolDrainTimeout as exc:
+            # Report through the logger _configure_logging() just set up, the
+            # way _build_service reports its own failure, instead of letting
+            # the default excepthook print a bare traceback to stderr.
+            log.error("Single poll cycle did not complete: %s", exc)
+            # stop() here rather than leaving the pool to
+            # concurrent.futures' interpreter-exit hook: the shutdown is then
+            # inside main's control and logged. A worker stuck FOREVER still
+            # blocks — shutdown(wait=True) joins non-daemon executor threads
+            # either way, and forcing exit past that would need os._exit.
+            service.stop()
+            return 1
         service.stop()
         return 0
 

--- a/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
+++ b/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
@@ -239,25 +239,6 @@ def test_one_poison_zid_does_not_starve_healthy_zids(engine, pg_url,
 # --------------------------------------------------------------------------- #
 # The join timeout
 # --------------------------------------------------------------------------- #
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "DEFECT (P-022 §C R10): poll_once IGNORES the pool join result. "
-        "polismath/poller/service.py:365 calls `self._pool.join(timeout=120.0)` "
-        "and discards its boolean; ConversationWorkerPool.join returns False on "
-        "timeout (polismath/poller/worker_pool.py:156). So a cycle whose work "
-        "never drained returns NORMALLY and looks like a completed poll — the "
-        "`--once` CLI exits 0, and the integration harness treats a stuck "
-        "conversation as a successful cycle. P-022 §C: 'Exhaust a join timeout: "
-        "poll_once must surface failure, not successful completion.' The fix is "
-        "to raise (or return a status) when join() is False; that is a separate "
-        "decision (#2708 raises PoolDrainTimeout). The oracle requires the poll "
-        "thread to have COMPLETED and the failure to be that named class "
-        "(resolved by name, falling back to the builtin TimeoutError on this "
-        "base): a permanently hung observer used to satisfy the old "
-        "`raised is not None or not returned` form."
-    ),
-)
 def test_poll_once_surfaces_a_join_timeout(engine, pg_url, make_service):
     """Stall a worker past the join bound and require ``poll_once`` to surface
     the failure instead of returning as if the cycle completed."""

--- a/delphi/tests/poller/test_poll_once_timeout.py
+++ b/delphi/tests/poller/test_poll_once_timeout.py
@@ -1,0 +1,150 @@
+"""R10: observable cycle failure, paced daemon recovery, and zid isolation."""
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from polismath.poller.service import MathPollerService, PollerConfig
+from polismath.poller.worker_pool import VOTES
+from scripts import math_poller
+
+
+def _service(**kwargs):
+    pg = MagicMock()
+    pg.poll_votes_since.return_value = []
+    pg.poll_moderation_since.return_value = []
+    return MathPollerService(pg, PollerConfig(**kwargs))
+
+
+@pytest.mark.parametrize("drained", [True, False])
+def test_once_cli_only_returns_success_after_pool_drains(monkeypatch, drained):
+    svc = _service()
+    svc._pool = MagicMock()
+    svc._pool.parked_zids.return_value = set()
+    svc._pool.join.return_value = drained
+    monkeypatch.setattr(math_poller, "_build_service", lambda config: svc)
+
+    if drained:
+        assert math_poller.main(["--once"]) == 0
+        svc._pool.shutdown.assert_called_once_with(wait=True)
+    else:
+        # main's exception propagates through SystemExit(main()) as a nonzero
+        # CLI failure, just like a failed SELECT; it must never return zero.
+        with pytest.raises(TimeoutError, match="worker pool did not drain"):
+            math_poller.main(["--once"])
+        svc._pool.join.assert_called_once_with(timeout=120.0)
+
+
+@pytest.mark.parametrize(
+    "loop,cycle,interval,log_message,wait_first",
+    [
+        ("_vote_loop", "_poll_votes_once", "vote_interval_ms",
+         "Vote poll cycle failed", False),
+        ("_mod_loop", "_poll_moderation_once", "mod_interval_ms",
+         "Moderation poll cycle failed", False),
+        ("_reconcile_loop", "_reconcile_once", "reconcile_interval_ms",
+         "Reconcile cycle failed", True),
+    ],
+)
+def test_daemon_logs_failure_waits_and_runs_next_cycle(
+    monkeypatch, caplog, loop, cycle, interval, log_message, wait_first
+):
+    svc = _service(**{interval: 137})
+    events = []
+    attempts = 0
+
+    def poll():
+        nonlocal attempts
+        attempts += 1
+        events.append("poll")
+        if attempts == 1:
+            raise TimeoutError("injected poll timeout")
+        svc._stop.set()
+
+    def wait(seconds):
+        assert seconds == 0.137
+        events.append("wait")
+        return svc._stop.is_set()
+
+    monkeypatch.setattr(svc, cycle, poll)
+    monkeypatch.setattr(svc._stop, "wait", wait)
+    getattr(svc, loop)()
+
+    assert attempts == 2
+    assert events == (["wait", "poll", "wait", "poll"] if wait_first else
+                      ["poll", "wait", "poll", "wait"])
+    assert [r.message for r in caplog.records] == [log_message]
+    assert caplog.records[0].exc_info[0] is TimeoutError
+
+
+def test_stalled_zid_does_not_block_healthy_zid_or_hide_timeout(monkeypatch):
+    svc = _service(worker_pool_size=2)
+    stalled = threading.Event()
+    release = threading.Event()
+    healthy = threading.Event()
+
+    def process(zid, batch):
+        if zid == 1:
+            stalled.set()
+            assert release.wait(10), "test did not release stalled worker"
+        else:
+            healthy.set()
+
+    monkeypatch.setattr(svc, "_run_engine", process)
+    svc._ensure_runtime()
+    real_join = svc._pool.join
+
+    def short_join(timeout):
+        assert stalled.wait(5), "worker never reached the stall"
+        return real_join(timeout=0.01)
+
+    monkeypatch.setattr(svc._pool, "join", short_join)
+    svc._pg.poll_votes_since.return_value = [
+        {"zid": 1, "created": 1}, {"zid": 2, "created": 2}
+    ]
+    try:
+        with pytest.raises(TimeoutError, match="worker pool did not drain"):
+            svc.poll_once()
+        assert healthy.wait(5), "healthy zid starved behind stalled zid"
+        assert not release.is_set()
+        release.set()
+        assert real_join(timeout=5)
+        monkeypatch.setattr(svc._pool, "join", real_join)
+        svc._pg.poll_votes_since.return_value = []
+        assert svc.poll_once() is None
+    finally:
+        release.set()
+        svc._pool.shutdown(wait=True)
+
+
+def test_poison_zid_has_bounded_retries_and_healthy_progress_with_one_worker(
+    monkeypatch, tmp_path
+):
+    svc = _service(worker_pool_size=1, retry_cap=1, dump_dir=str(tmp_path))
+    attempts = []
+    completed = []
+
+    def process(zid, batch):
+        if zid == 1:
+            attempts.append(zid)
+            raise ValueError("poison zid")
+        completed.extend((zid, row["cycle"]) for row in batch.votes)
+
+    monkeypatch.setattr(svc, "_run_engine", process)
+    svc._ensure_runtime()
+    try:
+        for cycle in range(3):
+            # Enqueue poison first even with only one executor slot. The
+            # circuit breaker must release that slot after its retry budget.
+            svc._unpark(1)
+            for zid in (1, 2, 3):
+                svc._pool.submit(zid, VOTES, [{"cycle": cycle}])
+            assert svc._pool.join(timeout=5)
+            assert svc._parked == {1}
+            assert len(attempts) == 2 * (cycle + 1)
+            assert completed == [
+                (zid, n) for n in range(cycle + 1) for zid in (2, 3)
+            ]
+    finally:
+        svc._pool.shutdown(wait=True)

--- a/delphi/tests/poller/test_poll_once_timeout.py
+++ b/delphi/tests/poller/test_poll_once_timeout.py
@@ -1,11 +1,16 @@
 """R10: observable cycle failure, paced daemon recovery, and zid isolation."""
 
+import logging
 import threading
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
-from polismath.poller.service import MathPollerService, PollerConfig
+from polismath.poller.service import (
+    MathPollerService,
+    PollerConfig,
+    PoolDrainTimeout,
+)
 from polismath.poller.worker_pool import VOTES
 from scripts import math_poller
 
@@ -17,23 +22,45 @@ def _service(**kwargs):
     return MathPollerService(pg, PollerConfig(**kwargs))
 
 
+def test_pool_drain_timeout_is_a_specific_timeout_type():
+    # The builtin TimeoutError is an OSError, so `except TimeoutError` around
+    # poll_once would also swallow socket/DB timeouts. The subclass keeps every
+    # existing handler matching while staying separately catchable.
+    assert issubclass(PoolDrainTimeout, TimeoutError)
+    assert not isinstance(TimeoutError("a socket timeout"), PoolDrainTimeout)
+
+
 @pytest.mark.parametrize("drained", [True, False])
-def test_once_cli_only_returns_success_after_pool_drains(monkeypatch, drained):
+def test_once_cli_only_returns_success_after_pool_drains(
+    monkeypatch, caplog, drained
+):
     svc = _service()
     svc._pool = MagicMock()
     svc._pool.parked_zids.return_value = set()
     svc._pool.join.return_value = drained
     monkeypatch.setattr(math_poller, "_build_service", lambda config: svc)
 
+    def errors():
+        return [
+            r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR
+        ]
+
     if drained:
         assert math_poller.main(["--once"]) == 0
-        svc._pool.shutdown.assert_called_once_with(wait=True)
+        assert errors() == []
     else:
-        # main's exception propagates through SystemExit(main()) as a nonzero
-        # CLI failure, just like a failed SELECT; it must never return zero.
-        with pytest.raises(TimeoutError, match="worker pool did not drain"):
-            math_poller.main(["--once"])
-        svc._pool.join.assert_called_once_with(timeout=120.0)
+        # A cycle that never drained is a CLI failure, just like a failed
+        # SELECT; it must never return zero. It is reported through the
+        # configured logger rather than as a bare excepthook traceback.
+        assert math_poller.main(["--once"]) == 1
+        assert errors() == [
+            "Single poll cycle did not complete: Poll cycle worker pool did "
+            "not drain within 120 seconds"
+        ]
+    assert svc._pool.join.call_args_list[0] == call(timeout=120.0)
+    # Either way the pool is shut down inside main(), not left to the
+    # concurrent.futures interpreter-exit hook.
+    svc._pool.shutdown.assert_called_once_with(wait=True)
 
 
 @pytest.mark.parametrize(
@@ -104,7 +131,7 @@ def test_stalled_zid_does_not_block_healthy_zid_or_hide_timeout(monkeypatch):
         {"zid": 1, "created": 1}, {"zid": 2, "created": 2}
     ]
     try:
-        with pytest.raises(TimeoutError, match="worker pool did not drain"):
+        with pytest.raises(PoolDrainTimeout, match="worker pool did not drain"):
             svc.poll_once()
         assert healthy.wait(5), "healthy zid starved behind stalled zid"
         assert not release.is_set()


### PR DESCRIPTION
Reopened against edge after #2742 merged and its branch was deleted; supersedes #2708. Rebased so only this PR's two commits remain.

## Why
`poll_once` joined the worker pool with a timeout and returned normally whether or not the pool had drained, so the `--once` CLI (and anything else that trusts a completed cycle) could report success on an undrained, possibly stuck pool. Recovery scenario R10 (pinned as a strict xfail in #2702) now passes.

## What
- `poll_once` raises `PoolDrainTimeout(TimeoutError)` when the join times out; success still returns `None`. Daemon loops log and continue (no crash, no hot loop); per-zid queues already isolate a poison zid from healthy ones (characterization tests added).
- `math_poller.py --once`: the failure goes through the configured logger and exits 1, and `service.stop()` runs inside `main()` so the pool shuts down there rather than at interpreter exit.
- R10 xfail removed (test unchanged); 8 unit tests in `tests/poller/test_poll_once_timeout.py`.

## Verification
On this base: 245 passed / 1 skipped / 9 xfailed → **254 / 1 / 8** (+8 unit, +1 un-xfailed R10). 10/10 consecutive runs of the R10 + unit tests green. Implemented by a headless worker; independently reviewed (ACCEPT; optional hardening applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s