### PR TITLE
feat(delphi): fixture bundles can capture the served math rows

### DIFF
--- a/delphi/docs/CERTIFICATION.md
+++ b/delphi/docs/CERTIFICATION.md
@@ -254,6 +254,68 @@ The event stream is the authoritative artifact and is LOSSLESS:
   before any row is written, rather than a `TypeError` from unary negation
   partway through a file.
 
+### Served math rows (optional, off by default)
+
+Everything above captures a conversation's **inputs**. A bundle may also capture
+what the Clojure engine actually **served** — the prerequisite for any
+off-policy fidelity comparison of a replacement engine against the Clojure era,
+and for inferring the recompute schedule (P-052 section 4.5).
+
+- **What is read.** Two additional `SELECT`s per conversation, against tables
+  that already exist: `math_main` (one row per `math_env` — the published blob,
+  `last_vote_timestamp`, `math_tick`, `caching_tick`, `modified`) and
+  `math_ticks` (the publish counter). **This is an extraction change and
+  nothing else: no migration, no new column, no trigger, no write of any kind.**
+- **How it is turned on.** By the committed selection config, like every other
+  rule that decides what a bundle contains:
+  `"served_math": {"capture": true}`, optionally with
+  `"math_envs": ["prod"]` to restrict it. The block is **absent** from the
+  shipped `certify_datasets.json`, which is what keeps the capture off and keeps
+  that file byte-identical — so `commits.config_sha256` in every manifest
+  already published is unchanged, and an extraction with the capture off
+  reproduces its bundle byte-for-byte. Turning it on is a reviewed config edit
+  that mints a new config version and therefore a new bundle version.
+- **What is written**, into the same opaque fixture directory:
+  `served_math.json` (per-`math_env` scalars, blob digests, and the consistency
+  diagnostic) and one `served-math-NNN.blob.json` per `math_env`. Blob files are
+  named by **row index, never by `math_env`** — `math_env` is a free
+  `VARCHAR(999)` and a value carrying a separator would otherwise choose the
+  path.
+- **The blob is verbatim.** `data` is selected as `::text`, so Postgres' own
+  jsonb key order and number rendering are the bundle bytes; nothing
+  re-serialises it. The blob file holds that text and nothing else — no trailing
+  newline — so its digest is at once the digest of the blob and of the file.
+- **Redaction.** Neither query selects a `zid`, and `served_math.json` carries
+  none. A verbatim served blob, however, retains whatever Clojure's `prep-main`
+  whitelist published inside it, **including the conversation's own `zid` key**.
+  When any role captured served rows, the manifest's `redactions` list says so
+  explicitly rather than leaving the blanket claim to cover for it. The blob
+  files are private-tier payload and are never published; the manifest itself
+  still carries no identity.
+- **Admission.** The block is optional, so an absent one is a complete
+  statement — this bundle did not capture what the engine served. A block that
+  IS present is admitted as strictly as everything else: closed key set, a
+  schema version admission recognises, and every file it names must be in the
+  inventory under the digest it claims.
+- **The watermark check is a DIAGNOSTIC, never a gate**, and admission refuses a
+  bundle that records it as one. `math_main` is a latest-only UPSERT and the
+  extraction snapshot is taken after the last publish, so votes arriving after
+  the served watermark are the ordinary production case; what the diagnostic
+  reports is which prefix of the vote stream the served blob was computed from.
+  Its verdicts are `consistent`, `votes-arrived-after-the-served-watermark`,
+  `no-votes-extracted`, and the one worth investigating,
+  `watermark-ahead-of-every-extracted-vote` — a served row citing a vote the
+  extract does not contain.
+- **Reading it back.** `polismath.replay.real_data.load_served_math` /
+  `read_served_math` return the rows, the tick counters and the verbatim blob
+  text, re-hashing each blob against the recorded digest;
+  `check_served_math_against_dataset` re-derives the diagnostic from whatever a
+  replay actually loaded, which is how a millisecond-stream capture and a
+  second-resolution compatibility CSV are kept from quietly disagreeing.
+- **`math_ticks.math_tick` counts publishes and defaults to 0**, so after `P`
+  publishes it reads `P - 1`. The raw column value is recorded, never a
+  corrected count.
+
 ## Release record
 
 _Empty. Filled in per release with the candidate commit/image, oracle

--- a/delphi/docs/CERTIFICATION.md
+++ b/delphi/docs/CERTIFICATION.md
@@ -259,12 +259,16 @@ The event stream is the authoritative artifact and is LOSSLESS:
 Everything above captures a conversation's **inputs**. A bundle may also capture
 what the Clojure engine actually **served** — the prerequisite for any
 off-policy fidelity comparison of a replacement engine against the Clojure era,
-and for inferring the recompute schedule (P-052 section 4.5).
+and an input to the schedule ensemble in P-052 section 4.5. A latest-only
+served row cannot identify the consumed prefix or actual recompute schedule.
 
-- **What is read.** Two additional `SELECT`s per conversation, against tables
+- **What is read.** Live `information_schema.columns` discovery for `math_ticks`,
+  followed by two row `SELECT`s per conversation against tables
   that already exist: `math_main` (one row per `math_env` — the published blob,
   `last_vote_timestamp`, `math_tick`, `caching_tick`, `modified`) and
-  `math_ticks` (the publish counter). **This is an extraction change and
+  `math_ticks` (the publish counter). Only available tick columns are selected;
+  `source_columns` records the actual column set, so absent `caching_tick`
+  differs from a captured SQL NULL. **This is an extraction change and
   nothing else: no migration, no new column, no trigger, no write of any kind.**
 - **How it is turned on.** By the committed selection config, like every other
   rule that decides what a bundle contains:
@@ -292,29 +296,31 @@ and for inferring the recompute schedule (P-052 section 4.5).
   explicitly rather than leaving the blanket claim to cover for it. The blob
   files are private-tier payload and are never published; the manifest itself
   still carries no identity.
-- **Admission.** The block is optional, so an absent one is a complete
-  statement — this bundle did not capture what the engine served. A block that
-  IS present is admitted as strictly as everything else: closed key set, a
-  schema version admission recognises, and every file it names must be in the
-  inventory under the digest it claims.
-- **The watermark check is a DIAGNOSTIC, never a gate**, and admission refuses a
-  bundle that records it as one. `math_main` is a latest-only UPSERT and the
-  extraction snapshot is taken after the last publish, so votes arriving after
-  the served watermark are the ordinary production case; what the diagnostic
-  reports is which prefix of the vote stream the served blob was computed from.
-  Its verdicts are `consistent`, `votes-arrived-after-the-served-watermark`,
-  `no-votes-extracted`, and the one worth investigating,
-  `watermark-ahead-of-every-extracted-vote` — a served row citing a vote the
-  extract does not contain.
+- **Admission.** Capture is optional. When present, `admit_manifest` requires
+  `payload_root`: it checks the metadata schema, strict scalar types, actual
+  columns, environment/row/file census, recomputed logical digest, blob lengths
+  and digests, and the entire manifest summary. `verify` performs the same
+  payload checks. Pull checks manifest structure before download and verifies
+  the payload before returning; push checks before publishing anything.
+- **The watermark check is a DIAGNOSTIC, never a gate.** Its counts describe
+  extracted event timestamps at/before or after the recorded watermark.
+  `watermark-equals-max-vote-timestamp` means timestamp equality only;
+  `vote-timestamps-after-the-served-watermark` means a positive timestamp tail.
+  Other relations are `no-votes-extracted`, `no-watermark-column`, and
+  `watermark-ahead-of-every-extracted-vote`. None establishes transaction
+  visibility, same-ms ordering, historical moderation, consumed vote prefix,
+  or a recompute schedule. P-052 must model those uncertainties across an
+  ensemble; an actual schedule needs a retained execution/publication trace.
 - **Reading it back.** `polismath.replay.real_data.load_served_math` /
   `read_served_math` return the rows, the tick counters and the verbatim blob
-  text, re-hashing each blob against the recorded digest;
+  text after validating metadata, paths, census, blob hashes and lengths, and
+  re-deriving the diagnostic from the retained millisecond event stream;
   `check_served_math_against_dataset` re-derives the diagnostic from whatever a
   replay actually loaded, which is how a millisecond-stream capture and a
   second-resolution compatibility CSV are kept from quietly disagreeing.
-- **`math_ticks.math_tick` counts publishes and defaults to 0**, so after `P`
-  publishes it reads `P - 1`. The raw column value is recorded, never a
-  corrected count.
+- **The raw `math_ticks.math_tick` counter** reads `P - 1` after `P` publishes
+  only with default initialization and an uninterrupted row lifecycle. It is
+  not a full history or an independent recompute count.
 
 ## Release record
 

