### PR TITLE
types(delphi): complete type annotations across polismath; pyright rules that already pass promoted to errors

### DIFF
--- a/delphi/polismath/benchmarks/bench_pca.py
+++ b/delphi/polismath/benchmarks/bench_pca.py
@@ -254,7 +254,7 @@ def profile_pca(votes_csv: Path) -> None:
 @runs_option
 @profile_option
 @compare_impls_option
-def main(votes_csv: Path, runs: int, profile: bool, compare_impls: bool):
+def main(votes_csv: Path, runs: int, profile: bool, compare_impls: bool) -> None:
     """Benchmark PCA computation performance."""
     if profile:
         profile_pca(votes_csv)

--- a/delphi/polismath/benchmarks/bench_repness.py
+++ b/delphi/polismath/benchmarks/bench_repness.py
@@ -171,7 +171,7 @@ def profile_repness(votes_csv: Path) -> None:
 @votes_csv_argument
 @runs_option
 @profile_option
-def main(votes_csv: Path, runs: int, profile: bool):
+def main(votes_csv: Path, runs: int, profile: bool) -> None:
     """Benchmark repness computation performance."""
     if profile:
         profile_repness(votes_csv)

--- a/delphi/polismath/benchmarks/bench_update_votes.py
+++ b/delphi/polismath/benchmarks/bench_update_votes.py
@@ -82,7 +82,7 @@ def benchmark_update_votes(votes_csv: Path, runs: int = 3) -> dict:
 @click.command()
 @votes_csv_argument
 @runs_option
-def main(votes_csv: Path, runs: int):
+def main(votes_csv: Path, runs: int) -> None:
     """Benchmark update_votes performance."""
     benchmark_update_votes(votes_csv, runs)
 

--- a/delphi/polismath/components/config.py
+++ b/delphi/polismath/components/config.py
@@ -149,7 +149,7 @@ class Config:
     Configuration manager for Pol.is math.
     """
     
-    def __init__(self, overrides: Optional[Dict[str, Any]] = None):
+    def __init__(self, overrides: Optional[Dict[str, Any]] = None) -> None:
         """
         Initialize configuration.
         
@@ -294,7 +294,7 @@ class Config:
         config = deepcopy(config)
         
         # Helper function for deep update
-        def deep_update(d, u):
+        def deep_update(d: Dict[str, Any], u: Dict[str, Any]) -> Dict[str, Any]:
             for k, v in u.items():
                 if isinstance(v, dict) and k in d and isinstance(d[k], dict):
                     d[k] = deep_update(d[k], v)

--- a/delphi/polismath/conversation/conversation.py
+++ b/delphi/polismath/conversation/conversation.py
@@ -7,7 +7,7 @@ including votes, clustering, and representativeness calculation.
 
 import numpy as np
 import pandas as pd
-from typing import Dict, List, Optional, Set, Tuple, Union, Any, Callable
+from typing import Dict, List, Mapping, Optional, Set, Tuple, Union, Any, Callable, TYPE_CHECKING
 from copy import deepcopy
 import time
 import logging
@@ -32,6 +32,9 @@ from polismath.pca_kmeans_rep.legacy_kmeans import (
 )
 from polismath.utils.clj_hash import clojure_hash_map_key_order
 from polismath.utils.output_profile import assert_restorable
+
+if TYPE_CHECKING:  # import cycle-free: annotation-only reference
+    from polismath.database.dynamodb import DynamoDBClient
 
 
 # Configure logging
@@ -176,7 +179,7 @@ class Conversation:
     def __init__(self, 
                 conversation_id: Union[str, int],
                 last_updated: Optional[int] = None,
-                votes: Optional[Dict[str, Any]] = None):
+                votes: Optional[Dict[str, Any]] = None) -> None:
         """
         Initialize a conversation.
         
@@ -248,7 +251,7 @@ class Conversation:
             self.update_votes(votes)
     
     def update_votes(self, 
-                    votes: Dict[str, Any],
+                    votes: Mapping[str, Any],
                     recompute: bool = True) -> 'Conversation':
         """
         Update the conversation with new votes.
@@ -616,7 +619,7 @@ class Conversation:
             }
     
     def update_moderation(self, 
-                         moderation: Dict[str, Any],
+                         moderation: Mapping[str, Any],
                          recompute: bool = True) -> 'Conversation':
         """
         Update moderation settings.
@@ -1826,7 +1829,7 @@ class Conversation:
         group_votes = {}
 
         # Helper to count votes of a specific type for a group
-        def count_votes_for_group(group_id, comment_id, vote_type):
+        def count_votes_for_group(group_id: Any, comment_id: Any, vote_type: str) -> int:
             group = next((g for g in unfolded if g.get('id') == group_id), None)
             if not group:
                 return 0
@@ -2176,7 +2179,7 @@ class Conversation:
         # Add PCA data efficiently
         if self.pca:
             # Function to safely convert numpy arrays to lists
-            def numpy_to_list(arr):
+            def numpy_to_list(arr: Any) -> Any:
                 if isinstance(arr, np.ndarray):
                     return arr.tolist()
                 elif isinstance(arr, list):
@@ -2472,7 +2475,7 @@ class Conversation:
         logger.info(f"Total to_dict time: {time.time() - overall_start_time:.4f}s")
         return result
     
-    def _convert_structure(self, data):
+    def _convert_structure(self, data: Any) -> Any:
         """
         Optimized conversion of nested data structures for Clojure compatibility.
         Much faster than the full recursive conversion.
@@ -2540,7 +2543,7 @@ class Conversation:
             'total': 0
         }
         
-        def _convert_inner(data, depth=0):
+        def _convert_inner(data: Any, depth: int = 0) -> Any:
             processed_count['total'] += 1
             
             # For immutable types, use memoization to avoid re-processing
@@ -2673,7 +2676,7 @@ class Conversation:
     
     # Reset the conversion cache whenever needed
     @staticmethod
-    def _reset_conversion_cache():
+    def _reset_conversion_cache() -> None:
         """Clear the conversion cache to free memory."""
         Conversation._conversion_cache = {}
     
@@ -2802,7 +2805,7 @@ class Conversation:
         # priorities reduce only iterates values). Improved mode is
         # unaffected in practice: priorities there read the CURRENT tick's
         # group-votes, and the recompute overwrites this attribute first.
-        def _numeric_key(k):
+        def _numeric_key(k: Any) -> Any:
             try:
                 return int(k)
             except (ValueError, TypeError):
@@ -2864,7 +2867,7 @@ class Conversation:
         }
         
         # Function to convert numpy arrays to lists
-        def numpy_to_list(obj):
+        def numpy_to_list(obj: Any) -> Any:
             if isinstance(obj, np.ndarray):
                 return obj.tolist()
             elif isinstance(obj, list):
@@ -2878,7 +2881,7 @@ class Conversation:
             return obj
         
         # Function to convert floats to Decimal for DynamoDB compatibility
