### PR TITLE
ci(certification): ship the battery recordings as an artifact; measurement enumerates the battery

### DIFF
--- a/.github/workflows/certification-ec2.yml
+++ b/.github/workflows/certification-ec2.yml
@@ -347,6 +347,27 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      # The battery's Clojure/Python recordings are the only output of this run
+      # that cannot be recomputed without paying for another instance, and they
+      # used to die with the box: certify writes them under the log directory
+      # and the evidence bundle tars the artifact directory. All the logic is in
+      # ci/p022_collect_recordings.sh; this must run before teardown.
+      - name: Collect the battery recordings
+        if: ${{ always() && env.INSTANCE_ID != '' && env.RUN_BATTERY == 'true' }}
+        run: bash ci/p022_collect_recordings.sh
+
+      # Separate artifact, longer retention: ~1.5-3 MB of public-fixture
+      # recordings that a later measurement run consumes, versus a 7-day
+      # evidence bundle read while the run is still fresh.
+      - name: Upload the battery recordings
+        if: ${{ always() && env.RUN_BATTERY == 'true' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: certification-recordings-${{ github.run_id }}-${{ github.run_attempt }}
+          path: recordings/
+          if-no-files-found: warn
+          retention-days: 90
+
       # ---------------------------------------------------------------- teardown
       # Re-assume first: a long run's launch-session credentials may be minutes
       # from expiry by now, and the one step that must not fail for lack of

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -122,7 +122,10 @@ jobs:
         # Iterate a CAPTURED list, not `... | while read`: a `docker compose exec`
         # inside a while-read loop drains the piped stdin and truncates the list to
         # its first item (observed: only server/src copied).
-        for rel in $(python3 delphi/scripts/projection_inventory.py --print-scan-inputs); do
+        # Recordings tests also load the packer and its digest helper from ci/.
+        # battery_coverage.py is already included in the declared delphi/scripts.
+        for rel in $(python3 delphi/scripts/projection_inventory.py --print-scan-inputs) \
+          ci/p022_recordings_manifest.py ci/p022_battery_digest.py; do
           docker compose -f docker-compose.test.yml exec -T delphi mkdir -p "/app/projgate/$(dirname "$rel")"
           docker compose -f docker-compose.test.yml cp "$rel" "delphi:/app/projgate/$rel" \
             || { echo "failed to copy scan input: $rel"; exit 1; }

--- a/ci/p022_collect_recordings.sh
+++ b/ci/p022_collect_recordings.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# P-022 §E — pull the battery's recording bundle off the worker, verified.
+#
+# Split out of .github/workflows/certification-ec2.yml on purpose: the workflow
+# file is the one file in this change that cannot be merged from the CLI, so it
+# gets two short steps and every line of logic lives here, where shellcheck can
+# read it.
+#
+# The transfer is the same base64-over-SSM channel the evidence bundle uses —
+# there is no other return path off that box (no inbound rule, no public IP, no
+# S3 grant on the instance role, and giving it one would reopen the data
+# boundary #2715 closed). So the bundle comes back in bounded chunks with a
+# declared length and sha256, and a short, corrupt or unverifiable bundle fails
+# this step rather than producing a plausible-looking directory of nothing.
+#
+#   env: INSTANCE_ID  (required)  the worker, exported by the workflow
+#        AWS_REGION   (required)  set by configure-aws-credentials
+#        REC_OUT_DIR  (optional)  where to extract (default: ./recordings)
+set -euo pipefail
+
+: "${INSTANCE_ID:?INSTANCE_ID required}"
+OUT_DIR="${REC_OUT_DIR:-recordings}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "$OUT_DIR"
+
+# Pack on the box. This phase fails if the battery passed but an admitted entry
+# has no clj+py pair — an incomplete inventory is a failure, not a smaller one.
+bash "$HERE/p022_ssm.sh" recordings \
+  'sudo env POLIS_CI_REPO_ROOT=/opt/polis bash /opt/polis/ci/p022_ec2_run.sh recordings'
+
+bash "$HERE/p022_ssm.sh" rec-bundle \
+  'sudo bash /opt/polis/ci/p022_ec2_run.sh rec-bundle' | tee rec-bundle.txt
+
+CHUNKS=$(sed -n 's/^p022 rec-bundle chunks=\([0-9]\+\)$/\1/p' rec-bundle.txt | tail -n1)
+CHARS=$(sed -n 's/^p022 rec-bundle chars=\([0-9]\+\)$/\1/p' rec-bundle.txt | tail -n1)
+DIGEST=$(sed -n 's/^p022 rec-bundle sha256=\([0-9a-f]\{64\}\)$/\1/p' rec-bundle.txt | tail -n1)
+if [ -z "$CHUNKS" ] || [ -z "$CHARS" ] || [ -z "$DIGEST" ]; then
+  echo "::error::worker did not declare a complete recordings bundle"
+  exit 1
+fi
+echo "recordings bundle: $CHUNKS chunk(s), $CHARS base64 chars"
+
+: > recordings.b64
+for i in $(seq 1 "$CHUNKS"); do
+  POLIS_SSM_MODE=base64 POLIS_SSM_TIMEOUT=300 bash "$HERE/p022_ssm.sh" "rec-chunk-$i" \
+    "sudo bash /opt/polis/ci/p022_ec2_run.sh rec-chunk $i" >> recordings.b64
+done
+
+GOT=$(wc -c < recordings.b64)
+if [ "$GOT" -ne "$CHARS" ]; then
+  echo "::error::recordings bundle length mismatch: expected $CHARS got $GOT"
+  exit 1
+fi
+base64 -d recordings.b64 > recordings.tar
+if ! echo "$DIGEST  recordings.tar" | sha256sum -c -; then
+  echo "::error::recordings bundle digest mismatch"
+  exit 1
+fi
+tar -xf recordings.tar -C "$OUT_DIR"
+
+# Re-hash every per-entry archive against the manifest the worker wrote. The
+# transfer digest above proves the tarball arrived intact; this proves the
+# manifest describes the archives inside it, which is what a downloader pins.
+python3 "$HERE/p022_recordings_manifest.py" --verify "$OUT_DIR"
+ls -la "$OUT_DIR" "$OUT_DIR/entries"

--- a/ci/p022_collect_recordings.sh
+++ b/ci/p022_collect_recordings.sh
@@ -19,6 +19,7 @@
 set -euo pipefail
 
 : "${INSTANCE_ID:?INSTANCE_ID required}"
+: "${BATTERY_DIGEST:?BATTERY_DIGEST required}"
 OUT_DIR="${REC_OUT_DIR:-recordings}"
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -57,10 +58,13 @@ if ! echo "$DIGEST  recordings.tar" | sha256sum -c -; then
   echo "::error::recordings bundle digest mismatch"
   exit 1
 fi
-tar -xf recordings.tar -C "$OUT_DIR"
+
 
 # Re-hash every per-entry archive against the manifest the worker wrote. The
 # transfer digest above proves the tarball arrived intact; this proves the
 # manifest describes the archives inside it, which is what a downloader pins.
-python3 "$HERE/p022_recordings_manifest.py" --verify "$OUT_DIR"
+python3 "$HERE/p022_recordings_manifest.py" --verify "$OUT_DIR" \
+  --extract-bundle recordings.tar --expected-inventory-digest "$BATTERY_DIGEST" \
+  --battery /tmp/p022-scripts/delphi/scripts/certify_battery.json \
+  --datasets /tmp/p022-scripts/delphi/scripts/certify_datasets.json
 ls -la "$OUT_DIR" "$OUT_DIR/entries"

--- a/ci/p022_ec2_run.sh
+++ b/ci/p022_ec2_run.sh
@@ -17,7 +17,22 @@
 # with values restricted to a fixed character class. Nothing else reaches SSM
 # stdout — no log tails, no greps of candidate output, no exception text. Full
 # logs stay in /var/log/polis-ci and die with the box. What comes back is a
-# fixed-schema summary.json plus one JUnit report per pytest invocation.
+# fixed-schema summary.json plus one JUnit report per pytest invocation, and —
+# separately — the battery's recordings.
+#
+# ## Two return streams
+#
+# `bundle`/`chunk` carry the EVIDENCE tree ($ART_DIR: summary.json, JUnit,
+# battery-selection.json), capped at 64 chunks because that tree must stay tiny.
+#
+# `recordings`/`rec-bundle`/`rec-chunk` carry the battery's Clojure/Python
+# RECORDINGS ($LOG_DIR/certify-run, the canonical replay-store layout). Round 5
+# ran the battery and then destroyed the only copy of its recordings, so a
+# dispatch returned a verdict and nothing to measure. Recordings of PUBLIC
+# fixtures carry no private data — the instance role cannot read any — so this
+# is a scope change, not a data-boundary change: the packer is still restricted
+# to the entries battery-selection.json admitted, still ships an allowlist of
+# file names, and still fails rather than shipping a partial bundle.
 #
 # ## Round 3 (review #2715 R2-F2/F3)
 #
@@ -41,6 +56,13 @@ ART_DIR="${ART_DIR:-$LOG_DIR/artifacts}"
 STATE_DIR="${STATE_DIR:-$LOG_DIR/state}"
 JUNIT_DIR="${JUNIT_DIR:-$LOG_DIR/junit}"
 BUNDLE="$LOG_DIR/polis-ci-artifacts.tar.gz"
+# The battery's recording store, and the packed copy of it that leaves the box.
+# `certify.py run --root` writes the canonical replay layout here
+# (polismath/replay/store.py:1-23); until this stream existed it died with the
+# instance, so a dispatch returned a verdict and no recordings.
+REC_SRC="${REC_SRC:-$LOG_DIR/certify-run}"
+REC_DIR="${REC_DIR:-$LOG_DIR/recordings}"
+REC_BUNDLE="$LOG_DIR/polis-ci-recordings.tar"
 # How many pytest invocations each phase must produce. C's race target loops
 # twenty times; the collector fails if it does not see exactly that many.
 EXPECTED_MAIN_REPORTS="${P022_EXPECTED_MAIN_REPORTS:-1}"
@@ -48,6 +70,19 @@ EXPECTED_RACE_REPORTS="${P022_EXPECTED_RACE_REPORTS:-20}"
 # SSM truncates GetCommandInvocation output at 24000 characters.
 CHUNK_CHARS=18000
 MAX_CHUNKS=64
+# The recordings stream is bigger than the evidence bundle and gets its own
+# budget rather than raising the evidence bundle's — a summary.json that grew to
+# megabytes would be a bug, and must keep failing at 64 chunks.
+#
+# Sizing (public battery, six entries): the step blob is the same shape as the
+# checked-in math blobs — 507 KB for vw, 1.36 MB for biodiversity, both ~17-21x
+# gzippable because they are dominated by integer arrays. Steps per engine:
+# uniform8 8, front-loaded6 6, single-cut 1, uniform8-restart4 8, every-vote-56
+# 56 (its cuts are the first 56 vote EVENTS, so those blobs are tiny) and
+# biodiversity/uniform8 8 — about 1.5-3 MB gzipped for both engines together.
+# 512 chunks is 9.2M base64 characters ~= 6.9 MB, i.e. 2-4x headroom; a run that
+# exceeds it fails as `too-large` rather than shipping a partial tarball.
+REC_MAX_CHUNKS="${P022_RECORDINGS_MAX_CHUNKS:-512}"
 
 mkdir -p "$LOG_DIR" "$ART_DIR" "$STATE_DIR"
 
@@ -544,43 +579,140 @@ PY
   status summary verdict "$verdict"
 }
 
-phase_bundle() {
-  tar -czf "$BUNDLE" -C "$ART_DIR" . || { status bundle result tar-failed; return 1; }
-  base64 -w0 "$BUNDLE" >"$LOG_DIR/artifacts.b64"
-  local chars chunks digest
-  chars=$(wc -c <"$LOG_DIR/artifacts.b64")
-  chunks=$(( (chars + CHUNK_CHARS - 1) / CHUNK_CHARS ))
-  digest=$(sha256sum "$BUNDLE" | cut -d' ' -f1)
-  # Evidence that does not fit is missing evidence: fail rather than ship a
-  # partial tarball.
-  if [ "$chunks" -gt "$MAX_CHUNKS" ]; then
-    status bundle result too-large
-    status bundle chars "$chars"
+# Pack the battery's Clojure/Python recordings into per-entry gzipped tarballs
+# plus an inventory manifest, so the one output of the run that cannot be
+# recomputed without paying for another instance leaves with it.
+#
+# Scope is the PUBLIC battery inventory and nothing else: the packer is handed
+# battery-selection.json and refuses to ship an entry that inventory did not
+# admit, and it copies that file's inventory_digest into the manifest so a
+# downloader can bind the recordings to the battery summary.json declares.
+phase_recordings() {
+  if [ ! -d "$REC_SRC" ]; then
+    # Never inferred: with the battery run, an absent recording root is a
+    # failure; the caller only invokes this phase when the battery ran.
+    status recordings result no-recording-root
     return 1
   fi
-  status bundle chunks "$chunks"
-  status bundle chars "$chars"
-  status bundle sha256 "$digest"
+  rm -rf "$REC_DIR"
+  mkdir -p "$REC_DIR"
+
+  # Fail closed on an incomplete inventory only when the battery actually
+  # passed. A recovery-only or failed-battery run has nothing to be complete
+  # about, and must not be failed for shipping less than six entries.
+  local battery_rc='' rc=0
+  if [ -f "$STATE_DIR/battery_rc" ]; then
+    battery_rc=$(cat "$STATE_DIR/battery_rc")
+  fi
+  local require=()
+  if [ "$battery_rc" = "0" ]; then
+    require=(--require-complete)
+  fi
+
+  python3 "$REPO_ROOT/ci/p022_recordings_manifest.py" \
+    --replays-root "$REC_SRC" \
+    --out "$REC_DIR" \
+    --battery "$REPO_ROOT/delphi/scripts/certify_battery.json" \
+    --selection "$STATE_DIR/battery-selection.json" \
+    ${require[@]+"${require[@]}"} \
+    >>"$LOG_DIR/recordings.log" 2>&1 || rc=$?
+
+  local manifest="$REC_DIR/recordings-manifest.json"
+  if [ ! -f "$manifest" ]; then
+    status recordings result no-manifest
+    return 1
+  fi
+  local entries missing steps bytes digest
+  entries=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["totals"]["entries"])' "$manifest")
+  missing=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["totals"]["missing"])' "$manifest")
+  steps=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["totals"]["step_files"])' "$manifest")
+  bytes=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["totals"]["archive_bytes"])' "$manifest")
+  digest=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["manifest_digest"])' "$manifest")
+  status recordings entries "$entries"
+  status recordings missing "$missing"
+  status recordings steps "$steps"
+  status recordings bytes "$bytes"
+  status recordings digest "$digest"
+  echo "$rc" >"$STATE_DIR/recordings_rc"
+  if [ "$rc" -ne 0 ]; then
+    status recordings result fail
+    return "$rc"
+  fi
+  status recordings result pass
 }
 
