### PR TITLE
docs(delphi): PCA docs describe the warm-started power-iteration solver

### DIFF
--- a/delphi/docs/deep-analysis-for-julien/02-pca-analysis.md
+++ b/delphi/docs/deep-analysis-for-julien/02-pca-analysis.md
@@ -81,6 +81,8 @@ Key properties:
 - No warm-starting from previous components
 - Single-shot computation (no iterative refinement across updates)
 
+> **Status at 045a8bc48 (2026-09-09):** Stale as a description of today's engine. Since commit `09f4d2e8f`, `pca_project_dataframe` always runs with `require_powerit=True` and is fed the previous tick's components as `start_vectors` — the sklearn snippet above is not the production path. See `delphi/polismath/pca_kmeans_rep/pca.py:236-243` (warm-start param/behavior) and `delphi/polismath/conversation/conversation.py:761-779` (threading `prev_pca['comps']` into `start_vectors`). The historical analysis above is left as-is; this note only flags that it no longer matches the code.
+
 ### 2.3 DISCREPANCY: PCA Method
 
 | Property | Clojure | Python |
@@ -91,10 +93,14 @@ Key properties:
 | Determinism | Random init (varies) | seed=42 (fixed) |
 | Large conv | Mini-batch with learning rate | Same as small |
 
+> **Status at 045a8bc48 (2026-09-09):** The "Warm-start: No" cell for Python is stale — Python's power-iteration solver now warm-starts from the previous tick's components too (same references as above: `pca.py:236-243`, `conversation.py:761-779`, plus the call sites at `conversation.py:1335` and `conversation.py:1355`). The rest of the row (algorithm/iterations comparison as a historical snapshot) is unchanged.
+
 **Impact**: For well-separated eigenvalues, both converge to the same subspace. However:
 - Power iteration may find slightly different orientations (sign flips, rotations within the eigenspace)
 - Warm-starting means Clojure's PCA is **temporally stable** — small vote additions cause small PCA changes. Python recomputes from scratch each time, potentially causing jumps.
 - For large conversations (>10K participants), Clojure uses mini-batch PCA with learning rate 0.01; Python has no such optimization.
+
+> **Status at 045a8bc48 (2026-09-09):** The "Python recomputes from scratch each time" claim above is stale. Python's PCA is now warm-started tick-to-tick from the previous components, the same as Clojure's `start-vectors` — see `delphi/polismath/pca_kmeans_rep/pca.py:236-243` and `delphi/polismath/conversation/conversation.py:761-779`. Left in place as the original comparison; not rewritten.
 
 ---
 

--- a/delphi/polismath/pca_kmeans_rep/pca.py
+++ b/delphi/polismath/pca_kmeans_rep/pca.py
@@ -1,8 +1,18 @@
 """
 PCA (Principal Component Analysis) for Pol.is.
 
-This module wraps sklearn PCA with Pol.is-specific handling: mean imputation
-of missing votes (NaN) and sparsity-aware projection scaling.
+The production solver is a Clojure-parity power-iteration eigensolver
+(`powerit_pca` / `_power_iteration` below), warm-started each tick from the
+previous tick's unit components (see `pca_project_dataframe`'s
+`start_vectors` param and conversation.py:761-779). A single-shot sklearn
+PCA path also exists (`POLISMATH_PCA_IMPL=sklearn`), but it cannot accept a
+warm start, so `pca_project_dataframe` overrides it back to power iteration
+whenever `require_powerit=True` or `start_vectors` is supplied — which is
+always the case in production (conversation.py:1335, 1355) — making the
+sklearn path unreachable outside of direct/test-only calls with
+`require_powerit=False`. On top of whichever solver runs, this module also
+handles mean imputation of missing votes (NaN) and sparsity-aware
+projection scaling.
 """
 
 import logging
@@ -220,9 +230,16 @@ def pca_project_dataframe(df: pd.DataFrame,
     Perform PCA on a DataFrame and project participants into PCA space.
 
     Missing votes (NaN) are imputed with column means before PCA.
-    Uses sklearn PCA internally. Projections are scaled by the square root
-    of the proportion of comments each participant has seen, to account
-    for vote sparsity.
+    Solves via the power-iteration eigensolver (`powerit_pca`/
+    `_power_iteration` above), warm-started from `start_vectors` when given
+    (the previous tick's components in production). An sklearn PCA path is
+    also selectable (`POLISMATH_PCA_IMPL=sklearn`), but it has no
+    start-vector hook, so it is overridden back to power iteration whenever
+    `require_powerit=True` or `start_vectors` is provided (see below) —
+    which is always the case at the production call sites
+    (conversation.py:1335, 1355), making the sklearn path unreachable there.
+    Projections are scaled by the square root of the proportion of comments
+    each participant has seen, to account for vote sparsity.
 
     Args:
         df: DataFrame with participants as rows and comments as columns.


### PR DESCRIPTION
Docs and docstrings only; no code change.

Since 09f4d2e8f the Python math engine computes PCA by power iteration, warm-started from the previous tick's components, and the sklearn path is unreachable in production (`require_powerit=True`; the env override is forced back). Several documentation lines still said the opposite and were misleading the engine's original author:

- `delphi/docs/deep-analysis-for-julien/02-pca-analysis.md`: three dated "Status at 045a8bc48" notes next to the stale claims (no warm-starting; recomputes from scratch), with file:line pointers. The historical analysis is left as written.
- `delphi/polismath/pca_kmeans_rep/pca.py`: module and `pca_project_dataframe` docstrings now describe the solver, the warm start, and the unreachable sklearn branch.

Other mentions in dated design/journal documents were left alone because they describe the pre-cutover plan or history, and the benchmark's "cold start" wording is accurate for the genuine first tick.

Verification: `uv run pytest tests -q -k pca` in `delphi/`: 71 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s