-        def float_to_decimal(obj):
+        def float_to_decimal(obj: Any) -> Any:
             if isinstance(obj, float):
                 return decimal.Decimal(str(obj))
             elif isinstance(obj, dict):
@@ -3182,7 +3185,7 @@ class Conversation:
         logger.info(f"[{time.time() - start_time:.2f}s] Conversion to DynamoDB format completed")
         return result
 
-    def export_to_dynamodb(self, dynamodb_client) -> bool:
+    def export_to_dynamodb(self, dynamodb_client: "DynamoDBClient") -> bool:
         """
         Export conversation data directly to DynamoDB.
         

--- a/delphi/polismath/conversation/manager.py
+++ b/delphi/polismath/conversation/manager.py
@@ -28,7 +28,7 @@ class ConversationManager:
     Manages multiple Pol.is conversations.
     """
     
-    def __init__(self, data_dir: Optional[str] = None):
+    def __init__(self, data_dir: Optional[str] = None) -> None:
         """
         Initialize a conversation manager.
         

--- a/delphi/polismath/database/dynamodb.py
+++ b/delphi/polismath/database/dynamodb.py
@@ -12,7 +12,10 @@ import os
 import logging
 import json
 import numpy as np
-from typing import Dict, Any, List, Optional, Union
+from typing import Dict, Any, List, Optional, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:  # import cycle-free: annotation-only reference
+    from polismath.conversation.conversation import Conversation
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -25,7 +28,7 @@ class DynamoDBClient:
                 endpoint_url: Optional[str] = None,
                 region_name: str = 'us-east-1',
                 aws_access_key_id: Optional[str] = None,
-                aws_secret_access_key: Optional[str] = None):
+                aws_secret_access_key: Optional[str] = None) -> None:
         """
         Initialize DynamoDB client.
         
@@ -43,7 +46,7 @@ class DynamoDBClient:
         self.dynamodb = None
         self.tables = {}
         
-    def initialize(self):
+    def initialize(self) -> None:
         """Initialize DynamoDB connection and create tables if needed."""
         # Set up environment variables for credentials if not provided and not already set
         if not self.aws_access_key_id and not os.environ.get('AWS_ACCESS_KEY_ID'):
@@ -69,7 +72,7 @@ class DynamoDBClient:
         # Create tables if they don't exist
         self._ensure_tables_exist()
     
-    def _ensure_tables_exist(self):
+    def _ensure_tables_exist(self) -> None:
         """Ensure all required tables exist."""
         # List existing tables
         existing_tables = [t.name for t in self.dynamodb.tables.all()]
@@ -189,7 +192,7 @@ class DynamoDBClient:
             except Exception as e:
                 logger.error(f"Error creating table {table_name}: {e}")
     
-    def _numpy_to_list(self, obj):
+    def _numpy_to_list(self, obj: Any) -> Any:
         """Convert numpy arrays to lists for JSON serialization."""
         import decimal
         
@@ -209,7 +212,7 @@ class DynamoDBClient:
             return decimal.Decimal(str(obj))
         return obj
     
-    def _replace_floats_with_decimals(self, obj):
+    def _replace_floats_with_decimals(self, obj: Any) -> Any:
         """
         Recursively replace all float values with Decimal objects.
         This is needed for DynamoDB compatibility.
@@ -233,7 +236,7 @@ class DynamoDBClient:
         else:
             return obj
             
-    def write_conversation(self, conv) -> bool:
+    def write_conversation(self, conv: "Conversation") -> bool:
         """
         Write a conversation's mathematical analysis data to DynamoDB,
         including all projections for all participants.
@@ -617,7 +620,7 @@ class DynamoDBClient:
             traceback.print_exc()
             return False
             
-    def write_projections_separately(self, conv) -> bool:
+    def write_projections_separately(self, conv: "Conversation") -> bool:
         """
         Write participant projections separately for large conversations.
         This method optimizes for reliability with very large conversations (10,000+ participants)

--- a/delphi/polismath/database/postgres.py
+++ b/delphi/polismath/database/postgres.py
@@ -14,11 +14,12 @@ from typing import Dict, List, Optional, Tuple, Union, Any, Callable
 from datetime import datetime
 import re
 import urllib.parse
+from collections.abc import Iterator
 from contextlib import contextmanager
 import asyncio
 
 import sqlalchemy as sa
-from sqlalchemy.orm import DeclarativeBase, sessionmaker, scoped_session
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker, scoped_session
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import text
 import numpy as np
@@ -72,7 +73,7 @@ class PostgresConfig:
         max_overflow: Optional[int] = None,
         ssl_mode: Optional[str] = None,
         math_env: Optional[str] = None,
-    ):
+    ) -> None:
         """
         Initialize PostgreSQL configuration.
 
@@ -198,7 +199,7 @@ class MathMain(Base):
     math_tick = sa.Column(sa.BigInteger, nullable=False, default=-1)
     modified = sa.Column(sa.BigInteger, server_default=text("now_as_millis()"))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<MathMain(zid={self.zid}, math_env='{self.math_env}')>"
 
 
@@ -215,7 +216,7 @@ class MathTicks(Base):
         sa.BigInteger, nullable=False, server_default=text("now_as_millis()")
     )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<MathTicks(zid={self.zid}, math_env='{self.math_env}', math_tick={self.math_tick})>"
 
 
@@ -230,7 +231,7 @@ class MathPtptStats(Base):
     data = sa.Column(JSONB, nullable=False)
     modified = sa.Column(sa.BigInteger, server_default=text("now_as_millis()"))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<MathPtptStats(zid={self.zid}, math_env='{self.math_env}')>"
 
 
@@ -247,7 +248,7 @@ class MathBidToPid(Base):
     data = sa.Column(JSONB, nullable=False)
     modified = sa.Column(sa.BigInteger, server_default=text("now_as_millis()"))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<MathBidToPid(zid={self.zid}, math_env='{self.math_env}')>"
 
 
@@ -262,7 +263,7 @@ class MathReportCorrelationMatrix(Base):
     math_tick = sa.Column(sa.BigInteger, nullable=False, default=-1)
     modified = sa.Column(sa.BigInteger, server_default=text("now_as_millis()"))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<MathReportCorrelationMatrix(rid={self.rid}, math_env='{self.math_env}')>"
         )
@@ -284,7 +285,7 @@ class WorkerTasks(Base):
     task_bucket = sa.Column(sa.BigInteger)
     finished_time = sa.Column(sa.BigInteger)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<WorkerTasks(task_type='{self.task_type}', finished_time={self.finished_time})"
 
 
@@ -295,7 +296,7 @@ class PostgresClient:
         self,
         config: Optional[PostgresConfig] = None,
         storage_agree_value: int = STORAGE_AGREE_VALUE,
-    ):
+    ) -> None:
         """
         Initialize PostgreSQL client.
 
@@ -383,7 +384,7 @@ class PostgresClient:
             logger.info("Shut down PostgreSQL connection")
 
     @contextmanager
-    def session(self):
+    def session(self) -> Iterator[Session]:
         """
         Get a database session context.
 
