### PR TITLE
fix(server): run OIDC user creation on one transaction client, not through the pool

### DIFF
--- a/server/__tests__/integration/oidc-transaction.test.ts
+++ b/server/__tests__/integration/oidc-transaction.test.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from "crypto";
+import type { PoolClient } from "pg";
+import pg from "../../src/db/pg-query";
+import { getOrCreateUserIDFromOidcSub } from "../../src/auth/create-user";
+import { pool, closePool } from "../setup/db-test-helpers";
+
+// Real application pool and real PostgreSQL; only scheduling is controlled.
+// Stealing a just-released BEGIN session recreates the production interleaving
+// deterministically. A transaction-owned client cannot be stolen this way.
+describe("OIDC transaction ownership", () => {
+  const suffix = randomUUID();
+  const email = `oidc-tx-${suffix}@example.invalid`;
+  const sub = `synthetic-oidc-tx-${suffix}`;
+  let uid: number;
+  let zid: number;
+  let pid: number;
+
+  beforeAll(async () => {
+    uid = (await pool.query("INSERT INTO users (email) VALUES ($1) RETURNING uid", [email])).rows[0].uid;
+    await pool.query("INSERT INTO oidc_user_mappings (oidc_sub,uid) VALUES ($1,$2)", [sub, uid]);
+    zid = (await pool.query("INSERT INTO conversations (owner,topic) VALUES ($1,$2) RETURNING zid", [uid, "Synthetic OIDC transaction witness"])).rows[0].zid;
+    pid = (await pool.query("INSERT INTO participants (uid,zid) VALUES ($1,$2) RETURNING pid", [uid,zid])).rows[0].pid;
+  });
+  afterAll(async () => {
+    await pool.query("DELETE FROM comments WHERE zid=$1", [zid]);
+    await pool.query("DELETE FROM participants WHERE zid=$1", [zid]);
+    await pool.query("DELETE FROM conversations WHERE zid=$1", [zid]);
+    await pool.query("DELETE FROM oidc_user_mappings WHERE uid=$1", [uid]);
+    await pool.query("DELETE FROM users WHERE uid=$1 OR email=$2", [uid, `new-${email}`]);
+    await closePool();
+  });
+
+  test("acknowledged seed survives pool eviction and its tid is never reused", async () => {
+    let held: PoolClient | undefined;
+    const original = pg.query;
+    const spy = jest.spyOn(pg, "query").mockImplementation((sql, ...args) => {
+      if (sql === "BEGIN") {
+        const callback = args[1];
+        return original(sql, args[0], (err: any, result: any) => {
+          if (err) return callback(err, result);
+          pg.connect().then((client) => { held = client; callback(null, result); }, callback);
+        });
+      }
+      return original(sql, ...args);
+    });
+    try {
+      expect(await getOrCreateUserIDFromOidcSub(sub, { email })).toBe(uid);
+    } finally {
+      spy.mockRestore();
+      held?.release();
+    }
+    const insert = (txt: string) => pg.queryP(
+      "INSERT INTO comments (pid,zid,uid,txt,is_seed) VALUES ($1,$2,$3,$4,true) RETURNING tid",
+      [pid,zid,uid,txt]
+    ) as Promise<{tid: number}[]>;
+    const [seed] = await insert("Synthetic acknowledged seed");
+    // Observe through a different pool, then deterministically evict the last
+    // application session (the same rollback as idle eviction, without a timer).
+    const visibleBefore = await pool.query("SELECT tid FROM comments WHERE zid=$1 AND tid=$2", [zid,seed.tid]);
+    const lastClient = await pg.connect();
+    lastClient.release(true);
+    const [next] = await insert("Synthetic subsequent seed");
+    const visibleAfter = await pool.query("SELECT tid FROM comments WHERE zid=$1 ORDER BY tid", [zid]);
+    expect(visibleBefore.rows).toEqual([{tid: seed.tid}]);
+    expect(next.tid).toBeGreaterThan(seed.tid);
+    expect(visibleAfter.rows).toEqual([{tid: seed.tid}, {tid: next.tid}]);
+  });
+
+  test("new users and replacement mappings commit on the same owned client", async () => {
+    const newSub = `${sub}-new`;
+    const newEmail = `new-${email}`;
+    const newUid = await getOrCreateUserIDFromOidcSub(newSub, {email: newEmail});
+    expect((await pool.query("SELECT uid FROM oidc_user_mappings WHERE oidc_sub=$1", [newSub])).rows).toEqual([{uid:newUid}]);
+    expect(await getOrCreateUserIDFromOidcSub(`${sub}-replacement`, {email})).toBe(uid);
+    expect((await pool.query("SELECT oidc_sub FROM oidc_user_mappings WHERE uid=$1", [uid])).rows).toEqual([{oidc_sub:`${sub}-replacement`}]);
+    await pool.query("DELETE FROM oidc_user_mappings WHERE uid=$1", [newUid]);
+  });
+
+  test("a rejected mapping write rolls back the preceding user upsert", async () => {
+    // Database varchar limit fails the mapping insert AFTER a successful upsert.
+    await expect(getOrCreateUserIDFromOidcSub("x".repeat(256), {email, name:"must roll back"})).rejects.toThrow();
+    expect((await pool.query("SELECT hname FROM users WHERE uid=$1", [uid])).rows[0].hname).not.toBe("must roll back");
+    expect((await pool.query("SELECT oidc_sub FROM oidc_user_mappings WHERE uid=$1", [uid])).rows).toEqual([{oidc_sub:`${sub}-replacement`}]);
+  });
+});