-phase_chunk() {
-  local n="$1"
-  case "$n" in ''|*[!0-9]*) status chunk result bad-index; return 2 ;; esac
-  if [ "$n" -lt 1 ] || [ "$n" -gt "$MAX_CHUNKS" ]; then
-    status chunk result bad-index
+# One bundling implementation, two streams. `phase` is the status-line label;
+# `compress` is `gzip` for the evidence tree and `store` for the recordings
+# (whose members are already gzipped per entry, so a second pass buys nothing).
+_bundle_stream() {
+  local phase="$1" src="$2" bundle="$3" b64="$4" max="$5" compress="$6"
+  if [ "$compress" = "gzip" ]; then
+    tar -czf "$bundle" -C "$src" . || { status "$phase" result tar-failed; return 1; }
+  else
+    tar -cf "$bundle" -C "$src" . || { status "$phase" result tar-failed; return 1; }
+  fi
+  base64 -w0 "$bundle" >"$b64"
+  local chars chunks digest
+  # `tr -d ' '`: some wc implementations pad the count, and a padded value is
+  # outside status()'s character class, so the declared length would come back
+  # as `<redacted>` and the collector would reject its own bundle.
+  chars=$(wc -c <"$b64" | tr -d ' ')
+  chunks=$(( (chars + CHUNK_CHARS - 1) / CHUNK_CHARS ))
+  digest=$(sha256sum "$bundle" | cut -d' ' -f1)
+  # Evidence that does not fit is missing evidence: fail rather than ship a
+  # partial tarball.
+  if [ "$chunks" -gt "$max" ]; then
+    status "$phase" result too-large
+    status "$phase" chars "$chars"
+    return 1
+  fi
+  status "$phase" chunks "$chunks"
+  status "$phase" chars "$chars"
+  status "$phase" sha256 "$digest"
+}
+
+_chunk_stream() {
+  local phase="$1" b64="$2" max="$3" n="$4"
+  case "$n" in ''|*[!0-9]*) status "$phase" result bad-index; return 2 ;; esac
+  if [ "$n" -lt 1 ] || [ "$n" -gt "$max" ]; then
+    status "$phase" result bad-index
+    return 2
+  fi
+  if [ ! -f "$b64" ]; then
+    status "$phase" result no-bundle
     return 2
   fi
   # base64 is ASCII, so character offsets are byte offsets. This is the one
   # place that prints something other than a status line, by design.
-  cut -c "$(( (n - 1) * CHUNK_CHARS + 1 ))-$(( n * CHUNK_CHARS ))" \
-    "$LOG_DIR/artifacts.b64"
+  cut -c "$(( (n - 1) * CHUNK_CHARS + 1 ))-$(( n * CHUNK_CHARS ))" "$b64"
+}
+
+phase_bundle() {
+  _bundle_stream bundle "$ART_DIR" "$BUNDLE" "$LOG_DIR/artifacts.b64" "$MAX_CHUNKS" gzip
+}
+
+phase_chunk() {
+  _chunk_stream chunk "$LOG_DIR/artifacts.b64" "$MAX_CHUNKS" "$1"
+}
+
+phase_rec_bundle() {
+  _bundle_stream rec-bundle "$REC_DIR" "$REC_BUNDLE" "$LOG_DIR/recordings.b64" \
+    "$REC_MAX_CHUNKS" store
+}
+
+phase_rec_chunk() {
+  _chunk_stream rec-chunk "$LOG_DIR/recordings.b64" "$REC_MAX_CHUNKS" "$1"
 }
 
 case "${1:-}" in
-  recovery) phase_recovery ;;
-  battery)  phase_battery ;;
-  summary)  phase_summary ;;
-  bundle)   phase_bundle ;;
-  chunk)    phase_chunk "${2:?chunk index required}" ;;
-  *) echo "usage: $0 {recovery|battery|summary|bundle|chunk N}" >&2; exit 2 ;;
+  recovery)     phase_recovery ;;
+  battery)      phase_battery ;;
+  summary)      phase_summary ;;
+  bundle)       phase_bundle ;;
+  chunk)        phase_chunk "${2:?chunk index required}" ;;
+  recordings)   phase_recordings ;;
+  rec-bundle)   phase_rec_bundle ;;
+  rec-chunk)    phase_rec_chunk "${2:?chunk index required}" ;;
+  *) echo "usage: $0 {recovery|battery|summary|bundle|chunk N|recordings|rec-bundle|rec-chunk N}" >&2
+     exit 2 ;;
 esac

--- a/ci/p022_recordings_manifest.py
+++ b/ci/p022_recordings_manifest.py
@@ -21,7 +21,9 @@ bytes were not reshaped in transit, without trusting this run's prose.
 * Only entries the PUBLIC battery selected. `--selection battery-selection.json`
   is the same six-entry inventory the run pins with its digest, so the manifest
   cannot claim recordings for an entry the battery never admitted. The battery's
-  `inventory_digest` is copied into the manifest verbatim, binding the two.
+  `inventory_digest` is recorded in the manifest; verification recomputes it
+  from the target commit’s battery, schedules and public fixture descriptors and
+  checks the workflow’s independently supplied expected digest.
 * Only an ALLOWLIST of file names inside each recording directory
   (`schedule.json`, `provenance.json`, `{clj,py}/step-*`, `{clj,py}/cache_manifest.json`).
   A stray file in a recording directory is not shipped and is reported as
@@ -41,18 +43,22 @@ failure, never an inferred "there was nothing to ship".
   usage: p022_recordings_manifest.py --replays-root DIR --out DIR
                                      [--battery FILE] [--selection FILE]
                                      [--require-complete]
-         p022_recordings_manifest.py --verify DIR
+         p022_recordings_manifest.py --verify DIR --expected-inventory-digest SHA256
 """
 
 from __future__ import annotations
 
 import argparse
 import fnmatch
+import gzip
 import hashlib
 import importlib.util
 import json
 import sys
 import tarfile
+import tempfile
+import shutil
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -140,8 +146,12 @@ def _listed_files(rec_dir: Path) -> tuple[list[Path], list[str]]:
     """
     listed: list[Path] = []
     unlisted: list[str] = []
+    if any(p.is_symlink() for p in (rec_dir, *rec_dir.parents)):
+        raise ValueError("symlink recording directory")
     root = str(rec_dir.resolve())
     for path in sorted(rec_dir.rglob("*")):
+        if path.is_symlink():
+            raise ValueError("symlink recording member")
         if path.is_dir():
             continue
         rel = path.relative_to(rec_dir).as_posix()
@@ -187,7 +197,7 @@ def _pack_entry(rec_dir: Path, ref, out_dir: Path) -> dict[str, Any]:
         info.mode = 0o644
         return info
 
-    with tarfile.open(archive, "w:gz", compresslevel=9) as tar:
+    with open(archive, "wb") as raw, gzip.GzipFile(fileobj=raw, filename="", mode="wb", mtime=0) as gz, tarfile.open(fileobj=gz, mode="w") as tar:
         for path in listed:
             rel = path.relative_to(rec_dir).as_posix()
             files[rel] = sha256_file(path)