@@ -445,7 +446,7 @@ class PostgresClient:
             return result.rowcount
 
     @contextmanager
-    def transaction(self):
+    def transaction(self) -> Iterator[sa.Connection]:
         """One commit/rollback boundary; the connection belongs to the caller.
 
         Never store it on this shared client: different zid workers must use

--- a/delphi/polismath/pca_kmeans_rep/clusters.py
+++ b/delphi/polismath/pca_kmeans_rep/clusters.py
@@ -21,7 +21,7 @@ class Cluster:
     def __init__(self, 
                 center: np.ndarray, 
                 members: Optional[List[int]] = None,
-                id: Optional[int] = None):
+                id: Optional[int] = None) -> None:
         """
         Initialize a cluster with a center and optional members.
         

--- a/delphi/polismath/pca_kmeans_rep/legacy_kmeans.py
+++ b/delphi/polismath/pca_kmeans_rep/legacy_kmeans.py
@@ -61,7 +61,7 @@ class _NamedData:
     behaviour, named_matrix.clj:258-265).
     """
 
-    def __init__(self, row_names: Sequence[Any], matrix: np.ndarray):
+    def __init__(self, row_names: Sequence[Any], matrix: np.ndarray) -> None:
         self.row_names: List[Any] = list(row_names)
         self.matrix: np.ndarray = np.asarray(matrix, dtype=float)
         if self.matrix.ndim != 2 or self.matrix.shape[0] != len(self.row_names):

--- a/delphi/polismath/poller/math_writer.py
+++ b/delphi/polismath/poller/math_writer.py
@@ -222,7 +222,7 @@ def derive_ptptstats(
 class MathWriter:
     """Writes a computed conversation's results to Postgres for one cycle."""
 
-    def __init__(self, pg_client: Any):
+    def __init__(self, pg_client: Any) -> None:
         self._pg = pg_client
 
     def write_conv_updates(self, zid: int, conv: Any) -> int:

--- a/delphi/polismath/poller/service.py
+++ b/delphi/polismath/poller/service.py
@@ -280,7 +280,7 @@ class PollerConfig:
 class MathPollerService:
     """Owns the poll loops, the in-memory conv cache, the worker pool + writer."""
 
-    def __init__(self, pg_client: Any, config: PollerConfig):
+    def __init__(self, pg_client: Any, config: PollerConfig) -> None:
         self._pg = pg_client
         self.config = config
         self._writer = MathWriter(pg_client)

--- a/delphi/polismath/poller/worker_pool.py
+++ b/delphi/polismath/poller/worker_pool.py
@@ -82,7 +82,7 @@ class ConversationWorkerPool:
         self,
         process_fn: Callable[[int, CoalescedBatch], None],
         max_workers: int = 4,
-    ):
+    ) -> None:
         self._process_fn = process_fn
         self._executor = ThreadPoolExecutor(
             max_workers=max_workers, thread_name_prefix="conv-worker"

--- a/delphi/polismath/queue/executor.py
+++ b/delphi/polismath/queue/executor.py
@@ -159,7 +159,7 @@ class CommitOutcomeUnknown(RuntimeError):
     caller can reconcile the identity it already holds; never infer a rollback.
     """
 
-    def __init__(self, reply: Any):
+    def __init__(self, reply: Any) -> None:
         super().__init__("queue_commit_outcome_unknown")
         self.reply = reply
 
@@ -271,7 +271,7 @@ class Database:
     transaction outcome is uncertain must not be handed to the next statement.
     """
 
-    def __init__(self, settings: Settings):
+    def __init__(self, settings: Settings) -> None:
         settings.check()
         self.settings = settings
 
@@ -337,7 +337,7 @@ class Executor:
         env: str,
         sleep: Callable[[float], None] = time.sleep,
         lease_seconds: int = 60,
-    ):
+    ) -> None:
         if _ENV_NAMESPACE.fullmatch(env) is None:
             raise ExecutorRefused("queue_noop_environment")
         self.db = database

--- a/delphi/polismath/regression/clojure_comparer.py
+++ b/delphi/polismath/regression/clojure_comparer.py
@@ -32,7 +32,7 @@ class ClojureComparer:
         rel_tolerance: float = 1e-6,
         jaccard_threshold: float = 0.95,
         distribution_tolerance: float = 0.05,
-    ):
+    ) -> None:
         """
         Initialize with tolerance configuration.
 

--- a/delphi/polismath/regression/comparer.py
+++ b/delphi/polismath/regression/comparer.py
@@ -33,7 +33,7 @@ class ConversationComparer:
         outlier_fraction: float = 0.01,
         loose_abs_tolerance: float | None = None,
         loose_rel_tolerance: float | None = None,
-    ):
+    ) -> None:
         """
         Initialize the comparer with numeric tolerances.
 
@@ -507,7 +507,7 @@ class ConversationComparer:
                             perf_emoji = "⚠️"   # Significantly slower
 
                     # Format times in appropriate units
-                    def format_time(t):
+                    def format_time(t: float) -> str:
                         if t < 0.001:
                             return f"{t*1000000:.0f}µs"
                         elif t < 1.0:
@@ -583,7 +583,7 @@ class ConversationComparer:
             # This handles the case where golden snapshot has Python int/float but current has numpy int64/float64
             import numpy as np
 
-            def is_numeric(val):
+            def is_numeric(val: Any) -> bool:
                 """Check if value is any numeric type (Python or numpy)"""
                 return isinstance(val, (int, float, np.integer, np.floating))
 
@@ -608,7 +608,7 @@ class ConversationComparer:
         # Handle dictionaries
         if isinstance(golden, dict):
             # Normalize keys: JSON converts int keys to strings, so we need to handle both
-            def normalize_key(k):
+            def normalize_key(k: Any) -> str:
                 """Convert to string for comparison, as JSON stores dict keys as strings"""
                 return str(k)
 
@@ -973,7 +973,7 @@ class ConversationComparer:
             return result
 
         # Check if all elements are numeric
-        def is_numeric(val):
+        def is_numeric(val: Any) -> bool:
             return isinstance(val, (int, float, np.integer, np.floating))
 
         if not all(is_numeric(g) and is_numeric(c) for g, c in zip(golden, current)):
@@ -1046,7 +1046,7 @@ class ConversationComparer:
             return None
 
         # Check if all elements are numeric
-        def is_numeric(val):
+        def is_numeric(val: Any) -> bool:
             return isinstance(val, (int, float, np.integer, np.floating))
 
         if not all(is_numeric(g) and is_numeric(c) for g, c in zip(golden, current)):
@@ -1589,7 +1589,7 @@ class ConversationComparer:
         all_pass = pass_max_err and pass_mean_err and pass_r2_all and pass_r2_dims and pass_procrustes
 
         # Helper for emoji
-        def check(passed):
+        def check(passed: object) -> str:
             return "✅" if passed else "❌"
 
         # Log the metrics with pass/fail indicators