--- a/delphi/polismath/replay/fixture_bundle.py
+++ b/delphi/polismath/replay/fixture_bundle.py
@@ -285,6 +285,13 @@ def build_manifest(
     binds the original's digests, never the other way round.
     """
     validate_storage_agree_value(storage_agree_value)
+    # P-052 §4.5. Derived from the role summaries rather than passed in, so no
+    # caller has to remember it and no caller can misdeclare it. When no role
+    # captured the served rows the manifest is byte-for-byte what it was before
+    # the capture existed.
+    served_math_captured = any(
+        isinstance(entry, dict) and entry.get("served_math")
+        for entry in selections)
     if transform is not None:
         bad = _validate_transform_shape(transform, storage_agree_value, bundle_id)
         if bad:
@@ -351,7 +358,23 @@ def build_manifest(
             "fixture directory names are RANDOM opaque prefixes assigned here, not a "
             "salted hash of the zid",
             "role -> zid mapping is confined to the restricted provenance object",
-        ],
+        ] + ([
+            # The blanket claim above is about what the EXTRACTOR selects and
+            # writes, and it stays true of every query: no served capture reads
+            # a zid column either. What a verbatim served blob CONTAINS is a
+            # different fact, and it would be dishonest to leave it implied by
+            # the line above, so it is stated here whenever such a blob is in
+            # the payload.
+            "served math_main blobs (served-math-NNN.blob.json) are captured "
+            "VERBATIM and therefore retain whatever Clojure's prep-main "
+            "whitelist published inside them, INCLUDING the conversation's own "
+            "'zid' key; they are private-tier payload, are never published, and "
+            "the qualifier above about payload files applies to the extractor's "
+            "own columns, not to the contents of a served blob",
+            "the served capture selects no zid column and writes none: "
+            "served_math.json carries math_env, the tick counters, the "
+            "watermark and digests only",
+        ] if served_math_captured else []),
         "retention": "Retained for the supported lifetime of the certificate. "
                      "Retirement requires an explicit privacy-approved decision, "
                      "never a short artifact TTL.",
@@ -1171,6 +1194,30 @@ DERIVED_FROM_KEYS = frozenset({"bundle_id", "source", "slug"})
 #: admission must not import the extractor; a test asserts the two agree.
 REQUIRED_COMPAT_NULL_VOTE_POLICY = "drop-counted"
 
+#: The served-math capture (P-052 §4.5) is OPTIONAL: a role entry either
+#: carries the block or does not, and an absent block means the bundle simply
+#: did not capture what the engine served. When the block IS present it is
+#: validated as strictly as everything else here — a closed key set, digests
+#: that name files the inventory actually holds, and the standing rule that the
+#: watermark consistency check is a DIAGNOSTIC and never a gate.
+#:
+#: Restated rather than imported, exactly like the NULL-vote policy above:
+#: admission does not import the extractor, and a test asserts the two agree.
+REQUIRED_SERVED_MATH_SCHEMA_VERSION = "certify-served-math/1"
+REQUIRED_SERVED_MATH_META_FILENAME = "served_math.json"
+
+#: Closed key set of a role's served-math block.
+SERVED_MATH_KEYS = frozenset({
+    "schema_version", "captured", "meta_file", "meta_sha256",
+    "logical_digest_sha256", "math_envs", "math_main_rows", "math_ticks_rows",
+    "blobs", "consistency",
+})
+
+#: Closed key set of one blob entry inside it.
+SERVED_MATH_BLOB_KEYS = frozenset({"math_env", "file", "sha256", "bytes"})
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
 #: Closed enums for the declared release policy. Every value is a VERSIONED
 #: token, not prose: a truthiness check on a free-text sentence admitted
 #: "same-input ties may differ arbitrarily" as a tie-order policy. The prose
@@ -1418,6 +1465,12 @@ def admit_manifest(
         P(root_digest(files) == manifest["root_digest"],
           "root_digest does not match the file inventory")
     dirs_present = {str(p).split("/", 1)[0] for p in paths if "/" in str(p)}
+    # path -> recorded sha256, so a role's own digest claim can be checked
+    # against the inventory the root digest is computed over.
+    sha256_by_path = {
+        str(f.get("path")): f.get("sha256") for f in files
+        if isinstance(f, dict)
+    }
 
     # --- ordering, precision, polarity ------------------------------------
     ordering = manifest["ordering"]
@@ -1679,6 +1732,16 @@ def admit_manifest(
           f"{entry.get('ordering_guarantee')!r}, but the manifest declares "
           f"{guarantee!r}: the extract and the declaration disagree")
 
+        # OPTIONAL served-math capture (P-052 §4.5). An absent block is a
+        # complete statement — this bundle did not capture what the engine
+        # served — so nothing is required here. A block that IS present must
+        # bind real files with real digests.
+        if "served_math" in entry:
+            _admit_served_math(
+                problems, slug=str(slug), block=entry.get("served_math"),
+                directory=str(directory) if directory else None,
+                sha256_by_path=sha256_by_path)
+
         # A per-role NULL-vote census is MANDATORY under the counted drop
         # policy. Omission previously defaulted to zero drops and passed, so a
         # role could lose NULL votes from its compatibility CSV silently.
@@ -1775,6 +1838,130 @@ def admit_manifest(
 
     if problems:
         raise AdmissionError(_admission_message(manifest, problems))
+
+
+def _admit_served_math(
+    problems: list[str], *, slug: str, block: Any, directory: str | None,
+    sha256_by_path: dict[str, Any],
+) -> None:
+    """Admit one role's OPTIONAL served-math block (P-052 §4.5).
+
+    What is checked is what a later off-policy comparison would otherwise have
+    to take on trust: the block names a schema version this code understands,
+    its key set is closed, every file it claims is in the inventory under the
+    digest it claims, the per-``math_env`` counts agree with the blob list, and
+    the watermark consistency record still declares itself a DIAGNOSTIC. That
+    last check is the important one — a consistency record that quietly became
+    a gate would start failing extractions for the ordinary case of votes
+    arriving after the last publish.
+    """
+    P = lambda cond, msg: _admission_problem(problems, cond, msg)  # noqa: E731
+
+    if not isinstance(block, dict) or not block:
+        P(False, f"role {slug!r} carries an empty or non-object served_math "
+                 f"block; omit the block entirely to say the served rows were "
+                 f"not captured")
+        return
+    for unknown in sorted(set(block) - SERVED_MATH_KEYS):
+        P(False, f"role {slug!r} served_math carries unknown field {unknown!r} "
+                 "(nothing validates it)")
+    for missing in sorted(SERVED_MATH_KEYS - set(block)):
+        P(False, f"role {slug!r} served_math is missing {missing!r}")
+    P(block.get("schema_version") == REQUIRED_SERVED_MATH_SCHEMA_VERSION,
+      f"role {slug!r} served_math.schema_version is "
+      f"{block.get('schema_version')!r}, expected "
+      f"{REQUIRED_SERVED_MATH_SCHEMA_VERSION!r}")
+    P(block.get("captured") is True,
+      f"role {slug!r} served_math.captured is {block.get('captured')!r}: a "
+      "block that is present declares a capture that happened")
+    P(block.get("meta_file") == REQUIRED_SERVED_MATH_META_FILENAME,
+      f"role {slug!r} served_math.meta_file is {block.get('meta_file')!r}, "
+      f"expected {REQUIRED_SERVED_MATH_META_FILENAME!r}")
+
+    def _digest_binds(label: str, filename: Any, digest: Any) -> None:
+        P(isinstance(digest, str) and bool(_SHA256_RE.match(digest)),
+          f"role {slug!r} served_math {label} digest {digest!r} is not a "
+          "lower-case sha256")
+        if directory is None or not isinstance(filename, str):
+            P(False, f"role {slug!r} served_math {label} names no file inside a "
+                     "fixture directory")
+            return
+        assert_safe_relpath(filename)
+        rel = f"{directory}/{filename}"
+        recorded = sha256_by_path.get(rel)
+        P(recorded is not None,
+          f"role {slug!r} served_math {label} names {rel!r}, which is not in "
+          "the file inventory: the block is declared but not materialised")
+        if recorded is not None:
+            P(recorded == digest,
+              f"role {slug!r} served_math {label} claims digest {digest!r} for "
+              f"{rel!r}, the inventory records {recorded!r}")
+
+    _digest_binds("meta_file", block.get("meta_file"), block.get("meta_sha256"))
+    P(isinstance(block.get("logical_digest_sha256"), str)
+      and bool(_SHA256_RE.match(str(block.get("logical_digest_sha256")))),
+      f"role {slug!r} served_math.logical_digest_sha256 is not a lower-case "
+      f"sha256 (got {block.get('logical_digest_sha256')!r})")
+
+    blobs = block.get("blobs")
+    P(isinstance(blobs, list),
+      f"role {slug!r} served_math.blobs is not a list (got {type(blobs).__name__})")
+    blobs = blobs if isinstance(blobs, list) else []
+    envs = block.get("math_envs")
+    P(isinstance(envs, list),
+      f"role {slug!r} served_math.math_envs is not a list")
+    envs = envs if isinstance(envs, list) else []
+    P(len(set(map(str, envs))) == len(envs),
+      f"role {slug!r} served_math.math_envs repeats a math_env: math_main is "
+      "UNIQUE(zid, math_env), so one environment cannot have served two rows")
+    P(_is_count(block.get("math_main_rows"))
+      and block.get("math_main_rows") == len(blobs),
+      f"role {slug!r} served_math declares {block.get('math_main_rows')!r} "
+      f"math_main row(s) but lists {len(blobs)} blob(s): every served row "
+      "carries exactly one blob")
+    P(list(map(str, envs)) == [str(b.get("math_env")) for b in blobs
+                               if isinstance(b, dict)],
+      f"role {slug!r} served_math.math_envs {envs!r} does not match the blob "
+      "list's environments in order")
+    P(_is_count(block.get("math_ticks_rows")),
+      f"role {slug!r} served_math.math_ticks_rows is not a count "
+      f"(got {block.get('math_ticks_rows')!r})")
+
+    seen_files: set[str] = set()
+    for i, blob in enumerate(blobs):
+        where = f"blobs[{i}]"
+        if not isinstance(blob, dict):
+            P(False, f"role {slug!r} served_math {where} is not an object")
+            continue
+        for unknown in sorted(set(blob) - SERVED_MATH_BLOB_KEYS):
+            P(False, f"role {slug!r} served_math {where} carries unknown field "
+                     f"{unknown!r}")
+        for missing in sorted(SERVED_MATH_BLOB_KEYS - set(blob)):
+            P(False, f"role {slug!r} served_math {where} is missing {missing!r}")
+        name = blob.get("file")
+        P(name not in seen_files,
+          f"role {slug!r} served_math {where} names file {name!r} twice")
+        seen_files.add(str(name))
+        P(_is_count(blob.get("bytes")) and blob.get("bytes") != 0,
+          f"role {slug!r} served_math {where} declares {blob.get('bytes')!r} "
+          "bytes: an empty blob is not a served output")
+        _digest_binds(where, name, blob.get("sha256"))
+
+    consistency = block.get("consistency")
+    P(isinstance(consistency, dict),
+      f"role {slug!r} served_math.consistency is not an object")
+    if isinstance(consistency, dict):
+        P(consistency.get("gate") is False and consistency.get("kind") == "diagnostic",
+          f"role {slug!r} served_math.consistency declares "
+          f"kind={consistency.get('kind')!r} gate={consistency.get('gate')!r}: "
+          "the served watermark check is a DIAGNOSTIC and must never be "
+          "recorded as a gate — math_main is a latest-only upsert, so votes "
+          "arriving after the last publish are the ordinary production case")
+        per_env = consistency.get("per_math_env")
+        P(isinstance(per_env, list) and len(per_env) == len(blobs),
+          f"role {slug!r} served_math.consistency covers "
+          f"{len(per_env) if isinstance(per_env, list) else '?'} environment(s) "
+          f"for {len(blobs)} served row(s)")
 
 
 def _failed_predicates(

--- a/delphi/polismath/replay/fixture_bundle.py
+++ b/delphi/polismath/replay/fixture_bundle.py
@@ -1000,7 +1000,9 @@ def push(
 
     if admit:
         admit_manifest(manifest, config=config, config_bytes=config_bytes,
-                       config_path=config_path)
+                       config_path=config_path, payload_root=payload_root)
+
+    _verify_served_payloads(payload_root, manifest)
 
     # 1. Pre-flight: verify EVERY payload digest against the manifest before a
     #    single byte is published.
@@ -1119,10 +1121,34 @@ def verify(payload_root: Path, manifest: dict[str, Any], *,
         problems.append(
             f"root digest mismatch: expected {manifest['root_digest']}, got {digest}")
 
+    try:
+        _verify_served_payloads(payload_root, manifest)
+    except VerificationError as exc:
+        problems.append(str(exc))
+
     if problems:
         raise VerificationError(
             f"bundle {manifest['bundle_id']} failed verification:\n  - "
             + "\n  - ".join(problems))
+
+
+def _verify_served_payloads(payload_root: Path, manifest: dict[str, Any]) -> None:
+    from polismath.replay.served_math import CaptureError, read_capture
+
+    named = set()
+    for role in manifest.get("roles", []):
+        if "served_math" not in role:
+            continue
+        try:
+            directory = safe_join(payload_root, role["dir"])
+            read_capture(directory, expected_summary=role["served_math"])
+            named.add(f"{role['dir']}/served_math.json")
+        except (CaptureError, KeyError, TypeError, ValueError) as exc:
+            raise VerificationError(f"served_math: {exc}") from exc
+    actual = {p.relative_to(payload_root).as_posix()
+              for p in payload_root.rglob("served_math.json")}
+    if actual != named:
+        raise VerificationError("served metadata file census differs from manifest roles")
 
 
 # ---------------------------------------------------------------------------
@@ -1325,6 +1351,28 @@ def _canonical_config(config: Any) -> str:
 
 
 def admit_manifest(
+    manifest: dict[str, Any], *, config: dict[str, Any] | None = None,
+    config_bytes: bytes | None = None, config_path: Path | None = None,
+    payload_root: Path | None = None,
+) -> None:
+    """Admit structure and, when served capture is present, its actual payload.
+
+    A served logical digest cannot be verified from the manifest alone. The
+    private pull preflight checks structure before download; full admission
+    checks the downloaded payload before making it available to consumers.
+    """
+    _admit_manifest_structure(manifest, config=config, config_bytes=config_bytes,
+                              config_path=config_path)
+    if any("served_math" in row for row in manifest["roles"]):
+        if payload_root is None:
+            raise AdmissionError("served_math admission requires payload_root")
+        try:
+            verify(payload_root, manifest)
+        except VerificationError as exc:
+            raise AdmissionError(str(exc)) from exc
+
+
+def _admit_manifest_structure(
     manifest: dict[str, Any], *, config: dict[str, Any] | None = None,
     config_bytes: bytes | None = None, config_path: Path | None = None,
 ) -> None:
@@ -1939,7 +1987,7 @@ def _admit_served_math(
         for missing in sorted(SERVED_MATH_BLOB_KEYS - set(blob)):
             P(False, f"role {slug!r} served_math {where} is missing {missing!r}")
         name = blob.get("file")
-        P(name not in seen_files,
+        P(isinstance(name, str) and name not in seen_files,
           f"role {slug!r} served_math {where} names file {name!r} twice")
         seen_files.add(str(name))
         P(_is_count(blob.get("bytes")) and blob.get("bytes") != 0,
@@ -2040,8 +2088,8 @@ def pull(
     # admitted must not leave a half-populated workspace behind that an engine
     # could pick up.
     if admit:
-        admit_manifest(manifest, config=config, config_bytes=config_bytes,
-                       config_path=config_path)
+        _admit_manifest_structure(manifest, config=config, config_bytes=config_bytes,
+                                  config_path=config_path)
 
     payload_root = dest / "payload"
     payload_root.mkdir()

--- a/delphi/polismath/replay/fixture_config.py
+++ b/delphi/polismath/replay/fixture_config.py
@@ -36,6 +36,10 @@ SEMANTIC RULES (all enforced by :func:`validate_config`):
 8. Roles sharing a ``selection_group`` must share identical ``predicates`` and
    ``order_by`` (they rank into ONE list) and must have DISTINCT ranks, must all
    be in the same ``group``, and must be contiguous in the array.
+9. The optional ``served_math`` block may name ``math_envs`` only when
+   ``capture`` is true, and those names must be non-empty and distinct — a
+   restriction list attached to a capture that never runs is a rule nobody
+   applies.
 """
 
 from __future__ import annotations
@@ -43,7 +47,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, NamedTuple
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
 DEFAULT_CONFIG_PATH = SCRIPTS_DIR / "certify_datasets.json"
@@ -73,6 +77,45 @@ _OPS = {
 
 class ConfigError(ValueError):
     """Raised for any structural or semantic defect in the selection config."""
+
+
+# ---------------------------------------------------------------------------
+# Served-math capture (P-052 §4.5) — optional, and ABSENT from the shipped
+# config.
+# ---------------------------------------------------------------------------
+
+
+class ServedMathOptions(NamedTuple):
+    """Whether an extraction also captures what the engine actually SERVED.
+
+    ``math_envs`` restricts the capture to the named environments; ``None``
+    means "every ``math_env`` the conversation has a row for".
+    """
+
+    capture: bool
+    math_envs: tuple[str, ...] | None
+
+
+#: The answer when the config carries no ``served_math`` block at all, which is
+#: the case for the shipped config. Keeping the block OPTIONAL rather than
+#: shipping ``{"capture": false}`` is deliberate: ``certify_datasets.json``
+#: keeps the exact bytes it has today, so ``commits.config_sha256`` in every
+#: manifest ever published is unchanged and an existing bundle re-extracts
+#: byte-for-byte. Turning the capture on is a reviewed config edit, which mints
+#: a new config version and therefore a new bundle version — the intended cost.
+SERVED_MATH_OFF = ServedMathOptions(capture=False, math_envs=None)
+
+
+def served_math_options(config: dict[str, Any]) -> ServedMathOptions:
+    """Read the served-math capture declaration. Absent block == off."""
+    block = config.get("served_math")
+    if not isinstance(block, dict):
+        return SERVED_MATH_OFF
+    envs = block.get("math_envs")
+    return ServedMathOptions(
+        capture=bool(block.get("capture", False)),
+        math_envs=None if envs is None else tuple(str(e) for e in envs),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -321,6 +364,28 @@ def _semantic_errors(config: dict[str, Any]) -> list[str]:
             errors.append(f"{where}: shape=lru-cohort requires cohort_size")
         if case.get("shape") != "lru-cohort" and "cohort_size" in case:
             errors.append(f"{where}: cohort_size is only meaningful for shape=lru-cohort")
+
+    # Rule 9 — served-math capture.
+    served = config.get("served_math")
+    if isinstance(served, dict):
+        capture = served.get("capture")
+        envs = served.get("math_envs")
+        if not isinstance(capture, bool):
+            errors.append(
+                f"$.served_math.capture must be an explicit boolean, got {capture!r}")
+        if envs is not None:
+            if capture is not True:
+                errors.append(
+                    "$.served_math.math_envs is only meaningful with capture=true; "
+                    "a restriction list attached to a capture that never runs is a "
+                    "rule nobody applies")
+            names = [e for e in envs if isinstance(e, str)]
+            if any(not e.strip() for e in names):
+                errors.append("$.served_math.math_envs: entries must be non-empty")
+            if len(set(names)) != len(names):
+                errors.append(
+                    f"$.served_math.math_envs: duplicate entries "
+                    f"{sorted({e for e in names if names.count(e) > 1})}")
 
     return errors
 

--- a/delphi/polismath/replay/fixture_extract.py
+++ b/delphi/polismath/replay/fixture_extract.py
@@ -43,7 +43,7 @@ the extractor writes two more kinds of file into the SAME opaque directory:
     — no Python json round-trip, so Postgres' own jsonb key order and number
     rendering survive into the bundle bytes.
 
-This is an EXTRACTION change and nothing else: two additional ``SELECT``s
+This is an EXTRACTION change and nothing else: schema discovery plus two additional row ``SELECT``s
 against tables that already exist. No migration, no new column, no trigger,
 no write of any kind. It is off by default, and the shipped selection config
 does not carry the block at all, so an existing bundle's bytes — and its
@@ -78,6 +78,10 @@ if TYPE_CHECKING:  # psycopg2 is a runtime dependency of the CALLER, not of this
     from psycopg2.extensions import cursor as PgCursor
 
 from polismath.replay import prodclone as pc
+from polismath.replay.served_math import (
+    MAIN_COLUMNS, TICK_COLUMNS, blob_watermark, served_math_consistency,
+    served_math_logical_digest, served_math_summary,
+)
 from polismath.utils.vote_convention import (
     EXPORT_AGREE_VALUE,
     STORAGE_AGREE_VALUE,
@@ -346,21 +350,15 @@ def sql_math_main_rows() -> str:
     """
 
 
-def sql_math_ticks_rows() -> str:
-    """The publish counter for one conversation, one row per ``math_env``.
+def sql_math_ticks_rows(columns: Sequence[str] = TICK_COLUMNS) -> str:
+    """Read available tick columns; the schema may omit caching_tick.
 
-    ``math_ticks(zid, math_tick, caching_tick, math_env, modified)``,
-    ``UNIQUE(zid, math_env)`` (``000000_initial.sql``). The counter DEFAULTS to
-    0 and ``inc-math-tick`` increments on conflict, so after ``P`` publishes it
-    reads ``P - 1`` — recorded here as the raw column value, never as a
-    corrected publish count. READ ONLY.
+    The raw counter is not a recompute history. P-1 applies only with default
+    initialization and an uninterrupted row lifecycle.
     """
-    return """
-        SELECT math_env, math_tick, caching_tick, modified
-        FROM math_ticks
-        WHERE zid = %s
-        ORDER BY math_env ASC
-    """
+    if not set(columns) <= set(TICK_COLUMNS) or "math_env" not in columns:
+        raise ValueError("unsupported math_ticks columns")
+    return "SELECT " + ", ".join(columns) + "\nFROM math_ticks\nWHERE zid = %s\nORDER BY math_env ASC"
 
 
 # ---------------------------------------------------------------------------
@@ -534,129 +532,14 @@ def stream_meta(
 # ---------------------------------------------------------------------------
 
 
-def blob_watermark(blob_text: str) -> tuple[int | None, str | None]:
-    """The blob's own ``lastVoteTimestamp``, and why it is absent when it is.
-
-    The blob is captured verbatim and is NOT rewritten by this parse; the parse
-    exists only to read one scalar for the consistency diagnostic. A blob that
-    does not parse, or that carries a non-integer watermark, yields
-    ``(None, reason)`` and is reported — never silently coerced.
-    """
-    try:
-        parsed = json.loads(blob_text)
-    except (json.JSONDecodeError, ValueError) as exc:
-        return None, f"blob is not parseable JSON: {exc}"
-    if not isinstance(parsed, dict):
-        return None, f"blob is a JSON {type(parsed).__name__}, not an object"
-    if SERVED_BLOB_WATERMARK_KEY not in parsed:
-        return None, f"blob carries no {SERVED_BLOB_WATERMARK_KEY!r} key"
-    value = parsed[SERVED_BLOB_WATERMARK_KEY]
-    if isinstance(value, bool) or not isinstance(value, int):
-        return None, (f"blob {SERVED_BLOB_WATERMARK_KEY!r} is "
-                      f"{type(value).__name__} {value!r}, not an integer")
-    return value, None
-
-
-def served_math_consistency(
-    rows: Sequence[dict[str, Any]], vote_created_ms: Sequence[int],
-) -> dict[str, Any]:
-    """DIAGNOSTIC: is each served watermark consistent with the votes extracted?
-
-    NOT A GATE, and deliberately so. The served row is the latest UPSERT, while
-    the extraction snapshot is taken later, so votes arriving after the last
-    publish are the ORDINARY production case and must not fail an extraction.
-    What this reports is the shape of the disagreement, which is what an
-    off-policy replay needs in order to know which prefix of the vote stream
-    the served blob was computed from:
-
-    ``consistent``
-        the watermark is exactly the newest extracted vote — the served blob
-        saw the whole stream.
-    ``votes-arrived-after-the-served-watermark``
-        expected; ``votes_after_watermark`` is the size of the tail the served
-        blob never saw.
-    ``watermark-ahead-of-every-extracted-vote``
-        SUSPICIOUS: the served row cites a vote the extract does not contain
-        (a different snapshot, a deleted conversation row, a clock artefact).
-    ``no-votes-extracted``
-        the conversation has no votes at all; nothing to compare.
-
-    ``rows`` are the per-``math_env`` entries built by
-    :func:`build_served_math`, so the blob is parsed exactly once.
-    """
-    times = sorted(int(t) for t in vote_created_ms)
-    max_ms = times[-1] if times else None
-    per_env: list[dict[str, Any]] = []
-    for row in rows:
-        watermark = row.get("last_vote_timestamp")
-        blob_watermark_value = row.get("blob_last_vote_timestamp")
-        entry: dict[str, Any] = {
-            "math_env": row.get("math_env"),
-            "last_vote_timestamp": watermark,
-            "blob_last_vote_timestamp": blob_watermark_value,
-            "column_matches_blob": (
-                None if blob_watermark_value is None or watermark is None
-                else blob_watermark_value == watermark),
-            "blob_watermark_absent_because": row.get("blob_watermark_absent_because"),
-        }
-        if watermark is None:
-            entry.update({
-                "verdict": "no-watermark-column",
-                "votes_at_or_before_watermark": None,
-                "votes_after_watermark": None,
-                "watermark_minus_max_vote_ms": None,
-                "watermark_is_a_vote_timestamp": None,
-            })
-        elif not times:
-            entry.update({
-                "verdict": "no-votes-extracted",
-                "votes_at_or_before_watermark": 0,
-                "votes_after_watermark": 0,
-                "watermark_minus_max_vote_ms": None,
-                "watermark_is_a_vote_timestamp": False,
-            })
-        else:
-            at_or_before = sum(1 for t in times if t <= watermark)
-            after = len(times) - at_or_before
-            assert max_ms is not None
-            if after:
-                verdict = "votes-arrived-after-the-served-watermark"
-            elif watermark > max_ms:
-                verdict = "watermark-ahead-of-every-extracted-vote"
-            else:
-                verdict = "consistent"
-            entry.update({
-                "verdict": verdict,
-                "votes_at_or_before_watermark": at_or_before,
-                "votes_after_watermark": after,
-                "watermark_minus_max_vote_ms": watermark - max_ms,
-                "watermark_is_a_vote_timestamp": watermark in set(times),
-            })
-        per_env.append(entry)
-    return {
-        "kind": "diagnostic",
-        "gate": False,
-        "vote_events": len(times),
-        "min_vote_created_ms": times[0] if times else None,
-        "max_vote_created_ms": max_ms,
-        "per_math_env": per_env,
-        "note": "DIAGNOSTIC ONLY, never a gate. math_main is a latest-only "
-                "UPSERT and the extraction snapshot is taken after the last "
-                "publish, so a nonzero votes_after_watermark is the ordinary "
-                "production case and identifies the vote prefix the served "
-                "blob was computed from. Only "
-                "'watermark-ahead-of-every-extracted-vote' indicates the "
-                "served row and the extracted votes came from different "
-                "states.",
-    }
-
-
 def build_served_math(
     *, math_main_rows: Sequence[dict[str, Any]],
     math_ticks_rows: Sequence[dict[str, Any]],
     vote_created_ms: Sequence[int],
     requested_math_envs: Sequence[str] | None = None,
     math_envs_present: Sequence[str] | None = None,
+    source_columns: dict[str, list[str]] | None = None,
+    math_envs_present_by_table: dict[str, list[str]] | None = None,
 ) -> tuple[dict[str, Any], list[str]]:
     """Build the served-math metadata document and the verbatim blob texts.
 
@@ -689,18 +572,23 @@ def build_served_math(
         })
         blob_texts.append(blob_text)
 
-    ticks = [{
-        "math_env": row["math_env"],
-        "math_tick": _optional_int(row.get("math_tick")),
-        "caching_tick": _optional_int(row.get("caching_tick")),
-        "modified": _optional_int(row.get("modified")),
-    } for row in math_ticks_rows]
+    if source_columns is None:
+        source_columns = {"math_main": list(MAIN_COLUMNS), "math_ticks": list(TICK_COLUMNS)}
+    ticks = [{"math_env": row["math_env"], **{
+        column: _optional_int(row[column]) for column in source_columns["math_ticks"]
+        if column != "math_env"}} for row in math_ticks_rows]
+    if math_envs_present_by_table is None:
+        math_envs_present_by_table = {
+            "math_main": sorted(r["math_env"] for r in math_main_rows),
+            "math_ticks": sorted(r["math_env"] for r in math_ticks_rows)}
 
     meta: dict[str, Any] = {
         "schema_version": SERVED_MATH_SCHEMA_VERSION,
         "captured": True,
         "source_tables": ["math_main", "math_ticks"],
-        "access": "READ ONLY: two SELECTs against tables that already exist. "
+        "source_columns": source_columns,
+        "math_envs_present_by_table": math_envs_present_by_table,
+        "access": "READ ONLY: schema discovery and two row SELECTs. "
                   "This capture makes no schema change of any kind — no "
                   "migration, no column, no trigger, no write.",
         "requested_math_envs": (None if requested_math_envs is None
@@ -729,8 +617,8 @@ def build_served_math(
             "are private-tier payload and are never published",
             "no comment text, topic, description, uid or report id is read by "
             "either query",
-            "math_ticks.math_tick counts PUBLISHES and defaults to 0, so it "
-            "reads P-1 after P publishes; the raw column value is recorded, "
+            "math_ticks.math_tick reads P-1 after P publishes only with default "
+            "initialization and an uninterrupted row lifecycle; the raw value is recorded, "
             "never a corrected count",
         ],
     }
@@ -745,60 +633,9 @@ def _optional_int(value: Any) -> int | None:
         return None
     if isinstance(value, bool):
         raise TypeError(f"expected an integer column value, got bool {value!r}")
-    return int(value)
-
-
-def served_math_logical_digest(meta: dict[str, Any]) -> str:
-    """SHA-256 over the served capture's LOGICAL content — the per-``math_env``
-    scalars and blob digests plus the tick rows, excluding the diagnostic and
-    the prose. Two extractions of the same snapshot agree on it; a changed
-    note does not move it, and a changed blob does."""
-    projection = {
-        "schema_version": meta["schema_version"],
-        "math_main": [{
-            "index": e["index"],
-            "math_env": e["math_env"],
-            "last_vote_timestamp": e["last_vote_timestamp"],
-            "math_tick": e["math_tick"],
-            "caching_tick": e["caching_tick"],
-            "modified": e["modified"],
-            "blob_sha256": e["blob_sha256"],
-            "blob_bytes": e["blob_bytes"],
-        } for e in meta["math_main"]],
-        "math_ticks": meta["math_ticks"],
-    }
-    return hashlib.sha256(json.dumps(
-        projection, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
-
-
-def served_math_summary(meta: dict[str, Any], meta_sha256: str) -> dict[str, Any]:
-    """The MANIFEST-SAFE projection of a served capture: digests, counts and
-    the diagnostic. Carries no zid and no blob content.
-
-    A blob file holds the verbatim blob text and NOTHING else — no trailing
-    newline — so ``blob_sha256`` is at once the digest of the blob and the
-    digest of the file that carries it, and there is no second number for the
-    two to disagree on. ``meta_sha256`` is the digest of ``served_math.json``
-    as written, which does end in a newline like every other JSON file here.
-    """
-    return {
-        "schema_version": meta["schema_version"],
-        "captured": True,
-        "meta_file": SERVED_MATH_META_FILENAME,
-        "meta_sha256": meta_sha256,
-        "logical_digest_sha256": meta["logical_digest_sha256"],
-        "math_envs": list(meta["math_envs_captured"]),
-        "math_main_rows": len(meta["math_main"]),
-        "math_ticks_rows": len(meta["math_ticks"]),
-        "blobs": [{
-            "math_env": entry["math_env"],
-            "file": entry["blob_file"],
-            "sha256": entry["blob_sha256"],
-            "bytes": entry["blob_bytes"],
-        } for entry in meta["math_main"]],
-        "consistency": meta["consistency"],
-    }
+    if type(value) is not int:
+        raise TypeError("expected an integer column value")
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -952,7 +789,7 @@ def fetch_conversation(conn: PgConnection, zid: int, tie_key: dict[str, Any]) ->
 def fetch_served_math(
     conn, zid: int, *, math_envs: Sequence[str] | None = None,
 ) -> dict[str, Any]:
-    """Read the SERVED rows for one conversation. Two ``SELECT``s, no writes.
+    """Read the SERVED rows with live tick-column discovery; no writes.
 
     ``math_envs`` restricts the capture to the named environments. The filter
     is applied in PYTHON rather than in SQL: an environment name is operator
@@ -965,10 +802,19 @@ def fetch_served_math(
     with conn.cursor() as cur:
         cur.execute(sql_math_main_rows(), (zid,))
         math_main = _rows_as_dicts(cur)
-        cur.execute(sql_math_ticks_rows(), (zid,))
+        cur.execute("""SELECT column_name FROM information_schema.columns
+                       WHERE table_schema = current_schema() AND table_name = %s""",
+                    ("math_ticks",))
+        available = {row[0] for row in cur.fetchall()}
+        columns = [column for column in TICK_COLUMNS if column in available]
+        if not {"math_env", "math_tick", "modified"} <= set(columns):
+            raise ValueError("math_ticks lacks required capture columns")
+        cur.execute(sql_math_ticks_rows(columns), (zid,))
         math_ticks = _rows_as_dicts(cur)
     present = sorted({str(r["math_env"]) for r in math_main}
                      | {str(r["math_env"]) for r in math_ticks})
+    present_by_table = {"math_main": sorted(r["math_env"] for r in math_main),
+                        "math_ticks": sorted(r["math_env"] for r in math_ticks)}
     if math_envs is not None:
         keep = set(math_envs)
         math_main = [r for r in math_main if str(r["math_env"]) in keep]
@@ -977,6 +823,8 @@ def fetch_served_math(
         "math_main": math_main,
         "math_ticks": math_ticks,
         "math_envs_present": present,
+        "math_envs_present_by_table": present_by_table,
+        "source_columns": {"math_main": list(MAIN_COLUMNS), "math_ticks": columns},
     }
 
 
@@ -1029,6 +877,8 @@ def extract_conversation(
             vote_created_ms=[e["created"] for e in events if e["kind"] == "vote"],
             requested_math_envs=served_math_envs,
             math_envs_present=served["math_envs_present"],
+            source_columns=served["source_columns"],
+            math_envs_present_by_table=served["math_envs_present_by_table"],
         )
         served_summary = served_math_summary(
             served_meta, write_served_math(target, served_meta, blob_texts))

--- a/delphi/polismath/replay/fixture_extract.py
+++ b/delphi/polismath/replay/fixture_extract.py
@@ -26,6 +26,30 @@ Per selected conversation the extractor writes, into one opaque directory:
     from the event stream. Comment text is blanked (column present, always
     empty).
 
+SERVED MATH ROWS — OPTIONAL, OFF BY DEFAULT (P-052 §4.5). Everything above is
+the conversation's INPUT. What the Clojure engine actually SERVED lives in two
+more tables, and without it there is nothing for an off-policy fidelity
+comparison to be scored against: ``math_main`` (one row per ``math_env``,
+holding the published blob, its ``last_vote_timestamp`` watermark, and the
+``math_tick``/``caching_tick``/``modified`` counters) and ``math_ticks`` (the
+publish counter). When the selection config declares ``served_math.capture``
+the extractor writes two more kinds of file into the SAME opaque directory:
+
+``served_math.json``
+    Per-``math_env`` scalars, blob digests, and the watermark-vs-votes
+    consistency DIAGNOSTIC. Never the ``zid`` column.
+``served-math-NNN.blob.json``
+    One published blob per ``math_env``, VERBATIM as ``data::text`` returns it
+    — no Python json round-trip, so Postgres' own jsonb key order and number
+    rendering survive into the bundle bytes.
+
+This is an EXTRACTION change and nothing else: two additional ``SELECT``s
+against tables that already exist. No migration, no new column, no trigger,
+no write of any kind. It is off by default, and the shipped selection config
+does not carry the block at all, so an existing bundle's bytes — and its
+manifest — are unchanged unless an operator turns it on in a reviewed config
+edit.
+
 TIE ORDER. :func:`detect_tie_key` inspects the LIVE schema for a stable tie
 key on ``votes`` (a primary key, a unique index, or an identity/serial
 surrogate column). If one exists it is used and recorded as
@@ -64,6 +88,27 @@ from polismath.utils.vote_convention import (
 #: NULLABLE in the stream. /1 coerced a NULL weight to 0, which silently
 #: rewrote a distinct storage fact.
 EVENT_STREAM_SCHEMA_VERSION = "certify-events/2"
+
+#: Schema version of the OPTIONAL served-math capture (P-052 §4.5). Separate
+#: from the event-stream version on purpose: the served rows are an additive,
+#: independently versioned artifact, and a bundle without them is not a bundle
+#: with an empty one.
+SERVED_MATH_SCHEMA_VERSION = "certify-served-math/1"
+
+#: File names the served capture writes into the conversation's opaque
+#: directory. The blob file is indexed by POSITION, never named after the
+#: ``math_env``: ``math_env`` is a free ``VARCHAR(999)`` in the production
+#: schema (``server/postgres/migrations/000000_initial.sql``) and a value
+#: carrying ``/`` or ``..`` would otherwise choose the path.
+SERVED_MATH_META_FILENAME = "served_math.json"
+SERVED_MATH_BLOB_FILENAME = "served-math-{index:03d}.blob.json"
+
+#: The key Clojure's ``prep-main`` whitelist publishes the final watermark
+#: under (``math/src/polismath/conv_man.clj``: ``:lastVoteTimestamp``). The
+#: ``math_main.last_vote_timestamp`` COLUMN is written from it
+#: (``polismath/components/postgres.clj``), so the two are expected to agree
+#: and a disagreement is worth reporting.
+SERVED_BLOB_WATERMARK_KEY = "lastVoteTimestamp"
 
 #: Raw storage sign of an AGREE vote (``server/postgres/migrations/000000_initial.sql``:
 #: "-1 = Agree, 1 = Disagree, 0 = Pass/Unsure"), and the export CSV's own
@@ -272,6 +317,52 @@ def sql_participant_flags() -> str:
     """
 
 
+def sql_math_main_rows() -> str:
+    """The SERVED math output for one conversation — one row per ``math_env``.
+
+    ``data::text``, not ``data``: the blob is captured VERBATIM as Postgres
+    renders its own jsonb, so key order and number formatting reach the bundle
+    unchanged. Reading it as ``data`` would hand psycopg2 a parsed Python
+    object and any re-serialisation would silently become the recorded fact.
+
+    ``zid`` is deliberately NOT selected: the identity stays in the restricted
+    provenance object, exactly as for every other extraction query here.
+
+    Columns are the production ones (``000000_initial.sql``: ``math_main(zid,
+    math_env, data, last_vote_timestamp, caching_tick, math_tick, modified)``,
+    ``UNIQUE(zid, math_env)``; ``caching_tick`` arrived in the archived
+    ``db_000008.sql``). READ ONLY.
+    """
+    return """
+        SELECT math_env,
+               data::text AS data_text,
+               last_vote_timestamp,
+               caching_tick,
+               math_tick,
+               modified
+        FROM math_main
+        WHERE zid = %s
+        ORDER BY math_env ASC
+    """
+
+
+def sql_math_ticks_rows() -> str:
+    """The publish counter for one conversation, one row per ``math_env``.
+
+    ``math_ticks(zid, math_tick, caching_tick, math_env, modified)``,
+    ``UNIQUE(zid, math_env)`` (``000000_initial.sql``). The counter DEFAULTS to
+    0 and ``inc-math-tick`` increments on conflict, so after ``P`` publishes it
+    reads ``P - 1`` — recorded here as the raw column value, never as a
+    corrected publish count. READ ONLY.
+    """
+    return """
+        SELECT math_env, math_tick, caching_tick, modified
+        FROM math_ticks
+        WHERE zid = %s
+        ORDER BY math_env ASC
+    """
+
+
 # ---------------------------------------------------------------------------
 # Event construction — pure.
 # ---------------------------------------------------------------------------
@@ -439,6 +530,278 @@ def stream_meta(
 
 
 # ---------------------------------------------------------------------------
+# Served math rows — OPTIONAL capture (P-052 §4.5). Pure functions.
+# ---------------------------------------------------------------------------
+
+
+def blob_watermark(blob_text: str) -> tuple[int | None, str | None]:
+    """The blob's own ``lastVoteTimestamp``, and why it is absent when it is.
+
+    The blob is captured verbatim and is NOT rewritten by this parse; the parse
+    exists only to read one scalar for the consistency diagnostic. A blob that
+    does not parse, or that carries a non-integer watermark, yields
+    ``(None, reason)`` and is reported — never silently coerced.
+    """
+    try:
+        parsed = json.loads(blob_text)
+    except (json.JSONDecodeError, ValueError) as exc:
+        return None, f"blob is not parseable JSON: {exc}"
+    if not isinstance(parsed, dict):
+        return None, f"blob is a JSON {type(parsed).__name__}, not an object"
+    if SERVED_BLOB_WATERMARK_KEY not in parsed:
+        return None, f"blob carries no {SERVED_BLOB_WATERMARK_KEY!r} key"
+    value = parsed[SERVED_BLOB_WATERMARK_KEY]
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, (f"blob {SERVED_BLOB_WATERMARK_KEY!r} is "
+                      f"{type(value).__name__} {value!r}, not an integer")
+    return value, None
+
+
+def served_math_consistency(
+    rows: Sequence[dict[str, Any]], vote_created_ms: Sequence[int],
+) -> dict[str, Any]:
+    """DIAGNOSTIC: is each served watermark consistent with the votes extracted?
+
+    NOT A GATE, and deliberately so. The served row is the latest UPSERT, while
+    the extraction snapshot is taken later, so votes arriving after the last
+    publish are the ORDINARY production case and must not fail an extraction.
+    What this reports is the shape of the disagreement, which is what an
+    off-policy replay needs in order to know which prefix of the vote stream
+    the served blob was computed from:
+
+    ``consistent``
+        the watermark is exactly the newest extracted vote — the served blob
+        saw the whole stream.
+    ``votes-arrived-after-the-served-watermark``
+        expected; ``votes_after_watermark`` is the size of the tail the served
+        blob never saw.
+    ``watermark-ahead-of-every-extracted-vote``
+        SUSPICIOUS: the served row cites a vote the extract does not contain
+        (a different snapshot, a deleted conversation row, a clock artefact).
+    ``no-votes-extracted``
+        the conversation has no votes at all; nothing to compare.
+
+    ``rows`` are the per-``math_env`` entries built by
+    :func:`build_served_math`, so the blob is parsed exactly once.
+    """
+    times = sorted(int(t) for t in vote_created_ms)
+    max_ms = times[-1] if times else None
+    per_env: list[dict[str, Any]] = []
+    for row in rows:
+        watermark = row.get("last_vote_timestamp")
+        blob_watermark_value = row.get("blob_last_vote_timestamp")
+        entry: dict[str, Any] = {
+            "math_env": row.get("math_env"),
+            "last_vote_timestamp": watermark,
+            "blob_last_vote_timestamp": blob_watermark_value,
+            "column_matches_blob": (
+                None if blob_watermark_value is None or watermark is None
+                else blob_watermark_value == watermark),
+            "blob_watermark_absent_because": row.get("blob_watermark_absent_because"),
+        }
+        if watermark is None:
+            entry.update({
+                "verdict": "no-watermark-column",
+                "votes_at_or_before_watermark": None,
+                "votes_after_watermark": None,
+                "watermark_minus_max_vote_ms": None,
+                "watermark_is_a_vote_timestamp": None,
+            })
+        elif not times:
+            entry.update({
+                "verdict": "no-votes-extracted",
+                "votes_at_or_before_watermark": 0,
+                "votes_after_watermark": 0,
+                "watermark_minus_max_vote_ms": None,
+                "watermark_is_a_vote_timestamp": False,
+            })
+        else:
+            at_or_before = sum(1 for t in times if t <= watermark)
+            after = len(times) - at_or_before
+            assert max_ms is not None
+            if after:
+                verdict = "votes-arrived-after-the-served-watermark"
+            elif watermark > max_ms:
+                verdict = "watermark-ahead-of-every-extracted-vote"
+            else:
+                verdict = "consistent"
+            entry.update({
+                "verdict": verdict,
+                "votes_at_or_before_watermark": at_or_before,
+                "votes_after_watermark": after,
+                "watermark_minus_max_vote_ms": watermark - max_ms,
+                "watermark_is_a_vote_timestamp": watermark in set(times),
+            })
+        per_env.append(entry)
+    return {
+        "kind": "diagnostic",
+        "gate": False,
+        "vote_events": len(times),
+        "min_vote_created_ms": times[0] if times else None,
+        "max_vote_created_ms": max_ms,
+        "per_math_env": per_env,
+        "note": "DIAGNOSTIC ONLY, never a gate. math_main is a latest-only "
+                "UPSERT and the extraction snapshot is taken after the last "
+                "publish, so a nonzero votes_after_watermark is the ordinary "
+                "production case and identifies the vote prefix the served "
+                "blob was computed from. Only "
+                "'watermark-ahead-of-every-extracted-vote' indicates the "
+                "served row and the extracted votes came from different "
+                "states.",
+    }
+
+
+def build_served_math(
+    *, math_main_rows: Sequence[dict[str, Any]],
+    math_ticks_rows: Sequence[dict[str, Any]],
+    vote_created_ms: Sequence[int],
+    requested_math_envs: Sequence[str] | None = None,
+    math_envs_present: Sequence[str] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Build the served-math metadata document and the verbatim blob texts.
+
+    Returns ``(meta, blob_texts)`` where ``blob_texts[i]`` is the blob of
+    ``meta["math_main"][i]``. The blob text is passed through UNCHANGED; the
+    only thing derived from it is its digest and its watermark scalar.
+    """
+    entries: list[dict[str, Any]] = []
+    blob_texts: list[str] = []
+    for index, row in enumerate(math_main_rows):
+        blob_text = row["data_text"]
+        if not isinstance(blob_text, str):
+            raise TypeError(
+                "math_main.data must be selected as ::text so the blob is "
+                f"captured verbatim; got {type(blob_text).__name__}")
+        watermark, absent_because = blob_watermark(blob_text)
+        encoded = blob_text.encode("utf-8")
+        entries.append({
+            "index": index,
+            "math_env": row["math_env"],
+            "last_vote_timestamp": _optional_int(row.get("last_vote_timestamp")),
+            "math_tick": _optional_int(row.get("math_tick")),
+            "caching_tick": _optional_int(row.get("caching_tick")),
+            "modified": _optional_int(row.get("modified")),
+            "blob_file": SERVED_MATH_BLOB_FILENAME.format(index=index),
+            "blob_sha256": hashlib.sha256(encoded).hexdigest(),
+            "blob_bytes": len(encoded),
+            "blob_last_vote_timestamp": watermark,
+            "blob_watermark_absent_because": absent_because,
+        })
+        blob_texts.append(blob_text)
+
+    ticks = [{
+        "math_env": row["math_env"],
+        "math_tick": _optional_int(row.get("math_tick")),
+        "caching_tick": _optional_int(row.get("caching_tick")),
+        "modified": _optional_int(row.get("modified")),
+    } for row in math_ticks_rows]
+
+    meta: dict[str, Any] = {
+        "schema_version": SERVED_MATH_SCHEMA_VERSION,
+        "captured": True,
+        "source_tables": ["math_main", "math_ticks"],
+        "access": "READ ONLY: two SELECTs against tables that already exist. "
+                  "This capture makes no schema change of any kind — no "
+                  "migration, no column, no trigger, no write.",
+        "requested_math_envs": (None if requested_math_envs is None
+                                else list(requested_math_envs)),
+        # What the database HELD, before any requested restriction: a bundle
+        # that captured one environment out of three should say so, rather than
+        # leaving a reader to conclude the conversation only ever had one.
+        "math_envs_present": (sorted({str(e["math_env"]) for e in entries})
+                              if math_envs_present is None
+                              else list(math_envs_present)),
+        "math_envs_captured": [e["math_env"] for e in entries],
+        "math_main": entries,
+        "math_ticks": ticks,
+        "consistency": served_math_consistency(entries, vote_created_ms),
+        "blob_handling": "each math_main.data is captured VERBATIM via "
+                         "data::text and written to its own blob file; this "
+                         "extractor never re-serialises it, so Postgres' own "
+                         "jsonb key order and number rendering are the bundle "
+                         "bytes",
+        "disclosures": [
+            "no zid column is selected or written by this capture; the "
+            "role -> zid mapping stays in the restricted provenance object",
+            "the served blob is VERBATIM and therefore retains whatever the "
+            "Clojure prep-main whitelist published inside it, including its "
+            "own 'zid' key (math/src/polismath/conv_man.clj) — the blob files "
+            "are private-tier payload and are never published",
+            "no comment text, topic, description, uid or report id is read by "
+            "either query",
+            "math_ticks.math_tick counts PUBLISHES and defaults to 0, so it "
+            "reads P-1 after P publishes; the raw column value is recorded, "
+            "never a corrected count",
+        ],
+    }
+    meta["logical_digest_sha256"] = served_math_logical_digest(meta)
+    return meta, blob_texts
+
+
+def _optional_int(value: Any) -> int | None:
+    """An integer column, or ``None`` when the column is NULL. A bool is a
+    typing accident here, not a counter, and is refused rather than coerced."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise TypeError(f"expected an integer column value, got bool {value!r}")
+    return int(value)
+
+
+def served_math_logical_digest(meta: dict[str, Any]) -> str:
+    """SHA-256 over the served capture's LOGICAL content — the per-``math_env``
+    scalars and blob digests plus the tick rows, excluding the diagnostic and
+    the prose. Two extractions of the same snapshot agree on it; a changed
+    note does not move it, and a changed blob does."""
+    projection = {
+        "schema_version": meta["schema_version"],
+        "math_main": [{
+            "index": e["index"],
+            "math_env": e["math_env"],
+            "last_vote_timestamp": e["last_vote_timestamp"],
+            "math_tick": e["math_tick"],
+            "caching_tick": e["caching_tick"],
+            "modified": e["modified"],
+            "blob_sha256": e["blob_sha256"],
+            "blob_bytes": e["blob_bytes"],
+        } for e in meta["math_main"]],
+        "math_ticks": meta["math_ticks"],
+    }
+    return hashlib.sha256(json.dumps(
+        projection, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def served_math_summary(meta: dict[str, Any], meta_sha256: str) -> dict[str, Any]:
+    """The MANIFEST-SAFE projection of a served capture: digests, counts and
+    the diagnostic. Carries no zid and no blob content.
+
+    A blob file holds the verbatim blob text and NOTHING else — no trailing
+    newline — so ``blob_sha256`` is at once the digest of the blob and the
+    digest of the file that carries it, and there is no second number for the
+    two to disagree on. ``meta_sha256`` is the digest of ``served_math.json``
+    as written, which does end in a newline like every other JSON file here.
+    """
+    return {
+        "schema_version": meta["schema_version"],
+        "captured": True,
+        "meta_file": SERVED_MATH_META_FILENAME,
+        "meta_sha256": meta_sha256,
+        "logical_digest_sha256": meta["logical_digest_sha256"],
+        "math_envs": list(meta["math_envs_captured"]),
+        "math_main_rows": len(meta["math_main"]),
+        "math_ticks_rows": len(meta["math_ticks"]),
+        "blobs": [{
+            "math_env": entry["math_env"],
+            "file": entry["blob_file"],
+            "sha256": entry["blob_sha256"],
+            "bytes": entry["blob_bytes"],
+        } for entry in meta["math_main"]],
+        "consistency": meta["consistency"],
+    }
+
+
+# ---------------------------------------------------------------------------
 # Writers.
 # ---------------------------------------------------------------------------
 
@@ -463,6 +826,30 @@ def write_participants_csv(path: Path, rows: Sequence[dict[str, Any]]) -> None:
                 "moderation": int(row["mod"]),
                 "created": "" if row["created"] is None else int(row["created"]),
             })
+
+
+def write_served_math(
+    target: Path, meta: dict[str, Any], blob_texts: Sequence[str],
+) -> str:
+    """Write ``served_math.json`` plus one verbatim blob file per ``math_env``.
+
+    Returns the sha256 of the metadata file AS WRITTEN. Each blob file holds
+    the blob text and nothing else — no trailing newline, no re-indentation —
+    so the bundle byte IS the served byte.
+    """
+    if len(blob_texts) != len(meta["math_main"]):
+        raise ValueError(
+            f"{len(blob_texts)} blob text(s) for {len(meta['math_main'])} "
+            "math_main row(s): the served capture would be incomplete")
+    target.mkdir(parents=True, exist_ok=True)
+    for entry, blob_text in zip(meta["math_main"], blob_texts):
+        # The name is generated from the row INDEX (never from math_env), so it
+        # cannot contain a separator; assert_safe_relpath in fixture_bundle is
+        # still the gate when the file reaches a manifest.
+        (target / entry["blob_file"]).write_bytes(blob_text.encode("utf-8"))
+    payload = (json.dumps(meta, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    (target / SERVED_MATH_META_FILENAME).write_bytes(payload)
+    return hashlib.sha256(payload).hexdigest()
 
 
 #: What the compatibility CSV does with a NULL ``votes.vote``. The event stream
@@ -562,16 +949,55 @@ def fetch_conversation(conn: PgConnection, zid: int, tie_key: dict[str, Any]) ->
     return {"votes": votes, "comments": comments, "participants": participants}
 
 
+def fetch_served_math(
+    conn, zid: int, *, math_envs: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Read the SERVED rows for one conversation. Two ``SELECT``s, no writes.
+
+    ``math_envs`` restricts the capture to the named environments. The filter
+    is applied in PYTHON rather than in SQL: an environment name is operator
+    input from the selection config, the row set per conversation is at most a
+    handful of rows, and keeping every query in this module a fixed string with
+    a single bound parameter is worth more than the predicate pushdown.
+    ``math_envs_present`` therefore always reports what the database actually
+    held, even when only a subset was kept.
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql_math_main_rows(), (zid,))
+        math_main = _rows_as_dicts(cur)
+        cur.execute(sql_math_ticks_rows(), (zid,))
+        math_ticks = _rows_as_dicts(cur)
+    present = sorted({str(r["math_env"]) for r in math_main}
+                     | {str(r["math_env"]) for r in math_ticks})
+    if math_envs is not None:
+        keep = set(math_envs)
+        math_main = [r for r in math_main if str(r["math_env"]) in keep]
+        math_ticks = [r for r in math_ticks if str(r["math_env"]) in keep]
+    return {
+        "math_main": math_main,
+        "math_ticks": math_ticks,
+        "math_envs_present": present,
+    }
+
+
 def extract_conversation(
     conn: PgConnection, *, zid: int, slug: str, role: str, payload_root: Path, guard_root: Path,
     dir_name: str, tie_key: dict[str, Any], measured: dict[str, Any] | None = None,
     storage_agree_value: int = STORAGE_AGREE_VALUE,
+    capture_served_math: bool = False,
+    served_math_envs: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     """Extract ONE conversation into ``<payload_root>/<dir_name>/``.
 
     ``guard_root`` is the real_data root whose ``.local/`` subtree every write
     must stay inside; ``prodclone.assert_under_local`` is the hard guard and is
     never bypassed. Returns a manifest-safe summary — it contains NO zid.
+
+    ``capture_served_math`` (P-052 §4.5) additionally reads the SERVED
+    ``math_main`` and ``math_ticks`` rows and writes them beside the event
+    stream. It is OFF by default and, when off, this function issues exactly
+    the queries and writes exactly the bytes it did before the option existed —
+    the summary gains no key either, so a manifest built from it is unchanged.
     """
     target = pc.assert_under_local(payload_root / dir_name, guard_root)
     raw = fetch_conversation(conn, zid, tie_key)
@@ -594,6 +1020,19 @@ def extract_conversation(
     pc.write_votes_csv(target / f"{dir_name}-votes.csv", votes_rows)
     pc.write_comments_csv(target / f"{dir_name}-comments.csv", comments_rows)
 
+    served_summary: dict[str, Any] | None = None
+    if capture_served_math:
+        served = fetch_served_math(conn, zid, math_envs=served_math_envs)
+        served_meta, blob_texts = build_served_math(
+            math_main_rows=served["math_main"],
+            math_ticks_rows=served["math_ticks"],
+            vote_created_ms=[e["created"] for e in events if e["kind"] == "vote"],
+            requested_math_envs=served_math_envs,
+            math_envs_present=served["math_envs_present"],
+        )
+        served_summary = served_math_summary(
+            served_meta, write_served_math(target, served_meta, blob_texts))
+
     summary = {
         "slug": slug,
         "role": role,
@@ -610,6 +1049,11 @@ def extract_conversation(
     }
     if measured is not None:
         summary["measured_metrics"] = {k: v for k, v in measured.items() if k != "zid"}
+    # Added ONLY when the capture ran: an absent key and a captured:false block
+    # are different claims, and a bundle extracted with the option off must be
+    # byte-identical to one extracted before the option existed.
+    if served_summary is not None:
+        summary["served_math"] = served_summary
     return summary
 
 
@@ -640,9 +1084,15 @@ def extract_from_config(
     Returns a private result dict. It contains zids (in ``provenance_rows``) and
     must be confined to ``real_data/.local/``.
     """
+    from polismath.replay import fixture_config as fcfg
     from polismath.replay import fixture_generate as fg
     from polismath.replay import fixture_survey as fs
 
+    # P-052 §4.5. Declared in the COMMITTED selection config, like every other
+    # rule that decides what a bundle contains, so turning the capture on is a
+    # reviewed edit that mints a new bundle version rather than an operator
+    # flag. Absent from the config means off.
+    served_math = fcfg.served_math_options(config)
     dir_names = dict(dir_names or {})
     guarantee = fs.open_readonly_repeatable_read(
         conn, snapshot_id=snapshot_id, writers_disabled=writers_disabled)
@@ -718,6 +1168,8 @@ def extract_from_config(
             conn, zid=sel.zid, slug=sel.slug, role=sel.role,
             payload_root=payload_root, guard_root=guard_root,
             dir_name=dir_name, tie_key=tie_key, measured=sel.metrics,
+            capture_served_math=served_math.capture,
+            served_math_envs=served_math.math_envs,
         )
         summary.update({
             "group": sel.group, "rank": sel.rank, "source": "production",
@@ -732,6 +1184,12 @@ def extract_from_config(
         "coverage_report": coverage,
         "transaction_guarantee": guarantee,
         "tie_key": tie_key,
+        "served_math": {
+            "capture": served_math.capture,
+            "math_envs": (None if served_math.math_envs is None
+                          else list(served_math.math_envs)),
+            "schema_version": SERVED_MATH_SCHEMA_VERSION,
+        },
         "roles": role_summaries,
         "generated": generated_summaries,
         "dir_names": dir_names,

--- a/delphi/polismath/replay/real_data.py
+++ b/delphi/polismath/replay/real_data.py
@@ -217,9 +217,9 @@ class ServedMathRow:
 
 @dataclass(frozen=True)
 class ServedMathTick:
-    """One ``math_ticks`` row. ``math_tick`` counts PUBLISHES and defaults to
-    0, so after ``P`` publishes it reads ``P - 1``; the raw column value is
-    what is carried here."""
+    """One raw ``math_ticks`` row. P-1 assumes default initialization and an
+    uninterrupted row lifecycle; it is not a recompute history. Missing optional
+    columns are distinguished from SQL NULL by ``ServedMath.meta.source_columns``."""
 
     math_env: str
     math_tick: int | None
@@ -254,41 +254,25 @@ def read_served_math(
     """Read a served-math capture out of ONE fixture directory.
 
     Returns ``None`` when the directory holds no capture. ``verify_digests``
-    re-hashes each blob file against the digest the capture recorded, so a
-    truncated or edited blob is caught at load rather than silently scored
-    against; pass ``False`` only for a deliberately partial workspace.
+    validates metadata, census and the event-timestamp diagnostic, then hashes
+    and sizes every blob. Pass ``False`` only to inspect changed blob bytes;
+    metadata and path validation remain required. Bundle verification separately
+    binds this metadata to the manifest.
     """
-    directory = Path(directory)
-    meta_path = directory / SERVED_MATH_META_FILENAME
-    if not meta_path.is_file():
-        return None
-    meta = json.loads(meta_path.read_text())
-    if not isinstance(meta, dict):
-        raise ServedMathError(f"{meta_path} does not hold a JSON object")
+    from polismath.replay.served_math import CaptureError, read_capture
 
+    directory = Path(directory)
+    try:
+        capture = read_capture(directory, verify_digests=verify_digests)
+    except CaptureError as exc:
+        raise ServedMathError(str(exc)) from exc
+    if capture is None:
+        return None
+    meta, raw_blobs = capture
     rows: list[ServedMathRow] = []
     for entry in meta.get("math_main", []):
         blob_file = str(entry["blob_file"])
-        # The capture names its blob files by row index, never by math_env, so
-        # a name is a plain component. Re-check rather than trust the file.
-        if "/" in blob_file or "\\" in blob_file or blob_file in (".", ".."):
-            raise ServedMathError(
-                f"{meta_path} names an unsafe blob file {blob_file!r}")
-        blob_path = directory / blob_file
-        if not blob_path.is_file():
-            raise ServedMathError(
-                f"{meta_path} names blob file {blob_file!r}, which is missing")
-        raw = blob_path.read_bytes()
-        if verify_digests:
-            actual = hashlib.sha256(raw).hexdigest()
-            if actual != entry.get("blob_sha256"):
-                raise ServedMathError(
-                    f"served blob {blob_path} hashes to {actual}, the capture "
-                    f"recorded {entry.get('blob_sha256')}")
-            if len(raw) != entry.get("blob_bytes"):
-                raise ServedMathError(
-                    f"served blob {blob_path} is {len(raw)} bytes, the capture "
-                    f"recorded {entry.get('blob_bytes')}")
+        raw = raw_blobs[blob_file]
         rows.append(ServedMathRow(
             math_env=str(entry["math_env"]),
             last_vote_timestamp=entry.get("last_vote_timestamp"),
@@ -346,7 +330,7 @@ def check_served_math_against_dataset(
     fact about the ingress, and it should be visible rather than assumed away.
 
     Reuses the extractor's implementation so there is exactly one definition of
-    what "consistent" means.
+    the timestamp relation.
     """
     from polismath.replay import fixture_extract as fx
 

--- a/delphi/polismath/replay/real_data.py
+++ b/delphi/polismath/replay/real_data.py
@@ -12,11 +12,28 @@ sign verbatim and era-A runs on export data are marked diagnostic-only.
 
 Datasets are located by slug glob (``real_data/*-<slug>``) so report-id
 directory names never appear in code.
+
+SERVED MATH ROWS. A private fixture bundle extracted with the optional
+served-math capture (P-052 §4.5,
+:mod:`polismath.replay.fixture_extract`) also carries, per conversation
+directory, ``served_math.json`` and one verbatim ``served-math-NNN.blob.json``
+per ``math_env`` — what the Clojure engine actually PUBLISHED, as opposed to
+what it was fed. :func:`load_served_math` reads them back so certify-side code
+can compare a candidate engine's final blob against the served one, and
+:func:`check_served_math_against_dataset` re-derives the watermark consistency
+DIAGNOSTIC from the votes actually loaded. A dataset without the capture
+returns ``None``: an absent capture is a complete statement, not an error.
 """
 
+from __future__ import annotations
+
 import csv
+import hashlib
+import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from polismath.replay.types import ModEvent, ReplayDataset
 
@@ -155,3 +172,191 @@ def load_votes_csv(
     convention) runs the SAME parse rather than a copy of it."""
     return ReplayDataset.build(read_export_vote_rows(path),
                                mod_events=list(mod_events or []))
+
+
+# ---------------------------------------------------------------------------
+# Served math rows — the output side of a private fixture bundle (P-052 §4.5).
+# ---------------------------------------------------------------------------
+
+SERVED_MATH_META_FILENAME = "served_math.json"
+
+
+class ServedMathError(RuntimeError):
+    """A served-math capture is present but does not read back intact."""
+
+
+@dataclass(frozen=True)
+class ServedMathRow:
+    """One ``math_main`` row as production served it, for one ``math_env``.
+
+    ``blob_text`` is the blob VERBATIM — the exact bytes ``data::text`` handed
+    the extractor. :meth:`blob` parses it for convenience; the text is the
+    authority, and nothing here rewrites it.
+    """
+
+    math_env: str
+    last_vote_timestamp: int | None
+    math_tick: int | None
+    caching_tick: int | None
+    modified: int | None
+    blob_file: str
+    blob_sha256: str
+    blob_bytes: int
+    blob_last_vote_timestamp: int | None
+    blob_watermark_absent_because: str | None
+    blob_text: str
+
+    def blob(self) -> dict[str, Any]:
+        parsed = json.loads(self.blob_text)
+        if not isinstance(parsed, dict):
+            raise ServedMathError(
+                f"served blob for math_env {self.math_env!r} is a JSON "
+                f"{type(parsed).__name__}, not an object")
+        return parsed
+
+
+@dataclass(frozen=True)
+class ServedMathTick:
+    """One ``math_ticks`` row. ``math_tick`` counts PUBLISHES and defaults to
+    0, so after ``P`` publishes it reads ``P - 1``; the raw column value is
+    what is carried here."""
+
+    math_env: str
+    math_tick: int | None
+    caching_tick: int | None
+    modified: int | None
+
+
+@dataclass(frozen=True)
+class ServedMath:
+    """Everything one conversation's served-math capture holds."""
+
+    path: Path
+    schema_version: str
+    math_envs_present: tuple[str, ...]
+    math_envs_captured: tuple[str, ...]
+    rows: tuple[ServedMathRow, ...]
+    ticks: tuple[ServedMathTick, ...]
+    consistency: dict[str, Any]
+    meta: dict[str, Any]
+
+    def row(self, math_env: str) -> ServedMathRow | None:
+        """The served row for one environment, or ``None`` if not captured."""
+        return next((r for r in self.rows if r.math_env == math_env), None)
+
+    def tick(self, math_env: str) -> ServedMathTick | None:
+        return next((t for t in self.ticks if t.math_env == math_env), None)
+
+
+def read_served_math(
+    directory: str | Path, *, verify_digests: bool = True,
+) -> ServedMath | None:
+    """Read a served-math capture out of ONE fixture directory.
+
+    Returns ``None`` when the directory holds no capture. ``verify_digests``
+    re-hashes each blob file against the digest the capture recorded, so a
+    truncated or edited blob is caught at load rather than silently scored
+    against; pass ``False`` only for a deliberately partial workspace.
+    """
+    directory = Path(directory)
+    meta_path = directory / SERVED_MATH_META_FILENAME
+    if not meta_path.is_file():
+        return None
+    meta = json.loads(meta_path.read_text())
+    if not isinstance(meta, dict):
+        raise ServedMathError(f"{meta_path} does not hold a JSON object")
+
+    rows: list[ServedMathRow] = []
+    for entry in meta.get("math_main", []):
+        blob_file = str(entry["blob_file"])
+        # The capture names its blob files by row index, never by math_env, so
+        # a name is a plain component. Re-check rather than trust the file.
+        if "/" in blob_file or "\\" in blob_file or blob_file in (".", ".."):
+            raise ServedMathError(
+                f"{meta_path} names an unsafe blob file {blob_file!r}")
+        blob_path = directory / blob_file
+        if not blob_path.is_file():
+            raise ServedMathError(
+                f"{meta_path} names blob file {blob_file!r}, which is missing")
+        raw = blob_path.read_bytes()
+        if verify_digests:
+            actual = hashlib.sha256(raw).hexdigest()
+            if actual != entry.get("blob_sha256"):
+                raise ServedMathError(
+                    f"served blob {blob_path} hashes to {actual}, the capture "
+                    f"recorded {entry.get('blob_sha256')}")
+            if len(raw) != entry.get("blob_bytes"):
+                raise ServedMathError(
+                    f"served blob {blob_path} is {len(raw)} bytes, the capture "
+                    f"recorded {entry.get('blob_bytes')}")
+        rows.append(ServedMathRow(
+            math_env=str(entry["math_env"]),
+            last_vote_timestamp=entry.get("last_vote_timestamp"),
+            math_tick=entry.get("math_tick"),
+            caching_tick=entry.get("caching_tick"),
+            modified=entry.get("modified"),
+            blob_file=blob_file,
+            blob_sha256=str(entry.get("blob_sha256")),
+            blob_bytes=int(entry.get("blob_bytes", len(raw))),
+            blob_last_vote_timestamp=entry.get("blob_last_vote_timestamp"),
+            blob_watermark_absent_because=entry.get(
+                "blob_watermark_absent_because"),
+            blob_text=raw.decode("utf-8"),
+        ))
+
+    ticks = tuple(
+        ServedMathTick(
+            math_env=str(t["math_env"]), math_tick=t.get("math_tick"),
+            caching_tick=t.get("caching_tick"), modified=t.get("modified"))
+        for t in meta.get("math_ticks", [])
+    )
+    return ServedMath(
+        path=directory,
+        schema_version=str(meta.get("schema_version")),
+        math_envs_present=tuple(meta.get("math_envs_present") or ()),
+        math_envs_captured=tuple(meta.get("math_envs_captured") or ()),
+        rows=tuple(rows),
+        ticks=ticks,
+        consistency=dict(meta.get("consistency") or {}),
+        meta=meta,
+    )
+
+
+def load_served_math(
+    slug: str, *, verify_digests: bool = True,
+) -> ServedMath | None:
+    """Locate a dataset by slug and read its served-math capture, if any."""
+    directory = dataset_dir(slug)
+    if directory is None:
+        raise FileNotFoundError(f"no dataset directory matching *-{slug}")
+    return read_served_math(directory, verify_digests=verify_digests)
+
+
+def check_served_math_against_dataset(
+    served: ServedMath, dataset: ReplayDataset,
+) -> dict[str, Any]:
+    """Re-derive the served watermark DIAGNOSTIC from the votes actually loaded.
+
+    A DIAGNOSTIC, never a gate — the same rule the extractor records the
+    capture under, and for the same reason: ``math_main`` is a latest-only
+    upsert, so votes arriving after the last publish are ordinary. The value of
+    running it again here is that the capture's own record was computed against
+    the private millisecond event stream, while a replay may be driven from the
+    second-resolution compatibility CSV; a disagreement between the two is a
+    fact about the ingress, and it should be visible rather than assumed away.
+
+    Reuses the extractor's implementation so there is exactly one definition of
+    what "consistent" means.
+    """
+    from polismath.replay import fixture_extract as fx
+
+    rows = [{
+        "math_env": r.math_env,
+        "last_vote_timestamp": r.last_vote_timestamp,
+        "blob_last_vote_timestamp": r.blob_last_vote_timestamp,
+        "blob_watermark_absent_because": r.blob_watermark_absent_because,
+    } for r in served.rows]
+    result = fx.served_math_consistency(rows, [v.t_ms for v in dataset.votes])
+    result["recomputed_from"] = "the loaded ReplayDataset's vote timestamps"
+    result["capture_recorded"] = served.consistency
+    return result

--- a/delphi/polismath/replay/served_math.py
+++ b/delphi/polismath/replay/served_math.py
@@ -1,0 +1,320 @@
+"""Shared validation of private served-math capture bytes and metadata.
+
+Stdlib only. Admission does not import the database extractor. Watermarks
+compare timestamps; they do not establish visibility, consumed prefixes, or
+recompute schedules. No diagnostic result is an engine acceptance gate.
+"""
+from __future__ import annotations
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Sequence
+
+SERVED_MATH_SCHEMA_VERSION = "certify-served-math/1"
+SERVED_MATH_META_FILENAME = "served_math.json"
+SERVED_BLOB_WATERMARK_KEY = "lastVoteTimestamp"
+MAIN_COLUMNS = ("math_env", "data", "last_vote_timestamp", "caching_tick", "math_tick", "modified")
+TICK_COLUMNS = ("math_env", "math_tick", "caching_tick", "modified")
+
+def blob_watermark(blob_text: str) -> tuple[int | None, str | None]:
+    """The blob's own ``lastVoteTimestamp``, and why it is absent when it is.
+
+    The blob is captured verbatim and is NOT rewritten by this parse; the parse
+    exists only to read one scalar for the consistency diagnostic. A blob that
+    does not parse, or that carries a non-integer watermark, yields
+    ``(None, reason)`` and is reported — never silently coerced.
+    """
+    try:
+        parsed = json.loads(blob_text)
+    except (json.JSONDecodeError, ValueError) as exc:
+        return None, f"blob is not parseable JSON: {exc}"
+    if not isinstance(parsed, dict):
+        return None, f"blob is a JSON {type(parsed).__name__}, not an object"
+    if SERVED_BLOB_WATERMARK_KEY not in parsed:
+        return None, f"blob carries no {SERVED_BLOB_WATERMARK_KEY!r} key"
+    value = parsed[SERVED_BLOB_WATERMARK_KEY]
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, (f"blob {SERVED_BLOB_WATERMARK_KEY!r} is "
+                      f"{type(value).__name__} {value!r}, not an integer")
+    return value, None
+
+
+def served_math_consistency(
+    rows: Sequence[dict[str, Any]], vote_created_ms: Sequence[int],
+) -> dict[str, Any]:
+    """Compare extracted event timestamps to a recorded watermark; never a gate.
+
+    Equality means the maximum extracted timestamp equals the watermark. Counts
+    at/before and after it do not identify consumed votes: same-ms ordering,
+    transaction visibility, poll cursors and moderation history remain unknown.
+    A latest-only row cannot recover the recompute schedule (P-052 uses an
+    ensemble of explicitly simulated schedules).
+    """
+    times = sorted(int(t) for t in vote_created_ms)
+    max_ms = times[-1] if times else None
+    per_env: list[dict[str, Any]] = []
+    for row in rows:
+        watermark = row.get("last_vote_timestamp")
+        blob_watermark_value = row.get("blob_last_vote_timestamp")
+        entry: dict[str, Any] = {
+            "math_env": row.get("math_env"),
+            "last_vote_timestamp": watermark,
+            "blob_last_vote_timestamp": blob_watermark_value,
+            "column_matches_blob": (
+                None if blob_watermark_value is None or watermark is None
+                else blob_watermark_value == watermark),
+            "blob_watermark_absent_because": row.get("blob_watermark_absent_because"),
+        }
+        if watermark is None:
+            entry.update({
+                "verdict": "no-watermark-column",
+                "votes_at_or_before_watermark": None,
+                "votes_after_watermark": None,
+                "watermark_minus_max_vote_ms": None,
+                "watermark_is_a_vote_timestamp": None,
+            })
+        elif not times:
+            entry.update({
+                "verdict": "no-votes-extracted",
+                "votes_at_or_before_watermark": 0,
+                "votes_after_watermark": 0,
+                "watermark_minus_max_vote_ms": None,
+                "watermark_is_a_vote_timestamp": False,
+            })
+        else:
+            at_or_before = sum(1 for t in times if t <= watermark)
+            after = len(times) - at_or_before
+            assert max_ms is not None
+            if after:
+                verdict = "vote-timestamps-after-the-served-watermark"
+            elif watermark > max_ms:
+                verdict = "watermark-ahead-of-every-extracted-vote"
+            else:
+                verdict = "watermark-equals-max-vote-timestamp"
+            entry.update({
+                "verdict": verdict,
+                "votes_at_or_before_watermark": at_or_before,
+                "votes_after_watermark": after,
+                "watermark_minus_max_vote_ms": watermark - max_ms,
+                "watermark_is_a_vote_timestamp": watermark in set(times),
+            })
+        per_env.append(entry)
+    return {
+        "kind": "diagnostic",
+        "gate": False,
+        "vote_events": len(times),
+        "min_vote_created_ms": times[0] if times else None,
+        "max_vote_created_ms": max_ms,
+        "per_math_env": per_env,
+        "note": "DIAGNOSTIC ONLY, never a gate. Counts compare extracted event "
+                "timestamps with the recorded watermark. They do not establish "
+                "transaction visibility, same-ms ordering, the consumed vote "
+                "prefix, historical moderation, or the recompute schedule. "
+                "Those uncertainties remain for P-052's schedule ensemble.",
+    }
+
+
+def served_math_logical_digest(meta: dict[str, Any]) -> str:
+    """SHA-256 over the served capture's LOGICAL content — the per-``math_env``
+    scalars and blob digests plus the tick rows, excluding the diagnostic and
+    the prose. Two extractions of the same snapshot agree on it; a changed
+    note does not move it, and a changed blob does."""
+    projection = {
+        "schema_version": meta["schema_version"],
+        "math_main": [{
+            "index": e["index"],
+            "math_env": e["math_env"],
+            "last_vote_timestamp": e["last_vote_timestamp"],
+            "math_tick": e["math_tick"],
+            "caching_tick": e["caching_tick"],
+            "modified": e["modified"],
+            "blob_sha256": e["blob_sha256"],
+            "blob_bytes": e["blob_bytes"],
+        } for e in meta["math_main"]],
+        "math_ticks": meta["math_ticks"],
+        "source_columns": meta["source_columns"],
+        "math_envs_present_by_table": meta["math_envs_present_by_table"],
+        "math_envs_present": meta["math_envs_present"],
+        "math_envs_captured": meta["math_envs_captured"],
+        "requested_math_envs": meta["requested_math_envs"],
+    }
+    return hashlib.sha256(json.dumps(
+        projection, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def served_math_summary(meta: dict[str, Any], meta_sha256: str) -> dict[str, Any]:
+    """The MANIFEST-SAFE projection of a served capture: digests, counts and
+    the diagnostic. Carries no zid and no blob content.
+
+    A blob file holds the verbatim blob text and NOTHING else — no trailing
+    newline — so ``blob_sha256`` is at once the digest of the blob and the
+    digest of the file that carries it, and there is no second number for the
+    two to disagree on. ``meta_sha256`` is the digest of ``served_math.json``
+    as written, which does end in a newline like every other JSON file here.
+    """
+    return {
+        "schema_version": meta["schema_version"],
+        "captured": True,
+        "meta_file": SERVED_MATH_META_FILENAME,
+        "meta_sha256": meta_sha256,
+        "logical_digest_sha256": meta["logical_digest_sha256"],
+        "math_envs": list(meta["math_envs_captured"]),
+        "math_main_rows": len(meta["math_main"]),
+        "math_ticks_rows": len(meta["math_ticks"]),
+        "blobs": [{
+            "math_env": entry["math_env"],
+            "file": entry["blob_file"],
+            "sha256": entry["blob_sha256"],
+            "bytes": entry["blob_bytes"],
+        } for entry in meta["math_main"]],
+        "consistency": meta["consistency"],
+    }
+
+
+class CaptureError(ValueError):
+    """Present capture metadata or bytes do not agree."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise CaptureError(message)
+
+
+def _strings(value: Any, label: str) -> list[str]:
+    _require(isinstance(value, list) and all(isinstance(v, str) for v in value),
+             f"{label} must be a string list")
+    _require(len(set(value)) == len(value), f"{label} repeats an environment")
+    return value
+
+
+def _integer(value: Any, label: str, *, nullable: bool = True) -> None:
+    _require(type(value) is int or (nullable and value is None),
+             f"{label} must be an integer" + (" or null" if nullable else ""))
+
+
+def validate_metadata(meta: Any) -> None:
+    """Strict shape, scalar, schema, logical digest and row-census validation."""
+    keys = {"schema_version", "captured", "source_tables", "source_columns", "access",
+            "requested_math_envs", "math_envs_present", "math_envs_present_by_table",
+            "math_envs_captured", "math_main", "math_ticks", "consistency",
+            "blob_handling", "disclosures", "logical_digest_sha256"}
+    _require(isinstance(meta, dict) and set(meta) == keys, "served metadata field set mismatch")
+    _require(meta["schema_version"] == SERVED_MATH_SCHEMA_VERSION, "served schema_version mismatch")
+    _require(meta["captured"] is True, "served captured must be true")
+    _require(meta["source_tables"] == ["math_main", "math_ticks"], "source_tables mismatch")
+    for field in ("access", "blob_handling"):
+        _require(isinstance(meta[field], str), f"{field} must be text")
+    _strings(meta["disclosures"], "disclosures")
+    columns = meta["source_columns"]
+    _require(isinstance(columns, dict) and set(columns) == {"math_main", "math_ticks"},
+             "source_columns mismatch")
+    _require(columns["math_main"] == list(MAIN_COLUMNS), "math_main column set mismatch")
+    tick_columns = _strings(columns["math_ticks"], "math_ticks columns")
+    _require(set(tick_columns) <= set(TICK_COLUMNS) and
+             {"math_env", "math_tick", "modified"} <= set(tick_columns), "math_ticks column set mismatch")
+    _require(tick_columns == [c for c in TICK_COLUMNS if c in tick_columns], "math_ticks column order mismatch")
+    present = _strings(meta["math_envs_present"], "math_envs_present")
+    captured = _strings(meta["math_envs_captured"], "math_envs_captured")
+    by_table = meta["math_envs_present_by_table"]
+    _require(isinstance(by_table, dict) and set(by_table) == {"math_main", "math_ticks"},
+             "math_envs_present_by_table mismatch")
+    for table in by_table:
+        _strings(by_table[table], table + " environments present")
+    _require(present == sorted(set(by_table["math_main"]) | set(by_table["math_ticks"])),
+             "present environment census mismatch")
+    requested = meta["requested_math_envs"]
+    if requested is not None:
+        _strings(requested, "requested_math_envs")
+    for table in ("math_main", "math_ticks"):
+        rows = meta[table]
+        _require(isinstance(rows, list) and all(isinstance(row, dict) for row in rows),
+                 f"{table} rows must be objects")
+        envs = [row.get("math_env") for row in rows]
+        _strings(envs, table + " row environments")
+        expected = sorted(e for e in by_table[table] if requested is None or e in requested)
+        _require(envs == expected, f"{table} captured environment census mismatch")
+        if table == "math_main":
+            _require(captured == envs, "math_envs_captured differs from blob rows")
+        for index, row in enumerate(rows):
+            if table == "math_ticks":
+                _require(set(row) == set(tick_columns), "tick row differs from captured columns")
+                for key in tick_columns:
+                    if key != "math_env":
+                        _integer(row[key], "math_ticks." + key)
+                continue
+            expected_keys = {"index", "math_env", "last_vote_timestamp", "math_tick", "caching_tick",
+                             "modified", "blob_file", "blob_sha256", "blob_bytes",
+                             "blob_last_vote_timestamp", "blob_watermark_absent_because"}
+            _require(set(row) == expected_keys, "math_main row field set mismatch")
+            _require(type(row["index"]) is int and row["index"] == index, "blob row index mismatch")
+            for key in ("last_vote_timestamp", "math_tick", "caching_tick", "modified", "blob_last_vote_timestamp"):
+                _integer(row[key], "math_main." + key)
+            _require(row["blob_file"] == f"served-math-{index:03d}.blob.json", "blob filename/index mismatch")
+            _require(isinstance(row["blob_sha256"], str) and
+                     re.fullmatch(r"[0-9a-f]{64}", row["blob_sha256"]) is not None, "blob digest malformed")
+            _integer(row["blob_bytes"], "blob_bytes", nullable=False)
+            _require(row["blob_bytes"] > 0, "blob_bytes must be positive")
+            reason = row["blob_watermark_absent_because"]
+            _require(reason is None or isinstance(reason, str), "blob watermark reason must be text or null")
+    consistency = meta["consistency"]
+    _require(isinstance(consistency, dict) and consistency.get("gate") is False and
+             consistency.get("kind") == "diagnostic", "consistency must be diagnostic with gate:false")
+    _require(meta["logical_digest_sha256"] == served_math_logical_digest(meta),
+             "logical_digest_sha256 differs from recomputed content")
+
+
+def read_capture(directory: Path, *, verify_digests: bool = True,
+                 expected_summary: dict[str, Any] | None = None) -> tuple[dict[str, Any], dict[str, bytes]] | None:
+    """Validate a fixture's capture, optionally binding its admitted manifest block.
+
+    The diagnostic is recomputed from the retained millisecond event stream.
+    ``verify_digests=False`` is only a loader debugging escape for changed blob
+    bytes; it still validates metadata, paths, census and diagnostic shape.
+    """
+    directory = Path(directory)
+    meta_path = directory / SERVED_MATH_META_FILENAME
+    try:
+        _require(not any(p.is_symlink() for p in (directory, *directory.parents, meta_path)), "symlink served capture")
+        if not meta_path.exists():
+            _require(expected_summary is None, "served metadata is missing")
+            _require(not list(directory.glob("served-math-*.blob.json")), "blob files without metadata")
+            return None
+        raw_meta = meta_path.read_bytes()
+        meta = json.loads(raw_meta)
+        validate_metadata(meta)
+        files = {row["blob_file"] for row in meta["math_main"]}
+        _require(files == {p.name for p in directory.glob("served-math-*.blob.json")},
+                 "blob file census mismatch: a claimed file is missing or an extra exists")
+        raw_blobs = {}
+        for row in meta["math_main"]:
+            path = directory / row["blob_file"]
+            _require(not path.is_symlink(), "symlink served blob")
+            raw = path.read_bytes()
+            raw_blobs[path.name] = raw
+            if verify_digests:
+                digest = hashlib.sha256(raw).hexdigest()
+                _require(digest == row["blob_sha256"], f"served blob hashes to {digest}, differs from metadata")
+                _require(len(raw) == row["blob_bytes"], "blob length differs from blob_bytes")
+                watermark, reason = blob_watermark(raw.decode("utf-8"))
+                _require((watermark, reason) == (row["blob_last_vote_timestamp"], row["blob_watermark_absent_because"]),
+                         "blob watermark metadata differs from content")
+        events_path = directory / "events.jsonl"
+        _require(not events_path.is_symlink(), "symlink event stream")
+        events = [json.loads(line) for line in events_path.read_text().splitlines() if line]
+        times = [event["created"] for event in events if event["kind"] == "vote"]
+        for value in times:
+            _integer(value, "vote created", nullable=False)
+        diagnostic = served_math_consistency(meta["math_main"], times)
+        _require(json.dumps(diagnostic, sort_keys=True) == json.dumps(meta["consistency"], sort_keys=True),
+                 "consistency differs from recomputed watermark diagnostic")
+        if expected_summary is not None:
+            actual = served_math_summary(meta, hashlib.sha256(raw_meta).hexdigest())
+            _require(json.dumps(actual, sort_keys=True) == json.dumps(expected_summary, sort_keys=True),
+                     "served manifest summary differs from verified metadata")
+        return meta, raw_blobs
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        if isinstance(exc, CaptureError):
+            raise
+        raise CaptureError(f"invalid served capture: {exc}") from exc

--- a/delphi/scripts/certify_data.py
+++ b/delphi/scripts/certify_data.py
@@ -232,7 +232,8 @@ def push(bundle_id: str, payload: Path, extract_json: Path, provenance_json: Pat
     )
     fb.verify(payload, manifest)
     try:
-        fb.admit_manifest(manifest, config=config, config_bytes=config_bytes)
+        fb.admit_manifest(manifest, config=config, config_bytes=config_bytes,
+                          payload_root=payload)
     except fb.AdmissionError as exc:
         raise click.ClickException(str(exc)) from exc
 
@@ -334,7 +335,7 @@ def verify(payload: Path, manifest_path: Path, config_path: Path | None,
         fb.verify(Path(payload), manifest)
         if admit:
             fb.admit_manifest(manifest, config=fc.load_config(config_path),
-                              config_bytes=Path(config_path).read_bytes())
+                              config_bytes=Path(config_path).read_bytes(), payload_root=Path(payload))
     except fb.BundleError as exc:
         click.echo(str(exc), err=True)
         sys.exit(1)

--- a/delphi/scripts/certify_datasets.schema.json
+++ b/delphi/scripts/certify_datasets.schema.json
@@ -49,6 +49,22 @@
         }
       }
     },
+    "served_math": {
+      "type": "object",
+      "description": "OPTIONAL (P-052 section 4.5). When present with capture=true, each extracted conversation additionally captures what the Clojure engine actually SERVED: the math_main row per math_env (blob verbatim, last_vote_timestamp, math_tick, caching_tick, modified) and the math_ticks row. This is an EXTRACTION change only - two additional SELECTs against tables that already exist, no migration, no new column, no trigger, no write. The block is ABSENT from the shipped config, which is what keeps the capture off by default and keeps certify_datasets.json byte-identical (and therefore every published manifest's commits.config_sha256 unchanged). Turning it on is a reviewed edit that mints a new config version.",
+      "additionalProperties": false,
+      "required": ["capture"],
+      "properties": {
+        "capture": {"type": "boolean"},
+        "math_envs": {
+          "type": "array",
+          "description": "Restrict the capture to these math_env values. Omit to capture every math_env the conversation has a row for. Only meaningful with capture=true.",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "notes": {"type": "string"}
+      }
+    },
     "roles": {
       "type": "array",
       "minItems": 1,

--- a/delphi/tests/test_certify_bundle_integration.py
+++ b/delphi/tests/test_certify_bundle_integration.py
@@ -600,15 +600,15 @@ def test_the_watermark_diagnostic_reaches_every_verdict(extracted_served):
     assert revote["gate"] is False
     prod = next(e for e in revote["per_math_env"] if e["math_env"] == "prod")
     # 700 vote events, 200 of them revotes at BASE_MS + 900000000 + g; the
-    # publish happened at +900000100, so exactly 99 later revotes are the tail
-    # the served blob never saw.
-    assert prod["verdict"] == "votes-arrived-after-the-served-watermark"
+    # watermark is +900000100, so exactly 99 revote timestamps fall after it.
+    # This relation does not establish which events the engine consumed.
+    assert prod["verdict"] == "vote-timestamps-after-the-served-watermark"
     assert prod["votes_after_watermark"] == 99
     assert prod["column_matches_blob"] is True
 
     midmix = by_slug["pc-v1-midmix"]["served_math"]["consistency"]
     entry = midmix["per_math_env"][0]
-    assert entry["verdict"] == "consistent"
+    assert entry["verdict"] == "watermark-equals-max-vote-timestamp"
     assert entry["votes_after_watermark"] == 0
 
     zerovote = by_slug["pc-v1-zerovote"]["served_math"]["consistency"]
@@ -645,7 +645,8 @@ def test_a_captured_bundle_verifies_admits_and_leaks_no_identity(
         source_commit="1" * 40, coverage_report=result["coverage_report"],
     )
     fb.verify(payload, manifest)
-    fb.admit_manifest(manifest, config=config, config_bytes=config_bytes)
+    fb.admit_manifest(manifest, payload_root=payload, config=config,
+                      config_bytes=config_bytes)
     # The blobs on disk carry the zid; the manifest must not, and it must say
     # so rather than leaving the blanket redaction claim to cover for it.
     assert not fb.scan_public_output(json.dumps(manifest), PLANTED)

--- a/delphi/tests/test_certify_bundle_integration.py
+++ b/delphi/tests/test_certify_bundle_integration.py
@@ -24,6 +24,7 @@ themselves are covered by ``tests/test_certify_fixture_config.py``.
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 from pathlib import Path
 
@@ -173,6 +174,32 @@ def _seed(engine):
                 {"zid": zid, "n_p": n_p, "n_c": n_c, "n": extra_revotes,
                  "t": BASE_MS})
 
+    def served_math(conn, zid, rows):
+        """A published math_main + math_ticks row per math_env — what the
+        engine SERVED, which is what the P-052 §4.5 capture reads back.
+        ``rows`` are ``(math_env, last_vote_timestamp, math_tick)`` triples.
+
+        The blob is a synthetic stand-in for the Clojure prep-main whitelist,
+        including its ``zid`` key, so the capture's verbatim handling and the
+        manifest's redaction claim are both exercised on something recognisable.
+        """
+        for env, last_vote_ms, math_tick in rows:
+            blob = json.dumps({
+                "zid": zid, "n": 3, "n-cmts": 3, "tids": [0, 1, 2],
+                "lastVoteTimestamp": last_vote_ms,
+                "pca": {"center": [0.1, -0.2], "comps": [[1.0, 0.0]]},
+            })
+            params = {"zid": zid, "env": env, "data": blob, "lvt": last_vote_ms,
+                      "ct": math_tick + 100, "mt": math_tick,
+                      "mod": last_vote_ms + 1000}
+            conn.execute(sa.text(
+                "INSERT INTO math_main (zid, math_env, data, last_vote_timestamp, "
+                "caching_tick, math_tick, modified) VALUES "
+                "(:zid, :env, CAST(:data AS jsonb), :lvt, :ct, :mt, :mod)"), params)
+            conn.execute(sa.text(
+                "INSERT INTO math_ticks (zid, math_tick, caching_tick, math_env, "
+                "modified) VALUES (:zid, :mt, :ct, :env, :mod)"), params)
+
     with engine.begin() as conn:
         # replica mode disables FK triggers, the tid/pid auto triggers and the
         # votes_latest_unique RULE, so bulk seeding stays fast. The schema
@@ -213,6 +240,21 @@ def _seed(engine):
         for i, zid in enumerate(LARGE_ZIDS):
             conv(conn, zid); ptpts(conn, zid, 20); cmts(conn, zid, 250)
             votes(conn, zid, 20, 250, extra_revotes=len(LARGE_ZIDS) - i)
+
+        # Served output for three shapes, so the P-052 §4.5 capture is
+        # exercised against every verdict its diagnostic can reach:
+        #   revote   — published before the 200 revotes arrived (a tail the
+        #              served blob never saw), and in TWO math_envs;
+        #   midmix   — published at the newest vote (consistent);
+        #   zerovote — a conversation with no votes at all.
+        # Every other seeded conversation has NO math_main row, which is the
+        # fourth case: a role whose capture is legitimately empty.
+        served_math(conn, Z["revote"], [
+            ("preprod", BASE_MS + 900000000, 5),
+            ("prod", BASE_MS + 900000100, 7),
+        ])
+        served_math(conn, Z["midmix"], [("prod", BASE_MS + 19199, 3)])
+        served_math(conn, Z["zerovote"], [("prod", 0, 0)])
 
         conn.execute(sa.text("SET session_replication_role = DEFAULT"))
 
@@ -466,6 +508,167 @@ def test_repeat_extraction_yields_identical_logical_events(seeded_db, extracted)
     # byte-identical too.
     assert fb.root_digest(fb.scan_files(payload)) \
         == fb.root_digest(fb.scan_files(second_payload))
+
+
+# ---------------------------------------------------------------------------
+# Served math rows (P-052 §4.5) against the REAL math_main / math_ticks tables.
+# ---------------------------------------------------------------------------
+
+
+def served_config() -> dict:
+    """The scaled config with the served-math capture turned on."""
+    cfg = scaled_config()
+    cfg["served_math"] = {
+        "capture": True,
+        "notes": "integration test: capture what the engine served",
+    }
+    fc.validate_config(cfg)
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def extracted_served(seeded_db, tmp_path_factory):
+    """The same config-driven extraction, with the capture ON."""
+    import psycopg2
+
+    root = tmp_path_factory.mktemp("extract-served")
+    payload = root / ".local" / "payload"
+    payload.mkdir(parents=True)
+    conn = psycopg2.connect(seeded_db)
+    try:
+        result = fx.extract_from_config(
+            conn, config=served_config(), payload_root=payload, guard_root=root,
+            include_generated=False)
+    finally:
+        conn.close()
+    return root, payload, result
+
+
+def test_capture_off_reads_neither_served_table(extracted):
+    """The shipped path. Nothing in the payload, nothing in the summaries."""
+    _, payload, result = extracted
+    assert result["served_math"]["capture"] is False
+    assert not any("served_math" in role for role in result["roles"])
+    assert not list(payload.rglob("served_math.json"))
+    assert not list(payload.rglob("served-math-*.blob.json"))
+
+
+def test_the_capture_reads_the_real_math_main_columns(seeded_db):
+    """Straight at the production schema: every column P-052 §4.5 names is
+    selected, comes back typed, and no zid is among them."""
+    import psycopg2
+
+    conn = psycopg2.connect(seeded_db)
+    try:
+        served = fx.fetch_served_math(conn, Z["revote"])
+    finally:
+        conn.close()
+    assert served["math_envs_present"] == ["preprod", "prod"]
+    prod = next(r for r in served["math_main"] if r["math_env"] == "prod")
+    assert set(prod) == {"math_env", "data_text", "last_vote_timestamp",
+                         "caching_tick", "math_tick", "modified"}
+    # data::text, so the blob arrives as the bytes Postgres stores rather than
+    # as a Python object some later serialisation would have to re-render.
+    assert isinstance(prod["data_text"], str)
+    assert json.loads(prod["data_text"])["zid"] == Z["revote"]
+    assert prod["last_vote_timestamp"] == BASE_MS + 900000100
+    assert prod["math_tick"] == 7 and prod["caching_tick"] == 107
+    ticks = next(t for t in served["math_ticks"] if t["math_env"] == "prod")
+    assert ticks["math_tick"] == 7 and ticks["caching_tick"] == 107
+
+
+def test_the_capture_writes_one_blob_per_math_env(extracted_served):
+    _, payload, result = extracted_served
+    revote = next(r for r in result["roles"] if r["slug"] == "pc-v1-revote")
+    block = revote["served_math"]
+    assert block["math_envs"] == ["preprod", "prod"]
+    assert block["math_main_rows"] == 2 and block["math_ticks_rows"] == 2
+    directory = payload / revote["dir"]
+    for blob in block["blobs"]:
+        raw = (directory / blob["file"]).read_bytes()
+        assert hashlib.sha256(raw).hexdigest() == blob["sha256"]
+        assert len(raw) == blob["bytes"]
+        # Verbatim: this is what production served, zid key and all.
+        assert json.loads(raw)["zid"] == Z["revote"]
+
+
+def test_the_watermark_diagnostic_reaches_every_verdict(extracted_served):
+    _, _, result = extracted_served
+    by_slug = {r["slug"]: r for r in result["roles"]}
+
+    revote = by_slug["pc-v1-revote"]["served_math"]["consistency"]
+    assert revote["gate"] is False
+    prod = next(e for e in revote["per_math_env"] if e["math_env"] == "prod")
+    # 700 vote events, 200 of them revotes at BASE_MS + 900000000 + g; the
+    # publish happened at +900000100, so exactly 99 later revotes are the tail
+    # the served blob never saw.
+    assert prod["verdict"] == "votes-arrived-after-the-served-watermark"
+    assert prod["votes_after_watermark"] == 99
+    assert prod["column_matches_blob"] is True
+
+    midmix = by_slug["pc-v1-midmix"]["served_math"]["consistency"]
+    entry = midmix["per_math_env"][0]
+    assert entry["verdict"] == "consistent"
+    assert entry["votes_after_watermark"] == 0
+
+    zerovote = by_slug["pc-v1-zerovote"]["served_math"]["consistency"]
+    assert zerovote["per_math_env"][0]["verdict"] == "no-votes-extracted"
+    assert zerovote["vote_events"] == 0
+
+
+def test_a_conversation_production_never_published_captures_an_empty_document(
+        extracted_served):
+    _, payload, result = extracted_served
+    banned = next(r for r in result["roles"] if r["slug"] == "pc-v1-banned")
+    assert banned["served_math"]["math_main_rows"] == 0
+    assert banned["served_math"]["blobs"] == []
+    meta = json.loads(
+        (payload / banned["dir"] / "served_math.json").read_text())
+    assert meta["math_envs_present"] == [] and meta["captured"] is True
+
+
+def test_a_captured_bundle_verifies_admits_and_leaks_no_identity(
+        extracted_served, tmp_path_factory):
+    _, payload, result = extracted_served
+    config = served_config()
+    config_bytes = fb.canonical_json(config)
+    manifest = fb.build_manifest(
+        bundle_id="pcb-itest-served-0001", payload_root=payload, config=config,
+        config_bytes=config_bytes, selections=result["roles"],
+        generated_summaries=result["generated"],
+        snapshot={"identifier": "snap-itest", "created_at": "2026-09-07T00:00:00Z",
+                  "schema_migration_version": "000018"},
+        transaction_guarantee=result["transaction_guarantee"],
+        tie_key=result["tie_key"],
+        schedules=fb.collect_schedule_hashes(fc.SCRIPTS_DIR / "schedules"),
+        owner="polis-certification", extraction_commit="1" * 40,
+        source_commit="1" * 40, coverage_report=result["coverage_report"],
+    )
+    fb.verify(payload, manifest)
+    fb.admit_manifest(manifest, config=config, config_bytes=config_bytes)
+    # The blobs on disk carry the zid; the manifest must not, and it must say
+    # so rather than leaving the blanket redaction claim to cover for it.
+    assert not fb.scan_public_output(json.dumps(manifest), PLANTED)
+    assert any("VERBATIM" in line and "zid" in line
+               for line in manifest["redactions"])
+    assert not fb.scan_public_output(
+        json.dumps(fb.public_pin(manifest)), PLANTED)
+
+
+def test_the_loader_reads_the_served_rows_back(extracted_served):
+    from polismath.replay import real_data as rd
+
+    _, payload, result = extracted_served
+    revote = next(r for r in result["roles"] if r["slug"] == "pc-v1-revote")
+    served = rd.read_served_math(payload / revote["dir"])
+    assert served is not None
+    prod = served.row("prod")
+    assert prod is not None
+    assert prod.math_tick == 7 and prod.caching_tick == 107
+    assert prod.last_vote_timestamp == BASE_MS + 900000100
+    assert prod.blob()["lastVoteTimestamp"] == prod.last_vote_timestamp
+    assert prod.blob()["zid"] == Z["revote"]
+    assert served.tick("preprod") is not None
 
 
 def test_generated_cases_land_beside_the_extracted_ones(extracted):

--- a/delphi/tests/test_certify_fixture_config.py
+++ b/delphi/tests/test_certify_fixture_config.py
@@ -196,6 +196,47 @@ def test_selection_group_rejections(config, mutate, needle):
         fc.validate_config(_broken(config, mutate))
 
 
+# ---------------------------------------------------------------------------
+# Rule 9 — the optional served-math capture (P-052 §4.5).
+# ---------------------------------------------------------------------------
+
+
+def test_the_capture_block_is_optional_and_absent_from_the_shipped_config(config):
+    """Absent, not ``{"capture": false}``. That is what keeps the shipped
+    config's bytes — and therefore ``commits.config_sha256`` in every manifest
+    already published — unchanged by this feature."""
+    assert "served_math" not in config
+    assert fc.served_math_options(config) == fc.SERVED_MATH_OFF
+
+
+@pytest.mark.parametrize("block,capture,envs", [
+    ({"capture": False}, False, None),
+    ({"capture": True}, True, None),
+    ({"capture": True, "math_envs": ["prod", "preprod"]}, True,
+     ("prod", "preprod")),
+])
+def test_a_valid_capture_block_is_accepted_and_read_back(
+        config, block, capture, envs):
+    cfg = _broken(config, lambda c: c.update(served_math=block))
+    fc.validate_config(cfg)
+    options = fc.served_math_options(cfg)
+    assert options.capture is capture and options.math_envs == envs
+
+
+@pytest.mark.parametrize("block,needle", [
+    ({}, "missing required property 'capture'"),
+    ({"capture": "yes"}, "expected type boolean"),
+    ({"capture": True, "math_envs": []}, "0 items < minItems 1"),
+    ({"capture": True, "math_envs": [""]}, "shorter than minLength 1"),
+    ({"capture": True, "surprise": 1}, "unexpected property"),
+    ({"capture": False, "math_envs": ["prod"]}, "only meaningful with capture=true"),
+    ({"capture": True, "math_envs": ["prod", "prod"]}, "duplicate entries"),
+])
+def test_capture_block_rejections(config, block, needle):
+    with pytest.raises(fc.ConfigError, match=needle.replace("$", r"\$")):
+        fc.validate_config(_broken(config, lambda c: c.update(served_math=block)))
+
+
 def test_selection_group_members_rank_into_one_shared_list():
     """The spec's large-shape rule selects ranks 1/2/4/8/16 from ONE ordering;
     an earlier rank must not shift a later one."""

--- a/delphi/tests/test_certify_served_math.py
+++ b/delphi/tests/test_certify_served_math.py
@@ -1,0 +1,753 @@
+"""Served-math capture: the optional extraction of what Clojure actually SERVED.
+
+P-052 section 4.5. The fixture bundle already captures a conversation's
+*inputs* (votes with millisecond timestamps, comments, moderation state,
+participants). It did not capture the *output* the production engine published
+— the ``math_main`` row per ``math_env`` (blob, ``last_vote_timestamp``,
+``math_tick``, ``caching_tick``, ``modified``) and the ``math_ticks`` row — and
+without that there is nothing for an off-policy fidelity comparison to be
+scored against.
+
+This module covers the extraction change, which is READ ONLY: two additional
+``SELECT``s against tables that already exist. No migration, no new column, no
+trigger.
+
+EVERYTHING here is synthetic. The votes, comments, participants, blobs and
+tick counters below were invented for this file; no production identifier,
+conversation or blob appears anywhere in it.
+
+THE BYTE-IDENTITY PROOF. The feature is OFF by default and the shipped
+selection config does not carry the block at all, so:
+
+* ``certify_datasets.json`` keeps the exact bytes it had before this feature
+  existed — pinned as :data:`SHIPPED_CONFIG_SHA256`, which is the value every
+  existing manifest recorded in ``commits.config_sha256``;
+* an extraction with the option off writes exactly the five files it wrote
+  before, with exactly the bytes it wrote before — pinned as
+  :data:`BASELINE_FILE_SHA256`, computed by running the pre-change extractor on
+  the synthetic conversation below;
+* the manifest built from such an extraction is byte-for-byte the manifest the
+  pre-change code built — pinned as :data:`BASELINE_MANIFEST_SHA256`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Sequence
+
+import pytest
+
+from polismath.replay import fixture_config as fc
+from polismath.replay import fixture_extract as fx
+from polismath.replay import real_data as rd
+
+# ---------------------------------------------------------------------------
+# Synthetic conversation.
+# ---------------------------------------------------------------------------
+
+BASE_MS = 1_600_000_000_000
+
+#: (pid, tid, vote, weight_x_32767, created), in the frozen extract order the
+#: real query would return them in. Raw STORAGE signs (-1 = agree).
+SYNTH_VOTES: list[dict[str, Any]] = [
+    {"pid": 1, "tid": 0, "vote": -1, "weight_x_32767": 0, "created": BASE_MS + 100},
+    {"pid": 2, "tid": 0, "vote": 1, "weight_x_32767": 0, "created": BASE_MS + 200},
+    {"pid": 1, "tid": 1, "vote": 0, "weight_x_32767": 0, "created": BASE_MS + 300},
+    {"pid": 2, "tid": 1, "vote": -1, "weight_x_32767": 0, "created": BASE_MS + 400},
+    # a revote on an already-voted cell — the history production kept
+    {"pid": 1, "tid": 0, "vote": 1, "weight_x_32767": 0, "created": BASE_MS + 500},
+    {"pid": 3, "tid": 2, "vote": -1, "weight_x_32767": 0, "created": BASE_MS + 600},
+]
+
+SYNTH_COMMENTS: list[dict[str, Any]] = [
+    {"tid": 0, "pid": 1, "created": BASE_MS, "modified": BASE_MS,
+     "mod": 0, "is_meta": False},
+    {"tid": 1, "pid": 2, "created": BASE_MS + 1, "modified": BASE_MS + 1,
+     "mod": 0, "is_meta": False},
+    {"tid": 2, "pid": 3, "created": BASE_MS + 2, "modified": BASE_MS + 2,
+     "mod": -1, "is_meta": True},
+]
+
+SYNTH_PARTICIPANTS: list[dict[str, Any]] = [
+    {"pid": 1, "mod": 0, "created": BASE_MS},
+    {"pid": 2, "mod": 0, "created": BASE_MS + 1},
+    {"pid": 3, "mod": -1, "created": BASE_MS + 2},
+]
+
+#: The served blob, as ``data::text`` would hand it back: a jsonb rendering
+#: with Postgres' own key order and spacing, NOT a Python re-serialisation.
+#: The watermark is the FOURTH vote's timestamp, so two later votes arrived
+#: after the last publish — the ordinary production situation.
+SERVED_BLOB_PROD_TEXT = (
+    '{"n": 3, "pca": {"center": [0.1, -0.2], "comps": [[1.0, 0.0], [0.0, 1.0]]}, '
+    '"tids": [0, 1, 2], "zid": 424242, "n-cmts": 3, '
+    '"lastVoteTimestamp": 1600000000400, "comment-priorities": {"0": 49, "1": 49}}'
+)
+
+#: A second environment, one publish behind, to prove every ``math_env``
+#: present is captured rather than an arbitrary one.
+SERVED_BLOB_PREPROD_TEXT = (
+    '{"n": 2, "tids": [0, 1], "zid": 424242, "n-cmts": 2, '
+    '"lastVoteTimestamp": 1600000000200}'
+)
+
+SYNTH_MATH_MAIN: list[dict[str, Any]] = [
+    {"math_env": "preprod", "data_text": SERVED_BLOB_PREPROD_TEXT,
+     "last_vote_timestamp": BASE_MS + 200, "caching_tick": 3, "math_tick": 4,
+     "modified": BASE_MS + 250},
+    {"math_env": "prod", "data_text": SERVED_BLOB_PROD_TEXT,
+     "last_vote_timestamp": BASE_MS + 400, "caching_tick": 11, "math_tick": 7,
+     "modified": BASE_MS + 450},
+]
+
+SYNTH_MATH_TICKS: list[dict[str, Any]] = [
+    {"math_env": "preprod", "math_tick": 4, "caching_tick": 3,
+     "modified": BASE_MS + 250},
+    {"math_env": "prod", "math_tick": 7, "caching_tick": 11,
+     "modified": BASE_MS + 450},
+]
+
+TIE_KEY: dict[str, Any] = {
+    "available": False,
+    "columns": [],
+    "method": "physical-ctid",
+    "order_by": "created ASC, ctid ASC",
+    "guarantee": "frozen-extract-order",
+    "note": "synthetic fixture: votes has no portable event identity, so the "
+            "extract order is frozen into the bundle bytes.",
+}
+
+DIR_NAME = "0123456789abcdef-pc-v1-synthetic"
+
+
+# ---------------------------------------------------------------------------
+# A fake connection that dispatches on the SQL, not on call order.
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    """Answers whichever table the executed statement selects FROM.
+
+    Dispatching on the SQL rather than on a fixed result queue keeps the fake
+    honest when the extractor runs three queries (capture off) or five
+    (capture on), and makes an unexpected statement a loud failure instead of
+    a silently mismatched result set.
+    """
+
+    _TABLES = ("votes", "comments", "participants", "math_main", "math_ticks")
+
+    def __init__(self, rows_by_table: dict[str, list[dict[str, Any]]]) -> None:
+        self._rows_by_table = rows_by_table
+        self.statements: list[str] = []
+        self.params: list[Any] = []
+        self._current: list[dict[str, Any]] = []
+        self.description: list[tuple[str]] | None = None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.statements.append(sql)
+        self.params.append(params)
+        table = next(
+            (t for t in self._TABLES if f"FROM {t}\n" in sql or sql.rstrip().endswith(f"FROM {t}")),
+            None,
+        )
+        if table is None:
+            raise AssertionError(f"fake cursor got an unexpected statement:\n{sql}")
+        self._current = self._rows_by_table.get(table, [])
+        columns = _selected_columns(sql)
+        self.description = [(c,) for c in columns]
+        self._current = [
+            {c: row[c] for c in columns} for row in self._current
+        ]
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        assert self.description is not None
+        return [tuple(row[c[0]] for c in self.description) for row in self._current]
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+def _selected_columns(sql: str) -> list[str]:
+    """The column names the extractor's own SELECT list asks for.
+
+    The fake returns exactly those, in that order, so a test cannot pass by
+    accident on a column the production query does not select.
+    """
+    select = sql[sql.index("SELECT") + len("SELECT"):sql.index("FROM")]
+    names: list[str] = []
+    for part in select.split(","):
+        token = part.strip().split()[-1]
+        names.append(token)
+    return names
+
+
+class _FakeConn:
+    def __init__(self, *, math_main: Sequence[dict[str, Any]] | None = None,
+                 math_ticks: Sequence[dict[str, Any]] | None = None) -> None:
+        self.cursors: list[_FakeCursor] = []
+        self._rows = {
+            "votes": [dict(r) for r in SYNTH_VOTES],
+            "comments": [dict(r) for r in SYNTH_COMMENTS],
+            "participants": [dict(r) for r in SYNTH_PARTICIPANTS],
+            "math_main": [dict(r) for r in (SYNTH_MATH_MAIN if math_main is None
+                                            else math_main)],
+            "math_ticks": [dict(r) for r in (SYNTH_MATH_TICKS if math_ticks is None
+                                             else math_ticks)],
+        }
+
+    def cursor(self) -> _FakeCursor:
+        cur = _FakeCursor(self._rows)
+        self.cursors.append(cur)
+        return cur
+
+
+# ---------------------------------------------------------------------------
+# Extraction helper.
+# ---------------------------------------------------------------------------
+
+
+def _extract(tmp_path: Path, **kwargs: Any) -> tuple[Path, dict[str, Any], _FakeConn]:
+    """Run ``extract_conversation`` into a guarded ``.local`` payload root."""
+    root = tmp_path / "real_data"
+    payload = root / ".local" / "payload"
+    payload.mkdir(parents=True)
+    conn = _FakeConn(math_main=kwargs.pop("math_main", None),
+                     math_ticks=kwargs.pop("math_ticks", None))
+    summary = fx.extract_conversation(
+        conn, zid=424242, slug="pc-v1-synthetic", role="synthetic-role",
+        payload_root=payload, guard_root=root, dir_name=DIR_NAME,
+        tie_key=TIE_KEY, **kwargs,
+    )
+    return payload / DIR_NAME, summary, conn
+
+
+def _file_digests(directory: Path) -> dict[str, str]:
+    return {
+        p.name: hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in sorted(directory.rglob("*")) if p.is_file()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Baseline pins — the bytes the PRE-CHANGE extractor produced.
+# ---------------------------------------------------------------------------
+
+#: SHA-256 of ``delphi/scripts/certify_datasets.json``. Served-math capture is
+#: declared by an OPTIONAL block that the shipped config does not carry, so
+#: this digest — which every published manifest records as
+#: ``commits.config_sha256`` — is unchanged by the feature. Adding the block to
+#: the shipped config is a reviewed edit that mints a new bundle version, which
+#: is exactly the intended cost.
+SHIPPED_CONFIG_SHA256 = (
+    "37a637e3d273990265f990259f4306dc78d41e23e02742584acd0274e81db396")
+
+#: The five payload files an extraction wrote before served-math capture
+#: existed, and their exact bytes, for the synthetic conversation above.
+BASELINE_FILE_SHA256: dict[str, str] = {
+    "0123456789abcdef-pc-v1-synthetic-comments.csv":
+        "2aa2fc4757f2e6beb2f2e4df138d76745eba3263b0f5d05f082bf563b38d5b79",
+    "0123456789abcdef-pc-v1-synthetic-votes.csv":
+        "20c7b05940afd15440be109c785194b8dca1e4c32a05f6ff06dfcd85f4702917",
+    "events.jsonl":
+        "d3b936b7ddcde200493fab3c0f376390310fe7ff27524bf3391255af2d9c2fe1",
+    "events.meta.json":
+        "02372a06ebe67c81360cc13a26e79152ec789755556c032e340cea62d337ede3",
+    "participants.csv":
+        "f164d7404eba122bdf9b44b4ffe4d0c089b70c8feded352e5d8657abe49c411e",
+}
+
+#: ``root_digest`` over those five files, and the sha256 of the canonical
+#: manifest built from the resulting role summary with ``created_at`` (a
+#: wall-clock stamp, and the only non-deterministic field) removed.
+BASELINE_ROOT_DIGEST = (
+    "f79b6ef07a79155cd974f84dc4874d61aca96b8b23a8858a4cdc2b187611892b")
+BASELINE_MANIFEST_SHA256 = (
+    "00cbfb2829bcbe5f71198455f1cdb1541e7821effa949aa1d9173a8b88153491")
+
+#: A minimal, self-contained selection config for the manifest pins. The
+#: shipped config selects on production scale and would need a production-scale
+#: seed; what is under test here is the manifest bytes, not the rule set.
+BASELINE_CONFIG: dict[str, Any] = {
+    "schema_version": "certify-datasets/1",
+    "config_version": "synthetic-v1",
+    "metrics": {"V": {"definition": "vote events"}, "zid": {"definition": "id"}},
+    "roles": [{
+        "slug": "pc-v1-synthetic", "role": "synthetic-role", "group": "replacement",
+        "rank": 1, "on_missing": "fail",
+        "exercise": "the served-math capture, on a synthetic conversation",
+        "predicates": [{"metric": "V", "op": "ge", "value": 1}],
+        "order_by": [{"metric": "V", "direction": "desc"},
+                     {"metric": "zid", "direction": "asc"}],
+    }],
+    "workloads": [],
+    "generated": {
+        "generator_id": "gen-v1", "generator_version": "1", "seed": 7,
+        "cases": [{"id": "gen-v1-empty", "boundary": "no votes at all",
+                   "participants": 0, "comments": 0, "shape": "empty"}],
+    },
+}
+
+
+def _role_entry(summary: dict[str, Any]) -> dict[str, Any]:
+    """The role summary as ``extract_from_config`` would hand it to the
+    manifest builder, minus the wall-clock extraction stamp."""
+    entry = dict(summary)
+    entry.update({"group": "replacement", "rank": 1, "source": "production",
+                  "n_candidates": 1, "overlaps_with": [],
+                  "measured_metrics": {"V": 6}})
+    entry.pop("extracted_at", None)
+    return entry
+
+
+def _build_manifest(payload_root: Path, summary: dict[str, Any]) -> dict[str, Any]:
+    from polismath.replay import fixture_bundle as fb
+
+    return fb.build_manifest(
+        bundle_id="synthetic-0001", payload_root=payload_root,
+        config=BASELINE_CONFIG, config_bytes=fb.canonical_json(BASELINE_CONFIG),
+        selections=[_role_entry(summary)], generated_summaries=[],
+        snapshot={"identifier": "snap", "created_at": "2026-01-01T00:00:00Z",
+                  "schema_migration_version": "000018"},
+        transaction_guarantee={"isolation_level": "repeatable read",
+                               "access_mode": "read only",
+                               "single_transaction": True},
+        tie_key=TIE_KEY,
+        schedules=[{"path": "s.json", "schedule_id": "s", "sha256": "0" * 64,
+                    "n_cuts": 2, "expected_checkpoints": 2,
+                    "cuts_resolvable_without_dataset": True}],
+        owner="polis-certification", extraction_commit="1" * 40,
+        source_commit="1" * 40, coverage_report={},
+    )
+
+
+def _manifest_fingerprint(manifest: dict[str, Any]) -> str:
+    """SHA-256 of the canonical manifest with ``created_at`` removed — the one
+    field that is a wall clock and cannot be pinned."""
+    from polismath.replay import fixture_bundle as fb
+
+    return hashlib.sha256(fb.canonical_json(
+        {k: v for k, v in manifest.items() if k != "created_at"})).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# The option is off by default, and off means byte-identical.
+# ---------------------------------------------------------------------------
+
+
+def test_the_shipped_config_does_not_declare_the_capture():
+    """The block is OPTIONAL and absent. That absence is what keeps
+    ``certify_datasets.json`` byte-identical, and therefore keeps
+    ``commits.config_sha256`` unchanged in every manifest ever published."""
+    raw = fc.DEFAULT_CONFIG_PATH.read_bytes()
+    assert hashlib.sha256(raw).hexdigest() == SHIPPED_CONFIG_SHA256
+    assert "served_math" not in json.loads(raw)
+    assert fc.served_math_options(fc.load_config()) == fc.SERVED_MATH_OFF
+    assert fc.SERVED_MATH_OFF.capture is False
+
+
+def test_an_absent_block_and_an_explicit_false_both_mean_off():
+    assert fc.served_math_options({}).capture is False
+    assert fc.served_math_options({"served_math": {"capture": False}}).capture is False
+    opts = fc.served_math_options({"served_math": {"capture": True}})
+    assert opts.capture is True and opts.math_envs is None
+    opts = fc.served_math_options(
+        {"served_math": {"capture": True, "math_envs": ["prod"]}})
+    assert opts.math_envs == ("prod",)
+
+
+def test_extraction_with_the_capture_off_writes_the_pre_change_bytes(tmp_path):
+    """THE BYTE-IDENTITY PROOF, file by file.
+
+    The digests on the right were produced by running the extractor as it stood
+    BEFORE served-math capture existed, on the synthetic conversation above. An
+    extraction with the option off must reproduce them exactly: same file set,
+    same bytes, same ``root_digest``.
+    """
+    from polismath.replay import fixture_bundle as fb
+
+    directory, summary, conn = _extract(tmp_path)
+    assert _file_digests(directory) == BASELINE_FILE_SHA256
+    assert fb.root_digest(fb.scan_files(directory.parent)) == BASELINE_ROOT_DIGEST
+    # No served_math key at all: an absent key and a `captured: false` block are
+    # different claims, and only the absent key leaves the manifest untouched.
+    assert "served_math" not in summary
+    # And the two extra SELECTs were never issued.
+    statements = [s for cur in conn.cursors for s in cur.statements]
+    assert not [s for s in statements if "math_main" in s or "math_ticks" in s]
+
+
+def test_the_manifest_built_from_a_capture_off_extraction_is_unchanged(tmp_path):
+    directory, summary, _ = _extract(tmp_path)
+    manifest = _build_manifest(directory.parent, summary)
+    assert _manifest_fingerprint(manifest) == BASELINE_MANIFEST_SHA256
+    assert manifest["root_digest"] == BASELINE_ROOT_DIGEST
+    assert len(manifest["redactions"]) == 5
+    assert not any("served" in line for line in manifest["redactions"])
+
+
+# ---------------------------------------------------------------------------
+# The capture itself.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def captured(tmp_path):
+    return _extract(tmp_path, capture_served_math=True)
+
+
+def test_the_queries_read_only_and_never_select_a_zid(captured):
+    """An extraction change, not a schema change: two SELECTs, no writes, and
+    no zid column in either of them."""
+    _, _, conn = captured
+    statements = [s for cur in conn.cursors for s in cur.statements]
+    served = [s for s in statements if "math_main" in s or "math_ticks" in s]
+    assert len(served) == 2
+    for sql in served:
+        assert sql.strip().upper().startswith("SELECT")
+        for forbidden in ("INSERT", "UPDATE", "DELETE", "ALTER", "CREATE", "DROP"):
+            assert forbidden not in sql.upper(), sql
+        select_list = sql[sql.index("SELECT"):sql.index("FROM")]
+        assert "zid" not in select_list
+        # The zid is the bound parameter, never interpolated.
+        assert "WHERE zid = %s" in sql
+    assert fx.sql_math_main_rows().count("data::text") == 1, (
+        "the blob must be selected as text so it is captured verbatim")
+
+
+def test_every_math_env_present_is_captured(captured):
+    directory, summary, _ = captured
+    meta = json.loads((directory / "served_math.json").read_text())
+    assert meta["schema_version"] == fx.SERVED_MATH_SCHEMA_VERSION
+    assert meta["captured"] is True
+    assert meta["math_envs_present"] == ["preprod", "prod"]
+    assert meta["math_envs_captured"] == ["preprod", "prod"]
+    assert meta["requested_math_envs"] is None
+    assert [t["math_env"] for t in meta["math_ticks"]] == ["preprod", "prod"]
+    assert summary["served_math"]["math_envs"] == ["preprod", "prod"]
+    assert summary["served_math"]["math_main_rows"] == 2
+    assert summary["served_math"]["math_ticks_rows"] == 2
+
+
+def test_the_row_scalars_are_carried_verbatim(captured):
+    directory, _, _ = captured
+    meta = json.loads((directory / "served_math.json").read_text())
+    prod = next(e for e in meta["math_main"] if e["math_env"] == "prod")
+    assert prod["last_vote_timestamp"] == BASE_MS + 400
+    assert prod["math_tick"] == 7
+    assert prod["caching_tick"] == 11
+    assert prod["modified"] == BASE_MS + 450
+    ticks = next(t for t in meta["math_ticks"] if t["math_env"] == "prod")
+    assert ticks == {"math_env": "prod", "math_tick": 7, "caching_tick": 11,
+                     "modified": BASE_MS + 450}
+    # No zid anywhere in the metadata document.
+    assert "zid" not in json.dumps(meta["math_main"] + meta["math_ticks"])
+
+
+def test_the_blob_file_is_the_served_bytes_and_nothing_else(captured):
+    directory, summary, _ = captured
+    meta = json.loads((directory / "served_math.json").read_text())
+    prod = next(e for e in meta["math_main"] if e["math_env"] == "prod")
+    raw = (directory / prod["blob_file"]).read_bytes()
+    # Verbatim: the exact `data::text` string, no trailing newline, no
+    # re-indentation, no key reordering by a Python json round-trip.
+    assert raw == SERVED_BLOB_PROD_TEXT.encode("utf-8")
+    assert not raw.endswith(b"\n")
+    assert hashlib.sha256(raw).hexdigest() == prod["blob_sha256"]
+    assert len(raw) == prod["blob_bytes"]
+    blob_entry = next(b for b in summary["served_math"]["blobs"]
+                      if b["math_env"] == "prod")
+    assert blob_entry["sha256"] == prod["blob_sha256"]
+    assert blob_entry["file"] == prod["blob_file"] == "served-math-001.blob.json"
+
+
+def test_blob_files_are_named_by_index_never_by_math_env(tmp_path):
+    """``math_env`` is a free VARCHAR(999) in the production schema, so a value
+    carrying a separator would otherwise choose the path."""
+    hostile = [dict(SYNTH_MATH_MAIN[1], math_env="../../escape")]
+    directory, summary, _ = _extract(
+        tmp_path, capture_served_math=True, math_main=hostile, math_ticks=[])
+    files = {p.name for p in directory.iterdir()}
+    assert "served-math-000.blob.json" in files
+    assert not any(".." in name for name in files)
+    assert summary["served_math"]["math_envs"] == ["../../escape"]
+
+
+def test_the_watermark_diagnostic_locates_the_prefix_the_blob_saw(captured):
+    """``prod`` published at the fourth vote, so the last two votes arrived
+    after it — the ordinary production case, reported and never failed."""
+    directory, _, _ = captured
+    consistency = json.loads(
+        (directory / "served_math.json").read_text())["consistency"]
+    assert consistency["gate"] is False and consistency["kind"] == "diagnostic"
+    assert consistency["vote_events"] == 6
+    assert consistency["max_vote_created_ms"] == BASE_MS + 600
+    prod = next(e for e in consistency["per_math_env"] if e["math_env"] == "prod")
+    assert prod["verdict"] == "votes-arrived-after-the-served-watermark"
+    assert prod["votes_at_or_before_watermark"] == 4
+    assert prod["votes_after_watermark"] == 2
+    assert prod["watermark_minus_max_vote_ms"] == -200
+    assert prod["watermark_is_a_vote_timestamp"] is True
+    # The column and the blob's own lastVoteTimestamp agree, as production
+    # writes the column FROM the blob.
+    assert prod["column_matches_blob"] is True
+    assert prod["blob_last_vote_timestamp"] == BASE_MS + 400
+
+
+def test_a_watermark_matching_the_last_vote_reads_consistent(tmp_path):
+    rows = [dict(SYNTH_MATH_MAIN[1], last_vote_timestamp=BASE_MS + 600,
+                 data_text='{"lastVoteTimestamp": 1600000000600}')]
+    directory, _, _ = _extract(tmp_path, capture_served_math=True,
+                               math_main=rows, math_ticks=[])
+    consistency = json.loads(
+        (directory / "served_math.json").read_text())["consistency"]
+    entry = consistency["per_math_env"][0]
+    assert entry["verdict"] == "consistent"
+    assert entry["votes_after_watermark"] == 0
+    assert entry["watermark_minus_max_vote_ms"] == 0
+
+
+def test_a_watermark_past_every_extracted_vote_is_called_out(tmp_path):
+    """The one shape that means the served row and the extracted votes came
+    from different states. Still a diagnostic — but a named one."""
+    rows = [dict(SYNTH_MATH_MAIN[1], last_vote_timestamp=BASE_MS + 9_000,
+                 data_text='{"lastVoteTimestamp": 1600000009000}')]
+    directory, _, _ = _extract(tmp_path, capture_served_math=True,
+                               math_main=rows, math_ticks=[])
+    consistency = json.loads(
+        (directory / "served_math.json").read_text())["consistency"]
+    entry = consistency["per_math_env"][0]
+    assert entry["verdict"] == "watermark-ahead-of-every-extracted-vote"
+    assert entry["votes_after_watermark"] == 0
+    assert entry["watermark_minus_max_vote_ms"] == 8_400
+    assert entry["watermark_is_a_vote_timestamp"] is False
+    assert consistency["gate"] is False
+
+
+def test_a_column_and_blob_watermark_disagreement_is_reported(tmp_path):
+    rows = [dict(SYNTH_MATH_MAIN[1], last_vote_timestamp=BASE_MS + 300,
+                 data_text='{"lastVoteTimestamp": 1600000000400}')]
+    directory, _, _ = _extract(tmp_path, capture_served_math=True,
+                               math_main=rows, math_ticks=[])
+    entry = json.loads((directory / "served_math.json").read_text())[
+        "consistency"]["per_math_env"][0]
+    assert entry["column_matches_blob"] is False
+
+
+def test_an_unreadable_blob_watermark_says_why_and_does_not_fail(tmp_path):
+    rows = [
+        dict(SYNTH_MATH_MAIN[1], data_text='{"n": 1}'),
+        dict(SYNTH_MATH_MAIN[0], math_env="broken", data_text="not json at all"),
+    ]
+    directory, _, _ = _extract(tmp_path, capture_served_math=True,
+                               math_main=rows, math_ticks=[])
+    meta = json.loads((directory / "served_math.json").read_text())
+    reasons = {e["math_env"]: e["blob_watermark_absent_because"]
+               for e in meta["math_main"]}
+    assert "carries no 'lastVoteTimestamp' key" in reasons["prod"]
+    assert "not parseable JSON" in reasons["broken"]
+    # Both blobs are still captured verbatim; only the derived scalar is absent.
+    assert (directory / "served-math-001.blob.json").read_bytes() == b"not json at all"
+
+
+def test_a_conversation_with_no_served_row_captures_an_empty_document(tmp_path):
+    directory, summary, _ = _extract(tmp_path, capture_served_math=True,
+                                     math_main=[], math_ticks=[])
+    meta = json.loads((directory / "served_math.json").read_text())
+    assert meta["math_envs_captured"] == [] and meta["math_main"] == []
+    assert meta["consistency"]["per_math_env"] == []
+    assert summary["served_math"]["math_main_rows"] == 0
+    assert not list(directory.glob("served-math-*.blob.json"))
+
+
+def test_a_requested_math_env_restricts_the_capture_and_says_what_it_skipped(
+        tmp_path):
+    directory, summary, _ = _extract(
+        tmp_path, capture_served_math=True, served_math_envs=("prod",))
+    meta = json.loads((directory / "served_math.json").read_text())
+    assert meta["requested_math_envs"] == ["prod"]
+    assert meta["math_envs_captured"] == ["prod"]
+    # What the database HELD is still recorded, so a partial capture cannot be
+    # mistaken for a conversation that only ever had one environment.
+    assert meta["math_envs_present"] == ["preprod", "prod"]
+    assert summary["served_math"]["math_main_rows"] == 1
+
+
+def test_the_logical_digest_moves_with_a_changed_blob_but_not_with_prose(
+        captured, tmp_path):
+    directory, summary, _ = captured
+    meta = json.loads((directory / "served_math.json").read_text())
+    assert fx.served_math_logical_digest(meta) == meta["logical_digest_sha256"]
+    assert summary["served_math"]["logical_digest_sha256"] == \
+        meta["logical_digest_sha256"]
+
+    reworded = dict(meta, blob_handling="different prose entirely",
+                    disclosures=["shorter"])
+    assert fx.served_math_logical_digest(reworded) == meta["logical_digest_sha256"]
+
+    changed = json.loads(json.dumps(meta))
+    changed["math_main"][0]["blob_sha256"] = "0" * 64
+    assert fx.served_math_logical_digest(changed) != meta["logical_digest_sha256"]
+
+
+def test_a_parsed_blob_object_is_refused_at_the_boundary():
+    """``data`` must be selected as ``::text``. Handing this a parsed object
+    would make a Python re-serialisation the recorded fact."""
+    with pytest.raises(TypeError, match="::text"):
+        fx.build_served_math(
+            math_main_rows=[{"math_env": "prod", "data_text": {"n": 1},
+                             "last_vote_timestamp": 1, "math_tick": 1,
+                             "caching_tick": 1, "modified": 1}],
+            math_ticks_rows=[], vote_created_ms=[])
+
+
+# ---------------------------------------------------------------------------
+# Manifest + admission.
+# ---------------------------------------------------------------------------
+
+
+def test_the_manifest_records_the_capture_with_digests_and_no_identity(
+        captured, tmp_path):
+    from polismath.replay import fixture_bundle as fb
+
+    directory, summary, _ = captured
+    manifest = _build_manifest(directory.parent, summary)
+    inventory = {f["path"]: f["sha256"] for f in manifest["files"]}
+    block = manifest["roles"][0]["served_math"]
+    assert inventory[f"{DIR_NAME}/served_math.json"] == block["meta_sha256"]
+    for blob in block["blobs"]:
+        assert inventory[f"{DIR_NAME}/{blob['file']}"] == blob["sha256"]
+    # The blob is verbatim and carries the conversation's own zid key; the
+    # MANIFEST must not, and the redaction list must say so out loud.
+    assert "424242" not in json.dumps(manifest)
+    assert any("VERBATIM" in line and "zid" in line
+               for line in manifest["redactions"])
+    fb.verify(directory.parent, manifest)
+
+
+def test_a_captured_bundle_is_admissible(captured, tmp_path):
+    from polismath.replay import fixture_bundle as fb
+
+    directory, summary, _ = captured
+    manifest = _build_manifest(directory.parent, summary)
+    fb.admit_manifest(manifest, config=BASELINE_CONFIG,
+                      config_bytes=fb.canonical_json(BASELINE_CONFIG))
+
+
+def test_admission_restates_the_extractor_constants_it_must_not_import():
+    from polismath.replay import fixture_bundle as fb
+
+    assert fb.REQUIRED_SERVED_MATH_SCHEMA_VERSION == fx.SERVED_MATH_SCHEMA_VERSION
+    assert fb.REQUIRED_SERVED_MATH_META_FILENAME == fx.SERVED_MATH_META_FILENAME
+
+
+@pytest.mark.parametrize("mutate,expected", [
+    (lambda b: b.update(schema_version="certify-served-math/99"),
+     "served_math.schema_version"),
+    (lambda b: b.update(captured=False), "served_math.captured"),
+    (lambda b: b.update(meta_sha256="0" * 64), "claims digest"),
+    (lambda b: b["blobs"][0].update(sha256="0" * 64), "claims digest"),
+    (lambda b: b["blobs"][0].update(file="not-in-the-bundle.json"),
+     "not in the file inventory"),
+    (lambda b: b.update(math_main_rows=99), "blob(s): every served row"),
+    (lambda b: b.update(math_envs=["prod", "prod"]), "repeats a math_env"),
+    (lambda b: b.update(surprise=1), "unknown field 'surprise'"),
+    (lambda b: b.pop("consistency"), "missing 'consistency'"),
+    (lambda b: b["consistency"].update(gate=True), "DIAGNOSTIC and must never"),
+    (lambda b: b["blobs"][0].update(bytes=0), "empty blob"),
+])
+def test_admission_rejects_a_served_block_that_does_not_bind(
+        captured, mutate, expected):
+    from polismath.replay import fixture_bundle as fb
+
+    directory, summary, _ = captured
+    manifest = _build_manifest(directory.parent, summary)
+    mutate(manifest["roles"][0]["served_math"])
+    with pytest.raises(fb.AdmissionError, match=re.escape(expected)):
+        fb.admit_manifest(manifest, config=BASELINE_CONFIG,
+                          config_bytes=fb.canonical_json(BASELINE_CONFIG))
+
+
+def test_admission_still_accepts_a_bundle_that_captured_nothing(tmp_path):
+    """An absent block is a complete statement — this bundle did not capture
+    what the engine served — and must not become a new required field."""
+    from polismath.replay import fixture_bundle as fb
+
+    directory, summary, _ = _extract(tmp_path)
+    manifest = _build_manifest(directory.parent, summary)
+    assert "served_math" not in manifest["roles"][0]
+    fb.admit_manifest(manifest, config=BASELINE_CONFIG,
+                      config_bytes=fb.canonical_json(BASELINE_CONFIG))
+
+
+# ---------------------------------------------------------------------------
+# Loading the served rows back.
+# ---------------------------------------------------------------------------
+
+
+def test_the_loader_round_trips_the_served_rows(captured):
+    directory, _, _ = captured
+    served = rd.read_served_math(directory)
+    assert served is not None
+    assert served.schema_version == fx.SERVED_MATH_SCHEMA_VERSION
+    assert served.math_envs_captured == ("preprod", "prod")
+    prod = served.row("prod")
+    assert prod is not None
+    assert prod.blob_text == SERVED_BLOB_PROD_TEXT
+    assert prod.last_vote_timestamp == BASE_MS + 400
+    assert prod.math_tick == 7 and prod.caching_tick == 11
+    assert prod.blob()["lastVoteTimestamp"] == BASE_MS + 400
+    assert prod.blob()["comment-priorities"] == {"0": 49, "1": 49}
+    tick = served.tick("prod")
+    assert tick is not None and tick.math_tick == 7
+    assert served.row("no-such-env") is None
+
+
+def test_the_loader_returns_none_when_nothing_was_captured(tmp_path):
+    directory, _, _ = _extract(tmp_path)
+    assert rd.read_served_math(directory) is None
+
+
+def test_the_loader_refuses_a_tampered_blob(captured):
+    directory, _, _ = captured
+    victim = directory / "served-math-001.blob.json"
+    victim.write_bytes(victim.read_bytes().replace(b'"n": 3', b'"n": 9'))
+    with pytest.raises(rd.ServedMathError, match="hashes to"):
+        rd.read_served_math(directory)
+    # ...and can still be read for diagnosis when that is what is wanted.
+    assert rd.read_served_math(directory, verify_digests=False) is not None
+
+
+def test_the_loader_refuses_a_missing_blob(captured):
+    directory, _, _ = captured
+    (directory / "served-math-001.blob.json").unlink()
+    with pytest.raises(rd.ServedMathError, match="which is missing"):
+        rd.read_served_math(directory)
+
+
+def test_the_diagnostic_can_be_re_derived_from_a_loaded_dataset(captured):
+    """The capture computed its diagnostic against the private millisecond
+    stream; a replay is often driven from the second-resolution compatibility
+    CSV. Re-deriving it from whatever was actually loaded makes that difference
+    visible instead of assumed away."""
+    directory, _, _ = captured
+    served = rd.read_served_math(directory)
+    assert served is not None
+    dataset = rd.load_votes_csv(directory / f"{DIR_NAME}-votes.csv")
+    result = rd.check_served_math_against_dataset(served, dataset)
+    assert result["gate"] is False and result["kind"] == "diagnostic"
+    assert result["vote_events"] == len(dataset.votes) == 6
+    assert result["capture_recorded"] == served.consistency
+    prod = next(e for e in result["per_math_env"] if e["math_env"] == "prod")
+    # Second-resolution CSV timestamps: every vote in this synthetic
+    # conversation truncates to the same second, so the whole stream lands at
+    # or before the millisecond watermark. That is precisely the ingress fact
+    # this re-derivation exists to expose.
+    assert prod["votes_at_or_before_watermark"] == 6
+    assert prod["votes_after_watermark"] == 0
+    assert served.consistency["per_math_env"][1]["votes_after_watermark"] == 2

--- a/delphi/tests/test_certify_served_math.py
+++ b/delphi/tests/test_certify_served_math.py
@@ -8,7 +8,7 @@ participants). It did not capture the *output* the production engine published
 without that there is nothing for an off-policy fidelity comparison to be
 scored against.
 
-This module covers the extraction change, which is READ ONLY: two additional
+This module covers the extraction change, which is READ ONLY: schema discovery and two additional row
 ``SELECT``s against tables that already exist. No migration, no new column, no
 trigger.
 
@@ -132,7 +132,7 @@ class _FakeCursor:
     """Answers whichever table the executed statement selects FROM.
 
     Dispatching on the SQL rather than on a fixed result queue keeps the fake
-    honest when the extractor runs three queries (capture off) or five
+    honest when the extractor runs three queries (capture off) or six
     (capture on), and makes an unexpected statement a loud failure instead of
     a silently mismatched result set.
     """
@@ -149,6 +149,12 @@ class _FakeCursor:
     def execute(self, sql: str, params: Any = None) -> None:
         self.statements.append(sql)
         self.params.append(params)
+        if "information_schema.columns" in sql:
+            rows = self._rows_by_table["math_ticks"]
+            columns = list(rows[0]) if rows else list(fx.TICK_COLUMNS)
+            self.description = [("column_name",)]
+            self._current = [{"column_name": column} for column in columns]
+            return
         table = next(
             (t for t in self._TABLES if f"FROM {t}\n" in sql or sql.rstrip().endswith(f"FROM {t}")),
             None,
@@ -402,8 +408,8 @@ def captured(tmp_path):
 
 
 def test_the_queries_read_only_and_never_select_a_zid(captured):
-    """An extraction change, not a schema change: two SELECTs, no writes, and
-    no zid column in either of them."""
+    """An extraction change, not a schema change: two row SELECTs plus schema discovery,
+    no writes, and no zid column in the captured rows."""
     _, _, conn = captured
     statements = [s for cur in conn.cursors for s in cur.statements]
     served = [s for s in statements if "math_main" in s or "math_ticks" in s]
@@ -478,9 +484,8 @@ def test_blob_files_are_named_by_index_never_by_math_env(tmp_path):
     assert summary["served_math"]["math_envs"] == ["../../escape"]
 
 
-def test_the_watermark_diagnostic_locates_the_prefix_the_blob_saw(captured):
-    """``prod`` published at the fourth vote, so the last two votes arrived
-    after it — the ordinary production case, reported and never failed."""
+def test_the_watermark_diagnostic_counts_relative_event_timestamps(captured):
+    """Two timestamps exceed the watermark; publication visibility is unknown."""
     directory, _, _ = captured
     consistency = json.loads(
         (directory / "served_math.json").read_text())["consistency"]
@@ -488,7 +493,7 @@ def test_the_watermark_diagnostic_locates_the_prefix_the_blob_saw(captured):
     assert consistency["vote_events"] == 6
     assert consistency["max_vote_created_ms"] == BASE_MS + 600
     prod = next(e for e in consistency["per_math_env"] if e["math_env"] == "prod")
-    assert prod["verdict"] == "votes-arrived-after-the-served-watermark"
+    assert prod["verdict"] == "vote-timestamps-after-the-served-watermark"
     assert prod["votes_at_or_before_watermark"] == 4
     assert prod["votes_after_watermark"] == 2
     assert prod["watermark_minus_max_vote_ms"] == -200
@@ -499,7 +504,7 @@ def test_the_watermark_diagnostic_locates_the_prefix_the_blob_saw(captured):
     assert prod["blob_last_vote_timestamp"] == BASE_MS + 400
 
 
-def test_a_watermark_matching_the_last_vote_reads_consistent(tmp_path):
+def test_a_watermark_matching_the_last_vote_reports_timestamp_equality(tmp_path):
     rows = [dict(SYNTH_MATH_MAIN[1], last_vote_timestamp=BASE_MS + 600,
                  data_text='{"lastVoteTimestamp": 1600000000600}')]
     directory, _, _ = _extract(tmp_path, capture_served_math=True,
@@ -507,14 +512,13 @@ def test_a_watermark_matching_the_last_vote_reads_consistent(tmp_path):
     consistency = json.loads(
         (directory / "served_math.json").read_text())["consistency"]
     entry = consistency["per_math_env"][0]
-    assert entry["verdict"] == "consistent"
+    assert entry["verdict"] == "watermark-equals-max-vote-timestamp"
     assert entry["votes_after_watermark"] == 0
     assert entry["watermark_minus_max_vote_ms"] == 0
 
 
 def test_a_watermark_past_every_extracted_vote_is_called_out(tmp_path):
-    """The one shape that means the served row and the extracted votes came
-    from different states. Still a diagnostic — but a named one."""
+    """A watermark beyond the extracted timestamp range is described literally."""
     rows = [dict(SYNTH_MATH_MAIN[1], last_vote_timestamp=BASE_MS + 9_000,
                  data_text='{"lastVoteTimestamp": 1600000009000}')]
     directory, _, _ = _extract(tmp_path, capture_served_math=True,
@@ -635,7 +639,7 @@ def test_a_captured_bundle_is_admissible(captured, tmp_path):
 
     directory, summary, _ = captured
     manifest = _build_manifest(directory.parent, summary)
-    fb.admit_manifest(manifest, config=BASELINE_CONFIG,
+    fb.admit_manifest(manifest, payload_root=directory.parent, config=BASELINE_CONFIG,
                       config_bytes=fb.canonical_json(BASELINE_CONFIG))
 
 
@@ -669,7 +673,7 @@ def test_admission_rejects_a_served_block_that_does_not_bind(
     manifest = _build_manifest(directory.parent, summary)
     mutate(manifest["roles"][0]["served_math"])
     with pytest.raises(fb.AdmissionError, match=re.escape(expected)):
-        fb.admit_manifest(manifest, config=BASELINE_CONFIG,
+        fb.admit_manifest(manifest, payload_root=directory.parent, config=BASELINE_CONFIG,
                           config_bytes=fb.canonical_json(BASELINE_CONFIG))
 
 
@@ -681,7 +685,7 @@ def test_admission_still_accepts_a_bundle_that_captured_nothing(tmp_path):
     directory, summary, _ = _extract(tmp_path)
     manifest = _build_manifest(directory.parent, summary)
     assert "served_math" not in manifest["roles"][0]
-    fb.admit_manifest(manifest, config=BASELINE_CONFIG,
+    fb.admit_manifest(manifest, payload_root=directory.parent, config=BASELINE_CONFIG,
                       config_bytes=fb.canonical_json(BASELINE_CONFIG))
 
 
@@ -726,7 +730,7 @@ def test_the_loader_refuses_a_tampered_blob(captured):
 def test_the_loader_refuses_a_missing_blob(captured):
     directory, _, _ = captured
     (directory / "served-math-001.blob.json").unlink()
-    with pytest.raises(rd.ServedMathError, match="which is missing"):
+    with pytest.raises(rd.ServedMathError, match="missing"):
         rd.read_served_math(directory)
 
 
@@ -751,3 +755,174 @@ def test_the_diagnostic_can_be_re_derived_from_a_loaded_dataset(captured):
     assert prod["votes_at_or_before_watermark"] == 6
     assert prod["votes_after_watermark"] == 0
     assert served.consistency["per_math_env"][1]["votes_after_watermark"] == 2
+
+
+@pytest.mark.parametrize("has_caching_tick", [False, True])
+def test_live_schema_discovery_captures_both_tick_shapes(has_caching_tick):
+    import os
+    import psycopg2
+    url = os.environ.get("SERVED_MATH_TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("set SERVED_MATH_TEST_DATABASE_URL to an isolated test PostgreSQL")
+    with psycopg2.connect(url) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("CREATE TEMP TABLE math_main (zid int, math_env text, data jsonb, last_vote_timestamp bigint, caching_tick int, math_tick int, modified bigint)")
+            extra = ", caching_tick int" if has_caching_tick else ""
+            cursor.execute("CREATE TEMP TABLE math_ticks (zid int, math_env text, math_tick int, modified bigint" + extra + ")")
+            cursor.execute("SET LOCAL search_path = pg_temp")
+            cursor.execute("INSERT INTO math_main VALUES (424242, 'prod', '{\"lastVoteTimestamp\": 123}', 123, 2, 3, 456)")
+            cursor.execute("INSERT INTO math_ticks (zid, math_env, math_tick, modified) VALUES (424242, 'prod', 3, 456)")
+        fetched = fx.fetch_served_math(conn, 424242)
+        assert ("caching_tick" in fetched["source_columns"]["math_ticks"]) is has_caching_tick
+        assert ("caching_tick" in fetched["math_ticks"][0]) is has_caching_tick
+        if has_caching_tick:
+            assert fetched["math_ticks"][0]["caching_tick"] is None
+        meta, _ = fx.build_served_math(math_main_rows=fetched["math_main"],
+            math_ticks_rows=fetched["math_ticks"], vote_created_ms=[123],
+            source_columns=fetched["source_columns"],
+            math_envs_present_by_table=fetched["math_envs_present_by_table"])
+        assert ("caching_tick" in meta["math_ticks"][0]) is has_caching_tick
+        assert meta["source_columns"] == fetched["source_columns"]
+
+
+def test_absent_tick_column_is_not_recorded_as_sql_null(tmp_path):
+    ticks = [{k: v for k, v in row.items() if k != "caching_tick"} for row in SYNTH_MATH_TICKS]
+    directory, summary, _ = _extract(tmp_path, capture_served_math=True, math_ticks=ticks)
+    served = rd.read_served_math(directory)
+    assert "caching_tick" not in served.meta["source_columns"]["math_ticks"]
+    assert all("caching_tick" not in row for row in served.meta["math_ticks"])
+    from polismath.replay import fixture_bundle as fb
+    fb.admit_manifest(_build_manifest(directory.parent, summary), payload_root=directory.parent,
+                      config=BASELINE_CONFIG, config_bytes=fb.canonical_json(BASELINE_CONFIG))
+
+
+@pytest.mark.parametrize("mutate", [
+    lambda b: b.update(logical_digest_sha256="0" * 64),
+    lambda b: b["blobs"][0].update(bytes=999999),
+    lambda b: b.update(math_ticks_rows=123),
+    lambda b: b["consistency"].update(per_math_env=[{}, {}]),
+    lambda b: b["blobs"][0].update(file=[]),
+    lambda b: b["consistency"].update(vote_events=99),
+])
+def test_manifest_semantics_require_payload_agreement(captured, mutate):
+    from polismath.replay import fixture_bundle as fb
+    directory, summary, _ = captured
+    manifest = _build_manifest(directory.parent, summary)
+    mutate(manifest["roles"][0]["served_math"])
+    with pytest.raises(fb.AdmissionError):
+        fb.admit_manifest(manifest, payload_root=directory.parent,
+                          config=BASELINE_CONFIG, config_bytes=fb.canonical_json(BASELINE_CONFIG))
+    with pytest.raises(fb.VerificationError):
+        fb.verify(directory.parent, manifest)
+
+
+_METADATA_MUTATIONS = [
+    ("schema", lambda m: m.update(schema_version="unknown/99")),
+    ("captured", lambda m: m.update(captured=False)),
+    ("gate", lambda m: m["consistency"].update(gate=True)),
+    ("gate-number", lambda m: m["consistency"].update(gate=0)),
+    ("logical-digest", lambda m: m.update(logical_digest_sha256="0" * 64)),
+    ("blob-bytes", lambda m: m["math_main"][0].update(blob_bytes=999)),
+    ("blob-filename", lambda m: m["math_main"][0].update(blob_file=[])),
+    ("blob-hash", lambda m: m["math_main"][0].update(blob_sha256="0" * 64)),
+    ("index-bool", lambda m: m["math_main"][0].update(index=False)),
+    ("present", lambda m: m.update(math_envs_present=["invented"])),
+    ("present-by-table", lambda m: m["math_envs_present_by_table"].update(math_ticks=[])),
+    ("captured-envs", lambda m: m.update(math_envs_captured=["invented"])),
+    ("requested-envs", lambda m: m.update(requested_math_envs=["invented"])),
+    ("tick-census", lambda m: m["math_ticks"].pop()),
+    ("columns", lambda m: m["source_columns"]["math_ticks"].remove("caching_tick")),
+    ("diagnostic-empty", lambda m: m["consistency"].update(per_math_env=[{}, {}])),
+    ("diagnostic-count", lambda m: m["consistency"].update(vote_events="6")),
+    ("diagnostic-row-count", lambda m: m["consistency"]["per_math_env"][0].update(votes_after_watermark=999)),
+    ("blob-watermark", lambda m: m["math_main"][0].update(blob_last_vote_timestamp=123)),
+    ("blob-reason", lambda m: m["math_main"][0].update(blob_watermark_absent_because=True)),
+] + [(f"{table}-{field}", lambda m, table=table, field=field: m[table][0].update({field: "7"}))
+     for table, fields in (("math_main", ("last_vote_timestamp", "math_tick", "caching_tick", "modified")),
+                            ("math_ticks", ("math_tick", "caching_tick", "modified"))) for field in fields]
+
+
+@pytest.mark.parametrize("name,mutate", _METADATA_MUTATIONS, ids=[m[0] for m in _METADATA_MUTATIONS])
+def test_rehashed_metadata_mutations_refused_by_loader_admission_and_verifier(captured, name, mutate):
+    from polismath.replay import fixture_bundle as fb
+    directory, summary, _ = captured
+    path = directory / "served_math.json"
+    meta = json.loads(path.read_text())
+    mutate(meta)
+    # Refresh the logical digest too: structural/content checks must still hold.
+    if name != "logical-digest":
+        meta["logical_digest_sha256"] = fx.served_math_logical_digest(meta)
+    path.write_text(json.dumps(meta))
+    summary["served_math"] = fx.served_math_summary(meta, hashlib.sha256(path.read_bytes()).hexdigest())
+    manifest = _build_manifest(directory.parent, summary)
+    with pytest.raises(rd.ServedMathError):
+        rd.read_served_math(directory)
+    with pytest.raises(fb.VerificationError):
+        fb.verify(directory.parent, manifest)
+    with pytest.raises(fb.AdmissionError):
+        fb.admit_manifest(manifest, payload_root=directory.parent,
+                          config=BASELINE_CONFIG, config_bytes=fb.canonical_json(BASELINE_CONFIG))
+
+
+@pytest.mark.parametrize("filename", ["served_math.json", "served-math-000.blob.json", "events.jsonl"])
+def test_loader_refuses_symlinked_capture_members(captured, tmp_path, filename):
+    directory, _, _ = captured
+    path = directory / filename
+    outside = tmp_path / "outside"
+    path.rename(outside)
+    path.symlink_to(outside)
+    with pytest.raises(rd.ServedMathError, match="symlink"):
+        rd.read_served_math(directory)
+
+
+def test_present_empty_metadata_is_invalid(captured):
+    directory, _, _ = captured
+    (directory / "served_math.json").write_text("{}")
+    with pytest.raises(rd.ServedMathError):
+        rd.read_served_math(directory)
+
+
+def test_same_ms_votes_do_not_identify_visibility_or_consumed_prefix():
+    rows = [{"math_env": "prod", "last_vote_timestamp": 200, "blob_last_vote_timestamp": 200}]
+    a = fx.served_math_consistency(rows, [100, 200])
+    b = fx.served_math_consistency(rows, [100, 200, 200])
+    assert a["per_math_env"][0]["verdict"] == b["per_math_env"][0]["verdict"] == "watermark-equals-max-vote-timestamp"
+    assert b["per_math_env"][0]["votes_at_or_before_watermark"] == 3
+    assert "do not establish" in b["note"]
+    assert b["gate"] is False
+
+
+def test_served_admission_requires_payload(captured):
+    from polismath.replay import fixture_bundle as fb
+    directory, summary, _ = captured
+    with pytest.raises(fb.AdmissionError, match="requires payload_root"):
+        fb.admit_manifest(_build_manifest(directory.parent, summary), config=BASELINE_CONFIG,
+                          config_bytes=fb.canonical_json(BASELINE_CONFIG))
+
+
+def test_served_capture_local_bundle_roundtrip(captured, tmp_path):
+    from polismath.replay import fixture_bundle as fb
+    directory, summary, _ = captured
+    manifest = _build_manifest(directory.parent, summary)
+    store = fb.LocalStore(tmp_path / "store")
+    provenance = {"bundle_id": manifest["bundle_id"]}
+    fb.push(store, bundle_id=manifest["bundle_id"], payload_root=directory.parent,
+            manifest=manifest, provenance=provenance, config=BASELINE_CONFIG,
+            config_bytes=fb.canonical_json(BASELINE_CONFIG))
+    destination = tmp_path / "pulled"
+    fb.pull(store, bundle_id=manifest["bundle_id"], dest=destination,
+            config=BASELINE_CONFIG, config_bytes=fb.canonical_json(BASELINE_CONFIG))
+    assert rd.read_served_math(destination / "payload" / DIR_NAME).row("prod").blob_text == SERVED_BLOB_PROD_TEXT
+
+
+def test_invalid_capture_refused_before_local_publication_even_without_release_admission(captured, tmp_path):
+    from polismath.replay import fixture_bundle as fb
+    directory, summary, _ = captured
+    manifest = _build_manifest(directory.parent, summary)
+    manifest["roles"][0]["served_math"]["logical_digest_sha256"] = "0" * 64
+    store_dir = tmp_path / "store"
+    store = fb.LocalStore(store_dir)
+    with pytest.raises(fb.VerificationError):
+        fb.push(store, bundle_id=manifest["bundle_id"], payload_root=directory.parent,
+                manifest=manifest, provenance={"bundle_id": manifest["bundle_id"]}, admit=False)
+    assert not [p for p in store_dir.rglob("*") if p.is_file()]


### PR DESCRIPTION
Extraction change only: two additional read-only `SELECT`s per conversation, off by default. No migration, column, trigger, role, or write of any kind.

**Why.** The private certification bundle captures a conversation's inputs (votes with timestamps, comments, moderation) but not what the live engine actually served: the `math_main` row (blob, `last_vote_timestamp`, ticks, `modified`) and the `math_ticks` row. Those served rows are the prerequisite for judging any replacement engine against the Clojure era and for inferring the recompute schedule.

**What.** An optional `served_math: {capture, math_envs?, notes?}` block in the dataset config (absence is off; the shipped config is untouched). When on, the extractor writes `served_math.json` (per-`math_env` scalars, blob digests, envs present vs captured, a logical digest) plus one `served-math-NNN.blob.json` per row, written as the raw `data::text` bytes with no trailing newline so the bundle byte is the served byte. Blob files are named by row index, never by `math_env` (a free text column; there is a traversal test). The manifest gains a per-role `served_math` block; admission validates it only when present (closed key set, schema version, every file bound to the inventory digest, and a hard refusal if the consistency record ever declares itself a gate). A loader in `real_data.py` returns typed rows with the verbatim blob text and re-hashes on read. A consistency diagnostic compares the served `lastVoteTimestamp` with the extracted votes; it is `gate: false` and says so.

**Byte-identity proof.** With capture off, the pre-change and post-change extractor produce identical payload files, root digest, and canonical manifest (pins in the test, computed by running the pre-change code), and the two extra `SELECT`s are never issued.

**Tests.** 38 new on a SQL-dispatching fake connection; 7 new against the existing throwaway Postgres 17 seeded with real `math_main`/`math_ticks` rows; 11 new for the config rule and schema. Delphi suite before and after: identical failure and error sets (all environmental). pyright: no new diagnostics on the changed modules.

**Docs.** New section in `delphi/docs/CERTIFICATION.md`.

Schema impact: none. Running it against production data is gated behind the private-cert account decision (Q24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s