@@ -255,6 +265,7 @@ def build(
     not_public: list[str] = []
     not_admitted: list[str] = []
 
+    seen = set()
     for row in report["covered"] + report["missing"]:
         ref = cov.BatteryRef(**{k: v for k, v in row["entry"].items()})
         if datasets is not None and ref.dataset not in datasets:
@@ -267,6 +278,7 @@ def build(
             # ran. An entry outside it is not evidence of this run.
             not_admitted.append(row["key"])
             continue
+        seen.add(_ref_row(ref))
         if row["covered"]:
             packed.append(_pack_entry(Path(row["path"]), ref, out_dir))
         else:
@@ -276,6 +288,12 @@ def build(
                 "reasons": row["reasons"],
                 "engines": row["engines"],
             })
+
+    for absent in sorted((admitted or set()) - seen):
+        raw = json.loads(absent)
+        missing.append({"dataset": raw["dataset"],
+                        "schedule_id": raw.get("schedule") or str(raw.get("preset")),
+                        "reasons": ["selected-entry-absent-from-battery"], "engines": {}})
 
     entries = sorted(packed, key=lambda e: (e["dataset"], e["schedule_id"]))
     manifest = {
@@ -300,55 +318,129 @@ def build(
     }
     # Binds the manifest to the exact bytes it describes: one digest an operator
     # can quote, over every entry's archive digest and step digests.
-    manifest["manifest_digest"] = hashlib.sha256(
-        _canonical_json({
-            "schema": SCHEMA,
-            "battery_inventory_digest": inventory_digest,
-            "entries": [
-                {"dataset": e["dataset"], "schedule_id": e["schedule_id"],
-                 "archive_sha256": e["archive_sha256"],
-                 "engines": {k: v["step_sha256"] for k, v in e["engines"].items()}}
-                for e in entries
-            ],
-        }).encode("utf-8")
-    ).hexdigest()
+    manifest["manifest_digest"] = manifest_digest(manifest)
 
     (out_dir / MANIFEST_NAME).write_text(json.dumps(manifest, indent=1, sort_keys=True))
     rc = 1 if (require_complete and missing) else 0
     return manifest, rc
 
 
-def verify(bundle_dir: Path) -> int:
-    """Re-hash a downloaded bundle against its own manifest. 0 iff every byte matches."""
-    manifest_path = bundle_dir / MANIFEST_NAME
+def manifest_digest(manifest: dict[str, Any]) -> str:
+    # Timestamp is descriptive; every inventory/content field is bound.
+    body = {k: v for k, v in manifest.items() if k not in ("manifest_digest", "created_at")}
+    return hashlib.sha256(_canonical_json(body).encode()).hexdigest()
+
+
+def _inventory(battery: Path, datasets: Path):
+    mod = _load_coverage_module(_REPO_ROOT / "ci" / "p022_battery_digest.py")
+    canonical, selected, _ = mod.inventory(json.loads(battery.read_text()),
+        json.loads(datasets.read_text()), mod.reader_for(battery.parent))
+    return hashlib.sha256(canonical.encode()).hexdigest(), selected
+
+
+def _extract_regular(tar: tarfile.TarFile, destination: Path, allowed) -> None:
+    members = tar.getmembers()
+    names = set()
+    for member in members:
+        name = member.name.removeprefix("./")
+        if member.isdir() and name in ("", ".", "entries"):
+            continue
+        if not member.isfile() or name in names or not allowed(name):
+            raise ValueError(f"unsafe or unexpected archive member: {member.name}")
+        names.add(name)
+    # Validate ALL members before writing any of them. Never use extractall.
+    for member in members:
+        if not member.isfile():
+            continue
+        target = destination / member.name.removeprefix("./")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with tar.extractfile(member) as source, target.open("xb") as sink:
+            shutil.copyfileobj(source, sink)
+
+
+def verify(bundle_dir: Path, *, expected_inventory_digest: str | None = None,
+           battery: Path = _REPO_ROOT / "delphi/scripts/certify_battery.json",
+           datasets: Path = _REPO_ROOT / "delphi/scripts/certify_datasets.json") -> int:
+    """Verify content and inventory against independently supplied run inputs."""
     try:
-        manifest = json.loads(manifest_path.read_text())
-    except OSError as exc:
-        print(f"verify: cannot read {manifest_path}: {exc}", file=sys.stderr)
-        return 2
-    if manifest.get("schema") != SCHEMA:
-        print(f"verify: unexpected schema {manifest.get('schema')!r}", file=sys.stderr)
-        return 2
-    bad = 0
-    for entry in manifest.get("entries", []):
-        archive = bundle_dir / entry["archive"]
-        if not archive.is_file():
-            print(f"verify: MISSING {entry['archive']}", file=sys.stderr)
-            bad += 1
-            continue
-        got = sha256_file(archive)
-        if got != entry["archive_sha256"]:
-            print(f"verify: DIGEST MISMATCH {entry['archive']}", file=sys.stderr)
-            bad += 1
-            continue
-        print(f"verify: ok {entry['dataset']}/{entry['schedule_id']} "
-              f"clj={entry['engines']['clj']['steps']} py={entry['engines']['py']['steps']} "
-              f"{entry['archive_bytes']}B")
-    if manifest.get("missing"):
-        print(f"verify: manifest reports {len(manifest['missing'])} entry/entries WITHOUT "
-              f"recordings: {', '.join(m['dataset'] + '/' + m['schedule_id'] for m in manifest['missing'])}",
-              file=sys.stderr)
-    return 1 if bad else 0
+        digest, selected = _inventory(battery, datasets)
+        if not expected_inventory_digest or digest != expected_inventory_digest:
+            raise ValueError("expected inventory digest does not match local run inputs")
+        manifest = json.loads((bundle_dir / MANIFEST_NAME).read_text())
+        if (manifest.get("schema") != SCHEMA or not manifest.get("entries") or
+                manifest.get("manifest_digest") != manifest_digest(manifest) or
+                manifest.get("battery_inventory_digest") != digest or
+                manifest.get("battery_selected_count") != len(selected)):
+            raise ValueError("manifest schema, digest or inventory mismatch (or empty entries)")
+        cov = _load_coverage_module()
+        refs = [cov.parse_entry(e, battery_dir=battery.parent) for e in selected]
+        expected = {r.key: r for r in refs}
+        rows = manifest["entries"] + manifest["missing"]
+        keys = [f"{e['dataset']}/{e['schedule_id']}" for e in rows]
+        if len(keys) != len(set(keys)) or set(keys) != set(expected):
+            raise ValueError("entry census differs from selected inventory")
+        for entry in manifest["entries"]:
+            ref = expected[f"{entry['dataset']}/{entry['schedule_id']}"]
+            if entry["archive"] != f"entries/{ref.dataset}__{ref.schedule_id}.tar.gz":
+                raise ValueError("unsafe archive path")
+            archive = bundle_dir / entry["archive"]
+            if any(p.is_symlink() for p in (archive, *archive.parents)):
+                raise ValueError("symlink archive path")
+            if sha256_file(archive) != entry["archive_sha256"]:
+                raise ValueError("DIGEST MISMATCH " + entry["archive"])
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp).resolve() / "replays"
+                prefix = ref.key + "/"
+                def allowed(name):
+                    if not name.startswith(prefix):
+                        return False
+                    rel = name[len(prefix):]
+                    return (not any(c in (".", "..", "") for c in rel.split("/")) and
+                            any(fnmatch.fnmatchcase(rel, p) for p in FILE_ALLOWLIST) and
+                            len(rel.split("/")) <= 2)
+                with tarfile.open(archive) as tar:
+                    _extract_regular(tar, root, allowed)
+                row = cov.entry_coverage(ref, root)
+                if not row["covered"]:
+                    raise ValueError("incomplete archived recording: " + str(row["reasons"]))
+                actual = _pack_entry(root / ref.key, ref, Path(tmp).resolve() / "repacked")
+                # Unlisted files stayed on the worker; every shipped field must match.
+                for field in actual:
+                    if field != "unlisted" and actual[field] != entry[field]:
+                        raise ValueError("entry content mismatch: " + field)
+        entries = manifest["entries"]
+        totals = {"entries": len(entries), "missing": len(manifest["missing"]),
+                  "step_files": sum(e["engines"][k]["steps"] for e in entries for k in ("clj", "py")),
+                  "bytes": sum(e["bytes"] for e in entries),
+                  "archive_bytes": sum(e["archive_bytes"] for e in entries)}
+        if manifest["totals"] != totals:
+            raise ValueError("totals mismatch")
+    except (OSError, ValueError, KeyError, TypeError, tarfile.TarError) as exc:
+        print(f"verify: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def extract_bundle(archive: Path, destination: Path, **verify_args) -> int:
+    """Inspect the transport tar and verify its contents before publishing files."""
+    try:
+        if any(p.is_symlink() for p in (destination, *destination.parents)):
+            raise ValueError("symlink output directory")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            with tarfile.open(archive) as tar:
+                _extract_regular(tar, root, lambda name: name == MANIFEST_NAME or
+                    re.fullmatch(r"entries/[A-Za-z0-9_.-]+__+[A-Za-z0-9_.-]+\.tar\.gz", name))
+            if verify(root, **verify_args):
+                return 1
+            destination.mkdir(parents=True, exist_ok=True)
+            if any(destination.iterdir()):
+                raise ValueError("output directory must be empty")
+            shutil.copytree(root, destination, dirs_exist_ok=True)
+    except (OSError, ValueError, tarfile.TarError) as exc:
+        print(f"verify: {exc}", file=sys.stderr)
+        return 1
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -361,10 +453,17 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--require-complete", action="store_true",
                     help="exit 1 if a selected entry has no clj+py recording pair")
     ap.add_argument("--verify", default=None, help="verify a downloaded bundle directory instead")
+    ap.add_argument("--expected-inventory-digest")
+    ap.add_argument("--datasets", default=str(_REPO_ROOT / "delphi/scripts/certify_datasets.json"))
+    ap.add_argument("--extract-bundle", help="validate a transport tar before extracting into --verify")
     args = ap.parse_args(argv)
 
     if args.verify:
-        return verify(Path(args.verify))
+        kwargs = dict(expected_inventory_digest=args.expected_inventory_digest,
+                      battery=Path(args.battery), datasets=Path(args.datasets))
+        if args.extract_bundle:
+            return extract_bundle(Path(args.extract_bundle), Path(args.verify), **kwargs)
+        return verify(Path(args.verify), **kwargs)
     if not args.replays_root or not args.out:
         ap.error("--replays-root and --out are required unless --verify is given")
 

--- a/ci/p022_recordings_manifest.py
+++ b/ci/p022_recordings_manifest.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""P-022 §E — pack the battery's recordings, with an inventory that pins them.
+
+## Why this exists
+
+As merged, the run proved the public battery passed and then destroyed the box
+that held its output: `ci/p022_ec2_run.sh` runs certify with
+`--root "$LOG_DIR/certify-run"` but bundles only `$ART_DIR`, so the
+Clojure↔Python recording pairs — the one artefact of the run that cannot be
+recomputed without paying for another instance — died with the instance. A
+dispatch returned a verdict and no recordings.
+
+This script turns that recording root into a shippable, self-describing bundle:
+one gzipped tar per battery entry plus a manifest that names, for every entry,
+its dataset, schedule id, per-engine step count, the sha256 of every step file,
+and total bytes. A downloader can then say exactly what it got, and prove the
+bytes were not reshaped in transit, without trusting this run's prose.
+
+## What it will and will not pack
+
+* Only entries the PUBLIC battery selected. `--selection battery-selection.json`
+  is the same six-entry inventory the run pins with its digest, so the manifest
+  cannot claim recordings for an entry the battery never admitted. The battery's
+  `inventory_digest` is copied into the manifest verbatim, binding the two.
+* Only an ALLOWLIST of file names inside each recording directory
+  (`schedule.json`, `provenance.json`, `{clj,py}/step-*`, `{clj,py}/cache_manifest.json`).
+  A stray file in a recording directory is not shipped and is reported as
+  `unlisted`, rather than silently enlarging the artifact — the same
+  deny-by-default discipline `status()` applies to the box's stdout.
+* Nothing outside `--replays-root`: symlinks are refused, not followed.
+
+Recordings of public fixtures carry no private data — the worker's instance role
+cannot read any — so this is a scope change, not a data-boundary change.
+
+## Fail-closed
+
+With `--require-complete` (what the battery path passes), an entry the battery
+selected but did not record makes this exit non-zero. Missing evidence is a
+failure, never an inferred "there was nothing to ship".
+
+  usage: p022_recordings_manifest.py --replays-root DIR --out DIR
+                                     [--battery FILE] [--selection FILE]
+                                     [--require-complete]
+         p022_recordings_manifest.py --verify DIR
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import importlib.util
+import json
+import sys
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "polis-certification-recordings/1"
+MANIFEST_NAME = "recordings-manifest.json"
+ENTRIES_DIR = "entries"
+
+#: File names shipped out of a recording directory, relative to it. Everything
+#: else stays on the box. `.edn` full-fidelity dumps (math/dev/replay.clj:340)
+#: are deliberately NOT here: they are an order of magnitude larger than the
+#: blobs and no consumer of these recordings reads them.
+FILE_ALLOWLIST = (
+    "schedule.json",
+    "provenance.json",
+    "clj/cache_manifest.json",
+    "clj/step-*.blob.json",
+    "clj/step-*.meta.json",
+    "py/cache_manifest.json",
+    "py/step-*.json",
+)
+
+# ci/p022_recordings_manifest.py -> ci -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_COVERAGE_PATH = _REPO_ROOT / "delphi" / "scripts" / "battery_coverage.py"
+
+
+def _load_coverage_module(path: Path = _COVERAGE_PATH):
+    """Import delphi/scripts/battery_coverage.py by path.
+
+    The worker runs this under the system python3 with no delphi virtualenv, so
+    `import polismath...` is not available — and the enumeration must not be
+    restated here, because a second copy of "which entries exist" is exactly the
+    drift that let the G12 measurement report two of six forever.
+    """
+    name = "p022_battery_coverage"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load battery coverage module at {path}")
+    module = importlib.util.module_from_spec(spec)
+    # Registered BEFORE exec: @dataclass resolves annotations through
+    # sys.modules[cls.__module__], and a module that is not there yet fails.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _selected_keys(selection: dict[str, Any]) -> tuple[set[str], set[str]]:
+    """(public dataset slugs, canonical rows) the battery actually admitted."""
+    slugs = {s for s in selection.get("public_slugs", []) if isinstance(s, str)}
+    rows = {
+        _canonical_json({f: e.get(f) for f in ("dataset", "preset", "n_cuts", "schedule")})
+        for e in selection.get("selected", [])
+        if isinstance(e, dict)
+    }
+    return slugs, rows
+
+
+def _ref_row(ref) -> str:
+    return _canonical_json({
+        "dataset": ref.dataset,
+        "preset": ref.preset,
+        "n_cuts": ref.n_cuts,
+        "schedule": ref.schedule,
+    })
+
+
+def _listed_files(rec_dir: Path) -> tuple[list[Path], list[str]]:
+    """Split a recording directory into (allowlisted files, unlisted names).
+
+    Traversal is refused rather than sanitised: a symlink or a path that does
+    not resolve inside `rec_dir` is reported unlisted and left behind.
+    """
+    listed: list[Path] = []
+    unlisted: list[str] = []
+    root = str(rec_dir.resolve())
+    for path in sorted(rec_dir.rglob("*")):
+        if path.is_dir():
+            continue
+        rel = path.relative_to(rec_dir).as_posix()
+        if path.is_symlink():
+            unlisted.append(rel)
+            continue
+        try:
+            resolved = str(path.resolve(strict=True))
+        except OSError:
+            unlisted.append(rel)
+            continue
+        if not resolved.startswith(root + "/"):
+            unlisted.append(rel)
+            continue
+        if any(fnmatch.fnmatch(rel, pattern) for pattern in FILE_ALLOWLIST):
+            listed.append(path)
+        else:
+            unlisted.append(rel)
+    return listed, unlisted
+
+
+def _pack_entry(rec_dir: Path, ref, out_dir: Path) -> dict[str, Any]:
+    """Write one `<dataset>__<schedule_id>.tar.gz` and describe what went in.
+
+    Members are stored as `<dataset>/<schedule_id>/...` so extracting straight
+    into `delphi/real_data/.local/replays` reproduces the canonical store layout
+    (`polismath/replay/store.py:1-23`) with no path rewriting by the operator.
+    """
+    listed, unlisted = _listed_files(rec_dir)
+    archives = out_dir / ENTRIES_DIR
+    archives.mkdir(parents=True, exist_ok=True)
+    archive = archives / f"{ref.dataset}__{ref.schedule_id}.tar.gz"
+
+    files: dict[str, str] = {}
+    sizes: dict[str, int] = {}
+    prefix = f"{ref.dataset}/{ref.schedule_id}"
+    # A fixed mtime/uid/gid keeps the archive reproducible for a given step set,
+    # so two runs that recorded the same bytes produce the same archive digest.
+    def _reset(info: tarfile.TarInfo) -> tarfile.TarInfo:
+        info.uid = info.gid = 0
+        info.uname = info.gname = ""
+        info.mtime = 0
+        info.mode = 0o644
+        return info
+
+    with tarfile.open(archive, "w:gz", compresslevel=9) as tar:
+        for path in listed:
+            rel = path.relative_to(rec_dir).as_posix()
+            files[rel] = sha256_file(path)
+            sizes[rel] = path.stat().st_size
+            tar.add(path, arcname=f"{prefix}/{rel}", filter=_reset)
+
+    def _engine_rows(engine: str) -> dict[str, Any]:
+        glob = f"{engine}/" + ("step-*.blob.json" if engine == "clj" else "step-*.json")
+        steps = {k: v for k, v in files.items() if fnmatch.fnmatch(k, glob)}
+        engine_files = {k: v for k, v in files.items() if k.startswith(f"{engine}/")}
+        return {
+            "steps": len(steps),
+            "bytes": sum(sizes[k] for k in engine_files),
+            "step_sha256": dict(sorted(steps.items())),
+            "file_sha256": dict(sorted(engine_files.items())),
+        }
+
+    return {
+        "dataset": ref.dataset,
+        "schedule_id": ref.schedule_id,
+        "preset": ref.preset,
+        "n_cuts": ref.n_cuts,
+        "schedule": ref.schedule,
+        "archive": f"{ENTRIES_DIR}/{archive.name}",
+        "archive_sha256": sha256_file(archive),
+        "archive_bytes": archive.stat().st_size,
+        "bytes": sum(sizes.values()),
+        "file_count": len(files),
+        "engines": {engine: _engine_rows(engine) for engine in ("clj", "py")},
+        "root_sha256": {k: v for k, v in sorted(files.items()) if "/" not in k},
+        "unlisted": unlisted,
+    }
+
+
+def build(
+    *,
+    replays_root: Path,
+    out_dir: Path,
+    battery: Path,
+    selection: Path | None,
+    require_complete: bool,
+) -> tuple[dict[str, Any], int]:
+    """Pack every selected, covered entry; report both halves; return (manifest, rc)."""
+    cov = _load_coverage_module()
+    datasets: list[str] | None = None
+    admitted: set[str] | None = None
+    inventory_digest = ""
+    selected_count = None
+    if selection is not None:
+        sel = json.loads(selection.read_text())
+        slugs, rows = _selected_keys(sel)
+        datasets = sorted(slugs)
+        admitted = rows
+        raw_digest = str(sel.get("inventory_digest", ""))
+        inventory_digest = raw_digest if len(raw_digest) == 64 else ""
+        selected_count = sel.get("selected_count")
+
+    # Enumerate the WHOLE battery and then gate, so every entry this run did not
+    # ship is named with the reason it did not — a shorter list with no
+    # explanation is how "we only measured two of six" survived for months.
+    report = cov.coverage(battery=battery, root=replays_root, datasets=None)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    packed: list[dict[str, Any]] = []
+    missing: list[dict[str, Any]] = []
+    not_public: list[str] = []
+    not_admitted: list[str] = []
+
+    for row in report["covered"] + report["missing"]:
+        ref = cov.BatteryRef(**{k: v for k, v in row["entry"].items()})
+        if datasets is not None and ref.dataset not in datasets:
+            # Gate 1: public fixtures only, from certify_datasets.json. Nothing
+            # else can be on this box, and nothing else may be shipped from it.
+            not_public.append(row["key"])
+            continue
+        if admitted is not None and _ref_row(ref) not in admitted:
+            # Gate 2: the battery inventory is the authority on what this run
+            # ran. An entry outside it is not evidence of this run.
+            not_admitted.append(row["key"])
+            continue
+        if row["covered"]:
+            packed.append(_pack_entry(Path(row["path"]), ref, out_dir))
+        else:
+            missing.append({
+                "dataset": ref.dataset,
+                "schedule_id": ref.schedule_id,
+                "reasons": row["reasons"],
+                "engines": row["engines"],
+            })
+
+    entries = sorted(packed, key=lambda e: (e["dataset"], e["schedule_id"]))
+    manifest = {
+        "schema": SCHEMA,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "battery": Path(battery).name,
+        "battery_inventory_digest": inventory_digest,
+        "battery_selected_count": selected_count,
+        "layout": "extract each archive into delphi/real_data/.local/replays/",
+        "entries": entries,
+        "missing": sorted(missing, key=lambda e: (e["dataset"], e["schedule_id"])),
+        "skipped_not_public": sorted(not_public),
+        "skipped_not_in_inventory": sorted(not_admitted),
+        "totals": {
+            "entries": len(entries),
+            "missing": len(missing),
+            "step_files": sum(e["engines"]["clj"]["steps"] + e["engines"]["py"]["steps"]
+                              for e in entries),
+            "bytes": sum(e["bytes"] for e in entries),
+            "archive_bytes": sum(e["archive_bytes"] for e in entries),
+        },
+    }
+    # Binds the manifest to the exact bytes it describes: one digest an operator
+    # can quote, over every entry's archive digest and step digests.
+    manifest["manifest_digest"] = hashlib.sha256(
+        _canonical_json({
+            "schema": SCHEMA,
+            "battery_inventory_digest": inventory_digest,
+            "entries": [
+                {"dataset": e["dataset"], "schedule_id": e["schedule_id"],
+                 "archive_sha256": e["archive_sha256"],
+                 "engines": {k: v["step_sha256"] for k, v in e["engines"].items()}}
+                for e in entries
+            ],
+        }).encode("utf-8")
+    ).hexdigest()
+
+    (out_dir / MANIFEST_NAME).write_text(json.dumps(manifest, indent=1, sort_keys=True))
+    rc = 1 if (require_complete and missing) else 0
+    return manifest, rc
+
+
+def verify(bundle_dir: Path) -> int:
+    """Re-hash a downloaded bundle against its own manifest. 0 iff every byte matches."""
+    manifest_path = bundle_dir / MANIFEST_NAME
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except OSError as exc:
+        print(f"verify: cannot read {manifest_path}: {exc}", file=sys.stderr)
+        return 2
+    if manifest.get("schema") != SCHEMA:
+        print(f"verify: unexpected schema {manifest.get('schema')!r}", file=sys.stderr)
+        return 2
+    bad = 0
+    for entry in manifest.get("entries", []):
+        archive = bundle_dir / entry["archive"]
+        if not archive.is_file():
+            print(f"verify: MISSING {entry['archive']}", file=sys.stderr)
+            bad += 1
+            continue
+        got = sha256_file(archive)
+        if got != entry["archive_sha256"]:
+            print(f"verify: DIGEST MISMATCH {entry['archive']}", file=sys.stderr)
+            bad += 1
+            continue
+        print(f"verify: ok {entry['dataset']}/{entry['schedule_id']} "
+              f"clj={entry['engines']['clj']['steps']} py={entry['engines']['py']['steps']} "
+              f"{entry['archive_bytes']}B")
+    if manifest.get("missing"):
+        print(f"verify: manifest reports {len(manifest['missing'])} entry/entries WITHOUT "
+              f"recordings: {', '.join(m['dataset'] + '/' + m['schedule_id'] for m in manifest['missing'])}",
+              file=sys.stderr)
+    return 1 if bad else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="pack + inventory the battery's recordings")
+    ap.add_argument("--replays-root", help="certify --root used by the battery")
+    ap.add_argument("--out", help="directory to write the manifest and per-entry archives")
+    ap.add_argument("--battery", default=str(_REPO_ROOT / "delphi" / "scripts" / "certify_battery.json"))
+    ap.add_argument("--selection", default=None,
+                    help="battery-selection.json — restricts packing to the admitted inventory")
+    ap.add_argument("--require-complete", action="store_true",
+                    help="exit 1 if a selected entry has no clj+py recording pair")
+    ap.add_argument("--verify", default=None, help="verify a downloaded bundle directory instead")
+    args = ap.parse_args(argv)
+
+    if args.verify:
+        return verify(Path(args.verify))
+    if not args.replays_root or not args.out:
+        ap.error("--replays-root and --out are required unless --verify is given")
+
+    manifest, rc = build(
+        replays_root=Path(args.replays_root),
+        out_dir=Path(args.out),
+        battery=Path(args.battery),
+        selection=Path(args.selection) if args.selection else None,
+        require_complete=args.require_complete,
+    )
+    totals = manifest["totals"]
+    print(f"packed {totals['entries']} entry/entries, {totals['step_files']} step files, "
+          f"{totals['bytes']} B raw, {totals['archive_bytes']} B compressed")
+    for entry in manifest["missing"]:
+        print(f"NO RECORDING: {entry['dataset']}/{entry['schedule_id']} "
+              f"({','.join(entry['reasons'])})", file=sys.stderr)
+    return rc
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/ci/p022_ssm.sh
+++ b/ci/p022_ssm.sh
@@ -46,8 +46,20 @@ note "ssm[$LABEL] command=$command_id instance=$INSTANCE_ID"
 deadline=$(( $(date +%s) + TIMEOUT + 300 ))
 inv=''
 status=''