--- a/server/src/auth/create-user.ts
+++ b/server/src/auth/create-user.ts
@@ -72,158 +72,53 @@ async function getOrCreateUserIDFromOidcSub(
   // Use a single transaction to handle the entire user creation/mapping process
   // This prevents race conditions by ensuring atomicity
   try {
-    const result = await new Promise<number>((resolve, reject) => {
-      pg.query("BEGIN", [], (beginErr: any) => {
-        if (beginErr) {
-          logger.error("Failed to begin transaction:", beginErr);
-          return reject(beginErr);
+    const result = await pg.withTransaction(async (client) => {
+      const mapping = await client.query(
+        "SELECT uid FROM oidc_user_mappings WHERE oidc_sub = $1",
+        [oidcSub]
+      );
+      if (mapping.rows.length > 0) return mapping.rows[0].uid;
+
+      const user = await client.query(
+        `INSERT INTO users (email, hname, username, is_owner, created)
+         VALUES ($1, $2, $3, $4, now_as_millis())
+         ON CONFLICT (email) DO UPDATE SET
+           hname = EXCLUDED.hname,
+           username = EXCLUDED.username
+         RETURNING uid`,
+        [email, displayName, username, true]
+      );
+      if (!user.rows.length) throw new Error("Failed to create or find user");
+      const uid = user.rows[0].uid;
+      const existingMapping = await client.query(
+        "SELECT oidc_sub FROM oidc_user_mappings WHERE uid = $1",
+        [uid]
+      );
+      if (existingMapping.rows.length > 0) {
+        const existingOidcSub = existingMapping.rows[0].oidc_sub;
+        if (existingOidcSub === oidcSub) {
+          logger.info(`Mapping already exists for OIDC sub ${oidcSub}: uid ${uid}`);
+          return uid;
         }
-
-        // First, try to get existing mapping
-        pg.query(
-          "SELECT uid FROM oidc_user_mappings WHERE oidc_sub = $1",
-          [oidcSub],
-          (mappingErr: any, mappingResult: { rows: any[] }) => {
-            if (mappingErr) {
-              return pg.query("ROLLBACK", [], () => reject(mappingErr));
-            }
-
-            if (mappingResult.rows.length > 0) {
-              // Mapping exists, commit and return
-              const uid = mappingResult.rows[0].uid;
-              return pg.query("COMMIT", [], (commitErr: any) => {
-                if (commitErr) return reject(commitErr);
-                resolve(uid);
-              });
-            }
-
-            // No mapping exists, so we need to create user and/or mapping
-            // Use improved upsert approach that handles constraint violations better
-            const upsertUserQuery = `
-              INSERT INTO users (email, hname, username, is_owner, created) 
-              VALUES ($1, $2, $3, $4, now_as_millis())
-              ON CONFLICT (email) DO UPDATE SET
-                hname = EXCLUDED.hname,
-                username = EXCLUDED.username
-              RETURNING uid
-            `;
-
-            pg.query(
-              upsertUserQuery,
-              [email, displayName, username, true],
-              (userErr: any, userResult: { rows: { uid: number }[] }) => {
-                if (userErr) {
-                  return pg.query("ROLLBACK", [], () => reject(userErr));
-                }
-
-                if (!userResult.rows.length) {
-                  return pg.query("ROLLBACK", [], () =>
-                    reject(new Error("Failed to create or find user"))
-                  );
-                }
-
-                const uid = userResult.rows[0].uid;
-
-                // Check if this uid already has a mapping to a different oidc_sub
-                pg.query(
-                  "SELECT oidc_sub FROM oidc_user_mappings WHERE uid = $1",
-                  [uid],
-                  (
-                    existingMappingErr: any,
-                    existingMappingResult: { rows: any[] }
-                  ) => {
-                    if (existingMappingErr) {
-                      return pg.query("ROLLBACK", [], () =>
-                        reject(existingMappingErr)
-                      );
-                    }
-
-                    if (existingMappingResult.rows.length > 0) {
-                      const existingOidcSub =
-                        existingMappingResult.rows[0].oidc_sub;
-                      if (existingOidcSub === oidcSub) {
-                        // Same mapping already exists, just return the uid
-                        return pg.query("COMMIT", [], (commitErr: any) => {
-                          if (commitErr) return reject(commitErr);
-                          logger.info(
-                            `Mapping already exists for OIDC sub ${oidcSub}: uid ${uid}`
-                          );
-                          resolve(uid);
-                        });
-                      } else {
-                        // Different OIDC user is already mapped to this local user.
-                        // This can happen if a user changes the email on their social login,
-                        // or deletes and recreates their account. We want the new login to win.
-                        logger.warn(
-                          `Local user ${uid} (${email}) was mapped to old OIDC sub ${existingOidcSub}. Overwriting with new mapping for ${oidcSub}.`
-                        );
-
-                        // To prevent unique constraint violations on either uid or oidc_sub,
-                        // we must first remove any existing mappings that would conflict.
-                        const cleanupQuery =
-                          "DELETE FROM oidc_user_mappings WHERE oidc_sub = $1 OR uid = $2";
-
-                        pg.query(
-                          cleanupQuery,
-                          [oidcSub, uid],
-                          (deleteErr: any) => {
-                            if (deleteErr) {
-                              return pg.query("ROLLBACK", [], () =>
-                                reject(deleteErr)
-                              );
-                            }
-
-                            // Now that the coast is clear, insert the new mapping.
-                            pg.query(
-                              "INSERT INTO oidc_user_mappings (oidc_sub, uid, created) VALUES ($1, $2, now_as_millis())",
-                              [oidcSub, uid],
-                              (insertErr: any) => {
-                                if (insertErr) {
-                                  return pg.query("ROLLBACK", [], () =>
-                                    reject(insertErr)
-                                  );
-                                }
-
-                                // Success, commit.
-                                pg.query("COMMIT", [], (commitErr: any) => {
-                                  if (commitErr) return reject(commitErr);
-                                  resolve(uid);
-                                });
-                              }
-                            );
-                          }
-                        );
-                      }
-                    } else {
-                      // No existing mapping for this uid, create new one
-                      pg.query(
-                        "INSERT INTO oidc_user_mappings (oidc_sub, uid, created) VALUES ($1, $2, now_as_millis()) ON CONFLICT (oidc_sub) DO NOTHING",
-                        [oidcSub, uid],
-                        (mappingInsertErr: any) => {
-                          if (mappingInsertErr) {
-                            return pg.query("ROLLBACK", [], () =>
-                              reject(mappingInsertErr)
-                            );
-                          }
-
-                          // Commit the transaction
-                          pg.query("COMMIT", [], (commitErr: any) => {
-                            if (commitErr) return reject(commitErr);
-                            logger.info(
-                              `Successfully created/linked user for OIDC sub ${oidcSub}: uid ${uid}`
-                            );
-                            resolve(uid);
-                          });
-                        }
-                      );
-                    }
-                  }
-                );
-              }
-            );
-          }
+        // Preserve the existing policy: a new social login for this email wins.
+        logger.warn(
+          `Local user ${uid} (${email}) was mapped to old OIDC sub ${existingOidcSub}. Overwriting with new mapping for ${oidcSub}.`
         );
-      });
+        await client.query(
+          "DELETE FROM oidc_user_mappings WHERE oidc_sub = $1 OR uid = $2",
+          [oidcSub, uid]
+        );
+        await client.query(
+          "INSERT INTO oidc_user_mappings (oidc_sub, uid, created) VALUES ($1, $2, now_as_millis())",
+          [oidcSub, uid]
+        );
+      } else {
+        await client.query(
+          "INSERT INTO oidc_user_mappings (oidc_sub, uid, created) VALUES ($1, $2, now_as_millis()) ON CONFLICT (oidc_sub) DO NOTHING",
+          [oidcSub, uid]
+        );
+      }
+      return uid;
     });
 
     return result;


### PR DESCRIPTION
**Defect.** `server/src/auth/create-user.ts` issued `BEGIN`, its reads and writes, and `COMMIT`/`ROLLBACK` through the connection pool, so the statements could land on different connections. An abandoned transaction could acknowledge a comment insert and then roll it back when the pool evicted the idle client. Reproduced on real modules and real Postgres as an invisible acknowledged seed comment and a reused comment id. This was the cause of the intermittent `empty-math-comments` integration failures seen on #2755 (17 failures one run, clean the next).

**Fix.** The whole sequence runs inside `pg.withTransaction` on one client. Existing retry/recovery and mapping-replacement policy retained; the bounded session policy's finally/discard/unknown-COMMIT handling applies. Net −105 lines: the callback pyramid is gone. No schema change, no `pg-query` change. A search for sibling pooled transactions found the participant, domain, and import paths already pinned to one client.

**Tests.** New real-module integration suite `oidc-transaction.test.ts`: released-BEGIN theft witness, seed visibility through an independent pool, forced session eviction, no id reuse, new and replacement mappings, rollback of a preceding upsert. The original helper fails the invisible-seed control. Results: the new suite plus `empty-math-comments` 20/20; unit 223/223; integration 435 passed, 1 skipped.

**Review provenance.** Written by the second reviewer; the orchestrator reviewed the diff. A separate reviewer has not passed over it, since the implementation budget is the second reviewer's for now.

Schema impact: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s