### PR TITLE
fix(poller): guard the conversation cache's lookup/touch/evict sequence with one lock (R06)

### DIFF
--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -287,6 +287,11 @@ class MathPollerService:
         # LRU order: most-recently-touched zid last, so popitem(last=False) evicts
         # the coldest (see _remember).
         self._convs: "OrderedDict[int, Conversation]" = OrderedDict()
+        # One lock covers every cache access, including compound get/touch and
+        # store/evict operations. Never hold it across engine work or DB I/O:
+        # the pool serializes each zid, and a worker's local reference survives
+        # eviction until it publishes and remembers the updated conversation.
+        self._convs_lock = threading.Lock()
         self._retry_counts: Dict[int, int] = {}
         self._pool: Optional[ConversationWorkerPool] = None
         self._threads: List[threading.Thread] = []
@@ -541,7 +546,8 @@ class MathPollerService:
         if self._pool is None or not self._pool.is_parked(zid):
             return
         self._retry_counts.pop(zid, None)
-        self._convs.pop(zid, None)  # invalidate → next touch rebuilds full history
+        with self._convs_lock:
+            self._convs.pop(zid, None)  # next touch rebuilds full history
         self._pool.unpark(zid)  # pool owns parked truth (P-022 R04)
         logger.info(
             "Un-parked zid=%s: invalidated cache; next batch rebuilds full "
@@ -599,22 +605,24 @@ class MathPollerService:
         when conv_cache_cap (>0) is exceeded. An evicted conv is reloaded from
         math_main and fully rebuilt on its next touch (= Clojure-restart
         semantics), so eviction is lossless — just a memory/latency trade."""
-        self._convs[zid] = conv
-        self._convs.move_to_end(zid)
-        cap = self.config.conv_cache_cap
-        if cap and len(self._convs) > cap:
-            while len(self._convs) > cap:
-                evicted_zid, _ = self._convs.popitem(last=False)  # coldest
-                logger.info(
-                    "LRU-evicting cold conversation zid=%s (cache cap=%d); it will "
-                    "reload from math_main + rebuild on next touch",
-                    evicted_zid, cap,
-                )
+        with self._convs_lock:
+            self._convs[zid] = conv
+            self._convs.move_to_end(zid)
+            cap = self.config.conv_cache_cap
+            if cap and len(self._convs) > cap:
+                while len(self._convs) > cap:
+                    evicted_zid, _ = self._convs.popitem(last=False)  # coldest
+                    logger.info(
+                        "LRU-evicting cold conversation zid=%s (cache cap=%d); it will "
+                        "reload from math_main + rebuild on next touch",
+                        evicted_zid, cap,
+                    )
 
     def _run_engine(self, zid: int, coalesced: CoalescedBatch) -> None:
-        conv = self._convs.get(zid)
-        if conv is not None:
-            self._convs.move_to_end(zid)  # LRU touch
+        with self._convs_lock:
+            conv = self._convs.get(zid)
+            if conv is not None:
+                self._convs.move_to_end(zid)  # LRU touch
 
         # M1 (P-019): an explicit rebuild request (parked-zid reconciler) forces a
         # full-history reload even when a cached conv exists — the cached state may
@@ -758,7 +766,9 @@ class MathPollerService:
     def _on_engine_error(
         self, zid: int, coalesced: CoalescedBatch, error: BaseException
     ) -> None:
-        dump_error(zid, self._convs.get(zid), coalesced, error, self.config.dump_dir)
+        with self._convs_lock:
+            conv = self._convs.get(zid)
+        dump_error(zid, conv, coalesced, error, self.config.dump_dir)
         attempts = self._retry_counts.get(zid, 0) + 1
         self._retry_counts[zid] = attempts
         if attempts <= self.config.retry_cap:

--- a/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
+++ b/delphi/tests/poller/recovery/test_r06_lru_in_flight.py
@@ -215,24 +215,6 @@ def test_cache_stays_bounded_under_pool_concurrency(engine, pg_url,
 # --------------------------------------------------------------------------- #
 # The in-flight race itself
 # --------------------------------------------------------------------------- #
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "DEFECT (P-019 should-fix #5, unaddressed): the conversation cache is "
-        "an unsynchronized OrderedDict. polismath/poller/service.py:497 reads "
-        "`conv = self._convs.get(zid)` and then, as a separate step, calls "
-        "`self._convs.move_to_end(zid)`; polismath/poller/service.py:489 "
-        "concurrently evicts with `self._convs.popitem(last=False)` from "
-        "another pool thread. With the key evicted in that window, move_to_end "
-        "raises KeyError, which escapes _run_engine into _handle_zid's blanket "
-        "except (:476) and is treated as an ENGINE error: the batch is retried "
-        "or the healthy zid is PARKED, and an errorconv dump is written — a "
-        "spurious failure caused purely by cache bookkeeping. P-022 §C R06 "
-        "requires 'No KeyError, dropped handler or lost input; cache "
-        "bookkeeping synchronized.' The fix is a lock (or a thread-safe cache) "
-        "around get/touch/store/evict; that is a separate decision."
-    ),
-)
 def test_lru_touch_racing_an_eviction_does_not_park_a_healthy_zid(
     engine, pg_url, make_service
 ):

--- a/delphi/tests/poller/test_cache_lock.py
+++ b/delphi/tests/poller/test_cache_lock.py
@@ -1,0 +1,115 @@
+"""Deterministic R06 schedules; no Postgres or timing-based race assumptions."""
+
+import threading
+from collections import OrderedDict
+from unittest.mock import MagicMock
+
+import pytest
+
+from polismath.poller.service import MathPollerService, PollerConfig
+from polismath.poller.worker_pool import CoalescedBatch
+
+
+@pytest.mark.parametrize("cap", [1, 2])
+def test_eviction_between_lookup_and_touch_does_not_park(cap, tmp_path):
+    svc = MathPollerService(
+        MagicMock(),
+        PollerConfig(conv_cache_cap=cap, retry_cap=0, dump_dir=str(tmp_path)),
+    )
+    svc._ensure_runtime()
+    conv = MagicMock()
+    svc._remember(1, conv)
+    for zid in range(2, cap + 1):
+        svc._remember(zid, object())
+
+    lookup = threading.Barrier(2, timeout=5)
+    release_touch = threading.Event()
+    eviction_attempted = threading.Event()
+    eviction_finished = threading.Event()
+    errors = []
+
+    class ObservedLock:
+        """Signal actual lock contention, not merely a thread being started."""
+
+        def __init__(self, lock):
+            self.lock = lock
+
+        def __enter__(self):
+            if not self.lock.acquire(blocking=False):
+                eviction_attempted.set()
+                assert self.lock.acquire(timeout=5), "cache lock never released"
+
+        def __exit__(self, *exc):
+            self.lock.release()
+
+    class LatchedCache(OrderedDict):
+        def get(self, key, default=None):
+            value = super().get(key, default)
+            if key == 1 and value is not None:
+                lookup.wait()
+                assert release_touch.wait(5), "lookup was not released"
+            return value
+
+        def popitem(self, last=True):
+            item = super().popitem(last=last)
+            # Also release the test driver on the broken, unlocked code. It
+            # will resume the lookup after eviction and expose the KeyError.
+            eviction_attempted.set()
+            return item
+
+    svc._convs_lock = ObservedLock(
+        getattr(svc, "_convs_lock", threading.Lock())
+    )
+    svc._convs = LatchedCache(svc._convs)
+    svc._on_engine_error = MagicMock(wraps=svc._on_engine_error)
+    svc._writer = MagicMock()
+
+    def recompute():
+        # Eviction must proceed while the engine holds a local conversation:
+        # a lock spanning computation would deadlock this schedule.
+        assert eviction_finished.wait(5), "eviction blocked by engine work"
+        with svc._convs_lock:
+            assert 1 not in svc._convs
+        return conv
+
+    conv.recompute.side_effect = recompute
+
+    def evict():
+        # After the touch, evict every old entry, including the active zid.
+        for zid in range(cap + 1, 2 * cap + 1):
+            svc._remember(zid, object())
+        eviction_finished.set()
+
+    def run(fn):
+        try:
+            fn()
+        except BaseException as exc:
+            errors.append(exc)
+
+    worker = threading.Thread(
+        target=run, args=(lambda: svc._handle_zid(1, CoalescedBatch()),),
+        daemon=True,
+    )
+    evictor = threading.Thread(target=run, args=(evict,), daemon=True)
+    worker.start()
+    try:
+        lookup.wait()  # The value has been read; move_to_end has not run.
+        evictor.start()
+        assert eviction_attempted.wait(5), "evictor never reached the cache"
+    finally:
+        release_touch.set()
+        worker.join(timeout=10)
+        if evictor.ident is not None:
+            evictor.join(timeout=10)
+        svc.stop()
+
+    assert not worker.is_alive() and not evictor.is_alive()
+    assert errors == []
+    svc._on_engine_error.assert_not_called()
+    assert svc._parked == set()
+    conv.recompute.assert_called_once_with()
+    svc._writer.write_conv_updates.assert_called_once_with(1, conv)
+    assert svc._convs[1] is conv  # The evicted in-flight result was published.
+    assert list(svc._convs)[-1] == 1
+    assert len(svc._convs) == cap
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
Reopened against edge after #2747 merged and its branch was deleted; supersedes #2710. Rebased so only this PR's single commit remains.

## Why
The conversation LRU cache (`_convs`) had no lock around the compound lookup → touch → evict sequence. With the worker pool's threads, a second zid's worker could evict an entry between lookup and `move_to_end`, and a healthy zid ended up parked with a `KeyError` and an error dump. Recovery scenario R06, pinned as a strict xfail in #2702, now passes. New in Julien's poller (the cache cap itself is new; Clojure never bounds memory).

## What
One `threading.Lock` around the five `_convs` accesses in `delphi/polismath/poller/service.py`; never held across `_load_or_init`, `poll_moderation`, `recompute`, `write_conv_updates`, or `dump_error` (the unit test asserts a concurrent eviction completes while the engine holds its conversation, so an over-broad lock also fails). Cap semantics unchanged (`0` unlimited, negative rejected, positive LRU). 42 lines, one file. R06 xfail removed; `tests/poller/test_cache_lock.py` added.

## Verification
On this base: 254 passed / 1 skipped / 8 xfailed → **257 / 1 / 7**. 20/20 loops of the new race test. Mutation: reverting the lock fails all three tests in 0.44 s with the exact production signature (`KeyError(1)` → dump → `PARKING zid=1`). Implemented by a headless worker; independently reviewed (APPROVE).

Known: the pinned R06 race test on #2702 latches inside `get` and now waits out its own 30 s barrier under the lock (still passes, still discriminates); the latch is being moved to the lock boundary on #2702's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s