@@ -1779,7 +1779,7 @@ class ConversationComparer:
                         perf_emoji = "⚠️"   # Significantly slower
 
                 # Format times in appropriate units
-                def format_time(t):
+                def format_time(t: float) -> str:
                     if t < 0.001:
                         return f"{t*1000000:.0f}µs"
                     elif t < 1.0:

--- a/delphi/polismath/regression/recorder.py
+++ b/delphi/polismath/regression/recorder.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class ConversationRecorder:
     """Records golden snapshots of Conversation computations for regression testing."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Golden snapshots are now stored in dataset-specific directories in real_data
         pass
 

--- a/delphi/polismath/replay/certify.py
+++ b/delphi/polismath/replay/certify.py
@@ -47,6 +47,7 @@ import uuid
 from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -625,7 +626,7 @@ def validate_checkpoint_blob(
                 "checkpoint-schema",
                 f"{label}: checkpoint blob is missing required field(s) {missing}")
 
-    def present(keys: tuple[str, ...]):
+    def present(keys: tuple[str, ...]) -> Iterator[tuple[str, Any]]:
         for k in keys:
             if k in canon:
                 yield k, canon[k]
@@ -1064,7 +1065,7 @@ def annotate_by_key(ledger: dict[str, Any], key: str) -> str | None:
 class CertifyError(RuntimeError):
     """A battery entry failed at a specific stage (driver subprocess, setup)."""
 
-    def __init__(self, stage: str, message: str):
+    def __init__(self, stage: str, message: str) -> None:
         super().__init__(message)
         self.stage = stage
 

--- a/delphi/polismath/replay/crosslang.py
+++ b/delphi/polismath/replay/crosslang.py
@@ -25,7 +25,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # stepcompare stays a lazy, in-function import at runtime
+    from polismath.replay.stepcompare import StepComparer
 
 # ---------------------------------------------------------------------------
 # prep-main key whitelist + projection.
@@ -289,7 +292,7 @@ def clj_recording_to_py_store(clj_dir: str | Path, dest_dir: str | Path) -> Path
     return dest_dir
 
 
-def _prep_main_projecting_comparer():
+def _prep_main_projecting_comparer() -> StepComparer:
     """A StepComparer that projects BOTH step blobs onto the prep-main whitelist
     (canonical kebab spelling) before diffing, so Python's snake_case keys align
     with Clojure's kebab and their VALUES land on the numeric compare path. The
@@ -301,7 +304,7 @@ def _prep_main_projecting_comparer():
     tolerant = frozenset(_kebab(k) for k in DEFAULT_TOLERANT_STAT_KEYS)
 
     class PrepMainProjectingComparer(StepComparer):
-        def compare_step(self, blob_a, blob_b, index):
+        def compare_step(self, blob_a: dict, blob_b: dict, index: int) -> dict[str, Any]:
             return super().compare_step(
                 project_prep_main(blob_a), project_prep_main(blob_b), index
             )
@@ -313,7 +316,7 @@ def compare_clj_vs_py(
     recording_dir: str | Path,
     *,
     shim_root: str | Path,
-    comparer=None,
+    comparer: StepComparer | None = None,
 ) -> dict[str, Any]:
     """Compare the ``clj/`` and ``py/`` recordings inside one recording dir.
 

--- a/delphi/polismath/replay/fixture_bundle.py
+++ b/delphi/polismath/replay/fixture_bundle.py
@@ -55,6 +55,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from collections.abc import Iterator
 from typing import Any, Iterable, Sequence
 
 from polismath.utils.vote_convention import (
@@ -677,7 +678,7 @@ class LocalStore(ObjectStore):
     orchestrator. Version ids are content digests, which is exactly the pinning
     property the S3 VersionId provides."""
 
-    def __init__(self, root: Path):
+    def __init__(self, root: Path) -> None:
         self.root = Path(root)
 
     def _path(self, key: str) -> Path:
@@ -754,7 +755,7 @@ _IF_NONE_MATCH_HOOK_ID = "certify-if-none-match"
 _conditional_put = threading.local()
 
 
-def _stamp_if_none_match(request, **_kwargs) -> None:
+def _stamp_if_none_match(request: Any, **_kwargs: Any) -> None:
     """Signing-time hook: stamp ``If-None-Match: *`` on the PutObject this
     thread is issuing as a conditional create, and on nothing else.
 
@@ -800,7 +801,7 @@ class S3Store(ObjectStore):
       never be sufficient to read identities.
     """
 
-    def __init__(self, bucket: str, prefix: str = "", client=None):
+    def __init__(self, bucket: str, prefix: str = "", client: Any = None) -> None:
         import boto3
 
         self.bucket = bucket
@@ -853,7 +854,7 @@ class S3Store(ObjectStore):
                          sha256=sha256_bytes(data))
 
     @contextmanager
