### PR TITLE
fix(delphi): job guard builds its DynamoDB client lazily through the shared credential helper

### DIFF
--- a/server/__tests__/unit/delphi-job-guard.test.ts
+++ b/server/__tests__/unit/delphi-job-guard.test.ts
@@ -1210,3 +1210,175 @@ describe("configFingerprint", () => {
     );
   });
 });
+
+/**
+ * The store's DynamoDB client is built through the shared
+ * `buildDynamoClientConfig`, lazily and once. The shared builder refuses to
+ * construct a client whose credentials the AWS SDK would resolve from the
+ * literal "local" placeholder that `config.ts` leaves for an unset variable.
+ * That refusal must reach the first admission — not module load, where it would
+ * take the whole server process down at startup — and it must fail the guarded
+ * route closed: {@link JobAdmissionUnavailableError}, no client, no write.
+ */
+describe("admitDelphiJob: lazy shared DynamoDB client construction", () => {
+  // The keys config.ts and the shared builder read to choose credential
+  // precedence. The suite owns them for the length of each test.
+  const MANAGED_KEYS = [
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_REGION",
+    "DYNAMODB_ENDPOINT",
+  ];
+  // eslint-disable-next-line no-restricted-properties
+  const env = process.env;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of MANAGED_KEYS) {
+      savedEnv[key] = env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of MANAGED_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete env[key];
+      } else {
+        env[key] = savedEnv[key];
+      }
+    }
+    jest.dontMock("@aws-sdk/client-dynamodb");
+    jest.dontMock("@aws-sdk/lib-dynamodb");
+    jest.resetModules();
+  });
+
+  function applyEnv(overrides: Record<string, string | undefined>) {
+    for (const key of MANAGED_KEYS) {
+      if (overrides[key] === undefined) {
+        delete env[key];
+      } else {
+        env[key] = overrides[key];
+      }
+    }
+  }
+
+  // Exactly what config.ts snapshots when AWS_ACCESS_KEY_ID and
+  // AWS_SECRET_ACCESS_KEY are the literal "local" placeholder and no DynamoDB
+  // Local endpoint is set: the default credential chain would otherwise resolve
+  // "local" from the environment and send it to AWS.
+  const PLACEHOLDER_ENV = {
+    AWS_ACCESS_KEY_ID: "local",
+    AWS_SECRET_ACCESS_KEY: "local",
+    AWS_REGION: undefined,
+    DYNAMODB_ENDPOINT: undefined,
+  };
+
+  // A clean, production-shaped environment: real explicit credentials, no local
+  // endpoint. The builder returns a config without consulting the environment
+  // credential provider, so no placeholder refusal can fire.
+  const REAL_ENV = {
+    AWS_ACCESS_KEY_ID: "AKIAREALLOOKINGID",
+    AWS_SECRET_ACCESS_KEY: "realLookingSecret",
+    AWS_REGION: "us-east-1",
+    DYNAMODB_ENDPOINT: undefined,
+  };
+
+  // A fresh copy of the module under the current environment, so config.ts
+  // re-snapshots the AWS variables set above. `mocks` runs inside the isolated
+  // registry, before the require, so any doMock applies to this copy alone.
+  function loadGuard(mocks?: () => void) {
+    let mod: typeof import("../../src/routes/delphi/jobGuard") | undefined;
+    jest.isolateModules(() => {
+      if (mocks) mocks();
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      mod = require("../../src/routes/delphi/jobGuard");
+    });
+    return mod as typeof import("../../src/routes/delphi/jobGuard");
+  }
+
+  it("imports without throwing when a placeholder credential is set", () => {
+    applyEnv(PLACEHOLDER_ENV);
+
+    // The inline client this replaced was built at module load; the shared
+    // builder would reject the placeholder there and crash the process at
+    // startup. Lazily, importing must be inert.
+    let mod: typeof import("../../src/routes/delphi/jobGuard") | undefined;
+    expect(() => {
+      mod = loadGuard();
+    }).not.toThrow();
+    expect(typeof mod?.admitDelphiJob).toBe("function");
+  });
+
+  it("fails the first admission closed on a placeholder, constructing no client and writing nothing", async () => {
+    applyEnv(PLACEHOLDER_ENV);
+
+    const dynamoConstructor = jest.fn();
+    const mod = loadGuard(() => {
+      jest.doMock("@aws-sdk/client-dynamodb", () => ({
+        __esModule: true,
+        ...jest.requireActual("@aws-sdk/client-dynamodb"),
+        DynamoDB: dynamoConstructor,
+      }));
+    });
+
+    await expect(
+      mod.admitDelphiJob({
+        scope,
+        jobItem: jobItem(),
+        idempotencyKey: null,
+      })
+    ).rejects.toBeInstanceOf(mod.JobAdmissionUnavailableError);
+
+    // The builder refused before `new DynamoDB(...)` ran, so no client exists
+    // to write with: the guard cannot have put a row.
+    expect(dynamoConstructor).not.toHaveBeenCalled();
+  });
+
+  it("builds one client on first use and reuses it on the normal path", async () => {
+    applyEnv(REAL_ENV);
+
+    const dynamoConstructor = jest.fn(() => ({}));
+    const docStub = {
+      get: jest.fn(async () => ({})),
+      transactWrite: jest.fn(async () => ({})),
+      put: jest.fn(async () => ({})),
+      delete: jest.fn(async () => ({})),
+      scan: jest.fn(async () => ({ Items: [] })),
+    };
+    const from = jest.fn(() => docStub);
+
+    const mod = loadGuard(() => {
+      jest.doMock("@aws-sdk/client-dynamodb", () => ({
+        __esModule: true,
+        ...jest.requireActual("@aws-sdk/client-dynamodb"),
+        DynamoDB: dynamoConstructor,
+      }));
+      jest.doMock("@aws-sdk/lib-dynamodb", () => ({
+        __esModule: true,
+        ...jest.requireActual("@aws-sdk/lib-dynamodb"),
+        DynamoDBDocument: { from },
+      }));
+    });
+
+    // Nothing is constructed at import.
+    expect(dynamoConstructor).not.toHaveBeenCalled();
+
+    // Two independent store reads through the real default store.
+    await mod.dynamoJobAdmissionStore.readGuard("scope-key");
+    await mod.dynamoJobAdmissionStore.readJob("job-1");
+
+    // Built exactly once (lazy + memoised) and reused for the second read.
+    expect(dynamoConstructor).toHaveBeenCalledTimes(1);
+    expect(from).toHaveBeenCalledTimes(1);
+    expect(docStub.get).toHaveBeenCalledTimes(2);
+    // A clean environment takes the explicit-credentials branch, never the
+    // placeholder refusal.
+    expect(dynamoConstructor.mock.calls[0][0]).toMatchObject({
+      credentials: {
+        accessKeyId: REAL_ENV.AWS_ACCESS_KEY_ID,
+        secretAccessKey: REAL_ENV.AWS_SECRET_ACCESS_KEY,
+      },
+    });
+  });
+});