+# Poll fast first, then settle at 15s. A flat 15s pre-sleep is invisible next to
+# a multi-hour battery, but the recordings stream is hundreds of `cut` commands
+# that each finish in milliseconds — paying 15s of sleep per chunk turned a
+# ~3 MB transfer into hours. The ceiling is unchanged, so the long phases poll
+# exactly as before.
+interval=2
 while :; do
-  sleep 15
+  sleep "$interval"
+  if [ "$interval" -lt 15 ]; then
+    interval=$(( interval * 2 ))
+  fi
+  if [ "$interval" -gt 15 ]; then
+    interval=15
+  fi
   if [ "$(date +%s)" -gt "$deadline" ]; then
     # No CancelCommand: the role no longer holds it (it cannot be scoped to a
     # single command), and the instance's own hard deadline plus the expiry
@@ -77,7 +89,12 @@ case "$MODE" in
   *)
     dropped=0
     while IFS= read -r line; do
-      if printf '%s' "$line" | grep -Eq '^p022 [a-z-]{1,24} [a-z_]{1,24}=[A-Za-z0-9._:/=+-]{1,96}$'; then
+      # The key class must admit digits: the bundle phase's own key is `sha256`
+      # (p022_ec2_run.sh `_bundle_stream`), and a `[a-z_]`-only class dropped
+      # that line — so the collector never saw a digest, declared the bundle
+      # incomplete and failed every collection. Still an allowlist: lowercase,
+      # digits and underscore, nothing else.
+      if printf '%s' "$line" | grep -Eq '^p022 [a-z-]{1,24} [a-z0-9_]{1,24}=[A-Za-z0-9._:/=+-]{1,96}$'; then
         printf '%s\n' "$line"
       else
         dropped=$((dropped + 1))

--- a/delphi/scripts/battery_coverage.py
+++ b/delphi/scripts/battery_coverage.py
@@ -11,7 +11,7 @@ reporting two of six after new recordings landed: an absent entry looked exactly
 like an entry nobody asked for.
 
 Coverage here means a *pair*: a Python step set, a Clojure step set, and the two
-agreeing on step count. Anything else is reported as missing WITH ITS REASON, so
+matching the resolved schedule’s exact indexed file sets. Anything else is reported as missing WITH ITS REASON, so
 a caller can distinguish "the run never produced it" from "the Clojure driver
 failed halfway" — never by inferring absence from a swallowed error.
 