-    def _if_none_match(self):
+    def _if_none_match(self) -> Iterator[None]:
         """Add ``If-None-Match: *`` to the PutObject inside this block, on this
         thread, REGARDLESS of what other threads are doing to the same client.
 

--- a/delphi/polismath/replay/fixture_extract.py
+++ b/delphi/polismath/replay/fixture_extract.py
@@ -46,7 +46,12 @@ import json
 import secrets
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Sequence
+
+if TYPE_CHECKING:  # psycopg2 is a runtime dependency of the CALLER, not of this
+    # module: it only ever receives an already-open connection/cursor.
+    from psycopg2.extensions import connection as PgConnection
+    from psycopg2.extensions import cursor as PgCursor
 
 from polismath.replay import prodclone as pc
 from polismath.utils.vote_convention import (
@@ -152,7 +157,7 @@ _SQL_SURROGATE_COLUMNS = """
 """
 
 
-def detect_tie_key(conn, table: str = "votes") -> dict[str, Any]:
+def detect_tie_key(conn: PgConnection, table: str = "votes") -> dict[str, Any]:
     """Inspect the LIVE schema for a stable tie key on ``table``.
 
     Returns ``{"available", "columns", "method", "order_by", "guarantee",
@@ -541,12 +546,12 @@ def compat_rows_from_events(
 # ---------------------------------------------------------------------------
 
 
-def _rows_as_dicts(cur) -> list[dict[str, Any]]:
+def _rows_as_dicts(cur: PgCursor) -> list[dict[str, Any]]:
     columns = [d[0] for d in cur.description]
     return [dict(zip(columns, row)) for row in cur.fetchall()]
 
 
-def fetch_conversation(conn, zid: int, tie_key: dict[str, Any]) -> dict[str, list]:
+def fetch_conversation(conn: PgConnection, zid: int, tie_key: dict[str, Any]) -> dict[str, list]:
     with conn.cursor() as cur:
         cur.execute(sql_vote_events(tie_key["order_by"]), (zid,))
         votes = _rows_as_dicts(cur)
@@ -558,7 +563,7 @@ def fetch_conversation(conn, zid: int, tie_key: dict[str, Any]) -> dict[str, lis
 
 
 def extract_conversation(
-    conn, *, zid: int, slug: str, role: str, payload_root: Path, guard_root: Path,
+    conn: PgConnection, *, zid: int, slug: str, role: str, payload_root: Path, guard_root: Path,
     dir_name: str, tie_key: dict[str, Any], measured: dict[str, Any] | None = None,
     storage_agree_value: int = STORAGE_AGREE_VALUE,
 ) -> dict[str, Any]:
@@ -614,7 +619,7 @@ def extract_conversation(
 
 
 def extract_from_config(
-    conn, *, config: dict[str, Any], payload_root: Path, guard_root: Path,
+    conn: PgConnection, *, config: dict[str, Any], payload_root: Path, guard_root: Path,
     snapshot_id: str | None = None, writers_disabled: bool = False,
     dir_names: dict[str, str] | None = None,
     accept_synthetic: Sequence[str] = (),

--- a/delphi/polismath/replay/fixture_generate.py
+++ b/delphi/polismath/replay/fixture_generate.py
@@ -24,7 +24,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
+
+if TYPE_CHECKING:  # `random` stays the lazy, in-function import it already was
+    import random
 
 from polismath.replay import fixture_extract as fx
 from polismath.replay import prodclone as pc
@@ -39,7 +42,7 @@ DAY_MS = 86_400_000
 _VOTE_VALUES = (-1, 1, 0)  # raw storage signs: agree, disagree, pass
 
 
-def case_rng(generated: dict[str, Any], case_id: str):
+def case_rng(generated: dict[str, Any], case_id: str) -> random.Random:
     import random
 
     return random.Random(
@@ -89,7 +92,7 @@ def _participant_rows(n_participants: int, *, base_ms: int) -> list[dict[str, An
 
 
 def build_case_rows(
-    case: dict[str, Any], rng,
+    case: dict[str, Any], rng: random.Random,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     """Materialise one generated case. Returns raw ``(votes, comments,
     participants)`` rows shaped exactly like the DB rows the extractor reads."""

--- a/delphi/polismath/replay/fixture_survey.py
+++ b/delphi/polismath/replay/fixture_survey.py
@@ -27,7 +27,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Sequence
+
+if TYPE_CHECKING:  # psycopg2 is a runtime dependency of the CALLER, not of this
+    # module: it only ever receives an already-open connection/cursor.
+    from psycopg2.extensions import connection as PgConnection
+    from psycopg2.extensions import cursor as PgCursor
 
 from polismath.replay.fixture_config import evaluate_predicates, sort_key_for
 
@@ -64,7 +69,7 @@ class RoleUnsatisfied(RuntimeError):
     """
 
     def __init__(self, role: str, slug: str, reason: str,
-                 synthetic_replacement: str | None = None):
+                 synthetic_replacement: str | None = None) -> None:
         self.role = role
         self.slug = slug
         self.reason = reason
@@ -194,7 +199,7 @@ def derive_metrics(row: dict[str, Any]) -> dict[str, Any]:
 
 
 def open_readonly_repeatable_read(
-    conn, *, snapshot_id: str | None = None, writers_disabled: bool = False,
+    conn: PgConnection, *, snapshot_id: str | None = None, writers_disabled: bool = False,
 ) -> dict[str, Any]:
     """Begin ONE read-only repeatable-read transaction on ``conn`` and return
     the guarantee record for the manifest.
@@ -226,12 +231,12 @@ def open_readonly_repeatable_read(
     }
 
 
-def _rows_as_dicts(cur) -> list[dict[str, Any]]:
+def _rows_as_dicts(cur: PgCursor) -> list[dict[str, Any]]:
     columns = [d[0] for d in cur.description]
     return [dict(zip(columns, row)) for row in cur.fetchall()]
 
 
-def fetch_metrics(conn) -> list[dict[str, Any]]:
+def fetch_metrics(conn: PgConnection) -> list[dict[str, Any]]:
     """Run :func:`sql_conversation_metrics` and derive every committed metric.
 
     MUST be called inside the transaction opened by
@@ -243,7 +248,7 @@ def fetch_metrics(conn) -> list[dict[str, Any]]:
     return [derive_metrics(row) for row in raw]
 
 
-def schema_migration_version(conn) -> str | None:
+def schema_migration_version(conn: PgConnection) -> str | None:
     """Best-effort migration marker for the manifest: the highest applied
     migration recorded by the server's migration table, when one exists.
     Returns ``None`` (recorded as unknown) rather than failing the run."""

--- a/delphi/polismath/replay/polarity.py
+++ b/delphi/polismath/replay/polarity.py
@@ -730,7 +730,9 @@ def _row(created: int, pid: int, tid: int, vote: int | None) -> dict[str, Any]:
     return {"created": created, "pid": pid, "tid": tid, "vote": vote}
 
 
-def _grid_rows(n_ptpt: int = 8, n_cmt: int = 6, t0: int = 1_600_000_000_000) -> list[dict[str, Any]]:
+def _grid_rows(
+    n_ptpt: int = 8, n_cmt: int = 6, t0: int = 1_600_000_000_000
+) -> list[dict[str, Any]]:
     """A dense, deterministic agree/disagree/pass grid with revotes."""
     rows = []
     t = t0

--- a/delphi/polismath/replay/polarity.py
+++ b/delphi/polismath/replay/polarity.py
@@ -730,7 +730,7 @@ def _row(created: int, pid: int, tid: int, vote: int | None) -> dict[str, Any]:
     return {"created": created, "pid": pid, "tid": tid, "vote": vote}
 
 
-def _grid_rows(n_ptpt: int = 8, n_cmt: int = 6, t0: int = 1_600_000_000_000):
+def _grid_rows(n_ptpt: int = 8, n_cmt: int = 6, t0: int = 1_600_000_000_000) -> list[dict[str, Any]]:
     """A dense, deterministic agree/disagree/pass grid with revotes."""
     rows = []
     t = t0

--- a/delphi/polismath/replay/poller_equiv.py
+++ b/delphi/polismath/replay/poller_equiv.py
@@ -664,7 +664,7 @@ class _SubprocessRunner:
     def __init__(
         self, cmd: list[str], *, cwd: Path, env: dict[str, str],
         log_path: Optional[Path] = None,
-    ):
+    ) -> None:
         self.cmd = cmd
         self.cwd = cwd
         self.env = env
@@ -808,7 +808,7 @@ class CljContainerRunner(_SubprocessRunner):
         logging_level: str = "info",
         base_env: Optional[dict[str, str]] = None,
         log_path: Optional[Path] = None,
-    ):
+    ) -> None:
         env = build_clj_env(
             database_url=database_url,
             math_env=math_env,
@@ -873,7 +873,7 @@ class PyPollerRunner(_SubprocessRunner):
         database_ssl_mode: str = "disable",
         base_env: Optional[dict[str, str]] = None,
         log_path: Optional[Path] = None,
-    ):
+    ) -> None:
         env = build_py_env(
             database_url=database_url,
             math_env=math_env,

--- a/delphi/polismath/replay/prodclone.py
+++ b/delphi/polismath/replay/prodclone.py
@@ -31,7 +31,12 @@ import hashlib
 import json
 import re
 from pathlib import Path
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
+
+if TYPE_CHECKING:  # psycopg2 is a runtime dependency of the CALLER, not of this
+    # module: it only ever receives an already-open connection/cursor.
+    from psycopg2.extensions import connection as PgConnection
+    from psycopg2.extensions import cursor as PgCursor
 
 from polismath.utils.vote_convention import (
     STORAGE_AGREE_VALUE,
@@ -515,37 +520,37 @@ def save_prodclone_map(path: Path, data: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _rows_as_dicts(cur) -> list[dict[str, Any]]:
+def _rows_as_dicts(cur: PgCursor) -> list[dict[str, Any]]:
     columns = [d[0] for d in cur.description]
     return [dict(zip(columns, row)) for row in cur.fetchall()]
 
 
-def fetch_conversation_stats(conn) -> list[dict[str, Any]]:
+def fetch_conversation_stats(conn: PgConnection) -> list[dict[str, Any]]:
     """Run :func:`sql_conversation_stats` and return one dict per conversation."""
     with conn.cursor() as cur:
         cur.execute(sql_conversation_stats())
         return _rows_as_dicts(cur)
 
 
-def fetch_votes(conn, zid: int) -> list[dict[str, Any]]:
+def fetch_votes(conn: PgConnection, zid: int) -> list[dict[str, Any]]:
     with conn.cursor() as cur:
         cur.execute(sql_votes_export(), (zid,))
         return _rows_as_dicts(cur)
 
 
-def fetch_comments(conn, zid: int) -> list[dict[str, Any]]:
+def fetch_comments(conn: PgConnection, zid: int) -> list[dict[str, Any]]:
     with conn.cursor() as cur:
         cur.execute(sql_comments_export(), (zid,))
         return _rows_as_dicts(cur)
 
 
-def fetch_comment_vote_counts(conn, zid: int) -> dict[int, tuple[int, int]]:
+def fetch_comment_vote_counts(conn: PgConnection, zid: int) -> dict[int, tuple[int, int]]:
     with conn.cursor() as cur:
         cur.execute(sql_comment_vote_counts(), (zid,))
         return {row["tid"]: (row["agrees"], row["disagrees"]) for row in _rows_as_dicts(cur)}
 
 
-def run_survey(conn, limit: int) -> dict[str, Any]:
+def run_survey(conn: PgConnection, limit: int) -> dict[str, Any]:
     """Fetch stats for every conversation, classify, and return the full
     survey result (candidates per feature + size-class counts + the
     threshold constants used, for the audit-trail JSON)."""
@@ -566,7 +571,7 @@ def run_survey(conn, limit: int) -> dict[str, Any]:
 
 
 def run_extract(
-    conn, *, zid: int, feature: str, out_root: Path, map_path: Path | None = None,
+    conn: PgConnection, *, zid: int, feature: str, out_root: Path, map_path: Path | None = None,
 ) -> dict[str, Any]:
     """Extract one conversation's votes + comments into
     ``<out_root>/.local/<fake-prefix>-<slug>/`` and merge-update

--- a/delphi/polismath/replay/stages.py
+++ b/delphi/polismath/replay/stages.py
@@ -763,7 +763,7 @@ def run_stage_dump(dataset: ReplayDataset, spec: ScheduleSpec, *,
     """
     documents: list[dict[str, Any]] = []
 
-    def collect(step: ReplayStep, conv: Conversation, record) -> None:
+    def collect(step: ReplayStep, conv: Conversation, record: _driver.StepRecord) -> None:
         documents.append(stage_document(
             conv,
             step_index=step.index,

--- a/delphi/polismath/replay/stepcompare.py
+++ b/delphi/polismath/replay/stepcompare.py
@@ -59,7 +59,7 @@ class StepComparer:
         outlier_fraction: float = 0.01,
         ignore_pca_sign_flip: bool = True,
         tolerant_stat_keys: frozenset[str] = DEFAULT_TOLERANT_STAT_KEYS,
-    ):
+    ) -> None:
         # One tolerant-configured comparer; PCA sign/scale handled internally.
         self._cmp = ConversationComparer(
             abs_tolerance=abs_tolerance,

--- a/delphi/polismath/run_math_pipeline.py
+++ b/delphi/polismath/run_math_pipeline.py
@@ -11,16 +11,27 @@ import argparse
 import json
 import decimal
 from datetime import datetime
+from typing import TYPE_CHECKING, Any, Optional
 
+from polismath.types import (
+    CommentRecord,
+    CommentsPayload,
+    ModerationPayload,
+    VoteRecord,
+    VotesPayload,
+)
 from polismath.utils.general import postgres_vote_to_delphi
 from polismath.utils.vote_convention import STORAGE_AGREE_VALUE
+
+if TYPE_CHECKING:  # psycopg2 stays a lazy, in-function import at runtime
+    import psycopg2.extensions
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def prepare_for_json(obj):
+def prepare_for_json(obj: Any) -> Any:
     import numpy as np
 
     if isinstance(obj, decimal.Decimal):
@@ -43,7 +54,7 @@ def prepare_for_json(obj):
         return obj
 
 
-def connect_to_db():
+def connect_to_db() -> Optional["psycopg2.extensions.connection"]:
     """Connect to PostgreSQL database using environment variables or defaults."""
     import psycopg2
     import urllib.parse
@@ -77,7 +88,7 @@ def connect_to_db():
         return None
 
 
-def fetch_votes(conn, conversation_id, storage_agree_value=STORAGE_AGREE_VALUE):
+def fetch_votes(conn: "psycopg2.extensions.connection", conversation_id: int, storage_agree_value: int = STORAGE_AGREE_VALUE) -> VotesPayload:
     """
     Fetch votes for a specific conversation from PostgreSQL.
     Returns a dictionary containing votes in the format expected by Conversation.
@@ -107,7 +118,7 @@ def fetch_votes(conn, conversation_id, storage_agree_value=STORAGE_AGREE_VALUE):
         logger.error(f"Error fetching votes: {e}")
         cursor.close()
         return {"votes": []}
-    votes_list = []
+    votes_list: list[VoteRecord] = []
     for vote in votes:
         if vote["timestamp"]:
             try:
@@ -129,7 +140,7 @@ def fetch_votes(conn, conversation_id, storage_agree_value=STORAGE_AGREE_VALUE):
     return {"votes": votes_list}
 
 
-def fetch_comments(conn, conversation_id):
+def fetch_comments(conn: "psycopg2.extensions.connection", conversation_id: int) -> CommentsPayload:
     """
     Fetch comments for a specific conversation from PostgreSQL.
     Returns a dictionary containing comments in the format expected by Conversation.
@@ -152,7 +163,7 @@ def fetch_comments(conn, conversation_id):
         logger.error(f"Error fetching comments: {e}")
         cursor.close()
         return {'comments': []}
-    comments_list = []
+    comments_list: list[CommentRecord] = []
     for comment in comments:
         if comment['moderated'] == '-1':
             continue
@@ -171,7 +182,7 @@ def fetch_comments(conn, conversation_id):
         })
     return {'comments': comments_list}
 
-def fetch_moderation(conn, conversation_id):
+def fetch_moderation(conn: "psycopg2.extensions.connection", conversation_id: int) -> ModerationPayload:
     """
     Fetch moderation data for a specific conversation from PostgreSQL.
     Returns a dictionary containing moderation data in the format expected by Conversation.
@@ -225,11 +236,11 @@ def fetch_moderation(conn, conversation_id):
 import sys
 
 
-def memory_usage_mb(obj, seen=None):
+def memory_usage_mb(obj: Any, seen: Optional[set[int]] = None) -> float:
     return memory_usage(obj) / (1024 * 1024)
 
 
-def memory_usage(obj, seen=None):
+def memory_usage(obj: Any, seen: Optional[set[int]] = None) -> int:
     """Recursively calculate size of objects"""
     size = sys.getsizeof(obj)
     if seen is None:
@@ -254,7 +265,7 @@ def memory_usage(obj, seen=None):
     return size
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description='Run math pipeline for a Polis conversation')
     parser.add_argument('--zid', type=int, required=True, help='Conversation ID to process')
     parser.add_argument('--max-votes', type=int, default=None, 

--- a/delphi/polismath/run_math_pipeline.py
+++ b/delphi/polismath/run_math_pipeline.py
@@ -24,7 +24,7 @@ from polismath.utils.general import postgres_vote_to_delphi
 from polismath.utils.vote_convention import STORAGE_AGREE_VALUE
 
 if TYPE_CHECKING:  # psycopg2 stays a lazy, in-function import at runtime
-    import psycopg2.extensions
+    from psycopg2.extensions import connection as PgConnection
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -54,7 +54,7 @@ def prepare_for_json(obj: Any) -> Any:
         return obj
 
 
-def connect_to_db() -> Optional["psycopg2.extensions.connection"]:
+def connect_to_db() -> Optional["PgConnection"]:
     """Connect to PostgreSQL database using environment variables or defaults."""
     import psycopg2
     import urllib.parse
@@ -88,7 +88,11 @@ def connect_to_db() -> Optional["psycopg2.extensions.connection"]:
         return None
 
 
-def fetch_votes(conn: "psycopg2.extensions.connection", conversation_id: int, storage_agree_value: int = STORAGE_AGREE_VALUE) -> VotesPayload:
+def fetch_votes(
+    conn: "PgConnection",
+    conversation_id: int,
+    storage_agree_value: int = STORAGE_AGREE_VALUE,
+) -> VotesPayload:
     """
     Fetch votes for a specific conversation from PostgreSQL.
     Returns a dictionary containing votes in the format expected by Conversation.
@@ -140,7 +144,7 @@ def fetch_votes(conn: "psycopg2.extensions.connection", conversation_id: int, st
     return {"votes": votes_list}
 
 
-def fetch_comments(conn: "psycopg2.extensions.connection", conversation_id: int) -> CommentsPayload:
+def fetch_comments(conn: "PgConnection", conversation_id: int) -> CommentsPayload:
     """
     Fetch comments for a specific conversation from PostgreSQL.
     Returns a dictionary containing comments in the format expected by Conversation.
@@ -182,7 +186,9 @@ def fetch_comments(conn: "psycopg2.extensions.connection", conversation_id: int)
         })
     return {'comments': comments_list}
 
-def fetch_moderation(conn: "psycopg2.extensions.connection", conversation_id: int) -> ModerationPayload:
+def fetch_moderation(
+    conn: "PgConnection", conversation_id: int
+) -> ModerationPayload:
     """
     Fetch moderation data for a specific conversation from PostgreSQL.
     Returns a dictionary containing moderation data in the format expected by Conversation.

--- a/delphi/polismath/types.py
+++ b/delphi/polismath/types.py
@@ -1,0 +1,86 @@
+"""Typed shapes for the dicts that cross the math engine's boundaries.
+
+These describe payloads that already exist and are already stable; nothing here
+changes a runtime shape. They are declared as ``TypedDict`` so a reader (or a
+port to another language) can see the field set and its element types without
+tracing every producer.
+
+Scope is deliberately narrow: only the shapes whose producer *and* consumer are
+both in-tree and whose key set is fixed.
+
+- :class:`VoteRecord` / :class:`VotesPayload` — what
+  :func:`polismath.run_math_pipeline.fetch_votes` builds and
+  :meth:`polismath.conversation.conversation.Conversation.update_votes` reads.
+  Vote signs are already normalised to the Delphi convention (AGREE=+1,
+  DISAGREE=-1, PASS=0) at that Postgres boundary; see
+  :mod:`polismath.utils.vote_convention`.
+- :class:`CommentRecord` / :class:`CommentsPayload` — the comment rows the same
+  entrypoint builds.
+- :class:`ModerationPayload` — the four moderation id lists
+  ``Conversation.update_moderation`` consumes.
+
+``created`` is ``int | None`` in the record types because the Postgres columns
+are nullable and the producers pass ``None`` straight through rather than
+substituting a sentinel.
+"""
+
+from typing import Any, TypedDict
+
+
+class VoteRecord(TypedDict):
+    """One vote as handed to ``Conversation.update_votes``.
+
+    ``pid``/``tid`` are stringified at the fetch boundary (the engine keys its
+    matrices by the string form); ``vote`` is a float in the Delphi convention;
+    ``created`` is epoch milliseconds.
+    """
+
+    pid: str
+    tid: str
+    vote: float
+    created: int | None
+
+
+class VotesPayload(TypedDict, total=False):
+    """The ``update_votes`` envelope.
+
+    ``votes`` is always present. ``lastVoteTimestamp`` is optional — the
+    consumer falls back to the conversation's own ``last_updated`` when it is
+    absent — which is why this TypedDict is ``total=False``.
+    """
+
+    votes: list[VoteRecord]
+    lastVoteTimestamp: int
+
+
+class CommentRecord(TypedDict):
+    """One comment row. ``txt`` is the raw body; ``created`` epoch millis."""
+
+    tid: str
+    created: int | None
+    txt: str
+    is_seed: bool
+
+
+class CommentsPayload(TypedDict):
+    """The comments envelope built alongside :class:`VotesPayload`."""
+
+    comments: list[CommentRecord]
+
+
+class ModerationPayload(TypedDict, total=False):
+    """Moderation ids as consumed by ``Conversation.update_moderation``.
+
+    The four id lists are always written together by the fetch boundary;
+    ``lastModTimestamp`` is optional (the consumer keeps its existing value when
+    it is absent), so this TypedDict is ``total=False``.
+
+    ``mod`` uses the production convention: -1 moderated-out, 1 moderated-in.
+    ``meta_tids`` mirrors ``comments.is_meta`` and is independent of ``mod``.
+    """
+
+    mod_out_tids: list[str]
+    mod_in_tids: list[str]
+    meta_tids: list[str]
+    mod_out_ptpts: list[str]
+    lastModTimestamp: Any

--- a/delphi/polismath/utils/serialization.py
+++ b/delphi/polismath/utils/serialization.py
@@ -7,10 +7,12 @@ blob may carry numpy scalar/array types. It lives here (rather than nested insid
 share the exact same coercion.
 """
 
+from typing import Any
+
 import numpy as np
 
 
-def convert_numpy_types(obj):
+def convert_numpy_types(obj: Any) -> Any:
     """Convert numpy scalar/array types to JSON-native Python types.
 
     Use as the ``default=`` callback for ``json.dumps``. Without it, a blob that

--- a/delphi/pyproject.toml
+++ b/delphi/pyproject.toml
@@ -178,3 +178,70 @@ exclude = [
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.12"
+
+# Strictness.
+#
+# `typeCheckingMode` was previously unset, which meant "whatever this pyright
+# release defaults to". Pinning it makes an upgrade a deliberate change rather
+# than a silent one. It applies to everything in `include` above.
+typeCheckingMode = "standard"
+
+# `polismath/` is annotated to 100% of parameters and returns, so it is held to
+# a higher bar than the rest of `include`. The rules below are pyright's
+# `strict`-mode settings that ALREADY hold across `polismath/` with zero
+# diagnostics, promoted to errors so they stay held. The load-bearing one is
+# `reportMissingParameterType`: it is what stops the annotation coverage
+# regressing one unannotated parameter at a time.
+#
+# Scoped to `polismath/` deliberately. `umap_narrative/`, `tests/` and
+# `scripts/` are NOT annotated to the same level yet (2742 parameters there
+# still have no annotation), so promoting these repo-wide would fail on day
+# one. Widening the root is the follow-on once those are annotated too.
+[[tool.pyright.executionEnvironments]]
+root = "polismath"
+reportMissingParameterType = "error"
+reportUntypedFunctionDecorator = "error"
+reportUntypedClassDecorator = "error"
+reportUntypedBaseClass = "error"
+reportUntypedNamedTuple = "error"
+reportTypeCommentUsage = "error"
+reportConstantRedefinition = "error"
+reportDeprecated = "error"
+reportInconsistentOverload = "error"
+reportOverlappingOverload = "error"
+reportInvalidStubStatement = "error"
+reportIncompleteStub = "error"
+reportInvalidTypeVarUse = "error"
+reportUnnecessaryCast = "error"
+reportUnnecessaryContains = "error"
+reportUnusedExpression = "error"
+reportAssertAlwaysTrue = "error"
+reportSelfClsParameterName = "error"
+reportMatchNotExhaustive = "error"
+reportShadowedImports = "error"
+reportUninitializedInstanceVariable = "error"
+
+# NOT enabled for `polismath/` either, with the reason. Each number is the
+# diagnostic count that rule adds on top of `standard` today; none can be
+# cleared by annotation alone, so none is silenced with an `Any` or an ignore
+# comment.
+#
+#   reportUnknownVariableType      976 |
+#   reportUnknownMemberType        913 | numpy / pandas / sqlalchemy inference.
+#   reportUnknownArgumentType      791 | An `ndarray` element or a DataFrame
+#   reportMissingTypeArgument      141 | column is `Any` at the library
+#   reportUnknownParameterType     129 | boundary; annotating our side does
+#   reportUnknownLambdaType         79 | not make the library's side known.
+#
+#   reportUnusedImport              61 | Dead-import cleanup: a behaviour-safe
+#   reportUnusedVariable             6 | but separate change (some are
+#   reportDuplicateImport            1 | re-exports).
+#   reportPrivateUsage              39 | The replay/regression harnesses reach
+#                                      | into engine internals on purpose.
+#   reportImplicitOverride          18 | Needs `@override` decorators added.
+#   reportUnnecessaryIsInstance     18 | Defensive isinstance chains on values
+#   reportUnnecessaryComparison     13 | typed narrower than they arrive.
+#   reportMissingTypeStubs          10 | Third-party packages ship no stubs.
+#
+# Blanket `strict` on `polismath/` reports 3192 today; `standard` reports 130.
+# Neither is reachable by adding annotations — closing them means editing logic.


### PR DESCRIPTION
Behaviour-neutral: annotations, typing imports, a `py.typed` marker, and pyright configuration. No executable statement changes.

**Coverage** (`delphi/polismath/`, 62 modules): return annotations 759/830 → 830/830; parameter annotations 1589/1651 → 1651/1651. Largest gaps closed: the conversation engine core, the pipeline entrypoint, the database package, the regression comparers.

**Checker**: the project's configured checker is pyright. `typeCheckingMode` pinned to `standard` (already the effective default, verified no diagnostic change) and the 21 strict-mode rules that hold at zero diagnostics across `polismath/` promoted to errors, scoped to that root via an execution environment; `reportMissingParameterType` locks in the 100%. `umap_narrative/`, `tests/`, `scripts/` are out of scope (2,742 unannotated parameters there). Remaining blockers to full strict are listed in the config with counts; they are numpy/pandas/sqlalchemy boundary inference and a handful of rules that need logic edits.

**Proof of neutrality**: every annotation (parameters, returns, annotated assignments, `TYPE_CHECKING` blocks) was stripped from both trees and the ASTs diffed; the only structural deltas are added typing imports. All 62 modules import cleanly; new runtime imports are `typing` names, `collections.abc.Iterator`, an already-imported `sqlalchemy.orm.Session`, and a new `polismath.types` module that imports only `typing`.

**Tests**: full `delphi/tests` (minus the Pakistan conversation, as CI does) before and after: identical FAILED/ERROR lists (1 pre-existing failure, 142 pre-existing environmental errors from the recovery matrix without `POLIS_TEST_POSTGRES_URL`). Projection gate: both pinned digests unchanged, `tests/projgate` 47 passed, no re-record needed.

**One widening to note**: `Conversation.update_votes(votes)` and `update_moderation(moderation)` accept `Mapping[str, Any]` instead of `Dict[str, Any]`; both only call `.get`, so every previous caller still type-checks. It lets the new `VotesPayload`/`ModerationPayload` TypedDicts flow from the fetch boundary without a cast.

**Findings surfaced, not fixed here** (15 new diagnostics from accurate annotations; recorded, not silenced): unguarded `None` paths in `dynamodb.py` (legacy `repness` branch), `_rows_as_dicts` iterating a nullable `cur.description` (prodclone, fixture_extract, fixture_survey), `fetchone()` unpacked without a check (fixture_survey, `run_math_pipeline.fetch_moderation`), and seven partial test doubles. Fixing them is logic; separate PR.

Schema impact: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s