--- a/server/src/routes/delphi/jobGuard.ts
+++ b/server/src/routes/delphi/jobGuard.ts
@@ -43,10 +43,13 @@
  * P-024 re-points both in the same cutover.
  */
 import { createHash, randomUUID } from "crypto";
-import { DynamoDB } from "@aws-sdk/client-dynamodb";
+import { DynamoDB, DynamoDBClientConfig } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
 import logger from "../../utils/logger";
-import Config from "../../config";
+import {
+  AwsCredentialsConfigurationError,
+  buildDynamoClientConfig,
+} from "../../utils/dynamoClient";
 
 export const JOB_QUEUE_TABLE = "Delphi_JobQueue";
 
@@ -369,24 +372,52 @@ function logScope(guardKey: string): string {
   return guardKey.slice(0, 14);
 }
 
-const dynamoDbConfig: any = {
-  region: Config.AWS_REGION || "us-east-1",
-};
+/**
+ * Lazily-built, memoised DynamoDB document client for the guard's store.
+ *
+ * Construction is deferred to the first store access and cached thereafter —
+ * never run at module load. It goes through {@link buildDynamoClientConfig}, the
+ * shared builder that gives every DynamoDB client in the server the same
+ * local-endpoint / explicit-credentials / default-chain precedence this module
+ * used to inline. Unlike that inline block, the shared builder also *refuses* to
+ * construct a client whose credentials the AWS SDK would resolve from the
+ * literal "local" placeholder that `config.ts` leaves in the environment for an
+ * unset variable — it raises {@link AwsCredentialsConfigurationError} rather
+ * than send `accessKeyId="local"` to AWS.
+ *
+ * That refusal is why the accessor is lazy. Running it at import time would let
+ * a misconfigured production environment throw while this module is first
+ * required, before any request is served, and take the whole server process
+ * down at startup. Deferring it makes a credential misconfiguration fail the
+ * *guarded route* instead: the builder's error is rethrown as
+ * {@link JobAdmissionUnavailableError}, which both producers already translate
+ * into a 503 that writes no job — the same fail-closed path they use for a
+ * missing guard table. No admission ever proceeds on a client that could not be
+ * built, so no un-deduplicated paid run can slip through a misconfiguration.
+ */
+let memoisedDocClient: DynamoDBDocument | null = null;
 