@@ -223,17 +223,42 @@ def entry_coverage(ref: BatteryRef, root: Path) -> dict[str, Any]:
     ``step-count-mismatch``.
     """
     rec_dir = root / ref.dataset / ref.schedule_id
-    engines = {name: engine_coverage(rec_dir, name) for name in ENGINES}
+    # Check every directory component before traversing or reading any bytes.
+    unsafe = any(p.is_symlink() for p in (root, *root.parents, rec_dir.parent, rec_dir))
+    if not unsafe and rec_dir.exists():
+        unsafe = any(p.is_symlink() for p in rec_dir.rglob("*"))
+    engines = {name: (EngineCoverage(name, False, 0, 0) if unsafe else
+                      engine_coverage(rec_dir, name)) for name in ENGINES}
     reasons: list[str] = []
-    if not rec_dir.is_dir():
+    if unsafe:
+        reasons.append("symlink-recording")
+    elif not rec_dir.is_dir():
         reasons.append("no-recording-dir")
     for name in ENGINES:
         if not engines[name].present:
             reasons.append(f"missing-{name}")
     if not reasons and engines["clj"].steps != engines["py"].steps:
-        # certify refuses a pair whose step sets differ (certify.py:1415-1420);
-        # a half-written recording must not read as coverage here either.
         reasons.append("step-count-mismatch")
+    if not reasons:
+        try:
+            spec = json.loads((rec_dir / "schedule.json").read_text())
+            cuts = spec["cuts"]["at"]
+            if (spec.get("schedule_id") != ref.schedule_id or
+                    spec["cuts"]["mode"] != "vote-count" or not cuts or
+                    any(type(c) is not int or c < 0 for c in cuts) or
+                    cuts != sorted(set(cuts))):
+                raise ValueError("invalid resolved schedule")
+            count = len(cuts)
+            expected = {f"step-{i:03d}" for i in range(count)}
+            for engine in ENGINES:
+                suffixes = (".blob.json", ".meta.json") if engine == "clj" else (".json",)
+                actual = {p.name for p in (rec_dir / engine).glob("step-*.json")}
+                if actual != {name + suffix for name in expected for suffix in suffixes}:
+                    reasons.append(f"step-set-mismatch-{engine}")
+            if not (rec_dir / "provenance.json").is_file():
+                reasons.append("missing-provenance")
+        except (OSError, ValueError, KeyError, TypeError):
+            reasons.append("invalid-resolved-schedule")
     return {
         "key": ref.key,
         "entry": ref.as_dict(),

--- a/delphi/scripts/battery_coverage.py
+++ b/delphi/scripts/battery_coverage.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Which ``certify_battery.json`` entries have BOTH engines' recordings on disk.
+
+Every consumer of the recording store — the P-044 G12 numerical measurement,
+the CI recordings manifest, an operator asking "did that dispatch actually give
+me the four entries I paid for?" — needs the same answer: enumerate the battery,
+resolve each entry to its on-disk ``<dataset>/<schedule_id>`` directory, and say
+which entries have a usable Clojure↔Python pair and which do not, *by name*.
+Hard-coding the entry list is what made the G12 measurement silently keep
+reporting two of six after new recordings landed: an absent entry looked exactly
+like an entry nobody asked for.
+
+Coverage here means a *pair*: a Python step set, a Clojure step set, and the two
+agreeing on step count. Anything else is reported as missing WITH ITS REASON, so
+a caller can distinguish "the run never produced it" from "the Clojure driver
+failed halfway" — never by inferring absence from a swallowed error.
+
+## Stdlib only, on purpose
+
+This module is imported by ``ci/p022_recordings_manifest.py``, which runs on the
+disposable CI worker under the system ``python3`` with no virtualenv and no
+delphi dependencies installed. So it must not import :mod:`polismath` — whose
+package ``__init__`` pulls in the config stack, and whose
+``polismath.replay.certify`` pulls numpy/sklearn/torch. The schedule-id
+derivation is therefore restated here rather than imported, and
+``delphi/tests/replay_harness/test_battery_coverage.py`` pins it against the
+real :func:`polismath.replay.certify.derive_schedule_id` /
+:func:`~polismath.replay.certify.load_battery` so the two cannot drift.
+
+Layout it reads (``polismath/replay/store.py:1-23``)::
+
+    <root>/<dataset>/<schedule_id>/
+      schedule.json
+      provenance.json
+      py/step-NNN.json               # Python driver
+      clj/step-NNN.blob.json         # Clojure driver (+ step-NNN.meta.json)
+
+Usage::
+
+    python3 delphi/scripts/battery_coverage.py            # human summary
+    python3 delphi/scripts/battery_coverage.py --json     # machine-readable
+    python3 delphi/scripts/battery_coverage.py --dataset vw --dataset biodiversity
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# scripts/battery_coverage.py -> scripts -> delphi
+_DELPHI_ROOT = Path(__file__).resolve().parents[1]
+
+DEFAULT_BATTERY_PATH = _DELPHI_ROOT / "scripts" / "certify_battery.json"
+DEFAULT_REPLAYS_ROOT = _DELPHI_ROOT / "real_data" / ".local" / "replays"
+
+#: Frozen suffix every battery schedule id carries on disk. Historical (minted
+#: while the engine still had a mode flag) and deliberately NOT part of the
+#: identity the battery file uses — mirrors ``certify._LEGACY_SUFFIX``.
+LEGACY_SUFFIX = "clojure-legacy"
+
+#: Presets whose id embeds a cut count; mirrors ``certify._NCUTS_PRESETS``.
+NCUTS_PRESETS = frozenset({"uniform", "front-loaded", "back-loaded"})
+#: Mirrors ``certify._VALID_PRESETS``.
+VALID_PRESETS = NCUTS_PRESETS | frozenset({"single-cut", "every-vote", "per-day"})
+
+#: How to count one engine's steps. The Clojure driver writes a ``.blob.json``
+#: AND a ``.meta.json`` per step (``math/dev/replay.clj:326-330``), so globbing
+#: ``step-*.json`` there would double every count.
+ENGINE_STEP_GLOB = {"py": "step-*.json", "clj": "step-*.blob.json"}
+ENGINES = ("clj", "py")
+
+
+class BatteryError(ValueError):
+    """A battery file this module refuses to guess about."""
+
+
+@dataclass(frozen=True)
+class BatteryRef:
+    """One battery entry, resolved to the directory name it records under."""
+
+    dataset: str
+    schedule_id: str
+    preset: str | None = None
+    n_cuts: int | None = None
+    schedule: str | None = None
+    notes: str = ""
+    optional: bool = False
+    role: str | None = None
+
+    @property
+    def key(self) -> str:
+        """``<dataset>/<schedule_id>`` — how an entry is named in reports."""
+        return f"{self.dataset}/{self.schedule_id}"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "dataset": self.dataset,
+            "schedule_id": self.schedule_id,
+            "preset": self.preset,
+            "n_cuts": self.n_cuts,
+            "schedule": self.schedule,
+            "optional": self.optional,
+            "role": self.role,
+        }
+
+
+def derive_schedule_id(
+    *,
+    preset: str | None = None,
+    n_cuts: int | None = None,
+    base_schedule_id: str | None = None,
+) -> str:
+    """``{base}-clojure-legacy`` — byte-identical to certify's derivation."""
+    if base_schedule_id is not None:
+        base = base_schedule_id
+    elif preset in NCUTS_PRESETS:
+        if n_cuts is None:
+            raise BatteryError(f"preset {preset!r} requires n_cuts to derive a schedule_id")
+        base = f"{preset}{n_cuts}"
+    else:
+        base = preset
+    return f"{base}-{LEGACY_SUFFIX}"
+
+
+def _safe_component(name: Any, *, label: str) -> str:
+    """Reject anything that would escape the store root (mirrors store.py)."""
+    if (
+        not isinstance(name, str)
+        or not name
+        or name in (".", "..")
+        or "/" in name
+        or "\\" in name
+    ):
+        raise BatteryError(f"unsafe {label} for recording path: {name!r}")
+    return name
+
+
+def parse_entry(entry: dict[str, Any], *, battery_dir: Path) -> BatteryRef:
+    """Parse one entry — ``{"schedule": path}`` or ``{"preset", "n_cuts"}``."""
+    if not isinstance(entry, dict):
+        raise BatteryError("battery entries must be objects")
+    dataset = _safe_component(entry.get("dataset"), label="dataset")
+    optional = bool(entry.get("optional", False))
+    role = entry.get("role")
+    notes = entry.get("notes", "")
+    if "schedule" in entry and "preset" in entry:
+        raise BatteryError(f"entry {dataset!r} declares schedule AND preset")
+
+    if "schedule" in entry:
+        rel = entry["schedule"]
+        path = Path(rel)
+        if not path.is_absolute():
+            path = battery_dir / path
+        try:
+            spec = json.loads(path.read_text())
+        except OSError as exc:
+            raise BatteryError(f"cannot read schedule {rel!r}: {exc}") from exc
+        base_id = spec.get("schedule_id")
+        if not base_id:
+            raise BatteryError(f"schedule {rel!r} declares no schedule_id")
+        schedule_id = derive_schedule_id(base_schedule_id=base_id)
+        _safe_component(schedule_id, label="schedule_id")
+        return BatteryRef(dataset=dataset, schedule_id=schedule_id, schedule=str(rel),
+                          notes=notes, optional=optional, role=role)
+
+    preset = entry.get("preset")
+    if preset not in VALID_PRESETS:
+        raise BatteryError(f"unknown preset {preset!r} for dataset {dataset!r}")
+    n_cuts = entry.get("n_cuts")
+    if n_cuts is not None and (type(n_cuts) is not int or n_cuts <= 0):
+        raise BatteryError("n_cuts must be a positive integer")
+    schedule_id = derive_schedule_id(preset=preset, n_cuts=n_cuts)
+    _safe_component(schedule_id, label="schedule_id")
+    return BatteryRef(dataset=dataset, schedule_id=schedule_id, preset=preset,
+                      n_cuts=n_cuts, notes=notes, optional=optional, role=role)
+
+
+def load_battery(path: str | Path = DEFAULT_BATTERY_PATH) -> list[BatteryRef]:
+    """Every entry in ``certify_battery.json``, in file order."""
+    path = Path(path)
+    data = json.loads(path.read_text())
+    if not isinstance(data, list):
+        raise BatteryError(f"{path} must contain a list of entries")
+    return [parse_entry(e, battery_dir=path.parent) for e in data]
+
+
+# ---------------------------------------------------------------------------
+# Coverage.
+# ---------------------------------------------------------------------------
+@dataclass
+class EngineCoverage:
+    """One engine's step files under ``<rec_dir>/<engine>/``."""
+
+    engine: str
+    present: bool
+    steps: int
+    bytes: int
+    files: list[Path] = field(default_factory=list)
+
+
+def engine_coverage(rec_dir: Path, engine: str) -> EngineCoverage:
+    """Count and size one engine's step files. Absent dir is 0 steps, not an error."""
+    if engine not in ENGINE_STEP_GLOB:
+        raise BatteryError(f"unknown engine {engine!r}")
+    step_dir = rec_dir / engine
+    if not step_dir.is_dir():
+        return EngineCoverage(engine=engine, present=False, steps=0, bytes=0)
+    files = sorted(p for p in step_dir.glob(ENGINE_STEP_GLOB[engine]) if p.is_file())
+    total = sum(p.stat().st_size for p in files)
+    return EngineCoverage(engine=engine, present=bool(files), steps=len(files),
+                          bytes=total, files=files)
+
+
+def entry_coverage(ref: BatteryRef, root: Path) -> dict[str, Any]:
+    """Resolve one entry against a replays root.
+
+    ``reasons`` is empty exactly when the entry is covered. Every non-covered
+    outcome names itself: ``no-recording-dir``, ``missing-clj``, ``missing-py``,
+    ``step-count-mismatch``.
+    """
+    rec_dir = root / ref.dataset / ref.schedule_id
+    engines = {name: engine_coverage(rec_dir, name) for name in ENGINES}
+    reasons: list[str] = []
+    if not rec_dir.is_dir():
+        reasons.append("no-recording-dir")
+    for name in ENGINES:
+        if not engines[name].present:
+            reasons.append(f"missing-{name}")
+    if not reasons and engines["clj"].steps != engines["py"].steps:
+        # certify refuses a pair whose step sets differ (certify.py:1415-1420);
+        # a half-written recording must not read as coverage here either.
+        reasons.append("step-count-mismatch")
+    return {
+        "key": ref.key,
+        "entry": ref.as_dict(),
+        "path": rec_dir,
+        "covered": not reasons,
+        "reasons": reasons,
+        "steps": engines["py"].steps if not reasons else None,
+        "engines": {
+            name: {"present": cov.present, "steps": cov.steps, "bytes": cov.bytes}
+            for name, cov in engines.items()
+        },
+        "_engines": engines,
+    }
+
+
+def coverage(
+    *,
+    battery: str | Path = DEFAULT_BATTERY_PATH,
+    root: str | Path = DEFAULT_REPLAYS_ROOT,
+    datasets: list[str] | None = None,
+    include_optional: bool = True,
+) -> dict[str, Any]:
+    """Enumerate the battery and split it into covered / missing entries.
+
+    ``datasets`` restricts the enumeration (the CI battery is public fixtures
+    only); ``None`` means every entry in the file. Both lists are always
+    reported — a caller that only reads ``covered`` is the bug this replaces.
+    """
+    root = Path(root)
+    refs = load_battery(battery)
+    if datasets is not None:
+        wanted = set(datasets)
+        refs = [r for r in refs if r.dataset in wanted]
+    if not include_optional:
+        refs = [r for r in refs if not r.optional]
+
+    covered, missing = [], []
+    for ref in refs:
+        row = entry_coverage(ref, root)
+        (covered if row["covered"] else missing).append(row)
+    return {
+        "battery": str(battery),
+        "root": str(root),
+        "datasets": sorted(datasets) if datasets is not None else None,
+        "enumerated": len(refs),
+        "covered": covered,
+        "missing": missing,
+        "covered_keys": [r["key"] for r in covered],
+        "missing_keys": [r["key"] for r in missing],
+    }
+
+
+def format_report(report: dict[str, Any]) -> str:
+    """A human summary that names both halves, never just the good one."""
+    lines = [
+        f"battery: {report['battery']}",
+        f"replays root: {report['root']}",
+        f"entries enumerated: {report['enumerated']}"
+        + ("" if report["datasets"] is None else f" (datasets: {', '.join(report['datasets'])})"),
+        f"covered: {len(report['covered'])}/{report['enumerated']}",
+    ]
+    for row in report["covered"]:
+        lines.append(
+            f"  + {row['key']}  steps={row['steps']}"
+            f"  clj={row['engines']['clj']['bytes']}B py={row['engines']['py']['bytes']}B"
+        )
+    lines.append(f"missing: {len(report['missing'])}/{report['enumerated']}")
+    for row in report["missing"]:
+        lines.append(f"  - {row['key']}  {','.join(row['reasons'])}")
+    return "\n".join(lines)
+
+
+def _jsonable(report: dict[str, Any]) -> dict[str, Any]:
+    def strip(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        out = []
+        for row in rows:
+            clean = {k: v for k, v in row.items() if k != "_engines"}
+            clean["path"] = str(clean["path"])
+            out.append(clean)
+        return out
+
+    return {**report, "covered": strip(report["covered"]), "missing": strip(report["missing"])}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    ap.add_argument("--battery", default=str(DEFAULT_BATTERY_PATH),
+                    help="certify_battery.json (default: delphi/scripts/certify_battery.json)")
+    ap.add_argument("--root", default=str(DEFAULT_REPLAYS_ROOT),
+                    help="replays root (default: delphi/real_data/.local/replays)")
+    ap.add_argument("--dataset", action="append", default=None, dest="datasets",
+                    help="restrict to this dataset slug (repeatable)")
+    ap.add_argument("--skip-optional", action="store_true",
+                    help="ignore entries marked optional")
+    ap.add_argument("--json", action="store_true", help="emit the report as JSON")
+    ap.add_argument("--require-complete", action="store_true",
+                    help="exit 1 if any enumerated entry is missing a recording")
+    args = ap.parse_args(argv)
+
+    try:
+        report = coverage(battery=args.battery, root=args.root, datasets=args.datasets,
+                          include_optional=not args.skip_optional)
+    except (BatteryError, OSError, ValueError) as exc:
+        print(f"battery_coverage: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        json.dump(_jsonable(report), sys.stdout, indent=1, sort_keys=True, default=str)
+        sys.stdout.write("\n")
+    else:
+        print(format_report(report))
+    if args.require_complete and report["missing"]:
+        print(f"battery_coverage: {len(report['missing'])} entry/entries without a "
+              f"clj+py pair: {', '.join(report['missing_keys'])}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/delphi/tests/replay_harness/test_battery_coverage.py
+++ b/delphi/tests/replay_harness/test_battery_coverage.py
@@ -1,0 +1,258 @@
+"""Battery coverage enumeration — the replacement for a hard-coded entry list.
+
+The P-044 G12 measurement hard-coded the two entries that happened to have
+recordings when it was written, so four in-battery entries stayed invisible: an
+entry nobody had recorded looked exactly like an entry nobody had asked for.
+These tests pin the enumeration that replaces it — the battery is the list, the
+disk decides coverage, and BOTH halves are reported by name.
+
+Synthetic recording roots only: no engine, no dataset, no CI. The three cases
+the G12 consumer actually hits are `present`, `missing clj` and `missing py`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_DELPHI = Path(__file__).resolve().parents[2]
+_MODULE_PATH = _DELPHI / "scripts" / "battery_coverage.py"
+
+
+def _load():
+    """Load the stdlib-only module by path (scripts/ is not a package)."""
+    name = "battery_coverage_under_test"
+    spec = importlib.util.spec_from_file_location(name, _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module  # @dataclass resolves through sys.modules
+    spec.loader.exec_module(module)
+    return module
+
+
+bc = _load()
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders.
+# ---------------------------------------------------------------------------
+def _write_battery(tmp_path: Path, entries: list[dict]) -> Path:
+    path = tmp_path / "battery.json"
+    path.write_text(json.dumps(entries))
+    return path
+
+
+def _write_steps(step_dir: Path, count: int, suffix: str) -> None:
+    step_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        (step_dir / f"step-{i:03d}{suffix}").write_text(json.dumps({"index": i, "blob": {}}))
+
+
+def _record(root: Path, dataset: str, schedule_id: str, *, clj: int | None, py: int | None) -> Path:
+    """Lay down a synthetic recording. ``None`` means that engine never ran."""
+    rec = root / dataset / schedule_id
+    rec.mkdir(parents=True, exist_ok=True)
+    (rec / "schedule.json").write_text(json.dumps({"schedule_id": schedule_id}))
+    (rec / "provenance.json").write_text(json.dumps({"engine": "test"}))
+    if clj is not None:
+        _write_steps(rec / "clj", clj, ".blob.json")
+        # The Clojure driver writes a meta file per step alongside each blob;
+        # counting `step-*.json` there would double every step count.
+        _write_steps(rec / "clj", clj, ".meta.json")
+    if py is not None:
+        _write_steps(rec / "py", py, ".json")
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# Schedule-id derivation (must match certify's, byte for byte).
+# ---------------------------------------------------------------------------
+def test_derive_schedule_id_forms():
+    assert bc.derive_schedule_id(preset="uniform", n_cuts=8) == "uniform8-clojure-legacy"
+    assert bc.derive_schedule_id(preset="front-loaded", n_cuts=6) == "front-loaded6-clojure-legacy"
+    assert bc.derive_schedule_id(preset="single-cut") == "single-cut-clojure-legacy"
+    assert bc.derive_schedule_id(base_schedule_id="every-vote-56") == "every-vote-56-clojure-legacy"
+
+
+def test_derive_schedule_id_requires_n_cuts_for_cut_presets():
+    with pytest.raises(bc.BatteryError):
+        bc.derive_schedule_id(preset="uniform")
+
+
+# ---------------------------------------------------------------------------
+# The three coverage cases the G12 measurement consumes.
+# ---------------------------------------------------------------------------
+@pytest.fixture()
+def three_case_root(tmp_path: Path) -> tuple[Path, Path]:
+    """A battery of three entries, one per outcome, over synthetic recordings."""
+    battery = _write_battery(tmp_path, [
+        {"dataset": "vw", "preset": "uniform", "n_cuts": 8},
+        {"dataset": "vw", "preset": "front-loaded", "n_cuts": 6},
+        {"dataset": "biodiversity", "preset": "uniform", "n_cuts": 8},
+    ])
+    root = tmp_path / "replays"
+    _record(root, "vw", "uniform8-clojure-legacy", clj=8, py=8)          # present
+    _record(root, "vw", "front-loaded6-clojure-legacy", clj=None, py=6)  # missing clj
+    _record(root, "biodiversity", "uniform8-clojure-legacy", clj=8, py=None)  # missing py
+    return battery, root
+
+
+def test_present_entry_is_covered(three_case_root):
+    battery, root = three_case_root
+    report = bc.coverage(battery=battery, root=root)
+    assert report["enumerated"] == 3
+    assert report["covered_keys"] == ["vw/uniform8-clojure-legacy"]
+    covered = report["covered"][0]
+    assert covered["reasons"] == []
+    assert covered["steps"] == 8
+    # The clj meta files must not inflate the count.
+    assert covered["engines"]["clj"]["steps"] == 8
+    assert covered["engines"]["py"]["steps"] == 8
+
+
+def test_missing_clj_is_reported_by_name(three_case_root):
+    battery, root = three_case_root
+    report = bc.coverage(battery=battery, root=root)
+    row = next(r for r in report["missing"] if r["key"] == "vw/front-loaded6-clojure-legacy")
+    assert row["reasons"] == ["missing-clj"]
+    assert row["engines"]["py"]["steps"] == 6
+    assert row["engines"]["clj"]["present"] is False
+
+
+def test_missing_py_is_reported_by_name(three_case_root):
+    battery, root = three_case_root
+    report = bc.coverage(battery=battery, root=root)
+    row = next(r for r in report["missing"] if r["key"] == "biodiversity/uniform8-clojure-legacy")
+    assert row["reasons"] == ["missing-py"]
+    assert row["engines"]["clj"]["steps"] == 8
+
+
+def test_both_halves_are_always_reported(three_case_root):
+    battery, root = three_case_root
+    report = bc.coverage(battery=battery, root=root)
+    assert len(report["covered"]) + len(report["missing"]) == report["enumerated"]
+    assert sorted(report["missing_keys"]) == [
+        "biodiversity/uniform8-clojure-legacy",
+        "vw/front-loaded6-clojure-legacy",
+    ]
+
+
+def test_no_recording_dir_at_all(tmp_path: Path):
+    battery = _write_battery(tmp_path, [{"dataset": "vw", "preset": "single-cut"}])
+    report = bc.coverage(battery=battery, root=tmp_path / "nothing-here")
+    row = report["missing"][0]
+    assert row["reasons"] == ["no-recording-dir", "missing-clj", "missing-py"]
+
+
+def test_step_count_mismatch_is_not_coverage(tmp_path: Path):
+    """A half-written pair must not read as covered — certify refuses it too."""
+    battery = _write_battery(tmp_path, [{"dataset": "vw", "preset": "uniform", "n_cuts": 8}])
+    root = tmp_path / "replays"
+    _record(root, "vw", "uniform8-clojure-legacy", clj=5, py=8)
+    report = bc.coverage(battery=battery, root=root)
+    assert report["covered"] == []
+    assert report["missing"][0]["reasons"] == ["step-count-mismatch"]
+
+
+def test_empty_engine_directory_is_missing_not_covered(tmp_path: Path):
+    battery = _write_battery(tmp_path, [{"dataset": "vw", "preset": "single-cut"}])
+    root = tmp_path / "replays"
+    rec = _record(root, "vw", "single-cut-clojure-legacy", clj=1, py=1)
+    for stale in (rec / "clj").glob("step-*.blob.json"):
+        stale.unlink()
+    report = bc.coverage(battery=battery, root=root)
+    assert report["missing"][0]["reasons"] == ["missing-clj"]
+
+
+# ---------------------------------------------------------------------------
+# Enumeration itself.
+# ---------------------------------------------------------------------------
+def test_schedule_file_entries_take_their_id_from_the_file(tmp_path: Path):
+    (tmp_path / "schedules").mkdir()
+    (tmp_path / "schedules" / "vw-every-vote-56.json").write_text(
+        json.dumps({"dataset": "vw", "schedule_id": "every-vote-56"}))
+    battery = _write_battery(tmp_path, [
+        {"dataset": "vw", "schedule": "schedules/vw-every-vote-56.json"},
+    ])
+    refs = bc.load_battery(battery)
+    assert [r.key for r in refs] == ["vw/every-vote-56-clojure-legacy"]
+    assert refs[0].schedule == "schedules/vw-every-vote-56.json"
+
+
+def test_dataset_filter_restricts_enumeration(tmp_path: Path):
+    battery = _write_battery(tmp_path, [
+        {"dataset": "vw", "preset": "single-cut"},
+        {"dataset": "pakistan", "preset": "uniform", "n_cuts": 8},
+    ])
+    report = bc.coverage(battery=battery, root=tmp_path / "replays", datasets=["vw"])
+    assert report["enumerated"] == 1
+    assert report["missing_keys"] == ["vw/single-cut-clojure-legacy"]
+
+
+def test_unsafe_dataset_is_refused(tmp_path: Path):
+    battery = _write_battery(tmp_path, [{"dataset": "../etc", "preset": "single-cut"}])
+    with pytest.raises(bc.BatteryError):
+        bc.load_battery(battery)
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+def test_require_complete_exits_nonzero_when_an_entry_is_missing(three_case_root, capsys):
+    battery, root = three_case_root
+    rc = bc.main(["--battery", str(battery), "--root", str(root), "--require-complete"])
+    assert rc == 1
+    out = capsys.readouterr()
+    assert "front-loaded6-clojure-legacy" in out.err
+
+
+def test_require_complete_passes_when_every_entry_is_present(tmp_path: Path):
+    battery = _write_battery(tmp_path, [{"dataset": "vw", "preset": "single-cut"}])
+    root = tmp_path / "replays"
+    _record(root, "vw", "single-cut-clojure-legacy", clj=1, py=1)
+    assert bc.main(["--battery", str(battery), "--root", str(root), "--require-complete"]) == 0
+
+
+def test_json_output_is_parseable_and_names_both_halves(three_case_root, capsys):
+    battery, root = three_case_root
+    assert bc.main(["--battery", str(battery), "--root", str(root), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["covered"]) == 1
+    assert len(payload["missing"]) == 2
+    assert "_engines" not in payload["covered"][0]
+
+
+# ---------------------------------------------------------------------------
+# Drift guard against the real certify implementation.
+# ---------------------------------------------------------------------------
+def test_agrees_with_certify_on_the_real_battery():
+    """The stdlib copy must resolve the shipped battery exactly as certify does.
+
+    This module cannot import certify (it runs on the CI worker under the system
+    python3), so the only thing standing between the two is this test.
+    """
+    certify = pytest.importorskip("polismath.replay.certify")
+    real = certify.load_battery(certify.DEFAULT_BATTERY_PATH)
+    mine = bc.load_battery(bc.DEFAULT_BATTERY_PATH)
+    assert [(e.dataset, e.schedule_id) for e in real] == [(e.dataset, e.schedule_id) for e in mine]
+    assert certify._LEGACY_SUFFIX == bc.LEGACY_SUFFIX
+    assert set(certify._VALID_PRESETS) == set(bc.VALID_PRESETS)
+    assert set(certify._NCUTS_PRESETS) == set(bc.NCUTS_PRESETS)
+
+
+def test_shipped_battery_enumerates_the_six_public_entries():
+    """The six the CI battery runs, named — the list G12 has to cover."""
+    refs = bc.load_battery(bc.DEFAULT_BATTERY_PATH)
+    public = [r.key for r in refs if r.dataset in ("vw", "biodiversity")]
+    assert public == [
+        "vw/uniform8-clojure-legacy",
+        "vw/front-loaded6-clojure-legacy",
+        "vw/single-cut-clojure-legacy",
+        "biodiversity/uniform8-clojure-legacy",
+        "vw/every-vote-56-clojure-legacy",
+        "vw/uniform8-restart4-clojure-legacy",
+    ]

--- a/delphi/tests/replay_harness/test_battery_coverage.py
+++ b/delphi/tests/replay_harness/test_battery_coverage.py
@@ -56,7 +56,7 @@ def _record(root: Path, dataset: str, schedule_id: str, *, clj: int | None, py: 
     """Lay down a synthetic recording. ``None`` means that engine never ran."""
     rec = root / dataset / schedule_id
     rec.mkdir(parents=True, exist_ok=True)
-    (rec / "schedule.json").write_text(json.dumps({"schedule_id": schedule_id}))
+    (rec / "schedule.json").write_text(json.dumps({"schedule_id": schedule_id, "cuts": {"mode": "vote-count", "at": list(range(1, max(clj or 0, py or 0) + 1))}}))
     (rec / "provenance.json").write_text(json.dumps({"engine": "test"}))
     if clj is not None:
         _write_steps(rec / "clj", clj, ".blob.json")
@@ -256,3 +256,33 @@ def test_shipped_battery_enumerates_the_six_public_entries():
         "vw/every-vote-56-clojure-legacy",
         "vw/uniform8-restart4-clojure-legacy",
     ]
+
+@pytest.mark.parametrize("mutation", ["truncate", "shift", "missing-meta", "extra-meta"])
+def test_exact_schedule_file_sets(three_case_root, mutation):
+    battery, root = three_case_root
+    rec = root / "vw/uniform8-clojure-legacy"
+    if mutation == "truncate":
+        for engine in ("clj", "py"):
+            for path in (rec / engine).glob("step-007*"):
+                path.unlink()
+    elif mutation == "shift":
+        (rec / "py/step-007.json").rename(rec / "py/step-008.json")
+    elif mutation == "missing-meta":
+        (rec / "clj/step-007.meta.json").unlink()
+    else:
+        (rec / "clj/step-008.meta.json").write_text("{}")
+    report = bc.coverage(battery=battery, root=root)
+    assert "vw/uniform8-clojure-legacy" in report["missing_keys"]
+    assert any("step-set-mismatch" in reason for row in report["missing"]
+               if row["key"] == "vw/uniform8-clojure-legacy" for reason in row["reasons"])
+
+@pytest.mark.parametrize("component", ["dataset", "recording", "engine"])
+def test_directory_symlinks_never_count_as_coverage(three_case_root, tmp_path, component):
+    battery, root = three_case_root
+    path = root / {"dataset": "vw", "recording": "vw/uniform8-clojure-legacy",
+                   "engine": "vw/uniform8-clojure-legacy/clj"}[component]
+    outside = tmp_path / "outside"
+    path.rename(outside)
+    path.symlink_to(outside, target_is_directory=True)
+    report = bc.coverage(battery=battery, root=root)
+    assert "vw/uniform8-clojure-legacy" in report["missing_keys"]

--- a/delphi/tests/replay_harness/test_ci_recordings_manifest.py
+++ b/delphi/tests/replay_harness/test_ci_recordings_manifest.py
@@ -13,13 +13,17 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import sys
 import tarfile
 from pathlib import Path
 
 import pytest
 
-_REPO = Path(__file__).resolve().parents[3]
+# CI copies tests to /app/tests and the checkout inputs to /app/projgate.
+# Use the same explicit root as the projection-gate tests; a missing input
+# remains a collection failure so this acceptance suite cannot silently skip.
+_REPO = Path(os.environ.get("POLIS_CHECKOUT_DIR", Path(__file__).resolve().parents[3]))
 _MODULE_PATH = _REPO / "ci" / "p022_recordings_manifest.py"
 
 

--- a/delphi/tests/replay_harness/test_ci_recordings_manifest.py
+++ b/delphi/tests/replay_harness/test_ci_recordings_manifest.py
@@ -1,0 +1,227 @@
+"""The CI recordings packer: what it ships, what it refuses, what it pins.
+
+`ci/p022_recordings_manifest.py` is what makes a certification dispatch return
+the recordings it produced instead of destroying them with the box. These tests
+run it over synthetic recording roots — no engine, no instance, no AWS.
+
+The properties that matter are all refusals: it packs only entries the battery
+inventory admitted, only allowlisted file names, and it fails rather than
+reporting a shorter-but-clean inventory when an admitted entry has no pair.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO / "ci" / "p022_recordings_manifest.py"
+
+
+def _load():
+    name = "p022_recordings_manifest_under_test"
+    spec = importlib.util.spec_from_file_location(name, _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module  # @dataclass resolves through sys.modules
+    spec.loader.exec_module(module)
+    return module
+
+
+pack = _load()
+
+
+def _write_steps(step_dir: Path, count: int, suffix: str) -> None:
+    step_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        (step_dir / f"step-{i:03d}{suffix}").write_text(json.dumps({"index": i, "blob": {"n": i}}))
+
+
+def _record(root: Path, dataset: str, schedule_id: str, *, clj: int | None, py: int | None) -> Path:
+    rec = root / dataset / schedule_id
+    rec.mkdir(parents=True, exist_ok=True)
+    (rec / "schedule.json").write_text(json.dumps({"schedule_id": schedule_id}))
+    (rec / "provenance.json").write_text(json.dumps({"engine": "test"}))
+    if clj is not None:
+        _write_steps(rec / "clj", clj, ".blob.json")
+        _write_steps(rec / "clj", clj, ".meta.json")
+        (rec / "clj" / "cache_manifest.json").write_text("{}")
+    if py is not None:
+        _write_steps(rec / "py", py, ".json")
+        (rec / "py" / "cache_manifest.json").write_text("{}")
+    return rec
+
+
+@pytest.fixture()
+def scene(tmp_path: Path):
+    """Two admitted entries (one recorded, one not) and one never admitted."""
+    battery = tmp_path / "battery.json"
+    battery.write_text(json.dumps([
+        {"dataset": "vw", "preset": "uniform", "n_cuts": 8},
+        {"dataset": "vw", "preset": "front-loaded", "n_cuts": 6},
+        {"dataset": "pakistan", "preset": "uniform", "n_cuts": 8},
+    ]))
+    selection = tmp_path / "battery-selection.json"
+    selection.write_text(json.dumps({
+        "public_slugs": ["biodiversity", "vw"],
+        "selected": [
+            {"dataset": "vw", "preset": "uniform", "n_cuts": 8},
+            {"dataset": "vw", "preset": "front-loaded", "n_cuts": 6},
+        ],
+        "selected_count": 2,
+        "missing": [],
+        "inventory_digest": "a" * 64,
+    }))
+    root = tmp_path / "certify-run"
+    _record(root, "vw", "uniform8-clojure-legacy", clj=3, py=3)
+    _record(root, "vw", "front-loaded6-clojure-legacy", clj=None, py=2)
+    _record(root, "pakistan", "uniform8-clojure-legacy", clj=2, py=2)
+    return battery, selection, root, tmp_path / "out"
+
+
+def test_packs_only_covered_admitted_entries(scene):
+    battery, selection, root, out = scene
+    manifest, rc = pack.build(replays_root=root, out_dir=out, battery=battery,
+                              selection=selection, require_complete=False)
+    assert rc == 0
+    assert [e["schedule_id"] for e in manifest["entries"]] == ["uniform8-clojure-legacy"]
+    assert [m["schedule_id"] for m in manifest["missing"]] == ["front-loaded6-clojure-legacy"]
+    # The private dataset is in the battery file, is not a public fixture, and
+    # is named as skipped rather than silently vanishing from the inventory.
+    assert manifest["skipped_not_public"] == ["pakistan/uniform8-clojure-legacy"]
+    assert manifest["skipped_not_in_inventory"] == []
+
+
+def test_an_entry_outside_the_admitted_inventory_is_not_shipped(scene):
+    """A public entry the battery did not select is evidence of some other run."""
+    battery, selection, root, out = scene
+    sel = json.loads(selection.read_text())
+    sel["selected"] = [e for e in sel["selected"] if e.get("preset") != "uniform"]
+    sel["selected_count"] = 1
+    selection.write_text(json.dumps(sel))
+    manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                             selection=selection, require_complete=False)
+    assert manifest["entries"] == []
+    assert manifest["skipped_not_in_inventory"] == ["vw/uniform8-clojure-legacy"]
+
+
+def test_manifest_records_steps_digests_and_bytes(scene):
+    battery, selection, root, out = scene
+    manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                             selection=selection, require_complete=False)
+    entry = manifest["entries"][0]
+    assert entry["dataset"] == "vw"
+    assert entry["engines"]["clj"]["steps"] == 3
+    assert entry["engines"]["py"]["steps"] == 3
+    assert sorted(entry["engines"]["py"]["step_sha256"]) == [
+        "py/step-000.json", "py/step-001.json", "py/step-002.json",
+    ]
+    assert all(len(v) == 64 for v in entry["engines"]["clj"]["step_sha256"].values())
+    assert entry["bytes"] > 0
+    assert entry["archive_bytes"] > 0
+    assert len(entry["archive_sha256"]) == 64
+    assert manifest["totals"]["step_files"] == 6
+    assert len(manifest["manifest_digest"]) == 64
+
+
+def test_archive_members_extract_into_the_canonical_store_layout(scene, tmp_path):
+    battery, selection, root, out = scene
+    manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                             selection=selection, require_complete=False)
+    archive = out / manifest["entries"][0]["archive"]
+    with tarfile.open(archive) as tar:
+        names = sorted(tar.getnames())
+    assert "vw/uniform8-clojure-legacy/schedule.json" in names
+    assert "vw/uniform8-clojure-legacy/py/step-000.json" in names
+    assert "vw/uniform8-clojure-legacy/clj/step-000.blob.json" in names
+
+    replays = tmp_path / "replays"
+    replays.mkdir()
+    with tarfile.open(archive) as tar:
+        tar.extractall(replays, filter="data")
+    assert (replays / "vw" / "uniform8-clojure-legacy" / "clj" / "step-002.meta.json").is_file()
+
+
+def test_unlisted_files_are_reported_and_left_behind(scene):
+    battery, selection, root, out = scene
+    rec = root / "vw" / "uniform8-clojure-legacy"
+    (rec / "clj" / "step-000.edn").write_text("{:huge true}")
+    (rec / "scratch.log").write_text("not evidence")
+    manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                             selection=selection, require_complete=False)
+    entry = manifest["entries"][0]
+    assert sorted(entry["unlisted"]) == ["clj/step-000.edn", "scratch.log"]
+    with tarfile.open(out / entry["archive"]) as tar:
+        names = tar.getnames()
+    assert not any(n.endswith(".edn") or n.endswith("scratch.log") for n in names)
+
+
+def test_require_complete_fails_on_an_admitted_entry_without_a_pair(scene):
+    battery, selection, root, out = scene
+    _, rc = pack.build(replays_root=root, out_dir=out, battery=battery,
+                       selection=selection, require_complete=True)
+    assert rc == 1
+
+
+def test_require_complete_passes_once_both_engines_are_present(scene):
+    battery, selection, root, out = scene
+    _record(root, "vw", "front-loaded6-clojure-legacy", clj=2, py=2)
+    manifest, rc = pack.build(replays_root=root, out_dir=out, battery=battery,
+                              selection=selection, require_complete=True)
+    assert rc == 0
+    assert manifest["totals"]["entries"] == 2
+    assert manifest["missing"] == []
+
+
+def test_battery_inventory_digest_is_carried_verbatim(scene):
+    battery, selection, root, out = scene
+    manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                             selection=selection, require_complete=False)
+    assert manifest["battery_inventory_digest"] == "a" * 64
+    assert manifest["battery_selected_count"] == 2
+
+
+def test_verify_accepts_a_faithful_bundle_and_rejects_a_tampered_one(scene, capsys):
+    battery, selection, root, out = scene
+    manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                             selection=selection, require_complete=False)
+    assert pack.verify(out) == 0
+
+    archive = out / manifest["entries"][0]["archive"]
+    archive.write_bytes(archive.read_bytes() + b"tamper")
+    assert pack.verify(out) == 1
+    assert "DIGEST MISMATCH" in capsys.readouterr().err
+
+
+def test_verify_reports_a_missing_archive_rather_than_passing(scene):
+    battery, selection, root, out = scene
+    manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                             selection=selection, require_complete=False)
+    (out / manifest["entries"][0]["archive"]).unlink()
+    assert pack.verify(out) == 1
+
+
+def test_archive_digest_is_stable_across_repacks(scene):
+    """Two packs of the same bytes must agree, so a digest identifies content."""
+    battery, selection, root, out = scene
+    first, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                          selection=selection, require_complete=False)
+    second, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                           selection=selection, require_complete=False)
+    assert first["entries"][0]["archive_sha256"] == second["entries"][0]["archive_sha256"]
+    assert first["manifest_digest"] == second["manifest_digest"]
+
+
+def test_without_a_selection_every_battery_entry_is_enumerated(scene):
+    battery, _selection, root, out = scene
+    manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                             selection=None, require_complete=False)
+    assert manifest["skipped_not_public"] == []
+    assert manifest["skipped_not_in_inventory"] == []
+    assert {e["dataset"] for e in manifest["entries"]} == {"vw", "pakistan"}
+    assert manifest["battery_inventory_digest"] == ""

