### PR TITLE
chore: remove internal reviewer labels from comments, test names and docs

### DIFF
--- a/.github/workflows/certification-ec2.yml
+++ b/.github/workflows/certification-ec2.yml
@@ -4,7 +4,7 @@ name: Synthetic recovery and public-fixture battery (EC2)
 # repository's PUBLIC fixtures on one disposable EC2 worker, then destroys it.
 #
 # THIS IS NOT PRIVATE CERTIFICATION and its verdict (`SYNTHETIC-PASS`) must
-# never be read as one. Astra's #2715 review found that round 1 staged the
+# never be read as one. The second reviewer's #2715 review found that round 1 staged the
 # private prod-derived bundle on a box GitHub could open a root shell on, and
 # returned its raw log to public Actions artifacts. Round 2 removes the private
 # data path outright: there is no fixture bucket, no evidence bucket, and the

--- a/cdk/ciEc2.ts
+++ b/cdk/ciEc2.ts
@@ -2,7 +2,7 @@
  * P-022 §E — disposable EC2 worker for the **synthetic** recovery matrix and
  * the **public-fixture** replay battery.
  *
- * ## Scope, after Astra's #2715 review (round 2)
+ * ## Scope, after the second reviewer's #2715 review (round 2)
  *
  * This is NOT private certification and must never be described as one. Round 1
  * attached the private fixture-bundle role to a box that GitHub could open a