-if (Config.dynamoDbEndpoint) {
-  dynamoDbConfig.endpoint = Config.dynamoDbEndpoint;
-  dynamoDbConfig.credentials = {
-    accessKeyId: "DUMMYIDEXAMPLE",
-    secretAccessKey: "DUMMYEXAMPLEKEY",
-  };
-} else if (Config.AWS_ACCESS_KEY_ID && Config.AWS_SECRET_ACCESS_KEY) {
-  dynamoDbConfig.credentials = {
-    accessKeyId: Config.AWS_ACCESS_KEY_ID,
-    secretAccessKey: Config.AWS_SECRET_ACCESS_KEY,
-  };
+function docClient(): DynamoDBDocument {
+  if (memoisedDocClient) {
+    return memoisedDocClient;
+  }
+  let clientConfig: DynamoDBClientConfig;
+  try {
+    clientConfig = buildDynamoClientConfig();
+  } catch (error) {
+    if (error instanceof AwsCredentialsConfigurationError) {
+      // Fail the route, not the process: surface as the unavailability the
+      // producers already handle by returning 503 and writing nothing.
+      throw new JobAdmissionUnavailableError(
+        `Delphi job admission cannot construct a DynamoDB client: ${error.message}`,
+        error
+      );
+    }
+    throw error;
+  }
+  memoisedDocClient = DynamoDBDocument.from(new DynamoDB(clientConfig));
+  return memoisedDocClient;
 }
-
-const docClient = DynamoDBDocument.from(new DynamoDB(dynamoDbConfig));
 
 function cancellationCodes(error: any): string[] {
   const reasons = error?.CancellationReasons;
@@ -450,7 +481,7 @@ export const dynamoJobAdmissionStore: JobAdmissionStore = {
     }
 
     try {
-      await docClient.transactWrite({ TransactItems: transactItems });
+      await docClient().transactWrite({ TransactItems: transactItems });
       return { outcome: "admitted" };
     } catch (error: any) {
       if (error?.name !== "TransactionCanceledException") {
@@ -473,7 +504,7 @@ export const dynamoJobAdmissionStore: JobAdmissionStore = {
   },
 
   async readGuard(guardKey) {
-    const result = await docClient.get({
+    const result = await docClient().get({
       TableName: JOB_GUARD_TABLE,
       Key: { guard_key: guardKey },
       ConsistentRead: true,
@@ -482,7 +513,7 @@ export const dynamoJobAdmissionStore: JobAdmissionStore = {
   },
 
   async readJob(jobId) {
-    const result = await docClient.get({
+    const result = await docClient().get({
       TableName: JOB_QUEUE_TABLE,
       Key: { job_id: jobId },
       ConsistentRead: true,
@@ -630,7 +661,7 @@ export const dynamoJobAdmissionStore: JobAdmissionStore = {
 
   async clearGuard(guard) {
     try {
-      await docClient.delete({
+      await docClient().delete({
         TableName: JOB_GUARD_TABLE,
         Key: { guard_key: guard.guard_key },
         // `version` is a DynamoDB reserved word, hence the name placeholder.
@@ -653,7 +684,7 @@ export const dynamoJobAdmissionStore: JobAdmissionStore = {
 
   async clearAlias(alias) {
     try {
-      await docClient.delete({
+      await docClient().delete({
         TableName: JOB_GUARD_TABLE,
         Key: { guard_key: alias.guard_key },
         ConditionExpression: "job_id = :jid",
@@ -713,7 +744,7 @@ export const dynamoJobAdmissionStore: JobAdmissionStore = {
       });
     }
     try {
-      await docClient.transactWrite({ TransactItems: items });
+      await docClient().transactWrite({ TransactItems: items });
       return true;
     } catch (error: any) {
       if (error?.name === "TransactionCanceledException") {
@@ -730,7 +761,7 @@ async function conditionalPut(
   keyName: string
 ): Promise<boolean> {
   try {
-    await docClient.put({
+    await docClient().put({
       TableName: table,
       Item: item,
       ConditionExpression: `attribute_not_exists(${keyName})`,
@@ -770,7 +801,7 @@ async function baseTableSweep(
   const matches: any[] = [];
   try {
     for (let page = 0; page < SCAN_MAX_PAGES; page++) {
-      const result = await docClient.scan(params);
+      const result = await docClient().scan(params);
       if (result.Items?.length) {
         matches.push(...result.Items);
       }


### PR DESCRIPTION
Follow-up from the #2743 second review. `jobGuard.ts` built its DynamoDB client inline and eagerly, duplicating the local / explicit / default-chain precedence of `buildDynamoClientConfig` without its placeholder-credential rejection.

- The client is now a lazy, memoised accessor through `buildDynamoClientConfig()`; construction happens on first store access, so a placeholder credential cannot throw at import and stop the process.
- The helper's `AwsCredentialsConfigurationError` is rethrown as `JobAdmissionUnavailableError`; the first store operation in every admission path is a read, so misconfiguration fails the guarded route closed (503, no job written), exactly like a missing guard table. `admitDelphiJob` behaviour unchanged.

Tests: three added (import succeeds with a placeholder set; first admission under a placeholder is refused and constructs no client; normal path builds one client and reuses it); unit 57/57 in the file, full unit suite +3 with the same pre-existing environmental failures as edge; `delphi-job-dedupe` integration 28/28 on an isolated stack; lint and `tsc` clean. No schema change; no workflow file. Second review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s