--- a/delphi/tests/replay_harness/test_ci_recordings_manifest.py
+++ b/delphi/tests/replay_harness/test_ci_recordings_manifest.py
@@ -45,7 +45,7 @@ def _write_steps(step_dir: Path, count: int, suffix: str) -> None:
 def _record(root: Path, dataset: str, schedule_id: str, *, clj: int | None, py: int | None) -> Path:
     rec = root / dataset / schedule_id
     rec.mkdir(parents=True, exist_ok=True)
-    (rec / "schedule.json").write_text(json.dumps({"schedule_id": schedule_id}))
+    (rec / "schedule.json").write_text(json.dumps({"schedule_id": schedule_id, "cuts": {"mode": "vote-count", "at": list(range(1, max(clj or 0, py or 0) + 1))}}))
     (rec / "provenance.json").write_text(json.dumps({"engine": "test"}))
     if clj is not None:
         _write_steps(rec / "clj", clj, ".blob.json")
@@ -66,6 +66,8 @@ def scene(tmp_path: Path):
         {"dataset": "vw", "preset": "front-loaded", "n_cuts": 6},
         {"dataset": "pakistan", "preset": "uniform", "n_cuts": 8},
     ]))
+    datasets = tmp_path / "datasets.json"
+    datasets.write_text(json.dumps({"public_fixtures": [{"slug": "vw"}, {"slug": "biodiversity"}]}))
     selection = tmp_path / "battery-selection.json"
     selection.write_text(json.dumps({
         "public_slugs": ["biodiversity", "vw"],
@@ -75,13 +77,21 @@ def scene(tmp_path: Path):
         ],
         "selected_count": 2,
         "missing": [],
-        "inventory_digest": "a" * 64,
+        "inventory_digest": pack._inventory(battery, datasets)[0],
     }))
     root = tmp_path / "certify-run"
     _record(root, "vw", "uniform8-clojure-legacy", clj=3, py=3)
     _record(root, "vw", "front-loaded6-clojure-legacy", clj=None, py=2)
     _record(root, "pakistan", "uniform8-clojure-legacy", clj=2, py=2)
     return battery, selection, root, tmp_path / "out"