--- a/cdk/test/alarms.test.ts
+++ b/cdk/test/alarms.test.ts
@@ -642,7 +642,7 @@ describe('synth-enforced health pairs', () => {
   // Review r2. `addPropertyOverride` writes into the resource's raw overrides,
   // which are merged in at render time and leave the typed getters untouched.
   // A gate reading `cfn.alarmActions` therefore passes while the EMITTED alarm
-  // carries the harmful value. These are Astra's three reproductions, inverted:
+  // carries the harmful value. These are the second reviewer's three reproductions, inverted:
   // each must now fail synth.
 
   test('A04 with ActionsEnabled overridden to false fails the real synth', () => {

--- a/ci/p022_battery_digest.py
+++ b/ci/p022_battery_digest.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """P-022 §E — canonical digest of the admitted PUBLIC battery inventory.
 
-Round 4 hashed dataset/preset/n_cuts/schedule **names**, stringified. Astra's
-review (R4-F3) showed two consequences:
+Round 4 hashed dataset/preset/n_cuts/schedule **names**, stringified. The
+second reviewer's review (R4-F3) showed two consequences:
 
   * deleting `restart_after` from `schedules/vw-uniform8-restart4.json` left the
     digest untouched — the seam the battery exists to exercise could be removed

--- a/ci/p022_check_summary.py
+++ b/ci/p022_check_summary.py
@@ -2,7 +2,7 @@
 """P-022 §E — validate the worker's fixed-schema summary against the run's
 declared scope, on the runner, before anyone reads it.
 
-## What this is NOT (Astra #2715 R2-F4, divergence ruling 8)
+## What this is NOT (review #2715 R2-F4, divergence ruling 8)
 
 This is **not** independent execution evidence and does not make the result
 unforgeable. Every field it inspects is produced by the same recipe that ran the

--- a/ci/p022_ec2_run.sh
+++ b/ci/p022_ec2_run.sh
@@ -19,7 +19,7 @@
 # logs stay in /var/log/polis-ci and die with the box. What comes back is a
 # fixed-schema summary.json plus one JUnit report per pytest invocation.
 #
-# ## Round 3 (Astra #2715 R2-F2/F3)
+# ## Round 3 (review #2715 R2-F2/F3)
 #
 #   * The recovery runtime is installed and VERIFIED in user-data, before the
 #     ready marker, because C's target runs host `uv run --no-sync pytest`. A

--- a/ci/p022_ssm.sh
+++ b/ci/p022_ssm.sh
@@ -10,7 +10,7 @@
 #          POLIS_SSM_TIMEOUT         execution timeout, seconds (default 21600)
 #          POLIS_SSM_MODE            status | base64   (default status)
 #
-# ## Output discipline (Astra #2715 E1)
+# ## Output discipline (review #2715 E1)
 #
 # Worker stdout is never echoed verbatim. In `status` mode only lines matching
 # the fixed `p022 <phase> <key>=<value>` grammar are printed; anything else is

--- a/ci/p022_teardown.py
+++ b/ci/p022_teardown.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """P-022 §E — terminate the disposable CI worker and PROVE it.
 
-Astra's #2715 review (E7) broke the round-1 shell version two ways, and both
+The second reviewer's #2715 review (E7) broke the round-1 shell version two ways, and both
 were the same mistake: treating the absence of evidence as evidence.
 
   * a failed ``describe-instances`` produced empty output, which the lost-ID

--- a/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
+++ b/delphi/docs/CLJ-PARITY-FIXES-JOURNAL.md
@@ -1672,7 +1672,7 @@ Re-record vw + biodiversity Python golden snapshots (PR-stack tip).
 
 ## Session: Copilot triage, review-fix PR #2586, merge prep (2026-07-04/05)
 
-Host session ("Fable-polis-merge-then-replay"). Goal: assess and execute the
+Host session (the merge-then-replay session). Goal: assess and execute the
 merge of the open 7-PR stack. Outcome: stack is code-complete, gate-green,
 review-resolved, and pushed — **merge deliberately NOT executed** (edge
 frozen for a prod issue; Julien: push PRs, merge nothing).
@@ -2005,7 +2005,7 @@ noted above.
 
 ## Session: Overnight orchestration — replay harness H-A, sequential-bits A/B/D′, input-fidelity fixes (2026-07-17→18)
 
-Host session "Fable-Pyclj-Parity". Julien handed over for the night with a new
+Host session (the Pyclj-parity session). Julien handed over for the night with a new
 directive: proceed autonomously on math-core with careful per-change notes and a
 morning walkthrough (recorded in project memory; see
 `scratch/MORNING_WALKTHROUGH_2026-07-18.md` for the full walkthrough — a local,

--- a/delphi/docs/MATH_POLLER_DESIGN.md
+++ b/delphi/docs/MATH_POLLER_DESIGN.md
@@ -1,6 +1,6 @@
 # Python Math Poller — Clojure math-container replacement design
 
-**Status:** Design + phase-1 implementation — 2026-07-18 (overnight session "Fable-Pyclj-Parity")
+**Status:** Design + phase-1 implementation — 2026-07-18 (the overnight Pyclj-parity session)
 **Recon basis:** every file:line below verified against the working tree on 2026-07-18
 (full recon in journal session entry). Companions: `SEQUENTIAL_BITS_PORT_SPEC.md` (the
 warm-started engine this poller hosts), `REPLAY_HARNESS_DESIGN.md` (validation),

--- a/delphi/docs/REPLAY_HARNESS_DESIGN.md
+++ b/delphi/docs/REPLAY_HARNESS_DESIGN.md
@@ -1,7 +1,7 @@
 # Replay Harness (H) — Design
 
 **Status:** DRAFT for review — 2026-07-05
-**Author:** Claude (host session "Fable-polis-merge-then-replay"), for Julien
+**Author:** Claude (the merge-then-replay host session), for Julien
 **Recon basis:** file:line pointers verified 2026-07-05 against `math/` and `delphi/`.
 
 ## 1. Purpose

--- a/delphi/docs/STORAGE_V2_DESIGN.md
+++ b/delphi/docs/STORAGE_V2_DESIGN.md
@@ -1,7 +1,7 @@
 # Delphi Storage V2 — Reproducible Runs, Unified Schema, Dual-Backend Storage
 
 **Status:** DRAFT for review — 2026-07-06
-**Author:** Claude (host session "Fable JobID"), for Julien
+**Author:** Claude (the storage-v2 design host session), for Julien
 **Recon basis:** file:line pointers verified 2026-07-06 against `delphi/`, `server/`, and clients.
 
 ## 1. Problem

--- a/delphi/polismath/replay/certify.py
+++ b/delphi/polismath/replay/certify.py
@@ -227,7 +227,7 @@ def _is_integral(value: Any) -> bool:
 #: every raw spelling involved. When the legacy twin is finally dropped, delete
 #: the entry and this policy becomes "no collisions at all".
 #:
-#: v2 round 2 (P-022 alias-twin Astra review, F1/F2). Equal group ``id`` lists
+#: v2 round 2 (P-022 alias-twin review, F1/F2). Equal group ``id`` lists
 #: plus a prose role label are NOT the schema the contract asks for: a producer
 #: could still ship ``group_clusters`` entries with ``members="not-members"``,
 #: no ``center``, ``id=False`` beside a canonical ``id=0`` (``False == 0`` in
@@ -349,7 +349,7 @@ def _bid_to_pids(blob: dict, label: str, where: str) -> dict[Any, list[Any]]:
     unevaluated relation is exactly the hole this policy closes.
 
     The mapping is the relation's TRUSTED INPUT, so it is typed with exactly the
-    same strictness as the two group views (Astra review round 2, R2-F1). Left
+    same strictness as the two group views (review round 2, R2-F1). Left
     untyped, ``False == 0`` and ``0.0 == 0`` reappeared one level below the
     views — a folded member ``0`` resolved a base-cluster ``id`` of ``False`` or
     ``0.0``, and an unfolded participant ``0`` matched a mapped ``False``, so all
@@ -581,8 +581,8 @@ def validate_checkpoint_blob(
     # Conversation.from_dict.
     # Presence, not validity: a malformed marker value is a corrupted projected
     # view, and treating it as unmarked raw data is how all four of
-    # {null, false, "projected", []} walked straight through this gate (Astra
-    # review #2730 F2). The reserved key is refused whenever it appears.
+    # {null, false, "projected", []} walked straight through this gate (review
+    # #2730 F2). The reserved key is refused whenever it appears.
     if has_marker(blob):
         marked = blob[OUTPUT_PROFILE_KEY]
         problems = marker_problems(marked)

--- a/delphi/polismath/replay/fixture_bundle.py
+++ b/delphi/polismath/replay/fixture_bundle.py
@@ -79,7 +79,7 @@ from polismath.utils.vote_convention import (
 #: :data:`ADMISSIBLE_MANIFEST_SCHEMA_VERSIONS`.
 MANIFEST_SCHEMA_VERSION = "certify-fixture-manifest/3"
 #: The PREVIOUS closed manifest schema. It stays verifiable and admissible
-#: BYTE-FOR-BYTE (Astra review #2730 F-compat): a /2 manifest carries no
+#: BYTE-FOR-BYTE (review #2730 F-compat): a /2 manifest carries no
 #: ``transform`` key at all and its polarity block already spells out the -1 it
 #: was pinned to, so the /3 rules evaluate on it unchanged once the absent
 #: ``transform`` is read as the "original capture" declaration it is. New
@@ -399,7 +399,7 @@ def build_transform_block(
     see :func:`build_derived_manifest` for what that deferral does and does not
     leave certified.
 
-    ``bijective_verified`` is NOT coerced (Astra review #2730 F3): ``bool("false")``
+    ``bijective_verified`` is NOT coerced (review #2730 F3): ``bool("false")``
     is ``True``, so coercion turned an unverified — or misspelled — declaration
     into a verified one. It must already be a real boolean, and admission
     requires it to be ``True``.
@@ -1145,7 +1145,7 @@ ORDERING_GUARANTEES = frozenset(TIE_ORDER_POLICIES)
 
 #: The role source of a DERIVED bundle: this role's fixture is the declared
 #: involution of an ADMITTED bundle's role, not a new production extraction and
-#: not an approved synthetic replacement (Astra review #2730 F1).
+#: not an approved synthetic replacement (review #2730 F1).
 #:
 #: Without it no flipped bundle could exist at all: 15 of the 17 required roles
 #: carry ``on_missing: fail``, so admission forbids substituting them, and the
@@ -1603,7 +1603,7 @@ def admit_manifest(
               f"{_failed_predicates(metrics, rule['predicates'])}")
         # The EFFECTIVE source: for a derived role, the source of the role it
         # was derived FROM. Every rule that governed the original governs the
-        # derivation too (Astra review #2730 R2-F1) — retaining a binding that
+        # derivation too (review #2730 R2-F1) — retaining a binding that
         # NAMES a synthetic origin, while skipping the offer/approval/generator
         # rules that make a synthetic role admissible, let a manifest claim an
         # origin its own policy forbids, and the whole verify/admit/push/pull
@@ -1695,7 +1695,7 @@ def admit_manifest(
         # field and are unaffected.
         if "storage_agree_value" in compat:
             census_sign = compat.get("storage_agree_value")
-            # TYPE before equality (Astra review #2730 R2-F2), the same
+            # TYPE before equality (review #2730 R2-F2), the same
             # strictness the C9 ids get: `True == 1` and `1.0 == 1`, so an
             # equality test alone admitted a bool and a float as a declared
             # convention.

--- a/delphi/polismath/replay/polarity.py
+++ b/delphi/polismath/replay/polarity.py
@@ -190,7 +190,7 @@ def vote_axis_involution(view: dict[str, Any]) -> dict[str, Any]:
     it is currently on, independently of the input storage sign.
     """
     # The COMPARISON boundary validates the marker's own values, not merely its
-    # presence (Astra review #2730 F2): an unknown profile or axis is a
+    # presence (review #2730 F2): an unknown profile or axis is a
     # corrupted view, and N must not translate one.
     if not has_marker(view):
         raise PolarityError(
@@ -304,7 +304,7 @@ PAIR_SIDE_FLIPPED = "flipped"
 
 #: Closed enums. "Unknown convention fails admission" (P-023 rev3) is a
 #: predicate, not a sentiment: a truthiness check accepted `unknown-input/99`
-#: (Astra review #2730 F2).
+#: (review #2730 F2).
 INPUT_CONVENTIONS: frozenset[str] = frozenset(
     {INPUT_CONVENTION_EXPORT_SEMANTIC, INPUT_CONVENTION_RAW_STORAGE})
 OUTPUT_CONVENTIONS: frozenset[str] = frozenset({OUTPUT_CONVENTION_AS_EMITTED})
@@ -325,7 +325,7 @@ class ConventionDescriptor:
 
     def __post_init__(self) -> None:
         validate_storage_agree_value(self.storage_agree_value)
-        # TYPE before membership (Astra review #2730 R2-F2): a container-valued
+        # TYPE before membership (review #2730 R2-F2): a container-valued
         # convention or side raised a raw `TypeError: unhashable type` out of
         # the set test instead of the named PolarityError this contract
         # promises. A container is not a convention token.
@@ -487,7 +487,7 @@ def _apply_control(
     side whose ingress converts twice (``None`` for every other control).
 
     Which side ``double-negate-ingress`` must break depends on the DECLARED
-    convention, and getting it wrong makes the control vacuous (Astra review
+    convention, and getting it wrong makes the control vacuous (review
     #2730 F4). A double conversion is arithmetically the identity
     (``s**2 == 1``), so a doubly-converted side emits raw ``V`` while the
     correct side emits ``V x s``: the two differ only when ``s == -1``.

--- a/delphi/polismath/replay/stages.py
+++ b/delphi/polismath/replay/stages.py
@@ -115,7 +115,7 @@ PY_STAGE_ENGINE = "py"
 STAGE_DIR_NAME = {"py": "py-stages", "clj": "clj-stages"}
 
 #: Axis orientation of ``pca.comment-projection``, declared rather than inferred
-#: (Astra F4): both engines emit ``n_comps`` rows of ``n_tids`` values, matching
+#: (review F4): both engines emit ``n_comps`` rows of ``n_tids`` values, matching
 #: Clojure's ``with-proj-and-extremtiy``. A comparer must VALIDATE against this,
 #: never guess from lengths — a square case (n_tids == n_comps) is ambiguous.
 COMMENT_PROJECTION_AXES = "comps-by-tids"

--- a/delphi/polismath/utils/output_profile.py
+++ b/delphi/polismath/utils/output_profile.py
@@ -95,7 +95,7 @@ def stamp(view: dict[str, Any], marker_value: dict[str, Any]) -> dict[str, Any]:
 def has_marker(blob: Any) -> bool:
     """True iff the reserved key is PRESENT, whatever its value.
 
-    The distinction matters at a gate (Astra review #2730 F2): a guard that
+    The distinction matters at a gate (review #2730 F2): a guard that
     only reacts to a well-formed dict treats ``{"__output_profile__": null}``,
     ``false``, a string or an array as unmarked raw data — so replacing a valid
     marker with any garbage walked a projected view straight through both
@@ -116,7 +116,7 @@ def marker_problems(value: Any) -> list[str]:
         problems.append(f"marker is missing {missing!r}")
     for unknown in sorted(set(value) - MARKER_KEYS):
         problems.append(f"marker carries unknown field {unknown!r}")
-    # TYPE before membership at every lookup (Astra review #2730 R2-F2): an
+    # TYPE before membership at every lookup (review #2730 R2-F2): an
     # unhashable value (`profile: []`, `vote_axis: {}`) raised a raw
     # `TypeError: unhashable type` out of the set test, escaping every gate
     # that promised a named, graded failure. A container is simply not a token.
@@ -199,7 +199,7 @@ def assert_restorable(blob: Any, *, label: str = "restore") -> None:
 
     Fails closed on PRESENCE, not on validity: a malformed marker value is a
     corrupted or hand-edited projected view, which is exactly the thing that
-    must not be restored (Astra review #2730 F2). An unmarked raw blob — every
+    must not be restored (review #2730 F2). An unmarked raw blob — every
     blob any producer actually emits — passes without inspection.
     """
     if not has_marker(blob):

--- a/delphi/scripts/projection_gate.py
+++ b/delphi/scripts/projection_gate.py
@@ -233,7 +233,7 @@ def _assert_statement_allowed(sql: str) -> None:
 
     The round-1 guard stripped ``--`` comments before inspecting the string, so a
     ``--`` inside a *string literal* hid a trailing multi-statement write
-    (Astra reproduced a committed INSERT through this). No comment stripping now:
+    (the second reviewer reproduced a committed INSERT through this). No comment stripping now:
     a comment token, a statement separator, or anything but a single leading
     SELECT is rejected outright. There is no ``pglast``/``sqlparse`` in the venv,
     so this is the sanctioned conservative rejection rather than a full parse; it
@@ -408,7 +408,7 @@ def classify(
     columns as a multiset (``Counter`` of full row tuples) — order-independent and
     multiplicity-preserving, so exact-duplicate votes and genuine permutations
     match, while a change that swaps values BETWEEN rows (e.g. two comments'
-    votes) breaks the row tuple and is caught (Astra round-2 defect: independent
+    votes) breaks the row tuple and is caught (review round-2 defect: independent
     per-column bags missed this). Column-set deviations (extra/missing/reordered)
     are read from the column lists directly.
     """

--- a/delphi/scripts/projection_inventory.py
+++ b/delphi/scripts/projection_inventory.py
@@ -124,7 +124,7 @@ class _Disposition:
     note: str
 
 
-# Reviewed dispositions (agree with Astra's P-042-wildcard-inventory.md). A hit
+# Reviewed dispositions (agree with the second reviewer's P-042-wildcard-inventory.md). A hit
 # that matches none of these is reported NEEDS-GATE and fails the inventory test.
 DISPOSITIONS: tuple[_Disposition, ...] = (
     _Disposition(
@@ -155,7 +155,7 @@ def _blank_comments(text: str, line_token: str, allow_block: bool) -> str:
     """Blank comments while PRESERVING string literals (', ", `) and line numbers.
 
     A char scanner, not a regex, so a `//` inside a string (e.g. an ``https://``
-    URL) is not mistaken for a comment (Astra round-3 defect 3). Comment characters
+    URL) is not mistaken for a comment (review round-3 defect 3). Comment characters
     are replaced by spaces; newlines are kept so offsets map to the right line.
     """
     out: list[str] = []
@@ -348,7 +348,7 @@ CLEARED_UNRESOLVED: tuple[ClearedUnresolved, ...] = (
         note="replay harness fetch_math_row; {table} guarded by `table not in "
         "EQUIV_TABLES` (math_main/bidtopid/ptptstats) — never a vote table. "
         "Query + guard set isolated into delphi/polismath/replay/equiv_query.py "
-        "(P-042 projgate-isolation; per Astra board [499]) so the whole-module pin "
+        "(P-042 projgate-isolation; per the second reviewer's board [499]) so the whole-module pin "
         "is disturbed only by an edit to the query/guard, not by unrelated edits to "
         "poller_equiv.py. Function digest UNCHANGED across the verbatim move "
         "(048839c8…); module digest recorded against the new isolated module; "
@@ -646,7 +646,7 @@ def _repo_root() -> str:
 
 class InventoryScanError(RuntimeError):
     """A requested scan root is missing/unreadable — an ungraded FAIL, never an
-    empty-success proof (Astra round-2 defect 4)."""
+    empty-success proof (review round-2 defect 4)."""
 
 
 def run_sweep(roots: Optional[Sequence[str]] = None, repo_root: Optional[str] = None) -> list[WildcardSite]:

--- a/delphi/tests/poller/recovery/restart_child.py
+++ b/delphi/tests/poller/recovery/restart_child.py
@@ -12,7 +12,7 @@ Stages (the P-022 §C R05 list):
 
 ``after_poll``
     after the poll cycle advanced the watermark, before any compute.  This one
-    is LATCHED, not merely hooked (astra review finding 4): see
+    is LATCHED, not merely hooked (review finding 4): see
     :func:`_install_after_poll_latch`.
 ``during_compute``
     inside ``Conversation.recompute``
@@ -40,7 +40,7 @@ import time
 
 # Exit codes with a specific meaning to the parent tests.  A crash for any
 # OTHER reason exits 1 (or dies by signal) and must never be mistaken for one
-# of these (astra review findings 3 and 4).
+# of these (review findings 3 and 4).
 EXIT_OK = 0
 EXIT_OWNERSHIP_REFUSED = 3
 EXIT_OWNERSHIP_LATCH_TIMEOUT = 4
@@ -96,14 +96,14 @@ def _install_after_poll_latch(svc) -> None:
     hooking ``_run_engine`` alone — what this child used to do — emits the stage
     marker from another thread at a moment that may PRECEDE the watermark
     assignment; the SIGKILL is real but the named ordering "after the poll cycle
-    advanced the watermark, before any compute" is unproven (astra review
+    advanced the watermark, before any compute" is unproven (review
     finding 4).
 
     The latch instead:
 
     1. gates ``_run_engine`` so no compute can start, and records that dispatch
        really happened (``GATE run_engine``).  The marker is WRITTEN AND FLUSHED
-       BEFORE ``dispatched`` is set (astra second-round review): setting the
+       BEFORE ``dispatched`` is set (second-round review): setting the
        event first lets the polling thread wake and print ``WM_ACK``/``STAGE``
        between the ``set()`` and the ``write()``, so the stdout ORDER the parent
        asserts would flake even though the watermark barrier itself is correct;
@@ -202,7 +202,7 @@ def main() -> int:
     # Startup is wrapped so that an OWNERSHIP refusal — a named, deliberate
     # refusal to run because someone else owns this shard — is reported with
     # its own exit code and marker, and can never be confused with an import
-    # error, a DB outage or any other crash (astra review finding 3).  The
+    # error, a DB outage or any other crash (review finding 3).  The
     # poller has no such path today; that absence is exactly what R07 asserts.
     try:
         pg = PostgresClient(

--- a/delphi/tests/poller/recovery/test_r01_stage_failures.py
+++ b/delphi/tests/poller/recovery/test_r01_stage_failures.py
@@ -193,7 +193,7 @@ def test_real_connection_loss_recovers(engine, pg_url, recovery_postgres_url,
     just BEFORE the next write and asserted only that its hook had run — which
     proves nothing: a fresh connection, or SQLAlchemy's pre-ping, can repair an
     idle killed connection without any failure ever reaching the retry path
-    (astra review finding 5).  So instead:
+    (review finding 5).  So instead:
 
     1. open a real transaction on the POLLER's own engine and latch its
        ``pg_backend_pid()``;
@@ -279,7 +279,7 @@ def test_real_connection_loss_recovers(engine, pg_url, recovery_postgres_url,
 def test_terminating_an_idle_backend_is_not_evidence_of_a_failed_write(
     engine, pg_url, recovery_postgres_url, make_service
 ):
-    """The control for the test above (astra review finding 5), asserted rather
+    """The control for the test above (review finding 5), asserted rather
     than assumed: terminating the database's backends between cycles does NOT
     surface any failure to the poller — the next cycle simply reconnects.
 
@@ -387,7 +387,7 @@ def test_real_serialization_failure_recovers(engine, pg_url, make_service):
 # Cache / temporal invariants around a failed write
 # --------------------------------------------------------------------------- #
 # Object identity and `last_updated` are NOT enough: an in-place smoother or
-# PCA mutation would leave both unchanged (astra review finding 6).  These
+# PCA mutation would leave both unchanged (review finding 6).  These
 # helpers take a DEEP, comparable snapshot of every piece of cached state that
 # can advance with a computation, so "no extra temporal advancement" is checked
 # against the actual numerical state and not only against a timestamp.
@@ -457,8 +457,8 @@ def test_failed_write_leaves_prior_cached_object_unchanged(engine, pg_url,
     """Write-before-cache (M2): on a failed write the in-memory cache must still
     hold the LAST PERSISTED conversation object — never an unpersisted one.
 
-    Checked three ways, because the first two are individually weak (astra
-    review finding 6): object identity, ``last_updated``, and a DEEP snapshot
+    Checked three ways, because the first two are individually weak (review
+    finding 6): object identity, ``last_updated``, and a DEEP snapshot
     of every temporal/geometric attribute (rating matrices cell by cell, PCA
     centre and components, per-participant projections, base/group clusters,
     in-conv, repness, moderation lineage).  An in-place smoother or PCA
@@ -512,7 +512,7 @@ def test_failed_write_leaves_prior_cached_object_unchanged(engine, pg_url,
 def test_recovered_state_matches_a_clean_reference_computation(engine, pg_url,
                                                                make_service):
     """The successful retry's geometry and lineage must equal what a CLEAN run
-    of the same inputs produces (astra review finding 6).
+    of the same inputs produces (review finding 6).
 
     The reference is a second service under its own math_env running the SAME
     checkpoint/restore schedule — one cold cycle over the same rows, then one
@@ -656,7 +656,7 @@ class TestNegativeControl:
     def test_the_temporal_snapshot_catches_an_in_place_mutation(
         self, engine, pg_url, make_service
     ):
-        """The correction itself, controlled (astra review finding 6): mutate
+        """The correction itself, controlled (review finding 6): mutate
         the cached conversation's PCA IN PLACE, leaving object identity and
         ``last_updated`` untouched.  The identity/timestamp assertions stay
         green; the deep snapshot must go red."""

--- a/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
+++ b/delphi/tests/poller/recovery/test_r05_mid_batch_restart.py
@@ -210,7 +210,7 @@ def test_after_poll_kill_point_is_latched_after_the_watermark_advance(
     engine, pg_url, children, tmp_path
 ):
     """The R05 "after poll/watermark advance, before any compute" kill point is
-    ORDERED, not hoped for (astra review finding 4).
+    ORDERED, not hoped for (review finding 4).
 
     ``_poll_votes_once`` submits to the pool BEFORE assigning ``_vote_wm``
     (``polismath/poller/service.py:437-448``) and ``_run_engine`` runs on a pool
@@ -225,7 +225,7 @@ def test_after_poll_kill_point_is_latched_after_the_watermark_advance(
     the event first — which it used to do — allowed the polling thread to
     interleave its two lines between the ``set()`` and the ``write()``, making
     this assertion flake on a harness detail rather than on the barrier it is
-    testing (astra second-round review)."""
+    testing (second-round review)."""
     seeded = seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     expected_wm = max(e["created"] for e in seeded.vote_events)
 

--- a/delphi/tests/poller/recovery/test_r07_overlapping_shards.py
+++ b/delphi/tests/poller/recovery/test_r07_overlapping_shards.py
@@ -44,7 +44,7 @@ MATH_ENV = "recovery"
 # The refusal contract, defined by the harness and asserted by name.
 #
 # "Nonzero exit" is NOT a refusal: an import error, a DB outage or two crashed
-# workers would all satisfy it (astra review finding 3).  A refusal is a
+# workers would all satisfy it (review finding 3).  A refusal is a
 # process that declined to run BECAUSE someone else owns this shard, and it
 # announces itself with this exit code and this marker
 # (``restart_child._is_ownership_refusal`` / ``OWNERSHIP_REFUSAL_MARKER``).
@@ -52,7 +52,7 @@ MATH_ENV = "recovery"
 OWNERSHIP_REFUSAL_EXIT = 3
 OWNERSHIP_REFUSAL_MARKER = "OWNERSHIP-REFUSED"
 
-# The FENCE contract, likewise defined by name (astra second-round review).
+# The FENCE contract, likewise defined by name (second-round review).
 #
 # "Any advisory lock, or any table whose name contains owner/lease/fence/shard"
 # is NOT a fence: creating an unrelated `lease_notes` table, or holding an
@@ -140,7 +140,7 @@ def test_rolling_shard_count_change_arithmetic_leaves_no_zid_unowned(
     """A rolling shard-count change (2 -> 3) may DOUBLE-cover a zid mid-roll,
     but it must never leave one unowned.  Assert both halves explicitly.
 
-    LIMITATION, kept explicit (astra review finding 3): this evaluates two
+    LIMITATION, kept explicit (review finding 3): this evaluates two
     complete arithmetic partitions side by side.  It is NOT a rolling ownership
     handoff — no process starts, stops, or hands anything over, and nothing
     here shows what the two generations of processes do to the same rows while
@@ -208,7 +208,7 @@ def _zid_ownership_leases(engine, zid: int) -> list:
     A candidate table qualifies only if its COLUMNS make it a lease — a zid
     column, an owner column and a version/epoch/fence-token column — and only
     if it actually holds a row for this zid with a non-null owner.  A table that
-    merely has "lease" in its name contributes nothing (astra second-round
+    merely has "lease" in its name contributes nothing (second-round
     review: ``unrelated_lease_notes`` used to flip this green)."""
     found = []
     with engine.connect() as conn:
@@ -296,7 +296,7 @@ def _await_ownership_outcome(kid, timeout=120.0):
         it exited without saying either — never a fence, always a real failure.
 
     Waiting for OWNED from BOTH children, which this helper used to do, makes
-    the PASSING shape unreachable (astra second-round review): a correctly
+    the PASSING shape unreachable (second-round review): a correctly
     refused startup exits before ``_hold_ownership`` and can never emit OWNED,
     so the helper timed out before the classifier ever saw the valid refusal."""
     deadline = time.monotonic() + timeout
@@ -329,7 +329,7 @@ def _run_two_latched_children(engine, pg_url, tmp_path, children, days=1.0,
                               zid=1):
     """Two identical poller processes driven to their ownership decision, held
     CONCURRENTLY if they both take ownership — so "both ran" cannot be two
-    one-shot processes running one after the other (astra review finding 3).
+    one-shot processes running one after the other (review finding 3).
 
     BOTH contract shapes are reachable from here:
 
@@ -447,7 +447,7 @@ def test_duplicate_shard_start_is_refused_or_fenced(engine, pg_url, tmp_path,
       :func:`_zid_keyed_advisory_locks`).  A zid-keyed lock is necessary but
       not sufficient: two processes that both completed a full write cycle were
       not exclusively owned no matter what the catalog holds, so the publisher
-      count is required as well (astra second-round review).
+      count is required as well (second-round review).
 
     Only the ownership question itself raises :class:`OwnershipNotFenced`.
     """
@@ -630,7 +630,7 @@ class TestNegativeControl:
     def test_an_unrelated_crash_is_not_classified_as_a_refusal(self, pg_url,
                                                                tmp_path,
                                                                children):
-        """The correction itself, controlled (astra review finding 3): a child
+        """The correction itself, controlled (review finding 3): a child
         that dies of a DB outage — the very thing "any nonzero exit" used to
         accept — must classify as a CRASH, never as an ownership refusal."""
         kid = _spawn(children, pg_url.replace("/rec_", "/nope_does_not_exist_"),
@@ -666,7 +666,7 @@ class TestNegativeControl:
         assert not _is_ownership_refusal(
             RuntimeError("could not connect to server"))
 
-    # -- the fence detector itself (astra second-round review) -------------- #
+    # -- the fence detector itself (second-round review) -------------- #
     def test_an_unrelated_lease_named_table_is_not_a_fence(self, engine):
         """The correction, controlled: a table whose NAME merely matches
         lease/owner/fence/shard used to flip the acceptance green with the same

--- a/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
+++ b/delphi/tests/poller/recovery/test_r09_partial_tables_readers.py
@@ -19,7 +19,7 @@ math_env = $2``) and ``server/src/utils/participants.ts:10``
 is D's job (see the notes file); what R09 needs is the exact query pair and the
 exact join, which is what is reproduced.
 
-What this module does and does NOT prove (astra review finding 2)
+What this module does and does NOT prove (review finding 2)
 -----------------------------------------------------------------
 :func:`read_generation` takes an observation in one of two modes:
 
@@ -244,7 +244,7 @@ def _mapping_problems(main_data, bid_data, pts_data=None):
 
     The pre-review version of this helper read those members as PIDS and only
     asked whether each appeared somewhere in the union of all ``bidToPid``
-    buckets.  That is wrong in both directions and the astra review (finding 1)
+    buckets.  That is wrong in both directions and the review (finding 1)
     reproduced both: with distinct bid/pid ranges it REJECTED a valid mapping,
     and it ACCEPTED a swap of two same-length buckets even though the swap
     routes every group to the wrong participants.  The checks below therefore
@@ -433,7 +433,7 @@ class ContinuousReader(threading.Thread):
 # Collected for the snapshot observer only.  ``#2704`` publishes all three
 # tables in ONE transaction, which guarantees a coherent generation *to a
 # snapshot reader* (``repeatable_read``) — and that is the only always-coherent
-# publication guarantee this atomic writer makes (astra review finding 1).  The
+# publication guarantee this atomic writer makes (review finding 1).  The
 # ``separate_statements`` observer is deliberately NOT collected here: a writer
 # commit can land BETWEEN its two independent autocommit SELECTs no matter how
 # atomically the writer publishes, so it MAY observe a mixed generation.  That
@@ -458,7 +458,7 @@ def test_reader_never_sees_a_mixed_generation(engine, pg_url, make_service,
     ``queryP_readOnly`` calls actually do — is NOT asserted coherent, because a
     commit can land between its two statements even under atomic publication;
     that hazard is witnessed deterministically by the two node-shaped-reader
-    tests below (see the module header, astra review finding 1). The body still
+    tests below (see the module header, review finding 1). The body still
     runs the coherence check for whatever ``mode`` it is CALLED with, so the
     review's scheduling witness can drive ``separate_statements`` directly and
     observe the mixed generation it must."""
@@ -605,7 +605,7 @@ def test_positional_bidtopid_contract_holds_for_a_complete_generation(
 def test_group_cluster_members_are_base_cluster_ids_not_pids(engine, pg_url,
                                                              make_service):
     """The namespace the checker depends on, asserted against a REAL published
-    blob (astra review finding 1): every ``group-clusters[*].members`` entry is
+    blob (review finding 1): every ``group-clusters[*].members`` entry is
     a ``base-clusters.id``, and the group's participants come out of the join,
     not out of the members list."""
     seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5)
@@ -639,7 +639,7 @@ def test_group_cluster_members_are_base_cluster_ids_not_pids(engine, pg_url,
 
 
 # --------------------------------------------------------------------------- #
-# The Node reader's OTHER hazard: a cached main blob (astra review finding 2)
+# The Node reader's OTHER hazard: a cached main blob (review finding 2)
 # --------------------------------------------------------------------------- #
 def _rebalance_one_participant(main_blob, bid_blob, pts_blob):
     """Move one pid from base cluster 0 to base cluster 1 in ALL THREE blobs —
@@ -820,7 +820,7 @@ class TestNegativeControl:
         non-atomic publication — the regression is about the WRITER, not
         about the check.
 
-        Scope, stated exactly (astra review finding 2): this is
+        Scope, stated exactly (review finding 2): this is
         writer-isolation evidence only.  It does NOT show that an atomic writer
         would make the SERVER's reader safe — see
         ``test_an_atomic_write_is_still_observed_mixed_by_a_node_shaped_reader``
@@ -887,7 +887,7 @@ class TestNegativeControl:
         """Swap two ``bidToPid`` buckets of a REAL published generation.  Every
         length and every id still resolves, so only the bid -> index -> pid
         join can see it — the exact corruption the pre-review checker accepted
-        (astra review finding 1)."""
+        (review finding 1)."""
         seed_conversation(engine, zid=1, n_ptpts=8, n_cmts=5)
         svc = make_service(pg_url, math_env=MATH_ENV, worker_pool_size=1)
         svc.poll_once()
@@ -910,7 +910,7 @@ class TestNegativeControl:
 
 
 # --------------------------------------------------------------------------- #
-# The astra review's synthetic mutation cases, as first-class controls.
+# The review's synthetic mutation cases, as first-class controls.
 #
 # These need no database: they are the exact observations
 # `cost-reduction/scripts/p022-review-2702-checks.py` makes, pinned so the

--- a/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
+++ b/delphi/tests/poller/recovery/test_r10_poll_load_failure_fairness.py
@@ -32,7 +32,7 @@ pytestmark = pytest.mark.recovery
 
 MATH_ENV = "recovery"
 
-# The join-timeout contract, named rather than inferred (astra review of #2708).
+# The join-timeout contract, named rather than inferred (review of #2708).
 #
 # #2708 introduces ``PoolDrainTimeout(TimeoutError)`` in
 # ``polismath/poller/service.py`` precisely so an exhausted POOL DRAIN is
@@ -296,7 +296,7 @@ def test_poll_once_surfaces_a_join_timeout(engine, pg_url, make_service):
 
     try:
         # "or not returned" alone was satisfied by an observer that simply
-        # HUNG — the very failure mode this row is about (astra review of
+        # HUNG — the very failure mode this row is about (review of
         # #2708).  Require both halves of the contract instead.
         assert not thread.is_alive(), (
             "poll_once never came back at all: a permanently blocked cycle is "
@@ -326,7 +326,7 @@ def test_poll_once_surfaces_a_join_timeout(engine, pg_url, make_service):
 # --------------------------------------------------------------------------- #
 class TestNegativeControl:
     def test_a_hung_observer_is_not_a_surfaced_failure(self):
-        """The join-timeout correction, controlled (astra review of #2708): a
+        """The join-timeout correction, controlled (review of #2708): a
         poll thread that simply never comes back satisfied the old
         ``raised is not None or not returned`` form.  The tightened oracle must
         go red on it, and its class check must be real."""

--- a/delphi/tests/poller/test_child_process_fence.py
+++ b/delphi/tests/poller/test_child_process_fence.py
@@ -466,7 +466,7 @@ def test_normal_parent_exit_still_fences_the_tree(monkeypatch, exit_code, kernel
 # --- Round 11: an incomplete or non-snapshot /proc read must not claim exit ---
 #
 # The round-10 zombie fix reads /proc to tell a live group member from a dead
-# entry. Two ways that read can be wrong were reported (Astra review, round 10);
+# entry. Two ways that read can be wrong were reported (review, round 10);
 # both must resolve to "still live", never to an authorized exit:
 #
 #   1. An unreadable or malformed `/proc/<pid>/stat` (a pid vanishing mid-read,
@@ -607,7 +607,7 @@ def test_running_member_keeps_the_group_alive(monkeypatch):
 
 @pytest.mark.skipif(not os.path.isdir("/proc"), reason="needs Linux /proc")
 def test_real_successor_forked_between_scans_is_not_reported_empty(monkeypatch):
-    """Astra's exact real-process interleaving, under Linux CI.
+    """The second reviewer's exact real-process interleaving, under Linux CI.
 
     Capture the /proc listing while the parent is alive, let it fork a sleeping
     successor and exit before the stats are read, then inspect that stale list:
@@ -660,7 +660,7 @@ def test_real_successor_forked_between_scans_is_not_reported_empty(monkeypatch):
 
 # --- Round 12: the kernel, not a /proc scan, is the emptiness authority -------
 #
-# Astra (round 11) showed that adding scan passes cannot win: N generations each
+# The second reviewer (round 11) showed that adding scan passes cannot win: N generations each
 # forking and exiting after their own enumeration make N passes all come back
 # empty while a live successor remains in the group. Enumeration is not a
 # snapshot and never will be. The fix stops scanning for the exit authority: the
@@ -698,7 +698,7 @@ def _install_fake_waitid(monkeypatch, fake):
 
 
 def test_two_generation_fork_race_does_not_authorize_exit(monkeypatch):
-    """Astra's round-11 defect: two (or more) generations defeat the scan.
+    """The second reviewer's round-11 defect: two (or more) generations defeat the scan.
 
     With the subreaper active the kernel is the authority: a live successor
     keeps `killpg(pgid, 0)` succeeding even for the exact /proc schedule that
@@ -797,7 +797,7 @@ def test_mark_child_subreaper_is_linux_only(monkeypatch):
     not sys.platform.startswith("linux"), reason="child-subreaper is Linux-only"
 )
 def test_real_two_generation_group_is_reaped_to_empty(monkeypatch):
-    """Astra's real interleaving, but decided by the kernel.
+    """The second reviewer's real interleaving, but decided by the kernel.
 
     A session-leader forks a child that forks a grandchild; the two ancestors
     exit, orphaning the live grandchild into the poller's (subreaper) care in the
@@ -852,7 +852,7 @@ def test_real_two_generation_group_is_reaped_to_empty(monkeypatch):
 
 # --- Round 13: without the kernel fence, exit confirmation fails CLOSED --------
 #
-# Astra (round 12) accepted the kernel path but showed that when subreaper setup
+# The second reviewer (round 12) accepted the kernel path but showed that when subreaper setup
 # FAILS the code fell back to the known-racy /proc scan and STILL claimed
 # process_exit_confirmed=True with a live successor in the group. "Logging
 # best-effort" does not protect the guard release. The fix: `confirm_process_tree_gone`
@@ -983,7 +983,7 @@ def test_startup_tolerates_non_linux_without_fence(monkeypatch):
     not sys.platform.startswith("linux"), reason="needs Linux /proc + fork"
 )
 def test_real_two_generation_without_fence_is_unconfirmed(monkeypatch):
-    """Astra's r12 defect case as a control: a failed/absent subreaper setup with
+    """The second reviewer's r12 defect case as a control: a failed/absent subreaper setup with
     a real two-generation live successor must return UNCONFIRMED, never confirm.
     """
     import scripts.job_poller as jp

--- a/delphi/tests/projgate/conftest.py
+++ b/delphi/tests/projgate/conftest.py
@@ -16,8 +16,8 @@ top-level ``scripts`` namespace package (``delphi/scripts``, e.g.
 It NEVER aborts the global pytest session: when no checkout is found it does nothing
 (each module fails closed to a per-test skip via its guarded import); when an
 EXPLICIT ``POLIS_CHECKOUT_DIR`` is set but unusable it records the reason in an env
-var that ``test_checkout_locator.py`` turns into a per-package FAILURE — Astra's
-fatal-on-bad-override requirement, scoped to this package rather than a session-wide
+var that ``test_checkout_locator.py`` turns into a per-package FAILURE — the second
+reviewer's fatal-on-bad-override requirement, scoped to this package rather than a session-wide
 ``UsageError``.
 """
 

--- a/delphi/tests/projgate/projection_gate_test.py
+++ b/delphi/tests/projgate/projection_gate_test.py
@@ -260,12 +260,12 @@ def test_gate_refuses_non_select() -> None:
 
 
 def test_readonly_guard_rejects_literal_comment_write() -> None:
-    """Round-1 defect (Astra): a ``--`` inside a string literal was stripped as a
+    """Round-1 defect (review): a ``--`` inside a string literal was stripped as a
     comment, hiding a trailing multi-statement write. The guard must reject it."""
-    astra = ("SELECT '--'; COMMIT; BEGIN READ WRITE; "
-             "INSERT INTO astra_readonly_probe VALUES (1); COMMIT; --")
+    comment_trick_sql = ("SELECT '--'; COMMIT; BEGIN READ WRITE; "
+             "INSERT INTO readonly_probe VALUES (1); COMMIT; --")
     with pytest.raises(pg.GateReadOnlyViolation):
-        pg._assert_statement_allowed(astra)
+        pg._assert_statement_allowed(comment_trick_sql)
     for bad in (
         "SELECT 1 -- trailing comment",
         "SELECT 1 /* block */",
@@ -296,7 +296,7 @@ def test_readonly_enforced_at_database_level(dsn: str) -> None:
 
 
 def test_repeatable_read_shared_snapshot(dsn: str) -> None:
-    """Round-1 defect (Astra): under READ COMMITTED a commit between the two reads
+    """Round-1 defect (review): under READ COMMITTED a commit between the two reads
     produced a phantom VALUE_DIFF. Under one REPEATABLE READ snapshot it cannot."""
     import psycopg2
     from unittest.mock import patch
@@ -346,7 +346,7 @@ def test_multiset_matching_is_order_and_duplicate_safe() -> None:
 
 
 def test_preflight_catches_swapped_row_associations() -> None:
-    """Round-2 defect (Astra): independent per-column bags accepted a swap of
+    """Round-2 defect (review): independent per-column bags accepted a swap of
     values BETWEEN two rows. Whole-row multiset comparison rejects it."""
     site = pg.SITES["handle_GET_votes_me"]
     before = [(0, -1), (1, 1)]  # (tid, vote)
@@ -362,7 +362,7 @@ def test_preflight_catches_swapped_row_associations() -> None:
 
 
 def test_empty_run_is_inconclusive_not_pass(dsn: str) -> None:
-    """Round-1 defect (Astra): an absent zid returned full GATE PASS with zero
+    """Round-1 defect (review): an absent zid returned full GATE PASS with zero
     cells. Zero rows carry no evidence -> INCONCLUSIVE, not PASS."""
     reports = pg.gate_all(dsn, {"zid": -SYNTHETIC_ZID})  # absent conversation
     assert reports

--- a/delphi/tests/projgate/projection_inventory_test.py
+++ b/delphi/tests/projgate/projection_inventory_test.py
@@ -66,7 +66,7 @@ def test_scan_inputs_declaration_present_in_layout() -> None:
 
 
 def test_umap_narrative_new_wildcard_is_caught(tmp_path) -> None:
-    """R16 (Astra control): a new wildcard under delphi/umap_narrative — a declared
+    """R16 (review control): a new wildcard under delphi/umap_narrative — a declared
     scan input that CI previously omitted — is caught (NEEDS-GATE) by the default,
     declaration-driven roots."""
     root = tmp_path / "projgate"
@@ -124,7 +124,7 @@ def _guarded_import(name: str):
 
 
 def test_import_guard_reraises_defects_not_just_missing(tmp_path) -> None:
-    """R14 (Astra import-regression witness): a LOCATED implementation that raises
+    """R14 (review import-regression witness): a LOCATED implementation that raises
     at import must FAIL the run, not turn green as a skip. Only a genuinely-absent
     named module is swallowed to a skip."""
     d = tmp_path / "guardpkg"
@@ -349,7 +349,7 @@ def test_mixed_projection_and_interpolated_qualifier_needs_gate(tmp_path) -> Non
 # Paths to the real replay-harness files — derived from the located implementation
 # (checkout/delphi/scripts), not this test's location, so they are correct wherever
 # the test tree is copied. The reviewed exemption now lives in the small isolated
-# ``equiv_query.py`` (P-042 projgate-isolation, Astra board [499]): it holds ONLY
+# ``equiv_query.py`` (P-042 projgate-isolation, per the second reviewer's board [499]): it holds ONLY
 # ``EQUIV_TABLES`` + ``fetch_math_row`` so the whole-module pin is disturbed only by
 # an edit to the query/guard. ``poller_equiv.py`` imports them and no longer carries
 # any wildcard SELECT.
@@ -517,7 +517,7 @@ def test_exemption_module_digest_binds_the_guard_set(tmp_path) -> None:
 
 
 def test_exemption_isolated_to_equiv_query_module(tmp_path) -> None:
-    """P-042 projgate-isolation (Astra board [499]): the exemption's query + guard
+    """P-042 projgate-isolation (per the second reviewer's board [499]): the exemption's query + guard
     set were moved verbatim out of the large ``poller_equiv.py`` into the small
     dedicated ``equiv_query.py``, whose WHOLE-module digest is the pin. The isolation
     boundary is proven both ways:

--- a/delphi/tests/projgate/test_checkout_locator.py
+++ b/delphi/tests/projgate/test_checkout_locator.py
@@ -12,7 +12,7 @@ import pytest
 
 
 def test_checkout_override_is_usable_when_set() -> None:
-    """Astra's fatal-on-bad-override, scoped to this package: an EXPLICIT but
+    """The second reviewer's fatal-on-bad-override, scoped to this package: an EXPLICIT but
     unusable POLIS_CHECKOUT_DIR is a per-package FAILURE (the conftest records the
     reason), never a session-wide UsageError."""
     fatal = os.environ.get("PROJGATE_LOCATE_FATAL")

--- a/delphi/tests/replay_harness/test_certify_strict_gate.py
+++ b/delphi/tests/replay_harness/test_certify_strict_gate.py
@@ -751,7 +751,7 @@ def test_alias_collision_is_caught_before_the_lossy_canonical_dict():
 #: step-000 — recorded so a defect that could otherwise only show under
 #: ``RUN_CLJ_INTEGRATION=1`` reproduces in ordinary CI. ``vw`` folds one
 #: participant per base cluster; ``biodiversity`` folds up to nine, so it is the
-#: fixture that can actually prove the unfolding relation (Astra review F2).
+#: fixture that can actually prove the unfolding relation (review F2).
 REAL_DRIVER_TWINS = json.loads(
     (Path(__file__).parent / "fixtures"
      / "real_driver_group_cluster_twins.json").read_text())
@@ -789,7 +789,7 @@ def test_real_driver_group_cluster_twins_are_two_views_not_a_duplicate(name):
 
 def test_biodiversity_fixture_actually_folds_many_participants_per_cluster():
     """The vw fold is one-to-one, so it cannot distinguish "unfolded through
-    base-clusters" from "relabelled"; biodiversity can (Astra review F2)."""
+    base-clusters" from "relabelled"; biodiversity can (review F2)."""
     assert REAL_DRIVER_GROUP_CLUSTER_TWINS["max_participants_per_base_cluster"] == 1
     assert FOLDED_TWINS["max_participants_per_base_cluster"] > 1
     folded, unfolded = FOLDED_TWINS["group-clusters"], FOLDED_TWINS["group_clusters"]
@@ -811,7 +811,7 @@ def test_declared_alias_pair_admits_the_real_driver_blob(name):
 
 
 def test_declared_alias_pair_admits_the_empty_and_singleton_group_states():
-    """Explicit empty/singleton behavior (Astra review F1): a conversation with
+    """Explicit empty/singleton behavior (review F1): a conversation with
     no groups is a legitimate state and needs no base-clusters to unfold, and a
     one-group one-member pair is admitted on its own terms."""
     cert.validate_checkpoint_blob(
@@ -825,12 +825,12 @@ def test_declared_alias_pair_admits_the_empty_and_singleton_group_states():
         "py: step-000")
 
 
-#: The six mutations Astra's probe (``cost-reduction/scripts/p2725-alias-review.py``)
+#: The six mutations the second reviewer's probe (``cost-reduction/scripts/p2725-alias-review.py``)
 #: drove through raw validation AND a full strict ``run_battery`` to PASS/exit 0
 #: under the first cut of policy v2: four raw-schema escapes (F1) and two
 #: well-typed but WRONG unfolded values (F2). Each mutates the UNFOLDED view of
 #: an otherwise-valid recorded pair. ``(mutate, needle)``.
-ASTRA_BAD_TWIN_MUTATIONS = {
+BAD_TWIN_MUTATIONS = {
     "string members": (lambda g: dict(g, members="not-members"), "members"),
     "string center": (lambda g: dict(g, center="not-geometry"), "center"),
     "missing members": (lambda g: {k: v for k, v in g.items() if k != "members"},
@@ -845,13 +845,13 @@ ASTRA_BAD_TWIN_MUTATIONS = {
 }
 
 
-@pytest.mark.parametrize("name", sorted(ASTRA_BAD_TWIN_MUTATIONS))
+@pytest.mark.parametrize("name", sorted(BAD_TWIN_MUTATIONS))
 @pytest.mark.parametrize("dataset", ["vw", "biodiversity"])
-def test_astra_bad_twin_controls_are_rejected(name, dataset):
-    """The six controls from the Astra review must FAIL the gate. `id=False`
+def test_bad_twin_controls_are_rejected(name, dataset):
+    """The six controls from the review must FAIL the gate. `id=False`
     matters on its own: Python's ``False == 0`` satisfied the old ordered-id
     comparison against a real group 0."""
-    mutate, needle = ASTRA_BAD_TWIN_MUTATIONS[name]
+    mutate, needle = BAD_TWIN_MUTATIONS[name]
     fixture = REAL_DRIVER_TWINS[dataset]
     unfolded = list(fixture["group_clusters"])
     unfolded[0] = mutate(unfolded[0])
@@ -865,7 +865,7 @@ def test_astra_bad_twin_controls_are_rejected(name, dataset):
 
 @pytest.mark.parametrize("dataset", ["vw", "biodiversity"])
 def test_membership_omission_and_duplication_break_the_unfolding_relation(dataset):
-    """Astra review F2: dropping or duplicating participants must fail the
+    """Review F2: dropping or duplicating participants must fail the
     relation rather than quietly shrinking/growing the unfolded view."""
     fixture = REAL_DRIVER_TWINS[dataset]
     unfolded = list(fixture["group_clusters"])
@@ -886,7 +886,7 @@ def test_folded_view_is_held_to_the_same_raw_schema_as_the_unfolded_one():
     """F1 applies to BOTH roles: the canonical view is not exempt just because
     it is the one the comparer reads."""
     fixture = FOLDED_TWINS
-    for mutate, needle in ASTRA_BAD_TWIN_MUTATIONS.values():
+    for mutate, needle in BAD_TWIN_MUTATIONS.values():
         folded = list(fixture["group-clusters"])
         mutated = mutate(folded[0])
         if mutated == folded[0]:
@@ -898,12 +898,12 @@ def test_folded_view_is_held_to_the_same_raw_schema_as_the_unfolded_one():
         assert excinfo.value.stage == "checkpoint-schema"
 
 
-#: Astra review round 2 (R2-F1): the relation's TRUSTED INPUT — the columnar
+#: Review round 2 (R2-F1): the relation's TRUSTED INPUT — the columnar
 #: ``base-clusters`` bid -> pid mapping — was not typed, so ``False == 0`` and
 #: ``0.0 == 0`` reappeared one level below the views. Each entry mutates a valid
 #: many-to-one blob and must now fail at ``checkpoint-schema`` with the named
 #: reason. ``(mutate, needle)``; ``mutate`` edits the blob in place.
-ASTRA_R2_BAD_MAPPINGS = {
+R2_BAD_MAPPINGS = {
     "boolean base id": (
         lambda b: b["base-clusters"].__setitem__("id", [False]),
         "must be an integer base-cluster id"),
@@ -936,7 +936,7 @@ ASTRA_R2_BAD_MAPPINGS = {
 
 def _many_to_one_twin_blob():
     """A minimal VALID many-to-one pair: one base cluster folding two
-    participants, one group, exact sign negation. Astra's r2 probe base."""
+    participants, one group, exact sign negation. The second reviewer's r2 probe base."""
     return copy.deepcopy({
         **VALID_BASE,
         "n": 2,
@@ -953,12 +953,12 @@ def test_many_to_one_mapping_baseline_is_admitted():
     cert.validate_checkpoint_blob(_many_to_one_twin_blob(), "py: step-000")
 
 
-@pytest.mark.parametrize("name", sorted(ASTRA_R2_BAD_MAPPINGS))
-def test_astra_r2_bad_mapping_controls_are_rejected(name):
+@pytest.mark.parametrize("name", sorted(R2_BAD_MAPPINGS))
+def test_r2_bad_mapping_controls_are_rejected(name):
     """The relation's mapping input is typed exactly as strictly as the views:
     strict integer bids and participant ids (``bool`` rejected), no unhashable
     id crash, and a fold that is a real partition."""
-    mutate, needle = ASTRA_R2_BAD_MAPPINGS[name]
+    mutate, needle = R2_BAD_MAPPINGS[name]
     blob = _many_to_one_twin_blob()
     mutate(blob)
     with pytest.raises(cert.CertifyError) as excinfo:
@@ -967,12 +967,12 @@ def test_astra_r2_bad_mapping_controls_are_rejected(name):
     assert needle in str(excinfo.value), str(excinfo.value)
 
 
-@pytest.mark.parametrize("name", sorted(ASTRA_R2_BAD_MAPPINGS))
-def test_astra_r2_bad_mappings_raise_no_bare_exception(name):
+@pytest.mark.parametrize("name", sorted(R2_BAD_MAPPINGS))
+def test_r2_bad_mappings_raise_no_bare_exception(name):
     """Every non-conforming mapping shape is a gate failure with a named
     reason, NEVER an exception escaping the gate (an array bid used to raise
     TypeError at dict membership)."""
-    mutate, _ = ASTRA_R2_BAD_MAPPINGS[name]
+    mutate, _ = R2_BAD_MAPPINGS[name]
     blob = _many_to_one_twin_blob()
     mutate(blob)
     try:
@@ -984,7 +984,7 @@ def test_astra_r2_bad_mappings_raise_no_bare_exception(name):
 
 
 @pytest.mark.parametrize("name", ["unknown bid", "wrong order", "wrong sign"])
-def test_astra_r2_positive_relation_rejections_still_hold(name):
+def test_r2_positive_relation_rejections_still_hold(name):
     """The r2 probe's three positive controls: the relation itself keeps
     rejecting an unknown bid, a permuted unfolding and an unflipped center."""
     blob = _many_to_one_twin_blob()

--- a/delphi/tests/replay_harness/test_polarity_property.py
+++ b/delphi/tests/replay_harness/test_polarity_property.py
@@ -377,7 +377,7 @@ MALFORMED_MARKERS = [
 @pytest.mark.parametrize("malformed", MALFORMED_MARKERS)
 def test_control_17b_a_malformed_marker_does_not_bypass_either_boundary(
         real_driver_blob, malformed):
-    """Astra #2730 F2. Both guards keyed on a well-formed dict, so replacing the
+    """Review #2730 F2. Both guards keyed on a well-formed dict, so replacing the
     marker value with null, false, a string or an array made the projected view
     read as unmarked RAW data: it passed the checkpoint gate and restored a
     conversation with zero groups. Malformed provenance is not the absence of
@@ -405,7 +405,7 @@ def test_N_refuses_a_malformed_marker_at_the_comparison_boundary(malformed):
 #: Marker values whose fields are CONTAINERS. These hashed before they were
 #: typed, so each raised a raw ``TypeError: unhashable type`` out of the set
 #: membership test — an ungraded crash at a gate that promises a named failure
-#: (Astra review #2730 R2-F2).
+#: (review #2730 R2-F2).
 NESTED_MARKER_VALUES = [
     ("profile", []), ("profile", {}), ("vote_axis", {}), ("vote_axis", set()),
     ("transforms", [[]]), ("transforms", [{}]),
@@ -480,7 +480,7 @@ def test_the_compensated_pair_holds_on_every_case_and_ingress(ingress, case_inde
 @pytest.mark.parametrize("ingress", pol.INGRESS_PATHS)
 @pytest.mark.parametrize("control", pol.FAILING_CONTROLS)
 def test_every_negative_control_reaches_its_gate_and_fails(ingress, control, declared):
-    """Under BOTH declarations (Astra #2730 F4). The double-conversion control
+    """Under BOTH declarations (review #2730 F4). The double-conversion control
     was injected unconditionally on the original side, which is the identity
     at s = +1: the "broken" pair passed on both ingress paths and the mandatory
     control proved nothing."""
@@ -543,7 +543,7 @@ def test_a_broken_ingress_conversion_fails_the_standing_property(monkeypatch):
     {"output_convention": ""},
     {"input_convention": ""},
     # "Unknown convention fails admission" is a predicate, not a sentiment:
-    # a truthiness check accepted these (Astra #2730 F2).
+    # a truthiness check accepted these (review #2730 F2).
     {"input_convention": "unknown-input/99"},
     {"output_convention": "unknown-output/99"},
 ])

--- a/delphi/tests/replay_harness/test_stage_oracle_e2e.py
+++ b/delphi/tests/replay_harness/test_stage_oracle_e2e.py
@@ -192,7 +192,7 @@ def test_both_engines_dump_stages_and_the_comparison_report_is_produced(tmp_path
     assert report["aligned_steps"] == 1
     assert report["step_count_mismatch"] is False
     # Two complete, step-identity-aligned, same-input recordings: the report is
-    # entitled to a headline (Astra F5 — an invalid input must withhold one).
+    # entitled to a headline (review F5 — an invalid input must withhold one).
     assert report["input_valid"] is True, report["input_problems"]
     assert report["headline_withheld"] is False
     step = report["per_step"][0]
@@ -208,7 +208,7 @@ def test_both_engines_dump_stages_and_the_comparison_report_is_produced(tmp_path
             assert "max_abs" in key and "max_rel" in key
 
     # The corrected R13 stage carries the engine contract's six geometric
-    # columns and is compared with no waiver (Astra F1). Its Python-only
+    # columns and is compared with no waiver (review F1). Its Python-only
     # correlation view rides along, explicitly ungraded.
     r13 = step["stages"]["R13_ptpt_stats"]["keys"]
     assert r13["ptpt-stats"]["n_compared"] > 0

--- a/delphi/tests/replay_harness/test_stages.py
+++ b/delphi/tests/replay_harness/test_stages.py
@@ -417,7 +417,7 @@ def test_certify_does_not_import_the_stage_oracle():
 
 
 # ---------------------------------------------------------------------------
-# Round 2 — regressions for the six findings in P-030-R-ORACLE-review.md.
+# Round 2 — regressions for the six findings from the R-ORACLE review round.
 # Each name says which finding it pins.
 # ---------------------------------------------------------------------------
 def test_f1_r13_emits_the_contract_geometry_from_the_production_adapter():

--- a/delphi/tests/replay_harness/test_stages.py
+++ b/delphi/tests/replay_harness/test_stages.py
@@ -337,10 +337,10 @@ def test_a_carved_key_does_not_hide_a_real_shape_difference_elsewhere():
 
 def test_only_carve_outs_with_a_rule_are_auto_applied():
     """AUTO_CARVED must be derived from the rules that exist, so the docs can
-    never claim a suppression the comparer does not implement (Astra F6/C5)."""
+    never claim a suppression the comparer does not implement (review F6/C5)."""
     assert sc.KEY_CARVE_OUT[("R09_group_clusters",
                              "group-clusterings-silhouettes")] == "C3"
-    # The contract geometry has NO waiver any more (Astra F1).
+    # The contract geometry has NO waiver any more (review F1).
     assert ("R13_ptpt_stats", "ptpt-stats") not in sc.KEY_CARVE_OUT
     assert set(sc.AUTO_CARVED) == {"C1", "C3"}
     for cid in sc.AUTO_CARVED:
@@ -417,7 +417,7 @@ def test_certify_does_not_import_the_stage_oracle():
 
 
 # ---------------------------------------------------------------------------
-# Round 2 — regressions for the six findings in P-030-R-ORACLE-astra-review.md.
+# Round 2 — regressions for the six findings in P-030-R-ORACLE-review.md.
 # Each name says which finding it pins.
 # ---------------------------------------------------------------------------
 def test_f1_r13_emits_the_contract_geometry_from_the_production_adapter():
@@ -1181,7 +1181,7 @@ def test_r3f4_the_ads_tally_shape_is_key_scoped_not_field_scoped():
 
 # ---------------------------------------------------------------------------
 # Round 5 — regressions for the two residual findings in the round-4 review
-# (R4-F1, R4-F2). Astra's seven reproductions, plus the cases they imply.
+# (R4-F1, R4-F2). The second reviewer's seven reproductions, plus the cases they imply.
 # ---------------------------------------------------------------------------
 def _recording_pair(tmp_path, mutate_b, *, target="doc"):
     """Two real on-disk recordings, the second corrupted. Exercises the PUBLIC

--- a/delphi/tests/test_certify_bundle.py
+++ b/delphi/tests/test_certify_bundle.py
@@ -1561,7 +1561,7 @@ def test_generated_case_metrics_use_latest_distinct_cells_not_revote_rows():
 # block, and the DERIVED role source that makes a flipped bundle admissible.
 #
 # Every test here runs the REAL admission gate end to end: no filtered problem
-# list (Astra review #2730 F1 — filtering hid the fact that no role source
+# list (review #2730 F1 — filtering hid the fact that no role source
 # existed under which a flipped bundle could be admitted at all), so an
 # unrelated admission error fails the test rather than being discarded.
 #
@@ -1806,7 +1806,7 @@ def _as_legacy_v2(manifest):
 
 def test_an_existing_manifest_v2_still_verifies_and_admits_unchanged(
         admitted, config):
-    """Astra #2730: a /2 manifest that verified and admitted under the parent
+    """Review #2730: a /2 manifest that verified and admitted under the parent
     implementation must not be invalidated by this bump. Its absent transform
     field IS the 'original capture' declaration, and its bytes are untouched."""
     payload, manifest = admitted
@@ -1837,7 +1837,7 @@ def test_a_v3_manifest_must_state_the_transform_field(admitted, config):
 
 
 # --- round 3: the origin's rules travel with the derivation -----------------
-# Astra review #2730 R2-F1. A derived role RETAINED a binding naming a
+# Review #2730 R2-F1. A derived role RETAINED a binding naming a
 # synthetic origin while skipping every rule that makes a synthetic role
 # admissible — offer, approval, generator, coverage — so a manifest could claim
 # an origin its own policy forbids and still verify, admit, push and pull.
@@ -1912,7 +1912,7 @@ def test_a_derived_synthetic_origin_must_satisfy_the_origin_rules(
 
 def test_a_derived_role_cannot_claim_an_origin_its_rule_forbids(
         derived_pair, config):
-    """Astra's witness, failing closed. Relabelling only the BINDING to a
+    """The second reviewer's witness, failing closed. Relabelling only the BINDING to a
     synthetic origin, on a role whose rule offers no replacement and with no
     approval or generator anywhere, previously passed the whole
     verify/admit/push/pull path."""

--- a/docs/engine-stage-oracles.md
+++ b/docs/engine-stage-oracles.md
@@ -519,7 +519,7 @@ random sample, non-finite handling, named-matrix shape — plus the comparer's
 canonicalization, tolerance classes and carve-outs.
 
 The `test_f1_…` through `test_f6_…` group is the regression set for the six
-findings in `cost-reduction/04-plans/P-030-R-ORACLE-astra-review.md`, one
+findings in `cost-reduction/04-plans/P-030-R-ORACLE-review.md`, one
 behaviour per name: the contract geometry at R13, C1's narrow scope, integer
 identities never seeing a tolerance, malformed matrices and undeclared axes
 becoming structural errors, incomplete input withholding the headline, and the

--- a/docs/engine-stage-oracles.md
+++ b/docs/engine-stage-oracles.md
@@ -518,12 +518,12 @@ sides — key order, integer formatting, exact double round-trip over a 5 000-va
 random sample, non-finite handling, named-matrix shape — plus the comparer's
 canonicalization, tolerance classes and carve-outs.
 
-The `test_f1_…` through `test_f6_…` group is the regression set for the six
-findings in `cost-reduction/04-plans/P-030-R-ORACLE-review.md`, one
-behaviour per name: the contract geometry at R13, C1's narrow scope, integer
-identities never seeing a tolerance, malformed matrices and undeclared axes
-becoming structural errors, incomplete input withholding the headline, and the
-non-finite tokens surviving polarity conversion.
+The `test_f1_…` through `test_f6_…` group is the regression set for six
+R-ORACLE review findings, one behaviour per name: the contract geometry at
+R13, C1's narrow scope, integer identities never seeing a tolerance,
+malformed matrices and undeclared axes becoming structural errors, incomplete
+input withholding the headline, and the non-finite tokens surviving polarity
+conversion.
 
 `test_stage_oracle_e2e.py` runs the whole loop on the smallest public battery
 case (`vw:single-cut`). The Clojure half is opt-in behind

--- a/math/test/stage_json_test.clj
+++ b/math/test/stage_json_test.clj
@@ -183,7 +183,7 @@
                "stages" "step" "tick" "vote_sign_convention"}
              (set (keys parsed))))
       (testing "the comment-projection axis orientation is DECLARED, so a
-                comparer never has to guess it from array lengths (Astra F4)"
+                comparer never has to guess it from array lengths (review F4)"
         (is (= "comps-by-tids" (get parsed "comment_projection_axes"))))
       (is (= "polis-stage-dump/1" (get parsed "schema")))
       (is (= "clj" (get parsed "engine")))

--- a/server/__tests__/integration/delphi-visualizations-metadata.test.ts
+++ b/server/__tests__/integration/delphi-visualizations-metadata.test.ts
@@ -226,7 +226,7 @@ describe("Delphi visualizations job metadata", () => {
   });
 
   it("returns an index-invisible live row alongside indexed ones", async () => {
-    // Astra's second half: adding one indexed terminal row must not be what
+    // The second reviewer's second half: adding one indexed terminal row must not be what
     // makes the hidden row visible.
     const hiddenId = `viz-sparse2-${Date.now()}`;
     written.push(hiddenId);

--- a/server/__tests__/integration/queue-substrate.test.ts
+++ b/server/__tests__/integration/queue-substrate.test.ts
@@ -826,7 +826,7 @@ describeProvisioned(
 
     it("never pools a session whose principal it could not verify", async () => {
       requireProvisioning();
-      // Astra's 22012 injection: the verification read fails AFTER SET ROLE has
+      // The second reviewer's 22012 injection: the verification read fails AFTER SET ROLE has
       // succeeded. The connection is fine, so "the query failed" is not
       // evidence that the socket is gone - the session is simply still acting
       // as the helper, and returning it to the pool hands that identity to the

--- a/server/__tests__/unit/delphi-job-guard.test.ts
+++ b/server/__tests__/unit/delphi-job-guard.test.ts
@@ -971,7 +971,7 @@ describe("admitDelphiJob: round-6 review", () => {
 
 describe("assessConversationLiveness: stable reads", () => {
   it("reports live when two sweeps disagree about a root", async () => {
-    // Astra's page schedule: the child is written between pages, past the
+    // The second reviewer's page schedule: the child is written between pages, past the
     // point page one already read, and the root completes in the same window.
     const sweeps = [
       [{ job_id: "root", status: "COMPLETED", process_exit_confirmed: true }],

--- a/server/__tests__/unit/pcaLatestExistingHttp.test.ts
+++ b/server/__tests__/unit/pcaLatestExistingHttp.test.ts
@@ -12,7 +12,7 @@
 //   server-helpers.ts:287   lost the consensus/repness tids -> no featured
 //                           comment authors at all
 //
-// Astra's review rejected treating that as a cost-authorized waiver, and asked
+// The second reviewer's review rejected treating that as a cost-authorized waiver, and asked
 // for a latest-EXISTING read that still returns undefined after a single query
 // when a conversation has no math row. That is `getLatestExistingPca`.
 //
@@ -147,7 +147,7 @@ import { getNextComment } from "../../src/nextComment";
 import { doFamousQuery } from "../../src/server-helpers";
 
 // Priorities that make the choice observable: with them, tid 0 wins; without
-// them every comment defaults to weight 1 and tid 1 wins. Astra's review used
+// them every comment defaults to weight 1 and tid 1 wins. The second reviewer's review used
 // exactly this shape ({0:100, 1:1}, random fraction 0.75).
 const PRIORITIES = { "0": 100, "1": 1 };
 const FIXED_RANDOM = 0.75;
@@ -264,7 +264,7 @@ describe("nextComment over HTTP reads the latest EXISTING generation", () => {
   });
 
   test("a conversation with no math row still routes, and still costs one query", async () => {
-    // The cheap path Astra asked to preserve: no `math_main` row means one
+    // The cheap path the second reviewer asked to preserve: no `math_main` row means one
     // query and an immediate undefined -- never createEmptyPcaStructure's
     // second `select tid from comments` synthesis.
     installPg(null);

--- a/server/__tests__/unit/pcaMathTickZero.test.ts
+++ b/server/__tests__/unit/pcaMathTickZero.test.ts
@@ -243,7 +243,7 @@ describe("getPca and a committed math generation of tick 0", () => {
 });
 
 describe("prefetchLatestPcaData column authority at zero", () => {
-  // Astra's review noted the prefetch guards had no direct committed test.
+  // The second reviewer's review noted the prefetch guards had no direct committed test.
   // These pin both of them, and the ONE place where the fix intentionally
   // changes bytes even at a positive math_tick.
   beforeEach(() => {
@@ -281,8 +281,8 @@ describe("prefetchLatestPcaData column authority at zero", () => {
   test("a numeric column caching_tick of 0 overrides the blob -- an INTENTIONAL byte change", async () => {
     // This is the one qualifier to "tick >= 1 bytes are identical". With a
     // numeric int8 parser, math_tick 1 and column caching_tick 0, prefetch now
-    // emits the column's 0 where it used to leave the blob's 34808. Astra
-    // reproduced this independently (34808 -> 0). It is the intended
+    // emits the column's 0 where it used to leave the blob's 34808. The second
+    // reviewer reproduced this independently (34808 -> 0). It is the intended
     // column-authority repair, not a regression: under the CURRENT
     // string-returning BIGINT parser no such row occurs, because "0" is truthy
     // and the column already won.
@@ -321,7 +321,7 @@ describe("getLatestExistingPca", () => {
   });
 
   test("returns undefined after exactly one query when there is no math row", async () => {
-    // The cheap no-row path Astra required: never createEmptyPcaStructure's
+    // The cheap no-row path the second reviewer required: never createEmptyPcaStructure's
     // second query. Contrast with getPca(zid), which synthesizes.
     serveNoRows();
     expect(await getLatestExistingPca(freshZid())).toBeUndefined();
@@ -340,7 +340,7 @@ describe("getLatestExistingPca", () => {
   });
 });
 
-describe("latest-existing cache provenance (Astra R2-F1)", () => {
+describe("latest-existing cache provenance (review R2-F1)", () => {
   // The [math_env, zid] cache is shared. Before this fix the
   // synthesizeEmptyWhenMissing option gated only the cold missing-row branch,
   // so whichever caller warmed the cache first decided what the
@@ -349,8 +349,8 @@ describe("latest-existing cache provenance (Astra R2-F1)", () => {
     queryP_readOnly.mockReset();
   });
 
-  test("Astra: latest-existing refuses a synthesized warm cache entry", async () => {
-    // Astra's acceptance test, verbatim in behaviour: ordinary latest
+  test("Review: latest-existing refuses a synthesized warm cache entry", async () => {
+    // The second reviewer's acceptance test, verbatim in behaviour: ordinary latest
     // synthesizes and caches an empty presentation for a conversation with no
     // row; latest-existing must not adopt it.
     serveNoRows();
@@ -361,7 +361,7 @@ describe("latest-existing cache provenance (Astra R2-F1)", () => {
   });
 
   test("it re-reads the store, so a first publication after the warm-up is visible", async () => {
-    // Astra's step 3: the synthetic entry must not hide a generation that was
+    // The second reviewer's step 3: the synthetic entry must not hide a generation that was
     // committed after it was cached.
     const zid = freshZid();
     serveNoRows();

--- a/server/__tests__/unit/pcaMathTickZeroHttp.test.ts
+++ b/server/__tests__/unit/pcaMathTickZeroHttp.test.ts
@@ -12,8 +12,8 @@
 //
 // These tests mount the real exported handlers on a real express app and drive
 // them with real HTTP requests, replicating only app.ts's parameter binding.
-// Confirms Astra's independent probe (cost-reduction/scripts/p2727-r2-node-review.cjs,
-// review cost-reduction/04-plans/P-026-step2-astra-review.md): pca2 answers 200
+// Confirms the second reviewer's independent probe (cost-reduction/scripts/p2727-r2-node-review.cjs,
+// review cost-reduction/04-plans/P-026-step2-review.md): pca2 answers 200
 // with ETag "0" at a committed generation 0.
 
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
@@ -205,7 +205,7 @@ function freshZid() {
  * Reads the `math_tick` default straight out of a route's real registration in
  * server/app.ts, via TypeScript's AST.
  *
- * Astra's review (F1) caught the earlier version of this file hardcoding -1,
+ * The second reviewer's review (F1) caught the earlier version of this file hardcoding -1,
  * which meant reverting the app.ts fix left every test passing. Binding to the
  * registration closes that: change `want("math_tick", getInt, assignToP, -1)`
  * back to `0` and the /api/v3/bid positive test below fails.
@@ -344,7 +344,7 @@ describe("HTTP routes at a committed math generation of 0", () => {
   });
 
   test('GET /api/v3/math/pca2 serves generation 0 with status 200 and ETag "0"', async () => {
-    // Astra's probe result, reproduced here as a route test: the route has no
+    // The second reviewer's probe result, reproduced here as a route test: the route has no
     // math_tick default, so routes/math.ts:82 substitutes -1 and the row is
     // served. This route was never broken by the tick-0 guard.
     serveTick("0");
@@ -401,7 +401,7 @@ describe("HTTP routes at a committed math generation of 0", () => {
   test("GET /api/v3/bid serves generation 0 using its REGISTERED math_tick default", async () => {
     // Bound to server/app.ts's actual want("math_tick", getInt, assignToP, -1).
     // Reverting that argument to 0 makes this test fail, which is the whole
-    // point (Astra F1).
+    // point (review F1).
     //
     // With the old default of 0, handle_GET_bid called getPca(zid, 0), got
     // undefined, and dereferencing items[2].asPOJO threw into the .catch ->
@@ -468,8 +468,8 @@ describe("GET /api/v3/participationInit at a committed math generation of 0", ()
   });
 });
 
-describe("cross-caller cache provenance over HTTP (Astra R2-F1)", () => {
-  // The defect Astra found: the [math_env, zid] cache is shared, so whichever
+describe("cross-caller cache provenance over HTTP (review R2-F1)", () => {
+  // The defect the second reviewer found: the [math_env, zid] cache is shared, so whichever
   // route warmed it first decided what the existing-only reader returned.
   // participationInit is a REAL route that synthesizes an empty presentation
   // for a conversation with no committed row; the existing-only reader must
@@ -534,7 +534,7 @@ describe("cross-caller cache provenance over HTTP (Astra R2-F1)", () => {
   });
 });
 
-describe("Astra: cache provenance must remain private over participationInit HTTP", () => {
+describe("Review: cache provenance must remain private over participationInit HTTP", () => {
   test.each(["missing", "1"])(
     "wrapper contains no synthesized key for %s",
     async (state) => {
@@ -593,20 +593,20 @@ function canonicalWrapper(pca: any) {
 //
 // This is equality of the NORMALIZED DECODED wrapper, not of the compressed
 // bytes on the wire: `expiration` is excluded and the gzip buffer is compared
-// decoded. Compressed-wire equality is established elsewhere, by Astra's
+// decoded. Compressed-wire equality is established elsewhere, by the second reviewer's
 // same-process before/after comparisons (44 positive-tick pairs), which is the
 // right instrument for it -- a cross-machine constant cannot be (see round 2).
 const EDGE_PARTICIPATION_WRAPPER_TICK1 =
   "267fc4b792e95eddb6cc3d161ac54ce37b1f4012ed427aa3ca53222a11c93af2";
 
-describe("participationInit's served wrapper matches edge, decoded (Astra r3)", () => {
-  // Astra's R3 finding: round 3 added an enumerable `synthesized` property to
+describe("participationInit's served wrapper matches edge, decoded (review r3)", () => {
+  // The second reviewer's R3 finding: round 3 added an enumerable `synthesized` property to
   // the cache entry, and participationInit assigns that entire entry to
   // `response.pca` and serializes it. So the wire gained a field production
   // never sent -- for EVERY tick, including 1. Keeping asPOJO/asJSON/the gzip
   // body clean did not protect the wrapper.
   //
-  // Astra's own acceptance tests above pin the key list. This pins the bytes.
+  // The second reviewer's own acceptance tests above pin the key list. This pins the bytes.
   beforeEach(() => {
     queryP_readOnly.mockReset();
   });

--- a/server/__tests__/unit/pcaMathTickZeroHttp.test.ts
+++ b/server/__tests__/unit/pcaMathTickZeroHttp.test.ts
@@ -13,7 +13,7 @@
 // These tests mount the real exported handlers on a real express app and drive
 // them with real HTTP requests, replicating only app.ts's parameter binding.
 // Confirms the second reviewer's independent probe (cost-reduction/scripts/p2727-r2-node-review.cjs,
-// review cost-reduction/04-plans/P-026-step2-review.md): pca2 answers 200
+// step 2 of that review round): pca2 answers 200
 // with ETag "0" at a committed generation 0.
 
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";


### PR DESCRIPTION
Text-only cleanup, zero behaviour change: 39 files had internal reviewer/worker labels in comments, docstrings, test names, describe/test strings, and docs. They are replaced with neutral wording ("review round N", "the second reviewer", "a headless worker"). Identifier renames are confined to test-only symbols (four test functions and two constants in `test_certify_strict_gate.py`; one local variable and one SQL literal in `projection_gate_test.py`), with every reference updated.

Not touched: `delphi/Dockerfile` and `delphi/docs/QUICK_START.md` (the unrelated `astral-sh` package maintainer), two lockfiles (the unrelated `astral-regex` npm package), and one notebook whose only match is a byte sequence inside a base64 image blob.

Verification: `py_compile` on every edited Python file; `bash -n` on the two shell scripts; YAML parse of the workflow; the Clojure test file reads as well-formed forms; `tsc --noEmit` clean for `server` and `cdk`; `test_stages` 172 passed, `test_polarity_property` 125 passed / 3 skipped, `tests/projgate` 47 passed, `test_certify_strict_gate` 143 passed, fence tests 23 passed / 8 skipped, four server unit files 95 passed, `cdk` alarms tests 49 passed. Integration suites that need the full Docker stack were not run here. Second review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s