+
+
+def _verify(scene, **overrides):
+    battery, selection, root, out = scene
+    args = dict(expected_inventory_digest=json.loads(selection.read_text())["inventory_digest"],
+                battery=battery, datasets=battery.parent / "datasets.json")
+    args.update(overrides)
+    return pack.verify(out, **args)
 
 
 def test_packs_only_covered_admitted_entries(scene):
@@ -182,7 +192,7 @@ def test_battery_inventory_digest_is_carried_verbatim(scene):
     battery, selection, root, out = scene
     manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
                              selection=selection, require_complete=False)
-    assert manifest["battery_inventory_digest"] == "a" * 64
+    assert manifest["battery_inventory_digest"] == json.loads(selection.read_text())["inventory_digest"]
     assert manifest["battery_selected_count"] == 2
 
 
@@ -190,11 +200,11 @@ def test_verify_accepts_a_faithful_bundle_and_rejects_a_tampered_one(scene, caps
     battery, selection, root, out = scene
     manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
                              selection=selection, require_complete=False)
-    assert pack.verify(out) == 0
+    assert _verify(scene) == 0
 
     archive = out / manifest["entries"][0]["archive"]
     archive.write_bytes(archive.read_bytes() + b"tamper")
-    assert pack.verify(out) == 1
+    assert _verify(scene) == 1
     assert "DIGEST MISMATCH" in capsys.readouterr().err
 
 
@@ -203,7 +213,7 @@ def test_verify_reports_a_missing_archive_rather_than_passing(scene):
     manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
                              selection=selection, require_complete=False)
     (out / manifest["entries"][0]["archive"]).unlink()
-    assert pack.verify(out) == 1
+    assert _verify(scene) == 1
 
 
 def test_archive_digest_is_stable_across_repacks(scene):
@@ -225,3 +235,112 @@ def test_without_a_selection_every_battery_entry_is_enumerated(scene):
     assert manifest["skipped_not_in_inventory"] == []
     assert {e["dataset"] for e in manifest["entries"]} == {"vw", "pakistan"}
     assert manifest["battery_inventory_digest"] == ""
+
+
+def test_selected_entry_absent_from_battery_is_missing(scene):
+    battery, selection, root, out = scene
+    battery.write_text(json.dumps(json.loads(battery.read_text())[1:]))
+    manifest, rc = pack.build(replays_root=root, out_dir=out, battery=battery,
+                              selection=selection, require_complete=True)
+    assert rc == 1
+    assert any("selected-entry-absent-from-battery" in row["reasons"] for row in manifest["missing"])
+
+@pytest.mark.parametrize("field", ["manifest_digest", "file_sha256", "inventory", "empty", "census", "steps", "bytes"])
+@pytest.mark.parametrize("resign", [False, True])
+def test_manifest_mutations_refused(scene, field, resign):
+    battery, selection, root, out = scene
+    manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                             selection=selection, require_complete=False)
+    entry = manifest["entries"][0]
+    if field == "manifest_digest":
+        manifest["manifest_digest"] = "0" * 64
+    elif field == "file_sha256":
+        entry["engines"]["py"]["file_sha256"]["py/step-000.json"] = "0" * 64
+    elif field == "inventory":
+        manifest["battery_inventory_digest"] = "0" * 64
+    elif field == "empty":
+        manifest["entries"] = []
+    elif field == "census":
+        manifest["missing"] = []
+    elif field == "steps":
+        entry["engines"]["clj"]["steps"] = 99
+    else:
+        entry["bytes"] += 1
+    if resign and field != "manifest_digest":
+        manifest["manifest_digest"] = pack.manifest_digest(manifest)
+    (out / pack.MANIFEST_NAME).write_text(json.dumps(manifest))
+    assert _verify(scene) == 1
+
+
+def test_verifier_requires_independent_inventory_anchor(scene):
+    battery, selection, root, out = scene
+    pack.build(replays_root=root, out_dir=out, battery=battery,
+               selection=selection, require_complete=False)
+    assert _verify(scene, expected_inventory_digest=None) == 1
+    assert _verify(scene, expected_inventory_digest="0" * 64) == 1
+
+@pytest.mark.parametrize("component", ["dataset", "recording", "engine"])
+def test_packer_refuses_directory_symlinks(scene, component):
+    battery, selection, root, out = scene
+    path = root / {"dataset": "vw", "recording": "vw/uniform8-clojure-legacy",
+                   "engine": "vw/uniform8-clojure-legacy/clj"}[component]
+    outside = root.parent / "outside"
+    path.rename(outside)
+    path.symlink_to(outside, target_is_directory=True)
+    manifest, rc = pack.build(replays_root=root, out_dir=out, battery=battery,
+                              selection=selection, require_complete=True)
+    assert rc == 1
+    assert not manifest["entries"]
+    assert not list(out.rglob("*.tar.gz"))
+
+@pytest.mark.parametrize("kind", ["parent", "absolute", "symlink", "hardlink", "duplicate"])
+def test_transport_rejects_unsafe_members_before_extraction(tmp_path, kind):
+    import io
+    archive = tmp_path / "transport.tar"
+    with tarfile.open(archive, "w") as tar:
+        names = ["recordings-manifest.json", {"parent": "../escape", "absolute": "/escape"}.get(kind, "entries/a__b.tar.gz")]
+        if kind == "duplicate":
+            names[-1] = names[0]
+        for index, name in enumerate(names):
+            info = tarfile.TarInfo(name)
+            if index and kind in ("symlink", "hardlink"):
+                info.type = tarfile.SYMTYPE if kind == "symlink" else tarfile.LNKTYPE
+                info.linkname = "../escape"
+            else:
+                info.size = 2
+            tar.addfile(info, io.BytesIO(b"{}"))
+    destination = tmp_path / "out"
+    assert pack.extract_bundle(archive, destination) == 1
+    assert not destination.exists()
+    assert not (tmp_path / "escape").exists()
+
+
+def test_safe_transport_is_verified_then_extracted(scene):
+    battery, selection, root, out = scene
+    pack.build(replays_root=root, out_dir=out, battery=battery,
+               selection=selection, require_complete=False)
+    transport = out.parent / "transport.tar"
+    with tarfile.open(transport, "w") as tar:
+        tar.add(out, arcname=".")
+    destination = out.parent / "download"
+    assert pack.extract_bundle(transport, destination,
+        expected_inventory_digest=json.loads(selection.read_text())["inventory_digest"],
+        battery=battery, datasets=battery.parent / "datasets.json") == 0
+    assert (destination / pack.MANIFEST_NAME).read_bytes() == (out / pack.MANIFEST_NAME).read_bytes()
+
+
+def test_inner_archive_traversal_rejected_even_with_updated_digests(scene):
+    import io
+    battery, selection, root, out = scene
+    manifest, _ = pack.build(replays_root=root, out_dir=out, battery=battery,
+                             selection=selection, require_complete=False)
+    entry = manifest["entries"][0]
+    archive = out / entry["archive"]
+    with tarfile.open(archive, "w:gz") as tar:
+        info = tarfile.TarInfo("vw/uniform8-clojure-legacy/../../escape")
+        info.size = 2
+        tar.addfile(info, io.BytesIO(b"{}"))
+    entry["archive_sha256"] = pack.sha256_file(archive)
+    manifest["manifest_digest"] = pack.manifest_digest(manifest)
+    (out / pack.MANIFEST_NAME).write_text(json.dumps(manifest))
+    assert _verify(scene) == 1

--- a/docs/ci-ec2.md
+++ b/docs/ci-ec2.md
@@ -32,6 +32,9 @@ code as root and could never have contained data it was given.
 | The phases that run on the worker | `ci/p022_ec2_run.sh` |
 | Teardown: terminate and prove it | `ci/p022_teardown.py` |
 | Fixed-schema summary validator, and the one definition of `SCHEMA` | `ci/p022_check_summary.py` |
+| Packing the battery's recordings + their inventory manifest | `ci/p022_recordings_manifest.py` |
+| Pulling that bundle off the worker, verified | `ci/p022_collect_recordings.sh` |
+| Which battery entries have a Clojure↔Python pair on disk | `delphi/scripts/battery_coverage.py` |
 
 ## Enabling it
 
@@ -247,8 +250,10 @@ independent control boundary in `P-022-E-ci-spec.md`, which is not built.
 
 ### What comes back, and what does not
 
-Artifacts (`synthetic-ec2-<run>-<attempt>`) contain a fixed-schema
-`summary.json`, pytest's JUnit XML and the battery's dataset selection. They do
+A run with the battery enabled uploads **two** artifacts.
+
+`synthetic-ec2-<run>-<attempt>` (7 days) is the evidence bundle: a fixed-schema
+`summary.json`, pytest's JUnit XML and the battery's dataset selection. It does
 **not** contain any log. The worker prints only lines matching
 
 ```
@@ -259,6 +264,47 @@ and `ci/p022_ssm.sh` drops anything that does not match rather than escaping it;
 worker stderr is never printed at all. The bundle is returned base64 in bounded
 chunks with a declared length and sha256, and a short or corrupt bundle fails
 the step rather than being quietly truncated.
+
+### Fetching the recordings and putting them where certify looks
+
+`certification-recordings-<run>-<attempt>` (90 days) is the second artifact: the
+battery's Clojure↔Python **recordings**, the one output of the run that cannot
+be recomputed without paying for another instance. Until this existed the
+battery wrote them under `/var/log/polis-ci/certify-run` and the box was then
+terminated with them still on it, so a dispatch came back with a verdict and
+nothing to measure. It holds one gzipped tar per battery entry under `entries/`
+plus a `recordings-manifest.json` naming, for every entry, its dataset, schedule
+id, per-engine step count, the sha256 of every step file, total bytes, and the
+battery `inventory_digest` that binds it to the run's own `summary.json`. Only
+entries the public inventory admitted are packed, and only an allowlist of file
+names inside each recording directory (`schedule.json`, `provenance.json`,
+`{clj,py}/step-*`, `{clj,py}/cache_manifest.json`); a `provenance.json` records
+the worker's own repository path, which is the only path information that
+leaves. Expect roughly 1.5–3 MB compressed for the six public entries. To fetch
+one and drop it into the canonical store (`polismath/replay/store.py`), from the
+repository root:
+
+```bash
+RUN=<run-id>; ATTEMPT=1
+gh run download "$RUN" --name "certification-recordings-$RUN-$ATTEMPT" --dir /tmp/certify-recordings
+
+# Re-hash every archive against the manifest before trusting a byte of it.
+python3 ci/p022_recordings_manifest.py --verify /tmp/certify-recordings
+
+# Each archive's members are already <dataset>/<schedule_id>/..., so this
+# reproduces real_data/.local/replays/<dataset>/<schedule_id>/{clj,py}/ exactly.
+mkdir -p delphi/real_data/.local/replays
+for a in /tmp/certify-recordings/entries/*.tar.gz; do
+  tar -xzf "$a" -C delphi/real_data/.local/replays
+done
+
+# Which battery entries now have a usable clj+py pair, and which still do not.
+python3 delphi/scripts/battery_coverage.py
+```
+
+`--verify` fails on a missing or altered archive, and prints the manifest's own
+list of entries that have **no** recording — so an incomplete download and an
+incomplete run are told apart, and neither is inferred from silence.
 
 `ci/p022_check_summary.py` is then given the run's **declared scope** and
 rejects, on top of extra keys, wrong types, control characters and non-public


### PR DESCRIPTION
Unblocks Q25. As merged, the EC2 certification run wrote its Clojure and Python recordings under the log directory but bundled only the artifact directory, so a dispatch returned a verdict and no recordings.

**Recordings artifact.** `ci/p022_ec2_run.sh` gains a second return stream; `ci/p022_recordings_manifest.py` packs the certify-run tree into one gzipped tar per battery entry (members shaped `<dataset>/<schedule_id>/…`, so extraction into `real_data/.local/replays/` reproduces the store layout) plus a manifest with per-entry dataset, schedule id, per-engine step counts, sha256 of every step file, bytes, archive digest, and an overall digest, with the battery inventory digest copied verbatim to bind recordings to the run's summary. Public slugs and admitted inventory are independent gates; a file-name allowlist (no `.edn`, no logs); symlink and traversal refused; fail-closed only when the battery passed; `summary.json`, its schema, and the `SYNTHETIC-PASS` validator untouched; teardown unchanged. Estimated 1.5–3 MB compressed for the six public entries; own chunk budget; 90-day retention.

**Workflow file: two steps added** (collect, then upload with the already-pinned action SHA), before teardown. All logic is in the shell script. This PR needs the browser merge.

**Two bugs in the merged collector, fixed here.** The SSM key allowlist in `ci/p022_ssm.sh` dropped digits, so `bundle sha256=…` was never seen and the existing evidence bundle could not come back either; a padded byte count from `wc -c` was redacted as unparseable. The poll loop now starts at 2 s and backs off to 15 s.

**Battery enumeration.** `delphi/scripts/battery_coverage.py` enumerates `certify_battery.json` filtered to entries whose Clojure and Python recordings are both present, reporting covered and missing explicitly; the CI packer consumes it. Pinned test: exactly the six public entries, matching Q25's four missing ids.

**Docs.** `docs/ci-ec2.md`: how to fetch the recordings artifact, verify, and place it where certify looks.

**Tests.** 28 passed, 1 skipped (a drift guard that runs where polismath is importable); shellcheck clean on the three scripts; `bash -n` clean; YAML validated and linted; end-to-end shell smoke on synthetic recordings through pack, chunk, reassemble, verify, extract, and coverage, plus the fail-closed path.

Schema impact: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s