### PR TITLE
feat(cdk): default-off private certification box (PrivateCertStack)

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -2,6 +2,8 @@
 import * as cdk from 'aws-cdk-lib';
 import { CdkStack } from '../lib/cdk-stack';
 import * as path from 'path'; // Use * as path
+import * as fs from 'fs';
+import { PrivateCertBox, PrivateAdmission } from '../privateCertBox';
 
 interface ExtendedStackProps extends cdk.StackProps {
   domainName?: string; // Make optional since we're not using it initially
@@ -57,3 +59,15 @@ if (props.enableSSHAccess) {
 
 
 new CdkStack(app, 'CdkStack', props);
+// P-053 is a sibling stack. OFF does not read admission/configuration or change
+// CdkStack, including its role policies, logical IDs and assets.
+if (app.node.tryGetContext('enablePrivateCertBox') === true ||
+    app.node.tryGetContext('enablePrivateCertBox') === 'true') {
+  const filename = process.env.PRIVATE_CERT_CONFIG;
+  if (!filename) throw new Error('PRIVATE_CERT_CONFIG must name a private admission JSON file');
+  const admission: PrivateAdmission = JSON.parse(fs.readFileSync(filename, 'utf8'));
+  const privateStack = new cdk.Stack(app, 'PrivateCertStack', {
+    env: { account: admission.account, region: admission.region },
+  });
+  new PrivateCertBox(privateStack, 'Box', admission);
+}

--- a/cdk/privateCertBox.ts
+++ b/cdk/privateCertBox.ts
@@ -1,0 +1,228 @@
+/** P-053: one admission per disposable private stack. No production references. */
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as cw from 'aws-cdk-lib/aws-cloudwatch';
+import * as actions from 'aws-cdk-lib/aws-cloudwatch-actions';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+export interface PrivateAdmission {
+  schema: 'polis-private-admission/1';
+  signerPublicKey: string; signature: string;
+  id: string; account: string; region: string; ami: string;
+  // Opaque per-run names only. This JSON is private, never a public CI artifact.
+  fixtureKey: string; fixtureVersion: string; fixtureSha256: string;
+  fixtureBytes: number; expandedBytes: number; maxMembers: number;
+  candidateSha: string; oracleSha: string; supervisorSha256: string;
+  runtimeSha256: string; runnerImage: string; verifierImage: string;
+  policySha256: string; scheduleSha256: string; inventorySha256: string;
+  // Hashes bind the complete census/coverage; these counts cannot replace it.
+  expectedChecks: number; stagingExpiresAt: string; expiresAt: string;
+  operatorRoleArn: string; curatorRoleArn: string; reviewerRoleArn: string;
+  notificationTopicArn: string; s3PrefixListId: string;
+  evidenceRetentionDays: 30 | 90;
+}
+
+export function validateAdmission(a: PrivateAdmission): PrivateAdmission {
+  const fail = (field: string): never => { throw new Error(`Invalid private admission: ${field}`); };
+  if (a.schema !== 'polis-private-admission/1') fail('schema');
+  if (!/^[a-f0-9]{64}$/.test(a.signerPublicKey ?? '') || !/^[a-f0-9]{128}$/.test(a.signature ?? '')) fail('signature');
+  const { signature, ...signed } = a;
+  const publicKey = crypto.createPublicKey({ key: Buffer.from('302a300506032b6570032100' + a.signerPublicKey, 'hex'), format: 'der', type: 'spki' });
+  if (!crypto.verify(null, Buffer.from(canonical(signed)), publicKey, Buffer.from(signature, 'hex'))) fail('signature');
+  for (const key of ['fixtureSha256', 'supervisorSha256', 'runtimeSha256', 'policySha256',
+    'scheduleSha256', 'inventorySha256'] as const) if (!/^[a-f0-9]{64}$/.test(a[key] ?? '')) fail(key);
+  for (const key of ['candidateSha', 'oracleSha'] as const) if (!/^[a-f0-9]{40}$/.test(a[key] ?? '')) fail(key);
+  if (!/^[a-f0-9]{32}$/.test(a.id ?? '')) fail('id');
+  if (!/^\d{12}$/.test(a.account ?? '')) fail('account');
+  if (!/^[a-z]{2}-[a-z]+-\d$/.test(a.region ?? '')) fail('region');
+  if (!/^ami-[a-f0-9]{17}$/.test(a.ami ?? '')) fail('ami');
+  if (!/^pl-[a-f0-9]+$/.test(a.s3PrefixListId ?? '')) fail('s3PrefixListId');
+  if (a.fixtureKey !== `staging/${a.id}/bundle.tar`) fail('fixtureKey');
+  if (!/^[A-Za-z0-9._~+\/-]{1,1024}$/.test(a.fixtureVersion ?? '') || a.fixtureVersion === 'null') fail('fixtureVersion');
+  for (const key of ['runnerImage', 'verifierImage'] as const)
+    if (!/^localhost\/polis-[a-z-]+@sha256:[a-f0-9]{64}$/.test(a[key] ?? '')) fail(key);
+  for (const key of ['fixtureBytes', 'expandedBytes', 'maxMembers', 'expectedChecks'] as const)
+    if (!Number.isSafeInteger(a[key]) || a[key] <= 0) fail(key);
+  if (a.fixtureBytes > 4 * 1024 ** 3 || a.expandedBytes > 180 * 1024 ** 3 || a.maxMembers > 1000000) fail('storage bounds');
+  if (!/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\dZ$/.test(a.expiresAt ?? '') || !Number.isFinite(Date.parse(a.expiresAt))) fail('expiresAt');
+  if (!/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\dZ$/.test(a.stagingExpiresAt ?? '') || !Number.isFinite(Date.parse(a.stagingExpiresAt)) || Date.parse(a.stagingExpiresAt) >= Date.parse(a.expiresAt)) fail('stagingExpiresAt');
+  for (const key of ['operatorRoleArn', 'curatorRoleArn', 'reviewerRoleArn'] as const)
+    if (!new RegExp(`^arn:aws:iam::${a.account}:role/[A-Za-z0-9_+=,.@/-]+$`).test(a[key] ?? '')) fail(key);
+  if (new Set([a.operatorRoleArn, a.curatorRoleArn, a.reviewerRoleArn]).size !== 3) fail('separate principals');
+  if (!new RegExp(`^arn:aws:sns:${a.region}:${a.account}:[A-Za-z0-9_-]+$`).test(a.notificationTopicArn ?? '')) fail('notificationTopicArn');
+  if (![30, 90].includes(a.evidenceRetentionDays)) fail('evidenceRetentionDays');
+  if (Buffer.byteLength(canonical(a)) > 2800) fail('admission exceeds control environment budget');
+  for (const key of ['stagingExpiresAt', 'expiresAt'] as const)
+    if (new Date(a[key]).toISOString().replace('.000Z', 'Z') !== a[key]) fail(key);
+  return a;
+}
+
+export function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value !== null && typeof value === 'object') return '{' + Object.keys(value).sort().map(
+    k => JSON.stringify(k) + ':' + canonical((value as Record<string, unknown>)[k])).join(',') + '}';
+  return JSON.stringify(value);
+}
+
+export class PrivateCertBox extends Construct {
+  constructor(scope: Construct, id: string, admission: PrivateAdmission) {
+    super(scope, id);
+    const a = validateAdmission(admission);
+    const stack = cdk.Stack.of(this);
+    if (stack.account !== a.account || stack.region !== a.region) throw new Error('Explicit admission account/region must match stack');
+    const digest = crypto.createHash('sha256').update(canonical(a)).digest('hex');
+    const name = `ppc-${a.account}-${a.id}`;
+    const run = `runs/${a.id}/`;
+    const tag = { key: 'polis:private-cert', value: a.id };
+    const instanceArn = `arn:aws:ec2:${a.region}:${a.account}:instance/*`;
+    const volumeArn = `arn:aws:ec2:${a.region}:${a.account}:volume/*`;
+    // L1 network resources avoid any lookup/default-SG custom resource role.
+    const vpc = new ec2.CfnVPC(this, 'Vpc', { cidrBlock: '10.253.0.0/24', enableDnsSupport: true, enableDnsHostnames: false });
+    const subnet = new ec2.CfnSubnet(this, 'Subnet', { vpcId: vpc.ref, cidrBlock: '10.253.0.0/26', mapPublicIpOnLaunch: false, availabilityZone: `${a.region}a` });
+    const routes = new ec2.CfnRouteTable(this, 'Routes', { vpcId: vpc.ref });
+    new ec2.CfnSubnetRouteTableAssociation(this, 'RouteAssociation', { routeTableId: routes.ref, subnetId: subnet.ref });
+    const sg = new ec2.CfnSecurityGroup(this, 'WorkerSg', {
+      groupDescription: 'Private certification: S3 TLS only; no ingress', vpcId: vpc.ref,
+      securityGroupEgress: [{ ipProtocol: 'tcp', fromPort: 443, toPort: 443, destinationPrefixListId: a.s3PrefixListId }],
+    });
+    const fixtureKey = new kms.Key(this, 'FixtureKey', { enableKeyRotation: true, removalPolicy: cdk.RemovalPolicy.RETAIN });
+    const evidenceKey = new kms.Key(this, 'EvidenceKey', { enableKeyRotation: true, removalPolicy: cdk.RemovalPolicy.RETAIN });
+    const bucket = (id: string, suffix: string, key: kms.Key, rules: s3.LifecycleRule[]) => new s3.Bucket(this, id, {
+      bucketName: `${name}-${suffix}`, encryption: s3.BucketEncryption.KMS, encryptionKey: key,
+      bucketKeyEnabled: false, versioned: true, blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_ENFORCED, enforceSSL: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN, lifecycleRules: rules,
+    });
+    const fixtures = bucket('Fixtures', 'fixtures', fixtureKey, [{ prefix: `staging/${a.id}/`, expiration: cdk.Duration.days(1), noncurrentVersionExpiration: cdk.Duration.days(1), abortIncompleteMultipartUploadAfter: cdk.Duration.days(1) }]);
+    const evidence = bucket('Evidence', 'evidence', evidenceKey, [{ prefix: run, expiration: cdk.Duration.days(a.evidenceRetentionDays), noncurrentVersionExpiration: cdk.Duration.days(a.evidenceRetentionDays), abortIncompleteMultipartUploadAfter: cdk.Duration.days(1) }]);
+    const control = bucket('Control', 'control', evidenceKey, []);
+    const endpoint = new ec2.CfnVPCEndpoint(this, 'S3Endpoint', {
+      vpcId: vpc.ref, vpcEndpointType: 'Gateway', serviceName: `com.amazonaws.${a.region}.s3`, routeTableIds: [routes.ref],
+      policyDocument: { Version: '2012-10-17', Statement: [{ Effect: 'Allow', Principal: '*', Action: ['s3:GetObject', 's3:GetObjectVersion', 's3:PutObject'], Resource: [fixtures.arnForObjects('*'), evidence.arnForObjects('*'), control.arnForObjects('*')] }] },
+    });
+    const worker = new iam.Role(this, 'Worker', { assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com') });
+    cdk.Tags.of(worker).add('polis:private-cert', a.id);
+    const profile = new iam.CfnInstanceProfile(this, 'Profile', { roles: [worker.roleName] });
+    const lifecycle = new iam.Role(this, 'Lifecycle', { assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com') });
+    const statement = (role: iam.Role, actions: string[], resources: string[], conditions?: Record<string, unknown>) => role.addToPolicy(new iam.PolicyStatement({ actions, resources, conditions }));
+    const dataConditions = { StringEquals: { 'aws:SourceVpce': endpoint.ref, 'aws:PrincipalTag/polis:private-cert': a.id } };
+    statement(worker, ['s3:GetObjectVersion'], [fixtures.arnForObjects(a.fixtureKey)], {
+      StringEquals: { ...dataConditions.StringEquals, 's3:VersionId': a.fixtureVersion }, DateLessThan: { 'aws:CurrentTime': a.expiresAt },
+    });
+    // Only one immutable boot record. No worker access to cleanup/public records.
+    statement(worker, ['s3:GetObject'], [control.arnForObjects(`boot/${a.id}.json`)], dataConditions);
+    const ownHeartbeat = control.arnForObjects(`heartbeats/${a.id}/` + '${ec2:SourceInstanceARN}.json');
+    statement(worker, ['s3:PutObject'], [ownHeartbeat], { ...dataConditions, DateLessThan: { 'aws:CurrentTime': a.expiresAt } });
+    const ownEvidence = evidence.arnForObjects(run + '${ec2:SourceInstanceARN}/*');
+    statement(worker, ['s3:PutObject'], [ownEvidence], {
+      StringEquals: { ...dataConditions.StringEquals, 's3:if-none-match': '*', 's3:x-amz-server-side-encryption': 'aws:kms', 's3:x-amz-server-side-encryption-aws-kms-key-id': evidenceKey.keyArn },
+      DateLessThan: { 'aws:CurrentTime': a.expiresAt },
+    });
+    const kmsConditions = (resource: string, like = false) => ({
+      StringEquals: { 'kms:ViaService': `s3.${a.region}.amazonaws.com` },
+      [like ? 'StringLike' : 'StringEquals']: {
+        'kms:ViaService': `s3.${a.region}.amazonaws.com`, 'kms:EncryptionContext:aws:s3:arn': resource,
+      },
+    });
+    statement(worker, ['kms:Decrypt'], [fixtureKey.keyArn], kmsConditions(fixtures.arnForObjects(a.fixtureKey)));
+    statement(worker, ['kms:Decrypt'], [evidenceKey.keyArn], kmsConditions(control.arnForObjects(`boot/${a.id}.json`)));
+    statement(worker, ['kms:GenerateDataKey'], [evidenceKey.keyArn], kmsConditions(ownEvidence, true));
+    statement(worker, ['kms:GenerateDataKey'], [evidenceKey.keyArn], kmsConditions(ownHeartbeat));
+    // Resource-side denies are independent of grants. Curator has upload only;
+    // reviewers see evidence, never fixture staging. No public CI trust exists.
+    const deny = (b: s3.Bucket, sid: string, actions: string[], resources: string[], conditions: Record<string, unknown>) => b.addToResourcePolicy(new iam.PolicyStatement({ sid, effect: iam.Effect.DENY, principals: [new iam.AnyPrincipal()], actions, resources, conditions }));
+    deny(fixtures, 'WorkerOnlyReader', ['s3:GetObject*'], [fixtures.arnForObjects('*')], { ArnNotEquals: { 'aws:PrincipalArn': worker.roleArn } });
+    deny(fixtures, 'EndpointOnlyReader', ['s3:GetObject*'], [fixtures.arnForObjects('*')], { StringNotEquals: { 'aws:SourceVpce': endpoint.ref } });
+    deny(fixtures, 'OnlyAdmittedVersion', ['s3:GetObject*'], [fixtures.arnForObjects('*')], { StringNotEquals: { 's3:VersionId': a.fixtureVersion } });
+    deny(fixtures, 'OnlyCuratorWrites', ['s3:PutObject*'], [fixtures.arnForObjects('*')], { ArnNotEquals: { 'aws:PrincipalArn': a.curatorRoleArn } });
+    deny(fixtures, 'ClosedIngestion', ['s3:PutObject*'], [fixtures.arnForObjects('*')], { DateGreaterThanEquals: { 'aws:CurrentTime': a.stagingExpiresAt } });
+    deny(fixtures, 'ExpiredStaging', ['s3:GetObject*'], [fixtures.arnForObjects('*')], { DateGreaterThanEquals: { 'aws:CurrentTime': a.expiresAt } });
+    deny(fixtures, 'OnlyCleanerDeletes', ['s3:DeleteObject*', 's3:AbortMultipartUpload'], [fixtures.arnForObjects('*')], { ArnNotEquals: { 'aws:PrincipalArn': lifecycle.roleArn } });
+    deny(evidence, 'PrivateReaders', ['s3:GetObject*', 's3:ListBucket*'], [evidence.bucketArn, evidence.arnForObjects('*')], { ArnNotEquals: { 'aws:PrincipalArn': a.reviewerRoleArn } });
+    deny(evidence, 'WorkerOnlyWrites', ['s3:PutObject*'], [evidence.arnForObjects('*')], { ArnNotEquals: { 'aws:PrincipalArn': worker.roleArn } });
+    deny(evidence, 'CreateOnly', ['s3:PutObject'], [evidence.arnForObjects('*')], { StringNotEquals: { 's3:if-none-match': '*' } });
+    deny(evidence, 'WorkerEndpoint', ['s3:PutObject'], [evidence.arnForObjects('*')], { StringNotEquals: { 'aws:SourceVpce': endpoint.ref } });
+    deny(control, 'TrustedControlWriters', ['s3:PutObject*', 's3:DeleteObject*'], [control.arnForObjects('*')], { ArnNotEquals: { 'aws:PrincipalArn': [lifecycle.roleArn, worker.roleArn] } });
+    deny(control, 'PrivateControlReaders', ['s3:GetObject*', 's3:ListBucket*'], [control.bucketArn, control.arnForObjects('*')], { ArnNotEquals: { 'aws:PrincipalArn': [worker.roleArn, lifecycle.roleArn, a.operatorRoleArn, a.reviewerRoleArn] } });
+    deny(control, 'WorkerCannotWriteRecords', ['s3:PutObject*', 's3:DeleteObject*'], [control.arnForObjects('control/*'), control.arnForObjects('boot/*')], { ArnEquals: { 'aws:PrincipalArn': worker.roleArn } });
+    for (const [b, key] of [[fixtures, fixtureKey], [evidence, evidenceKey], [control, evidenceKey]] as const) {
+      deny(b, 'RequireKms', ['s3:PutObject'], [b.arnForObjects('*')], { StringNotEquals: { 's3:x-amz-server-side-encryption': 'aws:kms' } });
+      deny(b, 'RequireOwnKey', ['s3:PutObject'], [b.arnForObjects('*')], { StringNotEquals: { 's3:x-amz-server-side-encryption-aws-kms-key-id': key.keyArn } });
+    }
+    const grantExternal = (principal: string, b: s3.Bucket, actions: string[], resource: string, key: kms.Key, keyActions: string[]) => {
+      b.addToResourcePolicy(new iam.PolicyStatement({ principals: [new iam.ArnPrincipal(principal)], actions, resources: [resource] }));
+      key.addToResourcePolicy(new iam.PolicyStatement({ principals: [new iam.ArnPrincipal(principal)], actions: keyActions, resources: ['*'], conditions: kmsConditions(`arn:aws:s3:::${name}-${b === fixtures ? 'fixtures/' + a.fixtureKey : b === evidence ? 'evidence/' + run + '*' : 'control/*'}`, b !== fixtures) }));
+    };
+    grantExternal(a.curatorRoleArn, fixtures, ['s3:PutObject'], fixtures.arnForObjects(a.fixtureKey), fixtureKey, ['kms:GenerateDataKey']);
+    grantExternal(a.reviewerRoleArn, evidence, ['s3:GetObjectVersion'], evidence.arnForObjects(run + '*'), evidenceKey, ['kms:Decrypt']);
+    for (const principal of [a.operatorRoleArn, a.reviewerRoleArn])
+      grantExternal(principal, control, ['s3:GetObject'], control.arnForObjects('*'), evidenceKey, ['kms:Decrypt']);
+
+    const template = new ec2.CfnLaunchTemplate(this, 'Template', { launchTemplateData: {
+      imageId: a.ami, instanceType: 'r8g.4xlarge', iamInstanceProfile: { arn: profile.attrArn },
+      // No UserData, KeyName, SSM profile, autoscaling or network overrides.
+      metadataOptions: { httpTokens: 'required', httpPutResponseHopLimit: 1, instanceMetadataTags: 'disabled' },
+      instanceInitiatedShutdownBehavior: 'terminate', hibernationOptions: { configured: false },
+      networkInterfaces: [{ deviceIndex: 0, subnetId: subnet.ref, groups: [sg.attrGroupId], associatePublicIpAddress: false, deleteOnTermination: true }],
+      blockDeviceMappings: [{ deviceName: '/dev/xvda', ebs: { volumeSize: 32, volumeType: 'gp3', encrypted: true, deleteOnTermination: true } }, { deviceName: '/dev/sdf', ebs: { volumeSize: 256, volumeType: 'gp3', encrypted: true, deleteOnTermination: true } }],
+      tagSpecifications: [{ resourceType: 'instance', tags: [tag] }, { resourceType: 'volume', tags: [tag] }],
+    } });
+    const templateArn = `arn:aws:ec2:${a.region}:${a.account}:launch-template/${template.ref}`;
+    statement(lifecycle, ['ec2:RunInstances'], [instanceArn, volumeArn, `arn:aws:ec2:${a.region}:${a.account}:network-interface/*`,
+      `arn:aws:ec2:${a.region}::image/${a.ami}`, `arn:aws:ec2:${a.region}:${a.account}:subnet/${subnet.ref}`,
+      `arn:aws:ec2:${a.region}:${a.account}:security-group/${sg.attrGroupId}`, templateArn], {
+      ArnEquals: { 'ec2:LaunchTemplate': templateArn }, Bool: { 'ec2:IsLaunchTemplateResource': 'true' },
+    });
+    statement(lifecycle, ['ec2:CreateTags'], [instanceArn, volumeArn], { StringEquals: { 'ec2:CreateAction': 'RunInstances', 'aws:RequestTag/polis:private-cert': a.id }, 'ForAllValues:StringEquals': { 'aws:TagKeys': ['polis:private-cert'] } });
+    statement(lifecycle, ['iam:PassRole'], [worker.roleArn], { StringEquals: { 'iam:PassedToService': 'ec2.amazonaws.com' } });
+    statement(lifecycle, ['ec2:DescribeInstances', 'ec2:DescribeVolumes', 'ec2:DescribeImages'], ['*']);
+    statement(lifecycle, ['ec2:TerminateInstances'], [instanceArn], { StringEquals: { 'ec2:ResourceTag/polis:private-cert': a.id } });
+    statement(lifecycle, ['ec2:DeleteVolume'], [volumeArn], { StringEquals: { 'ec2:ResourceTag/polis:private-cert': a.id } });
+    statement(lifecycle, ['s3:GetObject', 's3:PutObject'], [control.arnForObjects('*')]);
+    statement(lifecycle, ['kms:Decrypt', 'kms:GenerateDataKey'], [evidenceKey.keyArn], kmsConditions(control.arnForObjects('*'), true));
+    statement(lifecycle, ['s3:ListBucketVersions'], [fixtures.bucketArn], { StringLike: { 's3:prefix': `staging/${a.id}/*` } });
+    // ListBucketMultipartUploads has no s3:prefix IAM condition support.
+    // Metadata inventory is limited to this one admission's dedicated bucket;
+    // API filtering and the abort/delete grants retain the exact staging prefix.
+    statement(lifecycle, ['s3:ListBucketMultipartUploads'], [fixtures.bucketArn]);
+    statement(lifecycle, ['s3:DeleteObjectVersion', 's3:DeleteObject', 's3:AbortMultipartUpload'], [fixtures.arnForObjects(`staging/${a.id}/*`)]);
+    const logGroup = new logs.LogGroup(this, 'ControlLogs', { retention: logs.RetentionDays.ONE_MONTH, removalPolicy: cdk.RemovalPolicy.RETAIN });
+    logGroup.grantWrite(lifecycle);
+    const fn = new lambda.Function(this, 'ControlFunction', {
+      runtime: lambda.Runtime.PYTHON_3_12, architecture: lambda.Architecture.ARM_64,
+      handler: 'control.handler', code: lambda.Code.fromAsset(path.join(__dirname, '../ci/private_cert'), { exclude: ['__pycache__', 'test_*'] }),
+      timeout: cdk.Duration.minutes(5), reservedConcurrentExecutions: 1, role: lifecycle, logGroup,
+      environment: { ADMISSION: canonical(a), ADMISSION_SHA256: digest, FIXTURE_BUCKET: fixtures.bucketName,
+        EVIDENCE_BUCKET: evidence.bucketName, CONTROL_BUCKET: control.bucketName, CONTROL_KEY: evidenceKey.keyArn,
+        TEMPLATE: template.ref, TEMPLATE_VERSION: template.attrLatestVersionNumber, PROFILE: profile.attrArn,
+        SUBNET: subnet.ref, SECURITY_GROUP: sg.attrGroupId, ENDPOINT: endpoint.ref },
+    });
+    // Immutable configuration selected by the function, not caller parameters.
+    fn.addPermission('OperatorInvoke', { principal: new iam.ArnPrincipal(a.operatorRoleArn), action: 'lambda:InvokeFunction' });
+    new events.Rule(this, 'Sweep', { schedule: events.Schedule.rate(cdk.Duration.minutes(5)), targets: [new targets.LambdaFunction(fn, { event: events.RuleTargetInput.fromObject({ action: 'sweep', admissionId: a.id }) })] });
+    const topic = sns.Topic.fromTopicArn(this, 'Maintainer', a.notificationTopicArn);
+    for (const [label, metric, threshold, missing] of [
+      ['Error', fn.metricErrors({ period: cdk.Duration.minutes(5) }), 1, cw.TreatMissingData.BREACHING],
+      ['MissingSweep', fn.metricInvocations({ period: cdk.Duration.minutes(15) }), 1, cw.TreatMissingData.BREACHING],
+    ] as const) {
+      const alarm = new cw.Alarm(this, label, { metric, threshold, evaluationPeriods: 1, treatMissingData: missing,
+        comparisonOperator: label === 'MissingSweep' ? cw.ComparisonOperator.LESS_THAN_THRESHOLD : cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD });
+      alarm.addAlarmAction(new actions.SnsAction(topic));
+    }
+    new cdk.CfnOutput(this, 'ControlFunctionName', { value: fn.functionName });
+    new cdk.CfnOutput(this, 'AdmissionDigest', { value: digest });
+    new cdk.CfnOutput(this, 'FixtureBucket', { value: fixtures.bucketName });
+    new cdk.CfnOutput(this, 'EvidenceBucket', { value: evidence.bucketName });
+    new cdk.CfnOutput(this, 'ControlBucket', { value: control.bucketName });
+  }
+}

--- a/cdk/test/privateCertBox.test.ts
+++ b/cdk/test/privateCertBox.test.ts
@@ -1,0 +1,113 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as crypto from 'crypto';
+import { PrivateCertBox, PrivateAdmission, canonical, validateAdmission } from '../privateCertBox';
+const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+function admission(overrides: Partial<PrivateAdmission> = {}): PrivateAdmission {
+  const a: PrivateAdmission = {
+    schema: 'polis-private-admission/1', signerPublicKey: publicKey.export({format: 'der', type: 'spki'}).subarray(-32).toString('hex'), signature: '',
+    id: 'a'.repeat(32), account: '111111111111', region: 'us-east-1', ami: 'ami-' + '1'.repeat(17),
+    fixtureKey: `staging/${'a'.repeat(32)}/bundle.tar`, fixtureVersion: 'synthetic-version-1',
+    fixtureSha256: '1'.repeat(64), fixtureBytes: 2048, expandedBytes: 1024, maxMembers: 2,
+    candidateSha: '2'.repeat(40), oracleSha: '3'.repeat(40), supervisorSha256: '4'.repeat(64), runtimeSha256: '5'.repeat(64),
+    runnerImage: 'localhost/polis-producer@sha256:' + '6'.repeat(64), verifierImage: 'localhost/polis-verifier@sha256:' + '7'.repeat(64),
+    policySha256: '8'.repeat(64), scheduleSha256: '9'.repeat(64), inventorySha256: 'a'.repeat(64), expectedChecks: 6,
+    stagingExpiresAt: '2099-01-01T09:00:00Z', expiresAt: '2099-01-01T12:00:00Z', operatorRoleArn: 'arn:aws:iam::111111111111:role/synthetic-operator',
+    curatorRoleArn: 'arn:aws:iam::111111111111:role/synthetic-curator', reviewerRoleArn: 'arn:aws:iam::111111111111:role/synthetic-reviewer',
+    notificationTopicArn: 'arn:aws:sns:us-east-1:111111111111:synthetic-maintainer', s3PrefixListId: 'pl-12345678', evidenceRetentionDays: 30, ...overrides,
+  };
+  const { signature, ...signed } = a;
+  a.signature = crypto.sign(null, Buffer.from(canonical(signed)), privateKey).toString('hex');
+  return a;
+}
+function build(a = admission()) {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'Private', { env: { account: a.account, region: a.region } });
+  new PrivateCertBox(stack, 'Box', a);
+  const assembly = app.synth();
+  return { t: Template.fromStack(stack), json: assembly.getStackArtifact(stack.artifactId).template };
+}
+const ofType = (j: any, type: string): any[] => Object.values(j.Resources).filter((r: any) => r.Type === type);
+test('isolated sibling network, only S3 endpoint egress and no production or interactive services', () => {
+  const {t, json: j} = build();
+  t.resourceCountIs('AWS::EC2::VPC', 1); t.resourceCountIs('AWS::EC2::Subnet', 1);
+  for (const type of ['AWS::EC2::NatGateway', 'AWS::EC2::InternetGateway', 'AWS::EC2::VPCPeeringConnection', 'AWS::EC2::Route', 'AWS::SSM::Document', 'AWS::IAM::OIDCProvider', 'AWS::EC2::Instance']) t.resourceCountIs(type, 0);
+  const sg = ofType(j, 'AWS::EC2::SecurityGroup')[0].Properties;
+  expect(sg.SecurityGroupIngress).toBeUndefined();
+  expect(sg.SecurityGroupEgress).toEqual([{ IpProtocol: 'tcp', FromPort: 443, ToPort: 443, DestinationPrefixListId: 'pl-12345678' }]);
+  const endpoint = ofType(j, 'AWS::EC2::VPCEndpoint')[0].Properties;
+  expect(endpoint.VpcEndpointType).toBe('Gateway'); expect(endpoint.PolicyDocument.Statement[0].Resource).toHaveLength(3);
+});
+test('pinned launch with disposable encrypted disks; no userdata, keypair or public IP', () => {
+  const d = ofType(build().json, 'AWS::EC2::LaunchTemplate')[0].Properties.LaunchTemplateData;
+  expect(d.ImageId).toBe('ami-' + '1'.repeat(17)); expect(d.InstanceType).toBe('r8g.4xlarge');
+  expect(d.UserData).toBeUndefined(); expect(d.KeyName).toBeUndefined();
+  expect(d.MetadataOptions).toEqual({HttpTokens: 'required', HttpPutResponseHopLimit: 1, InstanceMetadataTags: 'disabled'});
+  expect(d.InstanceInitiatedShutdownBehavior).toBe('terminate');
+  expect(d.NetworkInterfaces).toHaveLength(1); expect(d.NetworkInterfaces[0].AssociatePublicIpAddress).toBe(false);
+  expect(d.BlockDeviceMappings.map((d: any) => d.Ebs)).toEqual([32, 256].map(VolumeSize => ({VolumeSize, VolumeType: 'gp3', Encrypted: true, DeleteOnTermination: true})));
+});
+test('worker exact version, endpoint, own create-only writes and narrow KMS; no runtime administration', () => {
+  const j = build().json;
+  const policy = Object.entries(j.Resources).find(([id, r]: any) => id.startsWith('BoxWorkerDefaultPolicy') && r.Type === 'AWS::IAM::Policy')![1] as any;
+  const statements = policy.Properties.PolicyDocument.Statement, all = JSON.stringify(statements);
+  for (const forbidden of ['ssm:', 'sts:', 'secretsmanager:', 'ec2:RunInstances', 's3:ListBucket', 's3:Delete', 'logs:']) expect(all).not.toContain(forbidden);
+  const get = statements.find((s: any) => s.Action === 's3:GetObjectVersion');
+  expect(get.Condition.StringEquals['s3:VersionId']).toBe('synthetic-version-1');
+  expect(get.Condition.StringEquals['aws:SourceVpce']).toBeDefined(); expect(get.Condition.DateLessThan).toBeDefined();
+  const evidence = statements.find((s: any) => s.Action === 's3:PutObject' && JSON.stringify(s.Resource).includes('/runs/'));
+  expect(JSON.stringify(evidence.Resource)).toContain('${ec2:SourceInstanceARN}');
+  expect(evidence.Condition.StringEquals['s3:if-none-match']).toBe('*');
+  for (const s of statements.filter((s: any) => JSON.stringify(s.Action).includes('kms:'))) {
+    expect(JSON.stringify(s.Condition)).not.toContain('SourceVpce');
+    expect(s.Condition.StringEquals?.['kms:ViaService'] ?? s.Condition.StringLike?.['kms:ViaService']).toBe('s3.us-east-1.amazonaws.com');
+    expect(JSON.stringify(s.Condition)).toContain('kms:EncryptionContext:aws:s3:arn');
+  }
+});
+test('retained versioned private buckets and independent denies', () => {
+  const j = build().json;
+  for (const r of ofType(j, 'AWS::S3::Bucket')) {
+    expect(r.DeletionPolicy).toBe('Retain'); expect(r.UpdateReplacePolicy).toBe('Retain');
+    expect(r.Properties.BucketName.length).toBeLessThanOrEqual(63);
+    expect(r.Properties.VersioningConfiguration.Status).toBe('Enabled');
+    expect(Object.values(r.Properties.PublicAccessBlockConfiguration)).toEqual([true, true, true, true]);
+    expect(r.Properties.BucketEncryption.ServerSideEncryptionConfiguration[0].BucketKeyEnabled).toBe(false);
+  }
+  const policies = ofType(j, 'AWS::S3::BucketPolicy').flatMap(r => r.Properties.PolicyDocument.Statement);
+  for (const sid of ['WorkerOnlyReader', 'EndpointOnlyReader', 'OnlyAdmittedVersion', 'PrivateReaders', 'CreateOnly', 'WorkerCannotWriteRecords']) expect(policies.find((s: any) => s.Sid === sid)?.Effect).toBe('Deny');
+  expect(ofType(j, 'AWS::KMS::Key')).toHaveLength(2);
+});
+test('serialized operator-only launch with independently scheduled and alarmed sweep', () => {
+  const j = build().json, fn = ofType(j, 'AWS::Lambda::Function')[0].Properties;
+  expect(fn.ReservedConcurrentExecutions).toBe(1); expect(fn.Environment.Variables.TEMPLATE_VERSION).toBeDefined();
+  expect(Buffer.byteLength(JSON.stringify(fn.Environment.Variables))).toBeLessThan(4096);
+  expect(ofType(j, 'AWS::Events::Rule')[0].Properties.ScheduleExpression).toBe('rate(5 minutes)');
+  expect(ofType(j, 'AWS::CloudWatch::Alarm')).toHaveLength(2); expect(JSON.stringify(j)).not.toContain('RunShellScript');
+  expect(ofType(j, 'AWS::Lambda::Permission').some(p => p.Properties.Principal === admission().operatorRoleArn)).toBe(true);
+});
+test.each([
+  ['moving image', {runnerImage: 'localhost/polis-producer:latest'}], ['missing version', {fixtureVersion: ''}],
+  ['null version', {fixtureVersion: 'null'}], ['wrong key', {fixtureKey: 'another/bundle.tar'}],
+  ['wildcard principal', {operatorRoleArn: '*'}], ['same principals', {curatorRoleArn: 'arn:aws:iam::111111111111:role/synthetic-operator'}],
+  ['missing expiry', {expiresAt: ''}], ['oversize unpack', {expandedBytes: 200 * 1024 ** 3}],
+  ['zero checks', {expectedChecks: 0}], ['retention', {evidenceRetentionDays: 1}],
+  ['missing digest', {policySha256: ''}], ['bad region', {region: 'bad'}],
+] as [string, any][])('rejects %s before provisioning', (_name, overrides) => {
+  expect(() => validateAdmission(admission(overrides))).toThrow('Invalid private admission');
+});
+test('mutated signed bytes fail', () => {
+  const a = admission(); a.fixtureVersion = 'different-version';
+  expect(() => validateAdmission(a)).toThrow('signature');
+});
+test('explicit account mismatch fails', () => {
+  const s = new cdk.Stack(new cdk.App(), 'Wrong', {env: {account: '222222222222', region: 'us-east-1'}});
+  expect(() => new PrivateCertBox(s, 'Box', admission())).toThrow('must match stack');
+});
+
+test('multipart inventory uses the dedicated bucket without unsupported prefix condition', () => {
+  const j = build().json;
+  const all = ofType(j, 'AWS::IAM::Policy').flatMap(p => p.Properties.PolicyDocument.Statement);
+  const statement = all.find((s: any) => s.Action === 's3:ListBucketMultipartUploads');
+  expect(statement).toBeDefined(); expect(statement.Condition).toBeUndefined();
+  expect(JSON.stringify(statement.Resource)).toContain('Fixtures');
+});

--- a/ci/private_cert/bake.sh
+++ b/ci/private_cert/bake.sh
@@ -5,11 +5,13 @@ set -euo pipefail
 [ "$(id -u)" = 0 ]
 [ "$(uname -m)" = aarch64 ]
 : "${PRIVATE_CERT_BOOTSTRAP:?path to public bootstrap JSON required}"
+: "${PRIVATE_CERT_IMAGE_LOCK:?reviewed canonical image-lock.json required}"
 for tool in podman nft python3 mkfs.ext4 mount systemctl; do command -v "$tool" >/dev/null; done
 python3 -c 'import boto3, cryptography'
 install -d -m 0755 /opt/polis-private
 install -m 0444 "$PRIVATE_CERT_BOOTSTRAP" /opt/polis-private/bootstrap.json
-for file in worker.py control.py dns.py; do install -m 0444 "$(dirname "$0")/$file" "/opt/polis-private/$file"; done
+install -m 0444 "$PRIVATE_CERT_IMAGE_LOCK" /opt/polis-private/image-lock.json
+for file in worker.py control.py dns.py image_admission.py; do install -m 0444 "$(dirname "$0")/$file" "/opt/polis-private/$file"; done
 # No remote commands, cloud-init, SSM, SSH or serial interactive console.
 for unit in cloud-init-local cloud-init cloud-config cloud-final sshd amazon-ssm-agent serial-getty@ttyS0; do systemctl mask "$unit.service"; done
 systemctl mask swap.target
@@ -102,7 +104,11 @@ python3 - <<'PYLOCK'
 import hashlib, json
 from pathlib import Path
 root = Path('/opt/polis-private')
-names = ['bootstrap.json', 'control.py', 'dns.py', 'start.sh', 'firewall.nft']
+names = ['bootstrap.json', 'control.py', 'dns.py', 'start.sh', 'firewall.nft',
+         'image_admission.py', 'image-lock.json']
+# Require canonical bytes so the runtime lock and reviewer use the same digest.
+image_bytes = (root/'image-lock.json').read_bytes()
+assert image_bytes == json.dumps(json.loads(image_bytes), sort_keys=True, separators=(',', ':')).encode()
 lock = {n: hashlib.sha256((root/n).read_bytes()).hexdigest() for n in names}
 raw = json.dumps(lock, sort_keys=True, separators=(',', ':')).encode()
 (root/'runtime-lock.json').write_bytes(raw)

--- a/ci/private_cert/bake.sh
+++ b/ci/private_cert/bake.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Run ONLY in the offline ARM64 image builder, never by user-data. Dependencies
+# must already be installed/pinned. No package repositories or executable fetch.
+set -euo pipefail
+[ "$(id -u)" = 0 ]
+[ "$(uname -m)" = aarch64 ]
+: "${PRIVATE_CERT_BOOTSTRAP:?path to public bootstrap JSON required}"
+for tool in podman nft python3 mkfs.ext4 mount systemctl; do command -v "$tool" >/dev/null; done
+python3 -c 'import boto3, cryptography'
+install -d -m 0755 /opt/polis-private
+install -m 0444 "$PRIVATE_CERT_BOOTSTRAP" /opt/polis-private/bootstrap.json
+for file in worker.py control.py dns.py; do install -m 0444 "$(dirname "$0")/$file" "/opt/polis-private/$file"; done
+# No remote commands, cloud-init, SSM, SSH or serial interactive console.
+for unit in cloud-init-local cloud-init cloud-config cloud-final sshd amazon-ssm-agent serial-getty@ttyS0; do systemctl mask "$unit.service"; done
+systemctl mask swap.target
+printf '* hard core 0\n* soft core 0\n' > /etc/security/limits.d/90-private-cert.conf
+printf 'kernel.core_pattern=|/bin/false\nvm.swappiness=0\n' > /etc/sysctl.d/90-private-cert.conf
+id private-dns >/dev/null 2>&1 || useradd --system --no-create-home --shell /sbin/nologin private-dns
+private_dns_uid="$(id -u private-dns)"
+cat > /opt/polis-private/firewall.nft <<NFT
+table inet private_cert {
+ chain output {
+  type filter hook output priority -10; policy accept;
+  ip daddr 127.0.0.1 accept
+  udp dport 53 meta skuid $private_dns_uid ip daddr 10.253.0.2 accept
+  udp dport 53 reject
+  tcp dport 53 reject
+  ip daddr 169.254.169.254 meta skuid != 0 reject
+  ip6 daddr fd00:ec2::254 reject
+ }
+}
+NFT
+cat > /etc/systemd/system/polis-private-dns.service <<'UNIT'
+[Unit]
+Before=polis-private-worker.service
+[Service]
+Type=simple
+User=private-dns
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ExecStart=/usr/bin/python3 /opt/polis-private/dns.py
+Restart=on-failure
+StandardOutput=null
+StandardError=null
+[Install]
+WantedBy=multi-user.target
+UNIT
+cat > /opt/polis-private/start.sh <<'START'
+#!/usr/bin/env bash
+set -euo pipefail
+# Arm termination before any mount, DNS or supervisor work can fail. EC2's
+# independent sweeper enforces absolute admission expiry and missing heartbeat.
+shutdown -h +720
+trap 'systemctl poweroff' EXIT
+swapoff -a
+ulimit -c 0
+nft -f /opt/polis-private/firewall.nft
+printf 'nameserver 127.0.0.1\noptions timeout:2 attempts:2\n' > /etc/resolv.conf
+systemctl start polis-private-dns.service
+# Match the EBS launch-template device name, never guess an NVMe disk number.
+private_disk=''
+for dev in /dev/nvme*n1; do
+  if /sbin/ebsnvme-id "$dev" 2>/dev/null | /usr/bin/grep -Eq '^(/dev/)?sdf$'; then private_disk="$dev"; fi
+done
+[ -n "$private_disk" ]
+[ -z "$(lsblk -n -o MOUNTPOINT "$private_disk" | tr -d '[:space:]')" ]
+mkfs.ext4 -F "$private_disk" >/dev/null
+mkdir -p /private-cert
+mount -o nodev,nosuid,noexec "$private_disk" /private-cert
+chmod 0700 /private-cert
+python3 /opt/polis-private/worker.py
+START
+chmod 0500 /opt/polis-private/start.sh
+cat > /etc/systemd/system/polis-private-worker.service <<'UNIT'
+[Unit]
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=oneshot
+ExecStart=/opt/polis-private/start.sh
+ExecStopPost=/usr/bin/systemctl poweroff
+TimeoutStartSec=43200
+LimitCORE=0
+UMask=0077
+StandardOutput=null
+StandardError=null
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl enable polis-private-worker.service
+# Images must have been podman-loaded in the builder from verified OCI archives.
+# AMI snapshots and package/image attestation are produced by the existing
+# private image-builder operator, not by this script or the runtime role.
+
+# Hash the actual installed bytes, after all generated files. The later signed
+# admission binds this lock. Never bake a not-yet-assigned AMI ID.
+python3 - <<'PYLOCK'
+import hashlib, json
+from pathlib import Path
+root = Path('/opt/polis-private')
+names = ['bootstrap.json', 'control.py', 'dns.py', 'start.sh', 'firewall.nft']
+lock = {n: hashlib.sha256((root/n).read_bytes()).hexdigest() for n in names}
+raw = json.dumps(lock, sort_keys=True, separators=(',', ':')).encode()
+(root/'runtime-lock.json').write_bytes(raw)
+(root/'runtime-lock.json').chmod(0o444)
+print(json.dumps({'runtimeSha256': hashlib.sha256(raw).hexdigest(),
+                  'supervisorSha256': hashlib.sha256((root/'worker.py').read_bytes()).hexdigest()}))
+PYLOCK

--- a/ci/private_cert/check_synth.py
+++ b/ci/private_cert/check_synth.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Compare full synth templates; do not normalize away any resource fields."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def compare(base, off):
+    a, b = json.loads(base.read_bytes()), json.loads(off.read_bytes())
+    changed = sorted(k for k in a['Resources'].keys() | b['Resources'].keys() if a['Resources'].get(k) != b['Resources'].get(k))
+    receipt = {'baseResources': len(a['Resources']), 'offResources': len(b['Resources']), 'changedResources': changed,
+               'wholeTemplateEqual': a == b, 'baseSha256': hashlib.sha256(base.read_bytes()).hexdigest(),
+               'offSha256': hashlib.sha256(off.read_bytes()).hexdigest()}
+    if changed or a != b:
+        raise ValueError('Default-off changed the existing template')
+    return receipt
+
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser()
+    p.add_argument('base', type=Path); p.add_argument('off', type=Path)
+    args = p.parse_args()
+    print(json.dumps(compare(args.base, args.off), indent=2))

--- a/ci/private_cert/control.py
+++ b/ci/private_cert/control.py
@@ -1,0 +1,227 @@
+"""P-053 trusted control plane. Never logs events, SDK errors or private bytes.
+
+One admission, one ClientToken, one launch attempt. Reserved concurrency is one.
+A lost RunInstances response is reconciled by token; it is NEVER retried as a new
+launch. Every mutation verifies template/profile/token/network AND ledger tags.
+Only fixture staging is deleted. Evidence and immutable control records remain.
+"""
+import datetime as dt
+import hashlib
+import json
+import os
+import time
+
+
+class Unknown(RuntimeError):
+    pass
+
+
+def encoded(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def sha(value):
+    return hashlib.sha256(encoded(value)).hexdigest()
+
+
+class Control:
+    def __init__(self, ec2, s3, cfg, now=None):
+        self.ec2, self.s3, self.c = ec2, s3, cfg
+        self.a = json.loads(cfg["ADMISSION"])
+        self.now = time.time() if now is None else now
+        if sha(self.a) != cfg["ADMISSION_SHA256"]:
+            raise Unknown("ADMISSION_INVALID")
+        self.expiry = dt.datetime.fromisoformat(self.a["expiresAt"].replace("Z", "+00:00")).timestamp()
+        self.token = self.c["ADMISSION_SHA256"]
+        self.prefix = f'control/{self.a["id"]}/'
+
+    def read(self, key):
+        try:
+            obj = self.s3.get_object(Bucket=self.c["CONTROL_BUCKET"], Key=key)
+        except Exception as e:
+            if getattr(e, "response", {}).get("Error", {}).get("Code") == "NoSuchKey":
+                return None
+            raise Unknown("CONTROL_READ_UNKNOWN") from None
+        raw = obj["Body"].read(65537)
+        if len(raw) > 65536:
+            raise Unknown("CONTROL_OVERSIZE")
+        return json.loads(raw)
+
+    def record(self, key, value):
+        """Create-only, including after lost acknowledgement. No hidden overwrite."""
+        try:
+            self.s3.put_object(Bucket=self.c["CONTROL_BUCKET"], Key=key, Body=encoded(value),
+                               IfNoneMatch="*", ServerSideEncryption="aws:kms", SSEKMSKeyId=self.c["CONTROL_KEY"])
+        except Exception:
+            if self.read(key) != value:
+                raise Unknown("RECORD_CONFLICT") from None
+
+    def own(self, i):
+        c, a = self.c, self.a
+        return (i.get("ClientToken") == self.token
+                and i.get("LaunchTemplate", {}).get("LaunchTemplateId") == c["TEMPLATE"]
+                and i.get("LaunchTemplate", {}).get("Version") == c["TEMPLATE_VERSION"]
+                and not i.get("PublicIpAddress")
+                and {g["GroupId"] for g in i.get("SecurityGroups", [])} == {c["SECURITY_GROUP"]}
+                and i.get("IamInstanceProfile", {}).get("Arn") == c["PROFILE"]
+                and i.get("ImageId") == a["ami"] and i.get("SubnetId") == c["SUBNET"]
+                and i.get("InstanceType") == "r8g.4xlarge"
+                and {t["Key"]: t["Value"] for t in i.get("Tags", [])}.get("polis:private-cert") == a["id"])
+
+    def instances(self):
+        found = []
+        for page in self.ec2.get_paginator("describe_instances").paginate(Filters=[
+            {"Name": "client-token", "Values": [self.token]},
+        ]):
+            for reservation in page["Reservations"]:
+                found.extend(reservation["Instances"])
+        if any(not self.own(i) for i in found) or len(found) > 1:
+            raise Unknown("INSTANCE_OWNERSHIP_UNKNOWN")
+        return found
+
+    def launch(self):
+        if self.now < dt.datetime.fromisoformat(self.a["stagingExpiresAt"].replace("Z", "+00:00")).timestamp():
+            raise Unknown("INGESTION_STILL_OPEN")
+        if self.now >= self.expiry or self.expiry - self.now > 12 * 3600:
+            raise Unknown("ADMISSION_EXPIRED_OR_OVER_BUDGET")
+        if self.read(self.prefix + "clean.json") or self.read(self.prefix + "cancel.json"):
+            raise Unknown("RUN_CLOSED")
+        if self.read(self.prefix + "claim.json"):
+            # No RunInstances retry: its idempotency horizon is not unbounded.
+            return self.reconcile()
+        image = self.ec2.describe_images(ImageIds=[self.a["ami"]])["Images"]
+        if len(image) != 1 or image[0].get("Architecture") != "arm64" or image[0].get("State") != "available" or image[0].get("OwnerId") != self.a["account"]:
+            raise Unknown("IMAGE_NOT_ADMITTED")
+        self.record(self.prefix + "claim.json", {"admissionSha256": self.token, "started": self.now})
+        # Body contains only fixed template and token. Caller cannot supply overrides.
+        self.ec2.run_instances(LaunchTemplate={"LaunchTemplateId": self.c["TEMPLATE"], "Version": self.c["TEMPLATE_VERSION"]},
+                               MinCount=1, MaxCount=1, ClientToken=self.token)
+        return self.reconcile()
+
+    def heartbeat_missing(self, instance, claim):
+        if self.now - claim["started"] < 600:
+            return False  # bounded boot grace, included in the campaign ceiling
+        arn = f'arn:aws:ec2:{self.a["region"]}:{self.a["account"]}:instance/{instance["InstanceId"]}'
+        try:
+            obj = self.s3.head_object(Bucket=self.c["CONTROL_BUCKET"], Key=f'heartbeats/{self.a["id"]}/{arn}.json')
+            return self.now - obj["LastModified"].timestamp() > 300
+        except Exception as e:
+            if getattr(e, "response", {}).get("Error", {}).get("Code") in ("404", "NoSuchKey", "NotFound"):
+                return True
+            raise Unknown("HEARTBEAT_UNKNOWN") from None
+
+    def dispose_fixture(self):
+        b, prefix = self.c["FIXTURE_BUCKET"], f'staging/{self.a["id"]}/'
+        # Paginate each inventory before mutating it; successful requests alone
+        # are insufficient. A fresh empty inventory is the deletion receipt.
+        for page in self.s3.get_paginator("list_multipart_uploads").paginate(Bucket=b, Prefix=prefix):
+            for u in page.get("Uploads", []):
+                self.s3.abort_multipart_upload(Bucket=b, Key=u["Key"], UploadId=u["UploadId"])
+        versions = []
+        for page in self.s3.get_paginator("list_object_versions").paginate(Bucket=b, Prefix=prefix):
+            versions.extend(page.get("Versions", []) + page.get("DeleteMarkers", []))
+        for v in versions:
+            self.s3.delete_object(Bucket=b, Key=v["Key"], VersionId=v["VersionId"])
+        for page in self.s3.get_paginator("list_object_versions").paginate(Bucket=b, Prefix=prefix):
+            if page.get("Versions") or page.get("DeleteMarkers"):
+                raise Unknown("FIXTURE_REMAINS")
+        for page in self.s3.get_paginator("list_multipart_uploads").paginate(Bucket=b, Prefix=prefix):
+            if page.get("Uploads"):
+                raise Unknown("UPLOAD_REMAINS")
+
+    def reconcile(self, cancel=False):
+        claim = self.read(self.prefix + "claim.json")
+        clean = self.read(self.prefix + "clean.json")
+        if clean:
+            return {"status": "CLEAN", "admissionId": self.a["id"]}
+        if cancel:
+            self.record(self.prefix + "cancel.json", {"admissionSha256": self.token})
+        expired = self.now >= self.expiry or (claim and self.now - claim["started"] >= 12 * 3600)
+        cancelled = bool(self.read(self.prefix + "cancel.json"))
+        if not claim:
+            if expired or cancelled:
+                self.dispose_fixture()
+                # No launch claim ever existed, so no launch can be in flight.
+                self.record(self.prefix + "clean.json", {"admissionSha256": self.token, "instanceId": None, "volumes": [], "fixtureVersions": 0, "status": "CLEAN"})
+                return {"status": "CLEAN", "admissionId": self.a["id"]}
+            return {"status": "STAGED", "admissionId": self.a["id"]}
+        if expired or cancelled:
+            # Expiry destroys staged bytes even if EC2 reconciliation is unknown.
+            self.dispose_fixture()
+        instances = self.instances()
+        if not instances:
+            raise Unknown("LAUNCH_ACK_UNKNOWN")
+        i = instances[0]
+        iid = i["InstanceId"]
+        volume_ids = sorted(b["Ebs"]["VolumeId"] for b in i.get("BlockDeviceMappings", []) if "Ebs" in b)
+        prior = self.read(self.prefix + "instance.json")
+        if not prior and volume_ids:
+            self.record(self.prefix + "instance.json", {"id": iid, "volumes": volume_ids, "admissionSha256": self.token})
+            prior = self.read(self.prefix + "instance.json")
+        if prior and prior["id"] != iid:
+            raise Unknown("INSTANCE_CHANGED")
+        if i["State"]["Name"] != "terminated":
+            if expired or cancelled or self.heartbeat_missing(i, claim):
+                self.ec2.terminate_instances(InstanceIds=[iid])
+                # Observe on a later sweep; do not call accepted termination CLEAN.
+                raise Unknown("TERMINATION_PENDING")
+            if not prior or len(prior["volumes"]) != 2:
+                raise Unknown("DISK_INVENTORY_UNKNOWN")
+            boot = {"admission": self.a, "admissionSha256": self.token, "instanceId": iid,
+                    "template": self.c["TEMPLATE"], "templateVersion": self.c["TEMPLATE_VERSION"],
+                    "fixtureBucket": self.c["FIXTURE_BUCKET"], "evidenceBucket": self.c["EVIDENCE_BUCKET"],
+                    "controlBucket": self.c["CONTROL_BUCKET"], "evidenceKey": self.c["CONTROL_KEY"],
+                    "endpoint": self.c["ENDPOINT"], "started": claim["started"]}
+            self.record(f'boot/{self.a["id"]}.json', boot)
+            return {"status": "RUNNING", "admissionId": self.a["id"]}
+        if not prior or len(prior["volumes"]) != 2:
+            raise Unknown("DISK_INVENTORY_UNKNOWN")
+        # Include tagged unexpected disks, but never delete on tag alone.
+        disks = []
+        for page in self.ec2.get_paginator("describe_volumes").paginate(Filters=[{"Name": "tag:polis:private-cert", "Values": [self.a["id"]]}]):
+            disks.extend(page["Volumes"])
+        if any(v["VolumeId"] not in prior["volumes"] for v in disks):
+            raise Unknown("UNKNOWN_DISK")
+        for v in disks:
+            if v.get("Attachments") or v.get("State") != "available":
+                raise Unknown("DISK_NOT_DETACHED")
+            self.ec2.delete_volume(VolumeId=v["VolumeId"])
+        # Independently query the actual IDs too; missing/changed tags cannot hide disks.
+        for vid in prior["volumes"]:
+            try:
+                response = self.ec2.describe_volumes(VolumeIds=[vid])
+            except Exception as e:
+                if getattr(e, "response", {}).get("Error", {}).get("Code") == "InvalidVolume.NotFound":
+                    continue
+                raise Unknown("DISK_DESCRIBE_UNKNOWN") from None
+            if response.get("Volumes"):
+                raise Unknown("DISK_REMAINS")
+            raise Unknown("DISK_DESCRIBE_EMPTY")
+        self.dispose_fixture()
+        self.record(self.prefix + "clean.json", {"admissionSha256": self.token, "instanceId": iid,
+                    "volumes": prior["volumes"], "fixtureVersions": 0, "status": "CLEAN"})
+        return {"status": "CLEAN", "admissionId": self.a["id"]}
+
+
+def handler(event, context):
+    import boto3
+    # No free-form output or private exception payload reaches CloudWatch.
+    try:
+        cfg = dict(os.environ)
+        a = json.loads(cfg["ADMISSION"])
+        if set(event) != {"action", "admissionId"} or event["admissionId"] != a["id"]:
+            raise Unknown("REQUEST_NOT_ADMITTED")
+        c = Control(boto3.client("ec2"), boto3.client("s3"), cfg)
+        if event["action"] == "launch":
+            result = c.launch()
+        elif event["action"] in ("sweep", "cancel", "status"):
+            result = c.reconcile(cancel=event["action"] == "cancel")
+        else:
+            raise Unknown("ACTION_NOT_ADMITTED")
+        print(json.dumps({"healthy": 1, "unknown": 0}))
+        return result
+    except Exception:
+        print(json.dumps({"healthy": 0, "unknown": 1}))
+        # Fixed exception makes Lambda Errors/alarm fire without leaking raw SDK
+        # responses, IDs, manifest fields or operator-supplied text.
+        raise RuntimeError("TEARDOWN_UNKNOWN") from None

--- a/ci/private_cert/dns.py
+++ b/ci/private_cert/dns.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Exact-name DNS forwarder for the baked host; run as private-dns UID.
+
+The worker SG does not filter Amazon DNS. nftables allows only this UID to
+reach the resolver; candidates have their own disconnected network namespace.
+"""
+import json
+import socket
+from pathlib import Path
+
+
+def question(packet):
+    if len(packet) < 17 or packet[4:6] != b'\x00\x01' or packet[6:12] != b'\x00' * 6:
+        raise ValueError('DNS_SHAPE')
+    at, labels = 12, []
+    while packet[at]:
+        n = packet[at]
+        if n > 63 or at + n + 1 >= len(packet):
+            raise ValueError('DNS_NAME')
+        labels.append(packet[at + 1:at + n + 1].decode('ascii').lower())
+        at += n + 1
+    if len(packet) != at + 5 or packet[-2:] != b'\x00\x01' or packet[-4:-2] not in (b'\x00\x01', b'\x00\x1c'):
+        raise ValueError('DNS_TYPE')
+    return '.'.join(labels)
+
+
+def run():
+    b = json.loads(Path('/opt/polis-private/bootstrap.json').read_bytes())
+    allowed = {f'ppc-{b["account"]}-{b["id"]}-{suffix}.s3.{b["region"]}.amazonaws.com' for suffix in ('fixtures', 'evidence', 'control')}
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(('127.0.0.1', 53))
+    while True:
+        packet, sender = sock.recvfrom(4096)
+        try:
+            if question(packet) not in allowed:
+                raise ValueError('DNS_DENIED')
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as upstream:
+                upstream.settimeout(3)
+                upstream.connect(('10.253.0.2', 53))
+                upstream.send(packet)
+                response = upstream.recv(65535)
+                if response[:2] != packet[:2]:
+                    raise ValueError('DNS_ID')
+            sock.sendto(response, sender)
+        except Exception:
+            # REFUSED, never include payload in a log.
+            if len(packet) >= 12:
+                sock.sendto(packet[:2] + b'\x81\x85' + packet[4:6] + b'\x00' * 6 + packet[12:], sender)
+
+
+if __name__ == '__main__':
+    run()

--- a/ci/private_cert/image_admission.py
+++ b/ci/private_cert/image_admission.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Offline P-053 OCI closure/admission checks. Does not pull, build or publish.
+
+An OCI manifest digest is not an image configuration ID or the tar SHA256.
+The reviewer pins all three separately. Labels are cross-checks of an already
+reviewed image, never proof of mathematical correctness or independence.
+"""
+import argparse
+import gzip
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import tarfile
+
+from control import encoded, sha
+
+SCHEMA = 'polis-private-images/1'
+ROLES = {'producer': 'produce', 'verifier': 'verify'}
+# BOARD [677]: step-2 paired-recording scope; shadow diagnostics are separate.
+GATES = {'inventory', 'strict', 'g12'}
+CONTROLS = {'missing-evidence', 'forged-evidence', 'truncated-evidence',
+            'short-inventory', 'wrong-input', 'wrong-policy', 'stale-checkpoint',
+            'candidate-control-isolation'}
+HEX = re.compile(r'^[a-f0-9]{64}$')
+COMMIT = re.compile(r'^[a-f0-9]{40}$')
+IMAGE = re.compile(r'^[a-z0-9][a-z0-9./:_-]*@sha256:[a-f0-9]{64}$')
+MANIFEST = 'application/vnd.oci.image.manifest.v1+json'
+CONFIG = 'application/vnd.oci.image.config.v1+json'
+LAYER = 'application/vnd.oci.image.layer.v1.tar'
+MAX_JSON = 4 * 1024 * 1024
+
+
+def digest_stream(f):
+    h = hashlib.sha256()
+    size = 0
+    for b in iter(lambda: f.read(1024 * 1024), b''):
+        size += len(b)
+        h.update(b)
+    return h.hexdigest(), size
+
+
+def file_digest(path):
+    with Path(path).open('rb') as f:
+        return digest_stream(f)[0]
+
+
+def json_bytes(raw):
+    def pairs(items):
+        out = {}
+        for k, v in items:
+            if k in out:
+                raise ValueError('DUPLICATE_JSON_KEY')
+            out[k] = v
+        return out
+    return json.loads(raw, object_pairs_hook=pairs,
+                      parse_constant=lambda _: (_ for _ in ()).throw(ValueError('NONFINITE_JSON')))
+
+
+def regular_path(name):
+    p = PurePosixPath(name)
+    if (not name or p.is_absolute() or '..' in p.parts or str(p) != name
+            or '\\' in name or any(ord(c) < 32 for c in name)):
+        raise ValueError('UNSAFE_IMAGE_PATH')
+    return p
+
+
+def validate_recipe(recipe):
+    fields = {'schema', 'role', 'sourceCommit', 'candidateSha', 'oracleSha',
+              'policySha256', 'runtimeImage', 'files', 'entrypoint', 'gates'}
+    if (type(recipe) is not dict or set(recipe) != fields
+            or recipe['schema'] != 'polis-private-image-recipe/1'
+            or recipe['role'] not in ROLES):
+        raise ValueError('IMAGE_RECIPE_SCHEMA')
+    for k in ('sourceCommit', 'candidateSha', 'oracleSha'):
+        if not isinstance(recipe[k], str) or not COMMIT.fullmatch(recipe[k]):
+            raise ValueError('IMAGE_SOURCE_PIN')
+    if not isinstance(recipe['policySha256'], str) or not HEX.fullmatch(recipe['policySha256']):
+        raise ValueError('IMAGE_POLICY_PIN')
+    if not isinstance(recipe['runtimeImage'], str) or not IMAGE.fullmatch(recipe['runtimeImage']):
+        raise ValueError('RUNTIME_IMAGE_PIN')
+    if (not isinstance(recipe['gates'], list) or len(recipe['gates']) != len(GATES)
+            or set(recipe['gates']) != GATES):
+        raise ValueError('INCOMPLETE_IMAGE_GATES')
+    files = recipe['files']
+    if not isinstance(files, dict) or not files:
+        raise ValueError('EMPTY_SOURCE_CLOSURE')
+    for name, digest in files.items():
+        p = regular_path(name)
+        # Source-only context: no ambient checkout/private data/credential copy.
+        if (any(part in {'.git', '.local', '.venv', '.aws', '.ssh', '__pycache__'}
+                or part == '.env' or part.endswith('.env') for part in p.parts)
+                or ('real_data' in p.parts and p.parts[:2] != ('delphi', 'real_data'))
+                or not isinstance(digest, str) or not HEX.fullmatch(digest)):
+            raise ValueError('UNSAFE_SOURCE_CLOSURE')
+    if recipe['entrypoint'] not in files or not recipe['entrypoint'].endswith('.py'):
+        raise ValueError('IMAGE_ENTRYPOINT')
+    return recipe
+
+
+def inspect_oci(path):
+    """Validate one Linux ARM64 image and its entire referenced blob closure.
+
+    Supports single-image OCI tar exports, gzip/plain layers, no attestations or
+    multi-platform index. Export the ARM manifest explicitly; do not guess which
+    platform or signature an index intended. No archive extraction occurs.
+    """
+    with tarfile.open(path, 'r:') as archive:
+        members = {}
+        for m in archive:
+            name = m.name.rstrip('/') if m.isdir() else m.name
+            regular_path(name)
+            if m.isdir():
+                continue
+            if not m.isfile() or name in members or m.size < 0:
+                raise ValueError('UNSAFE_OCI_MEMBER')
+            members[name] = m
+        used = set()
+        def read(name, limit=MAX_JSON):
+            if name not in members or members[name].size > limit:
+                raise ValueError('MISSING_OR_OVERSIZE_OCI_JSON')
+            used.add(name)
+            return archive.extractfile(members[name]).read()
+        if json_bytes(read('oci-layout')) != {'imageLayoutVersion': '1.0.0'}:
+            raise ValueError('OCI_LAYOUT')
+        index = json_bytes(read('index.json'))
+        if index.get('schemaVersion') != 2 or len(index.get('manifests', [])) != 1:
+            raise ValueError('SINGLE_OCI_IMAGE_REQUIRED')
+        def descriptor(d, media):
+            digest = d.get('digest', '')
+            if (d.get('mediaType') != media or not digest.startswith('sha256:')
+                    or not HEX.fullmatch(digest[7:]) or type(d.get('size')) is not int
+                    or d['size'] < 0 or d.get('urls')):
+                raise ValueError('OCI_DESCRIPTOR')
+            name = 'blobs/sha256/' + digest[7:]
+            if name not in members or members[name].size != d['size']:
+                raise ValueError('OCI_BLOB_SIZE')
+            used.add(name)
+            with archive.extractfile(members[name]) as f:
+                actual, size = digest_stream(f)
+            if actual != digest[7:] or size != d['size']:
+                raise ValueError('OCI_BLOB_DIGEST')
+            return name
+        md = index['manifests'][0]
+        manifest = json_bytes(read(descriptor(md, MANIFEST)))
+        if manifest.get('schemaVersion') != 2 or manifest.get('mediaType') != MANIFEST:
+            raise ValueError('OCI_MANIFEST')
+        config = json_bytes(read(descriptor(manifest['config'], CONFIG)))
+        if config.get('os') != 'linux' or config.get('architecture') != 'arm64':
+            raise ValueError('OCI_PLATFORM')
+        rootfs = config.get('rootfs', {})
+        layers = manifest.get('layers', [])
+        if rootfs.get('type') != 'layers' or len(rootfs.get('diff_ids', [])) != len(layers) or not layers:
+            raise ValueError('OCI_ROOTFS')
+        private_files = {}
+        private_root = 'opt/polis-private-image'
+        for d, expected in zip(layers, rootfs['diff_ids']):
+            media = d.get('mediaType')
+            if media not in {LAYER, LAYER + '+gzip'}:
+                raise ValueError('OCI_LAYER_TYPE')
+            name = descriptor(d, media)
+            with archive.extractfile(members[name]) as f:
+                stream = gzip.GzipFile(fileobj=f) if media.endswith('+gzip') else f
+                actual, _ = digest_stream(stream)
+            if 'sha256:' + actual != expected:
+                raise ValueError('OCI_DIFF_ID')
+            # Verify the final overlay's source closure, not just its labels.
+            with archive.extractfile(members[name]) as f:
+                stream = gzip.GzipFile(fileobj=f) if media.endswith('+gzip') else f
+                with tarfile.open(fileobj=stream, mode='r|') as layer:
+                    for member in layer:
+                        rel = member.name
+                        while rel.startswith('./'):
+                            rel = rel[2:]
+                        rel = rel.rstrip('/') if member.isdir() else rel
+                        if rel in ('', '.') and member.isdir():
+                            continue
+                        regular_path(rel)
+                        parent, _, leaf = rel.rpartition('/')
+                        ancestor = rel == private_root or private_root.startswith(rel + '/')
+                        inside = rel.startswith(private_root + '/')
+                        if (ancestor and not member.isdir()) or (
+                            inside and not (member.isfile() or member.isdir())):
+                            raise ValueError('OCI_SOURCE_LINK_OR_TYPE')
+                        if leaf.startswith('.wh.') and (
+                            private_root.startswith(parent + '/') or parent == private_root
+                            or parent.startswith(private_root + '/') or parent == ''):
+                            raise ValueError('OCI_SOURCE_WHITEOUT')
+                        if inside and member.isfile():
+                            with layer.extractfile(member) as body:
+                                value, _ = digest_stream(body)
+                            private_files[rel[len(private_root) + 1:]] = value
+        if set(members) != used:
+            raise ValueError('UNREFERENCED_OCI_CONTENT')
+        return {'manifestDigest': md['digest'], 'configDigest': manifest['config']['digest'],
+                'archiveSha256': file_digest(path), 'architecture': 'arm64', 'os': 'linux',
+                'config': config.get('config', {}), 'privateFiles': private_files}
+
+
+def validate_config(config, recipe):
+    labels = config.get('Labels', {})
+    expected = {'org.polis.private.role': recipe['role'], 'org.polis.private.recipe': sha(recipe)}
+    if any(labels.get(k) != v for k, v in expected.items()):
+        raise ValueError('IMAGE_LABEL_BINDING')
+    if (config.get('User') != '65534:65534'
+            or config.get('Entrypoint') != ['/usr/bin/python3', '/opt/polis-private-image/launcher.py']
+            or config.get('Cmd') not in (None, []) or config.get('Volumes')
+            or config.get('ExposedPorts') or config.get('OnBuild') or config.get('WorkingDir') != '/opt/polis-private-image'):
+        raise ValueError('IMAGE_EXECUTION_CONTRACT')
+    permitted = {'PATH', 'HOME', 'LANG', 'LC_ALL', 'JAVA_HOME', 'JAVA_VERSION',
+                 'PYTHON_VERSION', 'PYTHON_SHA256', 'GPG_KEY', 'PYTHONDONTWRITEBYTECODE',
+                 'PYTHONNOUSERSITE', 'PYTHONUNBUFFERED', 'UV_OFFLINE', 'PIP_NO_INDEX',
+                 'OPENBLAS_NUM_THREADS', 'OMP_NUM_THREADS', 'MKL_NUM_THREADS', 'NUMEXPR_NUM_THREADS'}
+    if any(not isinstance(e, str) or '=' not in e or e.split('=', 1)[0] not in permitted
+           for e in config.get('Env', [])):
+        raise ValueError('IMAGE_AMBIENT_ENVIRONMENT')
+
+
+def make_lock(producer, verifier, recipes, review):
+    """The supplied review is a separately reviewed artifact, not self-attestation.
+
+    Its digest is frozen in the signed runtime lock, alongside exact OCI bytes.
+    No tool fabricates a passing canary receipt from a successful build.
+    """
+    if (set(review) != {'schema', 'recipeSha256', 'controls', 'gateReviewSha256'}
+            or review['schema'] != 'polis-private-image-review/1'
+            or not isinstance(review['gateReviewSha256'], str)
+            or not HEX.fullmatch(review['gateReviewSha256'])
+            or set(review['controls']) != CONTROLS
+            or any(v != 'PASS' for v in review['controls'].values())):
+        raise ValueError('IMAGE_REVIEW_INCOMPLETE')
+    entries = {}
+    for role, archive in [('producer', producer), ('verifier', verifier)]:
+        recipe = validate_recipe(recipes[role])
+        if recipe['role'] != role or review['recipeSha256'].get(role) != sha(recipe):
+            raise ValueError('IMAGE_REVIEW_BINDING')
+        image = inspect_oci(archive)
+        validate_config(image.pop('config'), recipe)
+        launcher_sha = file_digest(Path(__file__).parent / 'images' / 'launcher.py')
+        files = {'recipe.json': sha(recipe), 'launcher.py': launcher_sha,
+                 **{'payload/' + k: v for k, v in recipe['files'].items()}}
+        if image.pop('privateFiles') != files:
+            raise ValueError('OCI_SOURCE_CLOSURE')
+        image['launcherSha256'] = launcher_sha
+        entries[role] = {**image, 'recipe': recipe, 'recipeSha256': sha(recipe)}
+    if entries['producer']['manifestDigest'] == entries['verifier']['manifestDigest']:
+        raise ValueError('VERIFIER_NOT_SEPARATE')
+    for key in ('candidateSha', 'oracleSha', 'policySha256'):
+        if recipes['producer'][key] != recipes['verifier'][key]:
+            raise ValueError('IMAGE_PAIR_BINDING')
+    return {'schema': SCHEMA, 'images': entries, 'reviewSha256': sha(review)}
+
+
+def validate_lock(lock, admission):
+    if set(lock) != {'schema', 'images', 'reviewSha256'} or lock['schema'] != SCHEMA:
+        raise ValueError('IMAGE_LOCK_SCHEMA')
+    if set(lock['images']) != set(ROLES) or not HEX.fullmatch(lock['reviewSha256']):
+        raise ValueError('IMAGE_LOCK_INCOMPLETE')
+    for role, image_key in [('producer', 'runnerImage'), ('verifier', 'verifierImage')]:
+        image = lock['images'][role]
+        if set(image) != {'manifestDigest', 'configDigest', 'archiveSha256', 'architecture',
+                          'os', 'recipe', 'recipeSha256', 'launcherSha256'}:
+            raise ValueError('IMAGE_LOCK_ENTRY')
+        recipe = validate_recipe(image['recipe'])
+        if (recipe['role'] != role or image['recipeSha256'] != sha(recipe)
+                or image['architecture'] != 'arm64' or image['os'] != 'linux'
+                or not IMAGE.fullmatch(admission[image_key])
+                or admission[image_key].rsplit('@', 1)[1] != image['manifestDigest']):
+            raise ValueError('IMAGE_ADMISSION_BINDING')
+        for key in ('candidateSha', 'oracleSha', 'policySha256'):
+            if recipe[key] != admission[key]:
+                raise ValueError('IMAGE_SOURCE_POLICY_BINDING')
+        if (not HEX.fullmatch(image['launcherSha256'])
+                or not HEX.fullmatch(image['archiveSha256'])
+                or not image['configDigest'].startswith('sha256:')
+                or not HEX.fullmatch(image['configDigest'][7:])):
+            raise ValueError('IMAGE_DIGEST_SCHEMA')
+    if lock['images']['producer']['manifestDigest'] == lock['images']['verifier']['manifestDigest']:
+        raise ValueError('VERIFIER_NOT_SEPARATE')
+    return lock
+
+
+def check_preloaded(lock, admission, *, verifier_only=False):
+    validate_lock(lock, admission)
+    roles = [('verifier', 'verifierImage')] if verifier_only else [('producer', 'runnerImage'), ('verifier', 'verifierImage')]
+    for role, key in roles:
+        # Local only. No pull/run and no mutable-tag fallback.
+        result = subprocess.run(['podman', 'image', 'inspect', admission[key]],
+                                check=True, capture_output=True, timeout=30)
+        rows = json_bytes(result.stdout)
+        if len(rows) != 1:
+            raise ValueError('PRELOADED_IMAGE_MISSING')
+        row, expected = rows[0], lock['images'][role]
+        if (row.get('Digest') != expected['manifestDigest']
+                or row.get('Id', '').removeprefix('sha256:') != expected['configDigest'][7:]
+                or row.get('Architecture') != 'arm64' or row.get('Os') != 'linux'):
+            raise ValueError('PRELOADED_IMAGE_BINDING')
+        validate_config(row.get('Config', {}), expected['recipe'])
+
+
+def bind_runtime_lock(image_lock, runtime_lock, admission):
+    if sha(runtime_lock) != admission['runtimeSha256'] or runtime_lock.get('image-lock.json') != sha(image_lock):
+        raise ValueError('IMAGE_RUNTIME_BINDING')
+    return validate_lock(image_lock, admission)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--producer-oci', type=Path, required=True)
+    p.add_argument('--verifier-oci', type=Path, required=True)
+    p.add_argument('--producer-recipe', type=Path, required=True)
+    p.add_argument('--verifier-recipe', type=Path, required=True)
+    p.add_argument('--review', type=Path, required=True)
+    p.add_argument('--out', type=Path, required=True)
+    a = p.parse_args()
+    lock = make_lock(a.producer_oci, a.verifier_oci,
+                     {r: json_bytes(getattr(a, r + '_recipe').read_bytes()) for r in ROLES},
+                     json_bytes(a.review.read_bytes()))
+    with a.out.open('xb') as f:
+        f.write(encoded(lock))
+    print(json.dumps({'imageLockSha256': sha(lock),
+                      'images': {r: {k: v for k, v in entry.items() if k != 'recipe'}
+                                 for r, entry in lock['images'].items()}}))
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/private_cert/images/Dockerfile
+++ b/ci/private_cert/images/Dockerfile
@@ -1,0 +1,19 @@
+# The separately reviewed ARM64 runtime must already contain /usr/bin/python3,
+# /opt/venv/bin/python, the locked numerical/JVM tools and offline
+# dependency closures appropriate to this role. No dependency install at build
+# or runtime. Build from the source-only context produced by stage.py.
+ARG RUNTIME_IMAGE
+FROM ${RUNTIME_IMAGE}
+ARG RECIPE_SHA256
+ARG IMAGE_ROLE
+LABEL org.polis.private.recipe=${RECIPE_SHA256}
+LABEL org.polis.private.role=${IMAGE_ROLE}
+USER 0:0
+WORKDIR /opt/polis-private-image
+COPY --chown=0:0 --chmod=0444 recipe.json launcher.py ./
+COPY --chown=0:0 payload/ ./payload/
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONNOUSERSITE=1 PYTHONUNBUFFERED=1
+ENV HOME=/tmp UV_OFFLINE=1 PIP_NO_INDEX=1
+USER 65534:65534
+ENTRYPOINT ["/usr/bin/python3", "/opt/polis-private-image/launcher.py"]
+CMD []

--- a/ci/private_cert/images/README.md
+++ b/ci/private_cert/images/README.md
@@ -1,0 +1,177 @@
+# P-053 step-2 image contents and admission
+
+This slice implements BOARD [671]/[677]: one producer runs paired Clojure/Python
+recordings over the admitted bundle, and a separately built verifier runs the
+reviewed certify + G12 comparison (absolute 1e-6, relative 1e-4, zero outliers).
+Stages are diagnostic only; recovery/consumption belong to shadow diagnostics.
+A scoped PASS is not writer transfer or a complete retirement certificate.
+
+**Integration dependency:** first apply the lossless-ingress change handed off
+in BOARD [675]. This branch starts at #2762 and intentionally does not duplicate
+that separate set of edits. The combined source must contain `event_ingress.py`,
+the updated Python/Clojure drivers and certify's event metadata binding before
+building or running the new tests. Public canaries use committed public CSVs;
+private entries require authoritative events.jsonl and metadata.
+
+## Source and runtime closure
+
+- `runtime.Dockerfile` composes the already reviewed, preloaded Linux ARM64 OS,
+  numerical Python and Clojure/JVM images. All three inputs must use immutable
+  repository@sha256 references. It copies only dependency paths; no package
+  manager, download or dependency resolution runs during the build or replay.
+  Review the numerical `/usr/local` tree, Java, Maven jars and the single baked
+  resolved classpath before pinning this runtime. It is a dependency image, not
+  the candidate/oracle source. No Postgres service is needed by paired replay.
+- `clojure-offline.py` accepts only `-M:replay`, reads the single baked classpath,
+  selects its pinned jars under `/opt/m2`, and runs the staged math source. It
+  never invokes Maven. The runtime must provide `/usr/bin/python3` and
+  `/opt/venv/bin/python` plus the locked numpy/scipy/sklearn/pandas closure.
+- `recipe.py` enumerates the explicit public source closure: replay/math code,
+  strict admission and battery/schema/schedule definitions, public fixture CSVs,
+  gate and accepted G12 implementation. `g12.py` copies the reviewed Q25 metric
+  core and its 17 controls, without its host-specific CLI/enumerator.
+- `stage.py` checks every listed file against both the reviewed source commit
+  and its SHA256; producer engine files additionally match candidate/oracle
+  commits. Only those bytes enter a fresh context. Ambient `.git`, `.local`,
+  virtualenvs, credentials, symlinks and private extraction data are excluded.
+- `Dockerfile` installs the source-only context as root-owned files, selects the
+  fixed launcher and UID/GID 65534, and clears the runtime's command. The launcher
+  checks the entire payload file census and hashes before invoking the gate with
+  isolated Python imports. Rebuild the verifier from its independently reviewed
+  checkout/recipe; never copy the producer's output into a verifier build.
+
+The image lock records **OCI manifest digest**, **configuration digest**, and
+**archive SHA256** separately. Docker's image ID is the configuration digest,
+not the OCI manifest digest. Runtime dependencies, source commits, role, gate and
+policy are bound in the reviewed recipe. The supervisor's signed runtime digest
+binds the canonical image lock, which binds both recipes and the review receipt.
+
+## Prepare a release build
+
+Run each role from a reviewed committed source checkout. The reviewer can use a
+separate source commit for verifier code while binding the same candidate/oracle/
+policy tuple. An uncommitted implementation cannot be labeled with a base commit.
+These commands only illustrate local preparation; they do not authorize a cloud
+build, private staging or publication.
+
+```sh
+python3 ci/private_cert/images/recipe.py --source "$SOURCE" --role producer \
+  --candidate "$CANDIDATE_SHA" --oracle "$ORACLE_SHA" \
+  --policy-sha256 "$POLICY_SHA256" --runtime-image "$RUNTIME_DIGEST_REF" \
+  --out /private/build/producer-recipe.json
+python3 ci/private_cert/images/stage.py --source "$SOURCE" \
+  --recipe /private/build/producer-recipe.json --out /private/build/producer-context
+```
+
+Repeat from the independently reviewed verifier source with `--role verifier`.
+Review `build.json` (recipe, Dockerfile and launcher hashes) for each context.
+Build/export each independently using the preloaded runtime, `--network=none`,
+`--pull=false`, `--platform=linux/arm64`, and build arguments `RUNTIME_IMAGE`,
+`IMAGE_ROLE`, `RECIPE_SHA256`. Export a single-platform OCI archive without
+attestations/index extras. If the local Docker driver cannot export OCI, save
+exactly one image and use `export_oci.py --docker-archive IMAGE.tar --out IMAGE.oci.tar`;
+it preserves config/layer bytes and deterministically creates the OCI manifest.
+Load the final archive in the admitted Podman builder and check that its actual
+manifest/config digests match. Never substitute a mutable tag or pull at boot.
+
+`image_admission.py` hashes every referenced blob and uncompressed layer, checks
+ARM64/configuration, and verifies the final source overlay against the reviewed
+recipe and launcher. It rejects unreferenced blobs, ambiguous indexes, source
+whiteouts/links, wrong entrypoints, ambient environment and incomplete controls.
+Its required independent review artifact is:
+
+```json
+{"schema":"polis-private-image-review/1","recipeSha256":{"producer":"RECIPE_SHA256","verifier":"RECIPE_SHA256"},"gateReviewSha256":"REVIEW_ARTIFACT_SHA256","controls":{"missing-evidence":"PASS","forged-evidence":"PASS","truncated-evidence":"PASS","short-inventory":"PASS","wrong-input":"PASS","wrong-policy":"PASS","stale-checkpoint":"PASS","candidate-control-isolation":"PASS"}}
+```
+
+Placeholders above must be replaced with actual SHA256s. The reviewer records
+observed synthetic canary results, not a receipt synthesized from image labels.
+Run the controls against the final images; hashes alone cannot establish source
+review, canary completion or independence.
+
+```sh
+python3 ci/private_cert/image_admission.py \
+  --producer-oci /private/build/producer.oci.tar \
+  --verifier-oci /private/build/verifier.oci.tar \
+  --producer-recipe /private/build/producer-recipe.json \
+  --verifier-recipe /private/build/verifier-recipe.json \
+  --review /private/build/review.json --out /private/build/image-lock.json
+```
+
+Pass `PRIVATE_CERT_IMAGE_LOCK` to `bake.sh`. The bake requires canonical JSON and
+hashes it plus the admission checker into `runtime-lock.json`. Signed admission
+uses the actual manifest digests as `runnerImage` and `verifierImage`. Before
+fetching any fixture, the worker checks the signed runtime binding and both
+preloaded Podman images' digest, configuration ID, OS/architecture and launcher
+contract. The independent reviewer CLI requires `--image-lock` and
+`--runtime-lock` and performs the same preflight for its verifier before download.
+
+## Bundle plan and executable ABI
+
+The uncompressed fixture tar contains only regular files, in this layout:
+
+```text
+plan.json
+manifest.json
+config.json
+payload/<opaque-role-directory>/events.jsonl
+payload/<opaque-role-directory>/events.meta.json
+payload/<other files listed by the extraction manifest>
+```
+
+Use the owned extraction's original manifest/config/payload; `prepare()` calls
+both fixture verification and admission, including census, polarity and opaque
+role bindings. A reviewed `plan.json` has exactly:
+
+```json
+{"schema":"polis-private-paired-plan/1","scope":"private","manifestSha256":"SHA256","configSha256":"SHA256","entries":[{"dataset":"BATTERY_ALIAS","schedule_id":"BATTERY_SCHEDULE_ID","role":"CONFIG_ROLE","directory":"MANIFEST_ROLE_DIR","schedule":{}}]}
+```
+
+`entries` must contain the complete battery scope (`public`, `private` or `all`),
+not a subset. `schedule` is the complete reviewed ScheduleSpec with fresh explicit
+cuts from this actual event stream. Entry count, checkpoint count, moderation,
+restart, Clojure options and coverage must preserve the battery recipe. Private
+entries must cover the full stream. An allowed public prefix needs its full-stream
+companion. Historical CSV cuts cannot silently truncate new lossless inputs.
+
+`plan.py --fixture DIR --candidate SHA --oracle SHA --out inputs.json` validates
+that already reviewed plan and derives the actual schedule/inventory digests and
+expected paired-checkpoint count for signing. It does not select roles, choose
+new cuts, run engines, sign or upload. This planning command needs the same locked
+Python dependencies and combined source as the gate. Do not hand-invent the
+inventory digest or use producer output to establish expected checks.
+
+The producer accepts `produce` with `/fixture:ro`, `/run-spec:ro`, `/output:rw`.
+`inputs.json` contains only candidateSha, oracleSha, policySha256, scheduleSha256,
+inventorySha256 and expectedChecks. `/admission` must be absent. Output must be
+fresh; engines run serially with no recording cache. It retains original fixture
+bytes, every raw step, schedule, logs, process exits, peak child RSS and output
+size. The supervisor contains credentials/control and records collector failure.
+
+The verifier accepts `verify` with `/evidence:ro`, `/admission:ro`, `/verdict:rw`.
+It independently derives inputs/checkpoints, verifies the complete file census
+and all engine exits, and applies certify + G12. Its receipt schema is
+`polis-private-gate/2`; `negativeControlsSha256` binds the actual controls JSON.
+The details include each entry's comparison and stage diagnostic. Raw checkpoint
+controls reject missing, forged, truncated and short evidence, in addition to the
+17 G12 controls. An exception yields INCOMPLETE with zero checks. Public output
+and cleanup still follow the separate supervisor/reviewer protocol.
+
+The host uses no network, read-only container root, no capabilities, no new
+privileges, fixed unprivileged user, bounded temporary storage/memory/processes,
+and disjoint mounts. Both images contain reviewed comparison code; the candidate
+has no access to the verifier process, mounted control record or verdict output.
+Actual Podman/AMI isolation, lifecycle/IAM canaries, private capacity and cleanup
+receipts remain mandatory before private activation.
+
+## Local validation scope
+
+Run `python -m unittest discover -s ci/private_cert -p 'test_*.py' -v` with the
+combined reviewed ingress/image source and Delphi dependencies. This covers OCI
+closure/admission, transport, controls and real bundle intake with synthetic role
+metadata. Full public image canaries run both engines and two independent
+verifier invocations offline on ARM64. Retain failed runs and control receipts.
+Development snapshots are not release pins: the second reviewer's canary recipes explicitly
+carry an extra `development` field and synthetic commit values, which the release
+recipe validator rejects. Local Docker canaries do not substitute for the actual
+admitted Podman host, signed boot or private data execution.

--- a/ci/private_cert/images/clojure-offline.py
+++ b/ci/private_cert/images/clojure-offline.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Use the baked resolved Maven closure, never a resolver or network download."""
+import os
+from pathlib import Path
+import sys
+
+if sys.argv[1:2] != ['-M:replay']:
+    raise SystemExit('Only the admitted replay alias is available')
+# The admitted oracle build must provide exactly one resolved classpath. Source
+# and dev/test paths from its build are discarded; only pinned JARs are retained.
+paths = list(Path('/opt/oracle-classpath').glob('*.cp'))
+if len(paths) != 1:
+    raise SystemExit('A single reviewed oracle classpath is required')
+jars = []
+for item in paths[0].read_text().strip().split(':'):
+    if item.startswith('/root/.m2/repository/') and item.endswith('.jar'):
+        path = item.replace('/root/.m2/repository/', '/opt/m2/', 1)
+        if not Path(path).is_file():
+            raise SystemExit('Incomplete offline oracle dependency closure')
+        jars.append(path)
+if not jars or not Path('src/polismath/math/conversation.clj').is_file():
+    raise SystemExit('Missing admitted math source/classpath')
+classpath = ':'.join(['src', *jars])
+os.execv('/opt/java/openjdk/bin/java', ['java', '-Xmx64g', '-cp', classpath,
+         'clojure.main', '-i', 'dev/replay.clj', '-m', 'replay', *sys.argv[2:]])

--- a/ci/private_cert/images/export_oci.py
+++ b/ci/private_cert/images/export_oci.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Deterministically convert one local `docker save` image to a plain OCI tar.
+
+For builders whose local Docker driver cannot export OCI. No registry, daemon,
+image load or push is performed. Config and layer bytes are kept unchanged.
+"""
+import argparse
+import hashlib
+import io
+import json
+from pathlib import Path
+import sys
+import tarfile
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from control import encoded
+from image_admission import CONFIG, LAYER, MANIFEST, digest_stream, json_bytes, regular_path
+
+
+def convert(source, destination):
+    with tarfile.open(source, 'r:') as src:
+        members = {}
+        for member in src:
+            name = member.name.rstrip('/') if member.isdir() else member.name
+            regular_path(name)
+            if member.isdir():
+                continue
+            if not member.isfile() or name in members:
+                raise ValueError('UNSAFE_DOCKER_ARCHIVE')
+            members[name] = member
+        rows = json_bytes(src.extractfile(members['manifest.json']).read())
+        if len(rows) != 1:
+            raise ValueError('EXACTLY_ONE_IMAGE_REQUIRED')
+        row = rows[0]
+        closure = []
+        def descriptor(name, media):
+            regular_path(name)
+            member = members[name]
+            with src.extractfile(member) as f:
+                digest, size = digest_stream(f)
+            closure.append((digest, member))
+            return {'mediaType': media, 'digest': 'sha256:' + digest, 'size': size}
+        cfg = descriptor(row['Config'], CONFIG)
+        layers = [descriptor(name, LAYER) for name in row['Layers']]
+        manifest = encoded({'schemaVersion': 2, 'mediaType': MANIFEST, 'config': cfg, 'layers': layers})
+        digest = hashlib.sha256(manifest).hexdigest()
+        index = encoded({'schemaVersion': 2, 'manifests': [
+            {'mediaType': MANIFEST, 'digest': 'sha256:' + digest, 'size': len(manifest)}]})
+        with destination.open('xb') as raw, tarfile.open(fileobj=raw, mode='w') as out:
+            def add(name, size, body):
+                info = tarfile.TarInfo(name)
+                info.size, info.mode, info.mtime = size, 0o444, 0
+                out.addfile(info, body)
+            for name, body in [('oci-layout', encoded({'imageLayoutVersion': '1.0.0'})),
+                               ('index.json', index), ('blobs/sha256/' + digest, manifest)]:
+                add(name, len(body), io.BytesIO(body))
+            seen = set()
+            for blob_digest, member in sorted(closure, key=lambda x: x[0]):
+                if blob_digest in seen:
+                    continue
+                seen.add(blob_digest)
+                with src.extractfile(member) as body:
+                    add('blobs/sha256/' + blob_digest, member.size, body)
+    return 'sha256:' + digest
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--docker-archive', type=Path, required=True)
+    parser.add_argument('--out', type=Path, required=True)
+    args = parser.parse_args()
+    print(convert(args.docker_archive, args.out))

--- a/ci/private_cert/images/g12.py
+++ b/ci/private_cert/images/g12.py
@@ -1,0 +1,885 @@
+#!/usr/bin/env python3
+"""P-044 G12 numeric-policy measurement (round 5, per BOARD [359]/[382]/[395]/[408]).
+
+Measures the PROPOSED G12 numeric policy against the EXISTING Clojure<->Python
+replay recordings on disk, before any Rust row exists (P-044 review Correction
+3). No engine, database, container or HTTP request is started; this reads JSON
+recordings only. Line citations are against the `origin/edge` tree.
+
+Round-2 corrections (second-reviewer round appended to P-044-g12-measurement.md):
+  1. ONE coupled axis transform, inferred from the admitted basis (`comps`,
+     the convention-invariant eigenvectors), applied to every linked field.
+     Projection-space fields additionally carry the DECLARED vote-sign
+     convention `d` read from each recording's `vote_sign_convention`
+     (clj `raw-db` vs py `delphi` => d=-1), a documented constant, NOT a
+     per-field fitted sign.  Component-frame fields carry only the per-axis PC
+     sign.  Magnitudes/distances carry neither.  Polarity is a separate
+     invariant: signs of statistics (repness/consensus/priority) are compared
+     exactly and never normalized.
+  2. Typed exact/shape inventories.  Integer counts / ids / memberships compare
+     EXACTLY regardless of magnitude or JSON int/float spelling, counted apart
+     from gated floats.  Label / key / row / column / step inventories must be
+     COMPLETE and EQUAL (no silent intersection): duplicate, missing or extra
+     labels, keyed members, matrix rows/cols and stages are rejected.
+  3. The symmetric G12 predicate is implemented directly (below), NOT by reusing
+     the comparer's asymmetric np.allclose kwargs.  The tightened-kwargs
+     StepComparer path is reported only as a "tightened legacy diagnostic".
+  4. Round 5: ONE typed schema (`SPEC`: role/rank/elem_kind/nullable per
+     field) drives BOTH admission and comparison. Admission is total at every
+     container boundary (rank/element/nullability), identities are raw-type-
+     admitted before hashing, and every exception is a graded shape fault.
+     `--self-test` runs seventeen false-acceptance probes (review rounds 1-4) as
+     NEGATIVE CONTROLS; each must be REJECTED with zero errors.
+
+G12 predicate (P-044-rust-vs-clojure-replay.md:256-258):
+    abs(a-b) <= 1e-6 + 1e-4*max(abs(a),abs(b))   with ZERO outliers,
+    after coupled sign normalization.  Symmetric denominator max(|a|,|b|).
+
+B1 tight (delphi/polismath/regression/comparer.py:30-33,49-54;1152):
+    |a-b| <= 1e-6 + 1e-2*|b|   (np.allclose asymmetric on b),
+    up to 1% of a list may exceed tight but must stay within loose
+    |a-b| <= 1e-3 + 1e-1*|b|   (:53-54,1155,1187).
+"""
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import math
+import sys
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Policy constants.
+# ---------------------------------------------------------------------------
+ABS = 1e-6           # comparer.py:30 ; P-044:256
+B1_REL = 1e-2        # comparer.py:31
+B1_LOOSE_ABS = 1e-3  # comparer.py:53 (1000*abs)
+B1_LOOSE_REL = 1e-1  # comparer.py:54 (10*rel)
+B1_OUTLIER = 0.01    # comparer.py:33
+G12_REL = 1e-4       # P-044:256-258
+G12_OUTLIER = 0.0
+
+# Declared vote-sign conventions -> relative data sign.  Read from the
+# recordings; d = product => -1 when the two sides differ (raw-db vs delphi).
+CONV_SIGN = {"raw-db": -1, "delphi": +1}
+
+# The field contract is the single `SPEC` schema defined further below (role /
+# rank / elem_kind / nullable per key); admission and comparison both derive from
+# it.  The two helpers here are the raw-type admission primitives that
+# `Collector.add_exact` applies at each exact leaf.  Raw kinds:
+#   "int"  -- integer-valued count/id/member (bool is NOT int; a string or a
+#             non-integral float is malformed)
+#   "int?" -- nullable int (a null field means the empty set)
+#   "str"  -- string tag (e.g. repful-for)     "bool" -- boolean flag (best-agree)
+#   "any"  -- opaque identity (e.g. zid), compared by equality with no type check
+def _admit(x, kind: str) -> bool:
+    """Does raw value `x` satisfy the field's declared raw type?"""
+    if kind == "any":
+        return True
+    if kind == "int?":
+        return x is None or _admit(x, "int")
+    if kind == "bool":
+        return isinstance(x, bool)
+    if kind == "str":
+        return isinstance(x, str)
+    if kind == "int":  # int OR integral-float; bool is NOT admitted as int
+        if isinstance(x, bool):
+            return False
+        if isinstance(x, int):
+            return True
+        return isinstance(x, float) and x.is_integer()
+    return False
+
+
+def _canon_exact(x, kind: str):
+    if kind in ("int", "int?") and x is not None:
+        return int(x)
+    return x
+
+
+# ---------------------------------------------------------------------------
+# Metric core (symmetric G12 + asymmetric B1-tight, verbatim).
+# ---------------------------------------------------------------------------
+def _rel(a: float, b: float) -> float:
+    d = max(abs(a), abs(b))
+    return 0.0 if d < 1e-15 else abs(a - b) / d
+
+
+def g12_fail(a: float, b: float) -> bool:
+    """P-044:256-258 symmetric predicate."""
+    return abs(a - b) > ABS + G12_REL * max(abs(a), abs(b))
+
+
+def b1_tight_fail(a: float, b: float) -> bool:
+    return abs(a - b) > ABS + B1_REL * abs(b)
+
+
+def b1_loose_fail(a: float, b: float) -> bool:
+    return abs(a - b) > B1_LOOSE_ABS + B1_LOOSE_REL * abs(b)
+
+
+def _floor(a: float, b: float) -> float:
+    d = max(abs(a), abs(b))
+    return 0.0 if d < 1e-15 else max(0.0, abs(a - b) - ABS) / d
+
+
+def field_metrics(pairs: list[tuple[float, float]]) -> dict:
+    finite = [(a, b) for a, b in pairs if math.isfinite(a) and math.isfinite(b)]
+    nonfinite = len(pairs) - len(finite)
+    n = len(finite)
+    if n == 0:
+        return {"n": 0, "nonfinite": nonfinite, "max_rel": 0.0, "max_abs": 0.0,
+                "frac_g12": 0.0, "frac_b1": 0.0, "floor": 0.0}
+    return {
+        "n": n, "nonfinite": nonfinite,
+        "max_rel": max(_rel(a, b) for a, b in finite),
+        "max_abs": max(abs(a - b) for a, b in finite),
+        "frac_g12": sum(g12_fail(a, b) for a, b in finite) / n,
+        "frac_b1": sum(b1_tight_fail(a, b) for a, b in finite) / n,
+        "floor": max(_floor(a, b) for a, b in finite),
+    }
+
+
+def _is_number(x) -> bool:
+    return isinstance(x, (int, float)) and not isinstance(x, bool)
+
+
+def _all_int(xs) -> bool:
+    return all(isinstance(x, int) and not isinstance(x, bool) for x in xs)
+
+
+# ---------------------------------------------------------------------------
+# Collector: gated floats, typed-exact checks, and shape/inventory violations.
+# ---------------------------------------------------------------------------
+class Collector:
+    def __init__(self) -> None:
+        self.pairs: dict[str, list[tuple[float, float]]] = {}   # gated floats
+        self.exact_mismatch: dict[str, int] = {}
+        self.exact_total: dict[str, int] = {}
+        self.shape: dict[str, int] = {}                          # inventory faults
+
+    def add_float(self, path: str, a: float, b: float) -> None:
+        self.pairs.setdefault(path, []).append((float(a), float(b)))
+
+    def add_exact(self, path: str, a, b, kind: str = "any") -> None:
+        self.exact_total[path] = self.exact_total.get(path, 0) + 1
+        # Raw type admission FIRST: a value whose raw JSON type violates the
+        # field contract is a shape fault even if both sides agree (1 vs True,
+        # a string where an integer count is required, a non-integral float).
+        if not _admit(a, kind) or not _admit(b, kind):
+            self.add_shape(path, f"raw-type expected {kind}")
+            return
+        if _canon_exact(a, kind) != _canon_exact(b, kind):
+            self.exact_mismatch[path] = self.exact_mismatch.get(path, 0) + 1
+
+    def add_shape(self, path: str, detail: str = "") -> None:
+        key = f"{path} [{detail}]" if detail else path
+        self.shape[key] = self.shape.get(key, 0) + 1
+
+
+# ---------------------------------------------------------------------------
+# Coupled axis transform.
+# ---------------------------------------------------------------------------
+def infer_axis_sign(comps_clj: list[list[float]], comps_py: list[list[float]]):
+    """Per-axis PC sign from the admitted basis (eigenvector loadings).
+
+    comps are [n_axes][n_tids], ALREADY tid-aligned.  Returns one sign per axis;
+    this single vector is applied to every linked field (no per-field re-choice).
+    """
+    if len(comps_clj) != len(comps_py):
+        return None  # axis-count mismatch -> caller rejects on shape
+    s = []
+    for j in range(len(comps_clj)):
+        A, B = comps_clj[j], comps_py[j]
+        if len(A) != len(B):
+            return None
+        e_pos = sum((a - b) ** 2 for a, b in zip(A, B))
+        e_neg = sum((a + b) ** 2 for a, b in zip(A, B))
+        s.append(-1 if e_neg < e_pos else 1)
+    return s
+
+
+class Axis:
+    """The single coupled transform for one cut: per-axis PC sign `s` and the
+    DECLARED projection-space data sign `d` (from vote_sign_convention)."""
+
+    def __init__(self, s, d: int):
+        self.s = s          # list[+/-1] or None
+        self.d = d          # +/-1, declared (not fitted)
+
+    def component(self, axis: int) -> int:
+        return self.s[axis] if self.s and axis < len(self.s) else 1
+
+    def projection(self, axis: int) -> int:
+        return self.component(axis) * self.d
+
+
+DEFAULT_AXIS = Axis(None, 1)  # toy/self-test default: no declared convention (d=1)
+
+
+# ---------------------------------------------------------------------------
+# Walk.
+# ---------------------------------------------------------------------------
+SKIP_KEYS = {"mat", "rating-mat", "raw-rating-mat", "participant-info-legacy"}
+
+
+# ---------------------------------------------------------------------------
+# THE typed field schema (single source for admission AND comparison).
+# ---------------------------------------------------------------------------
+# Each field key maps to a Spec whose `role` selects the comparison treatment
+# and whose (rank, elem_kind, nullable) drive raw-type/rank/nullability
+# admission.  Admission is applied at EVERY container boundary and leaf, not just
+# at leaves; matrix/label identities are raw-type-admitted BEFORE any hashing;
+# and every exception in a field comparison is turned into a graded shape fault.
+# Unlisted keys resolve to DEFAULT (adaptive recurse), which routes each child
+# through the schema again -- so counts/ids/geometry are always typed by key.
+class Spec:
+    __slots__ = ("role", "rank", "elem_kind", "nullable")
+
+    def __init__(self, role, rank="any", elem_kind="int", nullable=False):
+        self.role = role
+        self.rank = rank          # 0 scalar | 1 list | 2 list-of-list | "any"
+        self.elem_kind = elem_kind  # raw kind of exact leaves: int/str/bool
+        self.nullable = nullable  # whole value may be null (empty set)
+
+
+# roles
+EXACT = "exact"                 # typed scalar/array, rank + elem_kind enforced
+EXACT_CONTAINER = "exact-cont"  # nested; every descendant leaf is exact int
+GEOM_COMP = "geom-comp"         # [n_axes][n] float rows; sign = component
+GEOM_PROJ_ROWS = "geom-proj-rows"  # [n_axes][n] float rows; sign = projection
+GEOM_PROJ_MAT = "geom-proj-mat"    # matrix or bare [rows][axes]; sign = projection
+GEOM_PROJ_VEC = "geom-proj-vec"    # [n_axes] float vector; sign = projection
+INV_FLOAT = "inv-float"         # magnitudes/distances; float, no sign
+PCA_BLOCK = "pca-block"         # the pca sub-blob (own per-field frames)
+RECURSE = "recurse"             # adaptive: dict / list-of-dict / scalar
+SKIP = "skip"
+
+_S = Spec
+SPEC = {
+    # exact integer scalars
+    **{k: _S(EXACT, 0, "int") for k in (
+        "n", "n-cmts", "n-votes", "n-agree", "n-success", "n-trials",
+        "last-k", "last-k-count", "smoothed-k", "id", "gid", "pid", "tid",
+        "n-members", "count")},
+    "zid": _S(EXACT, 0, "any"),  # opaque conversation identity (string or int)
+    "lastVoteTimestamp": _S(EXACT, 0, "int", nullable=True),
+    "lastModTimestamp": _S(EXACT, 0, "int", nullable=True),
+    "repful-for": _S(EXACT, 0, "str"),
+    "best-agree": _S(EXACT, 0, "bool"),
+    # exact integer lists
+    **{k: _S(EXACT, 1, "int") for k in ("tids", "in-conv", "members")},
+    "mod-in": _S(EXACT, 1, "int", nullable=True),
+    "mod-out": _S(EXACT, 1, "int", nullable=True),
+    "meta-tids": _S(EXACT, 1, "int", nullable=True),
+    "bid-to-pid": _S(EXACT, 2, "int"),
+    # exact integer containers (nested; keys are JSON strings)
+    **{k: _S(EXACT_CONTAINER) for k in (
+        "user-vote-counts", "base-clusters-weights", "group-votes", "votes-base")},
+    # geometry (comparison sign derives from the coupled Axis)
+    "comps": _S(GEOM_COMP, 2, "float"),
+    "comment-projection": _S(GEOM_PROJ_ROWS, 2, "float"),
+    "proj": _S(GEOM_PROJ_MAT, "matrix", "float"),
+    "projections": _S(GEOM_PROJ_MAT, "matrix", "float"),
+    "base-clusters-proj": _S(GEOM_PROJ_MAT, "matrix", "float"),
+    "center": _S(GEOM_PROJ_VEC, 1, "float"),   # cluster centroid; pca.center is
+    "comment-extremity": _S(INV_FLOAT, 1, "float"),        # handled in pca-block
+    "bucket-dists": _S(INV_FLOAT, "matrix", "float"),
+    "pca": _S(PCA_BLOCK),
+    "base-clusters": _S("base-clusters"),  # columnar (main blob) OR row-wise (stages)
+    **{k: _S(SKIP) for k in SKIP_KEYS},
+}
+DEFAULT_SPEC = _S(RECURSE)
+
+
+def spec_for(key: str) -> Spec:
+    return SPEC.get(key, DEFAULT_SPEC)
+
+
+def _leaf_of(path: str) -> str:
+    leaf = path.rsplit(".", 1)[-1]
+    br = leaf.find("[")
+    return leaf[:br] if br != -1 else leaf
+
+
+def _labeled_matrix(x) -> bool:
+    return isinstance(x, dict) and {"matrix", "rownames", "colnames"} <= set(x)
+
+
+def _admit_label(x) -> bool:
+    """A matrix label / identity must be a hashable scalar of an admissible raw
+    type: an integer (NOT bool -- True must never alias key 1) or a string.
+    Lists/dicts (unhashable) and bools are refused BEFORE any dict/set is built."""
+    if isinstance(x, bool):
+        return False
+    return isinstance(x, int) or isinstance(x, str)
+
+
+def _inventory_ok(col, path, labels_a, labels_b) -> bool:
+    """Complete, unique, equal label sets -- raw types admitted before hashing."""
+    for lbl in list(labels_a) + list(labels_b):
+        if not _admit_label(lbl):
+            col.add_shape(path, f"label raw-type {type(lbl).__name__}")
+            return False
+    if len(labels_a) != len(set(labels_a)) or len(labels_b) != len(set(labels_b)):
+        col.add_shape(path, "duplicate-label"); return False
+    if set(labels_a) != set(labels_b):
+        col.add_shape(path, "label-set mismatch"); return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Single comparison entry point: resolve the spec, then dispatch (graded).
+# ---------------------------------------------------------------------------
+def walk(a, b, path: str, col: Collector, axis: Axis = DEFAULT_AXIS) -> None:
+    compare_field(a, b, path, col, axis, spec_for(_leaf_of(path)))
+
+
+def _walk_keyed(k, va, vb, p, col, axis: Axis = DEFAULT_AXIS) -> None:
+    """Back-compat single keyed entry (main-blob and probes) -> compare_field."""
+    compare_field(va, vb, p, col, axis, spec_for(k))
+
+
+def compare_field(a, b, path, col, axis, spec: Spec) -> None:
+    # TOTAL: any exception in a field comparison becomes a graded shape fault,
+    # so no input can leave a probe ungraded.
+    try:
+        _dispatch(a, b, path, col, axis, spec)
+    except Exception as exc:  # noqa: BLE001 -- deliberate: grade, never raise
+        col.add_shape(path, f"error:{type(exc).__name__}")
+
+
+def _dispatch(a, b, path, col, axis, spec: Spec) -> None:
+    role = spec.role
+    if role == SKIP:
+        return
+    if role == EXACT:
+        _exact_typed(a, b, path, col, spec.rank, spec.elem_kind, spec.nullable)
+    elif role == EXACT_CONTAINER:
+        _exact_tree(a, b, path, col, axis)
+    elif role == PCA_BLOCK:
+        _walk_pca_block(a, b, path, col, axis)
+    elif role == GEOM_COMP:
+        _geom_rows(a, b, path, col, axis, projection=False)
+    elif role == GEOM_PROJ_ROWS:
+        _geom_rows(a, b, path, col, axis, projection=True)
+    elif role == GEOM_PROJ_MAT:
+        _geom_proj_mat(a, b, path, col, axis)
+    elif role == GEOM_PROJ_VEC:
+        _geom_proj_vec(a, b, path, col, axis)
+    elif role == INV_FLOAT:
+        _inv_float(a, b, path, col, axis)
+    elif role == "base-clusters":
+        _base_clusters(a, b, path, col, axis)
+    else:  # RECURSE (adaptive)
+        _recurse(a, b, path, col, axis)
+
+
+def _base_clusters(a, b, path, col, axis) -> None:
+    """base-clusters has two admitted layouts: the stages' row-wise list of
+    {id, center, members} dicts, and the main blob's COLUMNAR dict
+    {id:[int], members:[[int]], count:[int], x:[float], y:[float]} where x/y are
+    the two projection axes."""
+    if isinstance(a, list) and isinstance(b, list):
+        _recurse(a, b, path, col, axis); return
+    if not (isinstance(a, dict) and isinstance(b, dict)):
+        col.add_shape(path, "base-clusters-rank"); return
+    ka, kb = set(a) - SKIP_KEYS, set(b) - SKIP_KEYS
+    if ka != kb:
+        col.add_shape(path, f"bc-keys only_a={sorted(ka - kb)} only_b={sorted(kb - ka)}")
+    # column key -> (treatment, rank/axis)
+    cols = {"id": ("exact", 1), "count": ("exact", 1), "members": ("exact", 2),
+            "x": ("proj", 0), "y": ("proj", 1)}
+    for k in ka & kb:
+        p, va, vb = f"{path}.{k}", a[k], b[k]
+        spec = cols.get(k)
+        if spec is None:
+            walk(va, vb, p, col, axis); continue
+        if spec[0] == "exact":
+            _exact_typed(va, vb, p, col, spec[1], "int", False)
+        else:  # projection-axis column vector
+            if not (isinstance(va, list) and isinstance(vb, list)):
+                col.add_shape(p, "col-rank"); continue
+            _collect_signed(va, vb, p, col, axis.projection(spec[1]))
+
+
+# ---------------------------------------------------------------------------
+# Exact roles.
+# ---------------------------------------------------------------------------
+def _is_container(x) -> bool:
+    return isinstance(x, (list, dict))
+
+
+def _exact_typed(a, b, path, col, rank, kind, nullable) -> None:
+    if a is None or b is None:
+        # nullable field: null == null (empty set); null-vs-value stays visible.
+        if not (nullable and a is None and b is None):
+            col.add_shape(path, "null")
+        return
+    if rank == 0:
+        if _is_container(a) or _is_container(b):
+            col.add_shape(path, "rank0-expected-scalar"); return
+        col.add_exact(path, a, b, kind); return
+    if rank == 1:
+        if not (isinstance(a, list) and isinstance(b, list)):
+            col.add_shape(path, "rank1-expected-list"); return
+        if len(a) != len(b):
+            col.add_shape(path, "len"); return
+        for x, y in zip(a, b):
+            if _is_container(x) or _is_container(y):
+                col.add_shape(path, "rank1-element-not-scalar"); continue
+            col.add_exact(path, x, y, kind)  # elements never nullable
+        return
+    if rank == 2:
+        if not (isinstance(a, list) and isinstance(b, list)):
+            col.add_shape(path, "rank2-expected-list"); return
+        if len(a) != len(b):
+            col.add_shape(path, "len"); return
+        for x, y in zip(a, b):
+            _exact_typed(x, y, path, col, 1, kind, False)
+        return
+    col.add_shape(path, f"bad-rank:{rank}")
+
+
+def _exact_tree(a, b, path, col, axis) -> None:
+    """Every descendant leaf of an exact container is an integer count; keys are
+    inventoried, labels raw-type-admitted, and rank mismatches are shape faults."""
+    if _labeled_matrix(a) or _labeled_matrix(b):
+        if not (_labeled_matrix(a) and _labeled_matrix(b)):
+            col.add_shape(path, "container-rank (matrix vs not)"); return
+        _walk_matrix(a, b, path, col, axis, mode="exact"); return
+    if isinstance(a, dict) or isinstance(b, dict):
+        if not (isinstance(a, dict) and isinstance(b, dict)):
+            col.add_shape(path, "container-rank (dict vs not)"); return
+        ka, kb = set(a), set(b)
+        if ka != kb:
+            col.add_shape(path, "keys"); 
+        for k in ka & kb:
+            _exact_tree(a[k], b[k], f"{path}.{k}", col, axis)
+        return
+    if isinstance(a, list) or isinstance(b, list):
+        if not (isinstance(a, list) and isinstance(b, list)):
+            col.add_shape(path, "container-rank (list vs not)"); return
+        if len(a) != len(b):
+            col.add_shape(path, "len"); return
+        for x, y in zip(a, b):
+            _exact_tree(x, y, path, col, axis)
+        return
+    col.add_exact(path, a, b, "int")  # scalar leaf: integer count
+
+
+# ---------------------------------------------------------------------------
+# Geometry roles (float; sign from the coupled Axis).
+# ---------------------------------------------------------------------------
+def _collect_signed(A, B, path, col, sign) -> None:
+    if len(A) != len(B):
+        col.add_shape(path, "len"); return
+    for x, y in zip(A, B):
+        if not (_is_number(x) and _is_number(y)):
+            col.add_shape(path, "nonnumeric"); continue
+        col.add_float(path, float(x) * sign, float(y))
+
+
+def _geom_rows(a, b, path, col, axis, projection: bool) -> None:
+    # [n_axes][n] float rows (comps: component sign; comment-projection: proj).
+    if not (isinstance(a, list) and isinstance(b, list)
+            and (not a or isinstance(a[0], list))):
+        col.add_shape(path, "geom-rows-rank"); return
+    if len(a) != len(b):
+        col.add_shape(path, "axis-count"); return
+    for j in range(len(a)):
+        sign = axis.projection(j) if projection else axis.component(j)
+        _collect_signed(a[j], b[j], f"{path}[{j}]", col, sign)
+
+
+def _geom_proj_mat(a, b, path, col, axis) -> None:
+    if _labeled_matrix(a) and _labeled_matrix(b):
+        _walk_matrix(a, b, path, col, axis, mode="proj"); return
+    if _labeled_matrix(a) != _labeled_matrix(b):
+        col.add_shape(path, "matrix vs bare"); return
+    # bare [n_rows][n_axes]; column = axis.
+    if not (isinstance(a, list) and isinstance(b, list)):
+        col.add_shape(path, "proj-rank"); return
+    if len(a) != len(b):
+        col.add_shape(path, "rows"); return
+    for i in range(len(a)):
+        ra, rb = a[i], b[i]
+        if not (isinstance(ra, list) and isinstance(rb, list)) or len(ra) != len(rb):
+            col.add_shape(path, "cols"); continue
+        for j in range(len(ra)):
+            _collect_signed([ra[j]], [rb[j]], path, col, axis.projection(j))
+
+
+def _geom_proj_vec(a, b, path, col, axis) -> None:
+    if not (isinstance(a, list) and isinstance(b, list)):
+        col.add_shape(path, "vec-rank"); return
+    if len(a) != len(b):
+        col.add_shape(path, "len"); return
+    for j in range(len(a)):
+        _collect_signed([a[j]], [b[j]], path, col, axis.projection(j))
+
+
+def _inv_float(a, b, path, col, axis) -> None:
+    if _labeled_matrix(a) and _labeled_matrix(b):
+        _walk_matrix(a, b, path, col, axis, mode="float"); return
+    if _labeled_matrix(a) != _labeled_matrix(b):
+        col.add_shape(path, "matrix vs bare"); return
+    if not (isinstance(a, list) and isinstance(b, list)):
+        col.add_shape(path, "invfloat-rank"); return
+    _collect_signed(a, b, path, col, 1)
+
+
+# ---------------------------------------------------------------------------
+# Matrices (label admission before hashing; per-mode cell treatment).
+# ---------------------------------------------------------------------------
+def _walk_matrix(a, b, path, col, axis, mode="float") -> None:
+    if not _inventory_ok(col, path, a["rownames"], b["rownames"]):
+        return
+    if not _inventory_ok(col, path + ".cols", a["colnames"], b["colnames"]):
+        return
+    wa, wb = len(a["colnames"]), len(b["colnames"])
+    if len(a["matrix"]) != len(a["rownames"]) or len(b["matrix"]) != len(b["rownames"]):
+        col.add_shape(path, "matrix-rows"); return
+    if any(len(r) != wa for r in a["matrix"]) or any(len(r) != wb for r in b["matrix"]):
+        col.add_shape(path, "matrix-row-width"); return
+    ra = {r: i for i, r in enumerate(a["rownames"])}
+    rb = {r: i for i, r in enumerate(b["rownames"])}
+    ca = {c: j for j, c in enumerate(a["colnames"])}
+    cb = {c: j for j, c in enumerate(b["colnames"])}
+    for cj, cname in enumerate(a["colnames"]):
+        sign = axis.projection(cj) if mode == "proj" else 1
+        for r in a["rownames"]:
+            va = a["matrix"][ra[r]][ca[cname]]
+            vb = b["matrix"][rb[r]][cb[cname]]
+            if mode == "exact":
+                col.add_exact(f"{path}.matrix", va, vb, "int")
+            elif not (_is_number(va) and _is_number(vb)):
+                col.add_shape(f"{path}.matrix", "nonnumeric")
+            else:
+                col.add_float(f"{path}.matrix", float(va) * sign, float(vb))
+
+
+# ---------------------------------------------------------------------------
+# The pca sub-blob (own per-field frames: comps=component, comment-projection=
+# projection, center=convention-only d, comment-extremity=invariant).
+# ---------------------------------------------------------------------------
+def _walk_pca_block(a, b, path, col, axis: Axis) -> None:
+    if not (isinstance(a, dict) and isinstance(b, dict)):
+        col.add_shape(path, "pca-not-dict"); return
+    ka, kb = set(a) - SKIP_KEYS, set(b) - SKIP_KEYS
+    if ka != kb:
+        col.add_shape(path, f"pca-keys only_a={sorted(ka - kb)} only_b={sorted(kb - ka)}")
+    for k in ka & kb:
+        va, vb, p = a[k], b[k], f"{path}.{k}"
+        if k == "comps":
+            _geom_rows(va, vb, p, col, axis, projection=False)
+        elif k == "comment-projection":
+            _geom_rows(va, vb, p, col, axis, projection=True)
+        elif k == "center":  # comment-indexed data mean: convention sign only
+            if not (isinstance(va, list) and isinstance(vb, list)):
+                col.add_shape(p, "center-rank"); continue
+            _collect_signed(va, vb, p, col, axis.d)
+        elif k == "comment-extremity":
+            _inv_float(va, vb, p, col, axis)
+        else:
+            walk(va, vb, p, col, axis)
+
+
+# ---------------------------------------------------------------------------
+# Adaptive recurse (dicts, keyed lists of dicts, and stray scalars).
+# ---------------------------------------------------------------------------
+def _default_scalar(a, b, path, col) -> None:
+    if _is_number(a) and _is_number(b):
+        if isinstance(a, int) and isinstance(b, int):
+            col.add_exact(path, a, b, "int")
+        else:
+            col.add_float(path, float(a), float(b))
+        return
+    col.add_exact(path, a, b, "any")  # strings / None / bool tags
+
+
+def _recurse(a, b, path, col, axis: Axis) -> None:
+    if _labeled_matrix(a) or _labeled_matrix(b):
+        if _labeled_matrix(a) and _labeled_matrix(b):
+            _walk_matrix(a, b, path, col, axis, mode="float"); return
+        col.add_shape(path, "recurse-rank (matrix vs not)"); return
+    if isinstance(a, dict) or isinstance(b, dict):
+        if not (isinstance(a, dict) and isinstance(b, dict)):
+            col.add_shape(path, "recurse-rank (dict vs not)"); return
+        ka, kb = set(a) - SKIP_KEYS, set(b) - SKIP_KEYS
+        if ka != kb:
+            col.add_shape(path, f"keys only_a={sorted(ka - kb)} only_b={sorted(kb - ka)}")
+        local = axis
+        if local is DEFAULT_AXIS and "comps" in a and "comps" in b:
+            local = Axis(infer_axis_sign(a["comps"], b["comps"]), 1)
+        for k in ka & kb:
+            walk(a[k], b[k], f"{path}.{k}", col, local)
+        return
+    if isinstance(a, list) or isinstance(b, list):
+        if not (isinstance(a, list) and isinstance(b, list)):
+            col.add_shape(path, "recurse-rank (list vs not)"); return
+        if len(a) != len(b):
+            col.add_shape(path, f"len {len(a)}!={len(b)}"); return
+        if not a:
+            return
+        if isinstance(a[0], dict):
+            # Each item is a dict to be recursed by its OWN keys -- never
+            # re-dispatched through the parent list's key (which would, e.g.,
+            # re-type a row-wise base-clusters item as the columnar layout).
+            key = next((kk for kk in ("tid", "id", "pid") if kk in a[0]), None)
+            if key is not None:
+                if not _inventory_ok(col, path, [d.get(key) for d in a],
+                                     [d.get(key) for d in b]):
+                    return
+                bmap = {d.get(key): d for d in b}
+                for d in a:
+                    _recurse(d, bmap[d.get(key)], path, col, axis)
+                return
+            for x, y in zip(a, b):
+                _recurse(x, y, path, col, axis)
+            return
+        for x, y in zip(a, b):  # nested / scalar list under recurse
+            walk(x, y, path, col, axis) if _is_container(x) or _is_container(y) \
+                else _default_scalar(x, y, path, col)
+        return
+    _default_scalar(a, b, path, col)
+
+# ---------------------------------------------------------------------------
+# Summary.
+# ---------------------------------------------------------------------------
+def summarize(col: Collector) -> dict:
+    all_pairs = [pr for prs in col.pairs.values() for pr in prs]
+    roll = field_metrics(all_pairs)
+    # Preserve the historical max_rel (whose denominator has a 1e-15 floor),
+    # and also expose the literal relative error, including near-zero values.
+    def literal_relative(a, b):
+        denominator = max(abs(a), abs(b))
+        return abs(a - b) / denominator if denominator else 0.0
+    finite = [(path, a, b) for path, pairs in col.pairs.items() for a, b in pairs
+              if math.isfinite(a) and math.isfinite(b)]
+    worst = max(finite, key=lambda row: (literal_relative(*row[1:]), *row), default=None)
+    roll["max_rel_all"] = literal_relative(*worst[1:]) if worst else 0.0
+    roll["worst_relative"] = ({"field": worst[0], "clj": worst[1], "py": worst[2]}
+                              if worst else None)
+    roll["g12_outliers"] = sum(g12_fail(a, b) for _, a, b in finite)
+    n_exact = sum(col.exact_total.values())
+    n_exact_bad = sum(col.exact_mismatch.values())
+    n_shape_bad = sum(col.shape.values())
+    roll["n_exact"] = n_exact
+    roll["exact_mismatches"] = n_exact_bad
+    roll["shape_faults"] = n_shape_bad
+    roll["g12_pass"] = (roll["frac_g12"] == 0.0 and n_exact_bad == 0
+                        and n_shape_bad == 0 and roll["nonfinite"] == 0)
+    # B1 pass at field granularity: no element beyond loose, tight-fail <= 1%.
+    b1_field_fail = 0
+    for pairs in col.pairs.values():
+        finite = [(a, b) for a, b in pairs if math.isfinite(a) and math.isfinite(b)]
+        if not finite:
+            continue
+        n = len(finite)
+        if (sum(b1_loose_fail(a, b) for a, b in finite) > 0
+                or sum(b1_tight_fail(a, b) for a, b in finite) / n > B1_OUTLIER):
+            b1_field_fail += 1
+    roll["b1_pass"] = (b1_field_fail == 0 and n_exact_bad == 0
+                       and n_shape_bad == 0 and roll["nonfinite"] == 0)
+    return {"rollup": roll, "exact_detail": dict(col.exact_mismatch),
+            "shape_detail": dict(col.shape)}
+
+
+# ---------------------------------------------------------------------------
+# Substrate 1: main-blob pairs (in-battery raw final output).
+# ---------------------------------------------------------------------------
+def _conv(engine_dir: Path, default: str) -> str:
+    p = engine_dir / "provenance.json"
+    if p.exists():
+        return json.loads(p.read_text()).get("vote_sign_convention", default)
+    return default
+
+
+def measure_main_blob(entry_dir: Path, repo_delphi: Path) -> dict:
+    sys.path.insert(0, str(repo_delphi))
+    from polismath.replay import crosslang
+    from polismath.replay.certify import project_acceptance, _acceptance_projecting_comparer
+    from polismath.replay.stepcompare import compare_recordings
+
+    # Tightened-legacy diagnostic (asymmetric np.allclose) -- NOT authoritative G12.
+    def legacy(**kw):
+        with tempfile.TemporaryDirectory() as shim:
+            crosslang.clj_recording_to_py_store(str(entry_dir / "clj"), shim)
+            return compare_recordings(shim, str(entry_dir), engine="py",
+                                      comparer=_acceptance_projecting_comparer(**kw))
+
+    b1 = legacy()
+    tightened = legacy(rel_tolerance=G12_REL, abs_tolerance=ABS, outlier_fraction=G12_OUTLIER)
+
+    # The main blob is the PUBLISHED prep-main output. Its vote-sign convention
+    # is already normalized in producing the output (the two engines' published
+    # rows share a data convention), so the only residual sign freedom is the
+    # per-component PCA sign (from comps): d=+1. This is corroborated by the real
+    # gate below, which matches these blobs with ignore_pca_sign_flip and NO
+    # convention flip (reported as legacy_diagnostic). Declared *input*
+    # conventions (clj raw-db, py delphi) describe the inputs, not this output.
+    d = 1
+    clj_blobs = crosslang.load_clj_blobs(str(entry_dir / "clj"))
+    py_steps = sorted((entry_dir / "py").glob("step-*.json"))
+    if len(clj_blobs) != len(py_steps):
+        return {"status": "STEP_COUNT_MISMATCH"}
+    col = Collector()
+    for i, cb in enumerate(clj_blobs):
+        A = project_acceptance(cb)
+        B = project_acceptance(json.loads(py_steps[i].read_text())["blob"])
+        pca_a, pca_b = A.get("pca"), B.get("pca")
+        s = infer_axis_sign(pca_a["comps"], pca_b["comps"]) if pca_a and pca_b else None
+        axis = Axis(s, d)
+        ka, kb = set(A), set(B)
+        if ka != kb:
+            col.add_shape("main", f"acceptance-keys only_a={sorted(ka-kb)} only_b={sorted(kb-ka)}")
+        for k in ka & kb:
+            _walk_keyed(k, A[k], B[k], k, col, axis)
+    rep = summarize(col)
+    rep["authoritative_g12"] = rep["rollup"]["g12_pass"]
+    rep["legacy_diagnostic"] = {
+        "b1_match": b1["overall_match"],
+        "tightened_kwargs_match": tightened["overall_match"],
+        "note": "tightened StepComparer is asymmetric np.allclose, not symmetric G12",
+    }
+    rep["n_steps"] = len(clj_blobs)
+    return rep
+
+
+# ---------------------------------------------------------------------------
+# Substrate 2: stage pairs (diagnostic surface).
+# ---------------------------------------------------------------------------
+STAGE_ORDER = ["R04_pca", "R05_projections", "R06_base_clusters",
+               "R09_group_clusters", "R10_tallies", "R11_repness",
+               "R12_priorities", "R13_ptpt_stats"]
+
+
+def _reorder_r04(pca: dict, tids_from: list, tids_to: list) -> dict:
+    """Reorder clj R04 comment-indexed arrays into the py tid order."""
+    idx = {t: i for i, t in enumerate(tids_from)}
+    if set(tids_from) != set(tids_to):
+        return pca  # inventory fault surfaced elsewhere
+    out = copy.deepcopy(pca)
+    for key in ("center", "comment-extremity"):
+        if isinstance(out.get(key), list):
+            out[key] = [pca[key][idx[t]] for t in tids_to]
+    for key in ("comps", "comment-projection"):
+        if isinstance(out.get(key), list) and out[key] and isinstance(out[key][0], list):
+            out[key] = [[row[idx[t]] for t in tids_to] for row in pca[key]]
+    return out
+
+
+def measure_stages(clj_dir: Path, py_dir: Path) -> dict:
+    clj_steps = sorted(clj_dir.glob("step-*.stages.json"))
+    py_steps = sorted(py_dir.glob("step-*.stages.json"))
+    col = Collector()
+    per_stage = {s: Collector() for s in STAGE_ORDER}
+    if len(clj_steps) != len(py_steps):
+        col.add_shape("battery", f"step-count {len(clj_steps)}!={len(py_steps)}")
+    idx_c = {int(p.name.split("-")[1].split(".")[0]): p for p in clj_steps}
+    idx_p = {int(p.name.split("-")[1].split(".")[0]): p for p in py_steps}
+    if set(idx_c) != set(idx_p):
+        col.add_shape("battery", "step-index set mismatch")
+    for step in sorted(set(idx_c) & set(idx_p)):
+        c = json.loads(idx_c[step].read_text())
+        p = json.loads(idx_p[step].read_text())
+        if c.get("input_digest") != p.get("input_digest"):
+            col.add_shape(f"step{step}", "input_digest"); continue
+        d = (CONV_SIGN.get(c.get("vote_sign_convention"), 1)
+             * CONV_SIGN.get(p.get("vote_sign_convention"), 1))
+        cst, pst = c["stages"], p["stages"]
+        tc = cst["R01_ingest"]["rating-mat"]["colnames"]
+        tp = pst["R01_ingest"]["rating-mat"]["colnames"]
+        cst = copy.deepcopy(cst)
+        cst["R04_pca"]["pca"] = _reorder_r04(cst["R04_pca"]["pca"], tc, tp)
+        pca_a, pca_b = cst["R04_pca"]["pca"], pst["R04_pca"]["pca"]
+        s = infer_axis_sign(pca_a["comps"], pca_b["comps"])
+        axis = Axis(s, d)
+        stages_present = set(STAGE_ORDER)
+        for stage in STAGE_ORDER:
+            if stage not in cst or stage not in pst:
+                col.add_shape("battery", f"missing-stage {stage} step{step}")
+                continue
+            walk(cst[stage], pst[stage], stage, col, axis)
+            walk(cst[stage], pst[stage], stage, per_stage[stage], axis)
+    rep = summarize(col)
+    rep["n_steps"] = len(clj_steps)
+    rep["per_stage"] = {s: summarize(pc)["rollup"]
+                        for s, pc in per_stage.items() if pc.pairs or pc.exact_total}
+    rep["exact_detail"] = dict(col.exact_mismatch)
+    rep["shape_detail"] = dict(col.shape)
+    return rep
+
+
+# ---------------------------------------------------------------------------
+# Self-test: seventeen probes (review rounds 1-4) must be REJECTED, zero errors.
+# ---------------------------------------------------------------------------
+def self_test() -> int:
+    def rejected(a, b, path, via="walk"):
+        col = Collector()
+        if via == "walk":
+            walk(a, b, path, col)
+        else:  # via == "keyed:<key>" -- exercise the direct keyed dispatch that
+            walk_key = via.split(":", 1)[1]  # main-blob uses (no parent walk())
+            _walk_keyed(walk_key, a, b, path, col, DEFAULT_AXIS)
+        return not summarize(col)["rollup"]["g12_pass"]
+
+    probes = [
+        # Round-1 controls ([357]).
+        ("uncoupled-signs",
+         {"comps": [[1., 2.]], "proj": [[3., 4.]]},
+         {"comps": [[-1., -2.]], "proj": [[3., 4.]]}, "output", "walk"),
+        ("extra-member",
+         [{"id": 1, "value": 1.}],
+         [{"id": 1, "value": 1.}, {"id": 2, "value": 2.}], "output", "walk"),
+        ("missing-matrix-row",
+         {"rownames": [1, 2], "colnames": [1], "matrix": [[1.], [2.]]},
+         {"rownames": [1], "colnames": [1], "matrix": [[1.]]}, "proj", "walk"),
+        ("integer-array-tolerance",
+         [100000], [100001], "group-clusters.members", "walk"),
+        # Round-2 controls ([382]).
+        ("trailing-matrix-cell",
+         {"rownames": [1], "colnames": [1], "matrix": [[1.0]]},
+         {"rownames": [1], "colnames": [1], "matrix": [[1.0, 999.0]]}, "proj", "walk"),
+        ("string-member-changed",
+         ["A"], ["B"], "group-clusters.members", "walk"),
+        ("float-spelled-count-drift",
+         {"user-vote-counts": {"0": 100000.0}},
+         {"user-vote-counts": {"0": 100001.0}}, "R13_ptpt_stats", "walk"),
+        # Round-3 controls ([395]).
+        ("boolean-membership",
+         {"members": [1]}, {"members": [True]}, "group-clusters", "walk"),
+        ("equal-invalid-membership",
+         {"members": ["A"]}, {"members": ["A"]}, "group-clusters", "walk"),
+        ("main-blob-container-dispatch",
+         {"0": {"A": 100000.0}}, {"0": {"A": 100001.0}}, "group-votes", "keyed:group-votes"),
+        # Round-4 controls ([408]): container rank, null element, key identity,
+        # and the previously-ungraded unhashable-label case.
+        ("object-in-scalar-count", {}, {}, "n", "keyed:n"),
+        ("array-in-scalar-count", [], [], "n", "keyed:n"),
+        ("object-in-member-array", [{}], [{}], "members", "keyed:members"),
+        ("wrong-member-rank", [[1]], [[1]], "members", "keyed:members"),
+        ("null-inside-nullable-set", [None], [None], "mod-in", "keyed:mod-in"),
+        ("boolean-matrix-identity",
+         {"rownames": [True], "colnames": [0], "matrix": [[1]]},
+         {"rownames": [1], "colnames": [0], "matrix": [[1]]}, "bucket-dists", "keyed:bucket-dists"),
+        ("unhashable-matrix-identity",
+         {"rownames": [[1]], "colnames": [0], "matrix": [[1]]},
+         {"rownames": [[1]], "colnames": [0], "matrix": [[1]]}, "bucket-dists", "keyed:bucket-dists"),
+    ]
+    ok = True
+    print("## SELF-TEST (seventeen false-acceptance probes as negative controls)")
+    for label, a, b, path, via in probes:
+        r = rejected(a, b, path, via)
+        print(f"  {label:<30} {'REJECTED (control passes)' if r else 'FALSELY ACCEPTED (control FAILS)'}")
+        ok = ok and r
+    print("  " + ("ALL 17 REJECTED" if ok else "SOME PROBES STILL ACCEPTED"))
+    return 0 if ok else 1
+
+
+
+# Vendored accepted Q25 metric core; step-2 admission: BOARD [677].

--- a/ci/private_cert/images/gate.py
+++ b/ci/private_cert/images/gate.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""P-053 step-2 paired-recording producer/verifier, per BOARD [677].
+
+Complete scope: admitted bundle/entries/checkpoints, certify raw schema and
+comparison, symmetric G12 abs1e-6+rel1e-4 with zero outliers. Recovery and serving
+schedule inference belong to shadow diagnostics. No private certificate or
+writer transfer follows from this scoped receipt.
+"""
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import resource
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# Under python -I the trusted source closure explicitly selects its own imports;
+# mounted data never enter sys.path. Producer/verifier closures are built apart.
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[2]
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(REPO / 'delphi'))
+sys.path.insert(0, str(HERE.parent))
+from control import encoded, sha
+from image_admission import file_digest, json_bytes, regular_path
+import g12
+from polismath.replay import certify, fixture_bundle, real_data, schedule, store
+from polismath.replay.event_ingress import input_hashes
+
+POLICY = {'schema': 'polis-private-paired-policy/1', 'absolute': 1e-6,
+          'relative': 1e-4, 'outlier_fraction': 0, 'strict_raw_schema': True,
+          'stages': 'diagnostic-only', 'recovery_consumption': 'shadow-diagnostic-only'}
+INPUT_KEYS = {'candidateSha', 'oracleSha', 'policySha256', 'scheduleSha256',
+              'inventorySha256', 'expectedChecks'}
+
+
+def dump(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open('xb') as f:
+        f.write(encoded(value))
+
+
+def read(path):
+    return json_bytes(path.read_bytes())
+
+
+def regular_tree(root):
+    result = {}
+    for path in sorted(root.rglob('*')):
+        if path.is_symlink() or (not path.is_file() and not path.is_dir()):
+            raise ValueError('UNSAFE_EVIDENCE')
+        if path.is_file():
+            result[str(path.relative_to(root))] = file_digest(path)
+    return result
+
+
+def prepare(fixture, inputs, scratch, *, bind=True):
+    """Re-derive every input/checkpoint from the bound fixture, independently."""
+    if set(inputs) != INPUT_KEYS or inputs['policySha256'] != sha(POLICY):
+        raise ValueError('PAIRED_POLICY_BINDING')
+    plan = read(fixture / 'plan.json')
+    if (set(plan) != {'schema', 'scope', 'manifestSha256', 'configSha256', 'entries'}
+            or plan['schema'] != 'polis-private-paired-plan/1'
+            or plan['scope'] not in ('public', 'private', 'all')):
+        raise ValueError('PLAN_SCHEMA')
+    manifest_path, config_path = fixture / 'manifest.json', fixture / 'config.json'
+    if file_digest(manifest_path) != plan['manifestSha256'] or file_digest(config_path) != plan['configSha256']:
+        raise ValueError('BUNDLE_METADATA_BINDING')
+    manifest, config = read(manifest_path), read(config_path)
+    payload = fixture / 'payload'
+    fixture_bundle.verify(payload, manifest)
+    fixture_bundle.admit_manifest(manifest, config=config, config_bytes=config_path.read_bytes(), payload_root=payload)
+    if regular_tree(fixture).keys() != {'plan.json', 'manifest.json', 'config.json'} | {
+        'payload/' + f['path'] for f in manifest['files']}:
+        raise ValueError('FIXTURE_EXTRA_FILES')
+    public = {r['slug'] for r in config['public_fixtures']}
+    battery = certify.load_battery(REPO / 'delphi/scripts/certify_battery.json')
+    required = {(e.dataset, e.schedule_id) for e in battery
+                if plan['scope'] == 'all' or (e.dataset in public) == (plan['scope'] == 'public')}
+    if not required or not isinstance(plan['entries'], list):
+        raise ValueError('EMPTY_BATTERY')
+    roles = {}
+    for row in manifest['roles']:
+        if row['role'] in roles:
+            raise ValueError('AMBIGUOUS_ROLE')
+        roles[row['role']] = row
+    mapping, prepared, seen = {}, [], set()
+    for item in plan['entries']:
+        if set(item) != {'dataset', 'schedule_id', 'role', 'directory', 'schedule'}:
+            raise ValueError('PLAN_ENTRY_SCHEMA')
+        key = item['dataset'], item['schedule_id']
+        if key in seen or key not in required:
+            raise ValueError('ENTRY_INVENTORY')
+        seen.add(key)
+        store.recording_dir(*key)
+        alias = item['dataset']
+        expected_role = next((r['role'] for r in config['public_fixtures'] if r['slug'] == alias),
+                             config['coverage_role_map'].get(alias))
+        role = roles.get(expected_role)
+        if item['role'] != expected_role or (alias not in public and (
+            role is None or item['directory'] != role['dir'])):
+            raise ValueError('OPAQUE_ROLE_BINDING')
+        regular_path(item['directory'])
+        directory = payload / item['directory']
+        if not directory.is_dir() or directory.is_symlink() or payload.resolve() not in directory.resolve().parents:
+            raise ValueError('INPUT_DIRECTORY')
+        if alias in public:
+            # Public fixtures are not owned-extraction roles. Bind their CSV
+            # bytes to the independently built verifier's committed public pin.
+            candidates = sorted(real_data.REAL_DATA_ROOT.glob('*-' + alias))
+            if len(candidates) != 1 or (directory / 'events.jsonl').exists():
+                raise ValueError('PUBLIC_FIXTURE_BINDING')
+            for pattern in ('*-votes.csv', '*-comments.csv'):
+                wanted, supplied = sorted(candidates[0].glob(pattern)), sorted(directory.glob(pattern))
+                if len(wanted) != 1 or len(supplied) != 1 or file_digest(wanted[0]) != file_digest(supplied[0]):
+                    raise ValueError('PUBLIC_FIXTURE_BINDING')
+        if alias not in public and not (directory / 'events.jsonl').is_file():
+            raise ValueError('PRIVATE_LOSSLESS_INGRESS_REQUIRED')
+        if alias in mapping and mapping[alias] != str(directory.resolve()):
+            raise ValueError('ALIAS_REBOUND')
+        mapping[alias] = str(directory.resolve())
+    if seen != required:
+        raise ValueError('INCOMPLETE_ENTRY_INVENTORY')
+    map_path = scratch / 'input-map.json'
+    dump(map_path, mapping)
+    os.environ['POLIS_REPLAY_INPUT_MAP'] = str(map_path)
+    for item in plan['entries']:
+        # New explicit cuts are already frozen in this plan; do not reuse a
+        # historical CSV schedule to silently truncate/reorder fresh events.
+        spec = schedule.ScheduleSpec.from_dict(item['schedule'])
+        if spec.dataset != item['dataset'] or spec.schedule_id != item['schedule_id']:
+            raise ValueError('SCHEDULE_IDENTITY')
+        spec_path = scratch / 'schedules' / item['dataset'] / (item['schedule_id'] + '.json')
+        spec_path.parent.mkdir(parents=True, exist_ok=True)
+        spec.write_json(spec_path)
+        entry = certify.BatteryEntry(item['dataset'], item['schedule_id'], schedule_path=spec_path,
+                                     role=item['role'])
+        expected = certify.prepare_entry(entry)
+        original = next(e for e in battery if (e.dataset, e.schedule_id) == (entry.dataset, entry.schedule_id))
+        recipe = certify.build_effective_spec(original, real_data.load_export_votes(entry.dataset))
+        if (spec.moderation != recipe.moderation or spec.restart_after != recipe.restart_after
+                or spec.clojure != recipe.clojure or spec.coverage != recipe.coverage):
+            raise ValueError('SCHEDULE_RECIPE_CHANGED')
+        declared_cuts = recipe.cuts.get('at', [])
+        if len(expected.checkpoints) != len(declared_cuts):
+            raise ValueError('SCHEDULE_CHECKPOINT_COUNT_CHANGED')
+        if expected.spec.coverage != 'full-stream' and plan['scope'] != 'public':
+            raise ValueError('PRIVATE_FULL_STREAM_REQUIRED')
+        prepared.append(expected)
+    full = {p.entry.dataset for p in prepared if p.spec.coverage == 'full-stream'}
+    if any(p.entry.dataset not in full for p in prepared):
+        raise ValueError('PREFIX_WITHOUT_FULL_COMPANION')
+    schedules = [p.spec.to_dict() for p in prepared]
+    inventory = [{'dataset': p.entry.dataset, 'schedule_id': p.entry.schedule_id,
+                  'role': p.entry.role, 'votesSha256': p.votes_sha,
+                  'eventsMetaSha256': p.events_meta_sha, 'commentsSha256': p.comments_sha,
+                  'manifestSha256': plan['manifestSha256'], 'configSha256': plan['configSha256'],
+                  'checkpoints': p.checkpoints, 'stream_end': p.stream_end} for p in prepared]
+    checks = sum(len(p.checkpoints) for p in prepared)  # one paired checkpoint = one check
+    if bind and (sha(schedules) != inputs['scheduleSha256'] or sha(inventory) != inputs['inventorySha256']
+            or type(inputs['expectedChecks']) is not int or checks != inputs['expectedChecks'] or checks == 0):
+        raise ValueError('ADMITTED_INVENTORY_BINDING')
+    return prepared, inventory
+
+
+def run_engine(cmd, cwd, log):
+    env = {'PATH': os.environ['PATH'], 'HOME': '/tmp', 'UV_OFFLINE': '1', 'PIP_NO_INDEX': '1',
+           'OMP_NUM_THREADS': '1', 'OPENBLAS_NUM_THREADS': '1', 'MKL_NUM_THREADS': '1',
+           'PYTHONHASHSEED': '0', 'PYTHONDONTWRITEBYTECODE': '1', 'PYTHONNOUSERSITE': '1',
+           'POLIS_REPLAY_INPUT_MAP': os.environ['POLIS_REPLAY_INPUT_MAP'],
+           'PYTHONPATH': str(REPO / 'delphi')}
+    with log.open('wb') as fh:
+        result = subprocess.run(cmd, cwd=cwd, env=env, stdout=fh, stderr=subprocess.STDOUT,
+                                timeout=certify.DRIVER_TIMEOUT_SEC)
+    return result.returncode
+
+
+def produce(fixture=Path('/fixture'), output=Path('/output'), inputs_path=Path('/run-spec/inputs.json')):
+    if Path('/admission').exists():
+        raise ValueError('PRODUCER_CONTROL_MOUNT')
+    inputs = read(inputs_path)
+    if list(output.iterdir()):
+        raise ValueError('FRESH_OUTPUT_REQUIRED')
+    with tempfile.TemporaryDirectory(prefix='paired-producer-') as tmp:
+        scratch = Path(tmp)
+        prepared, inventory = prepare(fixture, inputs, scratch)
+        # Verifier derives the same inventory from the same original bytes.
+        shutil.copytree(fixture, output / 'fixture')
+        runs = []
+        for expected in prepared:
+            entry = expected.entry
+            rec = store.recording_dir(entry.dataset, entry.schedule_id, root=output / 'recordings')
+            rec.mkdir(parents=True)
+            spec_path = scratch / 'resolved' / entry.dataset / (entry.schedule_id + '.json')
+            spec_path.parent.mkdir(parents=True, exist_ok=True)
+            expected.spec.write_json(spec_path)
+            event = expected.votes_csv.name == 'events.jsonl'
+            commands = [
+                ('clj', ['clojure', '-M:replay', '--schedule', str(spec_path),
+                         '--events' if event else '--votes', str(expected.votes_csv), '--out', str(rec)]
+                 + (['--comments', str(expected.comments_csv)] if expected.comments_csv else []), REPO / 'math'),
+                ('py', [sys.executable, 'scripts/replay_driver.py', 'run', '--schedule', str(spec_path),
+                        '--out', str(output / 'recordings')]
+                 + (['--events', str(expected.votes_csv)] if event else []), REPO / 'delphi')]
+            for engine, cmd, cwd in commands:
+                exit_code = run_engine(cmd, cwd, rec / (engine + '.log'))
+                runs.append({'dataset': entry.dataset, 'schedule_id': entry.schedule_id,
+                             'engine': engine, 'exit': exit_code})
+                if exit_code:
+                    break
+            if runs[-1]['exit']:
+                break
+        result = {'schema': 'polis-private-paired-output/1', 'inputs': inputs,
+                  'inventory': inventory, 'runs': runs,
+                  'resources': {'ru_maxrss': resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss,
+                                'ru_maxrss_unit': 'KiB on Linux; bytes on macOS',
+                                'output_bytes': sum(p.stat().st_size for p in output.rglob('*') if p.is_file())},
+                  'files': regular_tree(output)}
+        dump(output / 'producer.json', result)
+    # A nonzero engine exit is retained as INCOMPLETE evidence for the verifier;
+    # this trusted collector can finish normally without fabricating success.
+
+
+def verify_recordings(evidence, inputs, scratch):
+    prepared, inventory = prepare(evidence / 'fixture', inputs, scratch)
+    result = read(evidence / 'producer.json')
+    if set(result) != {'schema', 'inputs', 'inventory', 'runs', 'resources', 'files'} or result['schema'] != 'polis-private-paired-output/1':
+        raise ValueError('PRODUCER_SCHEMA')
+    if result['inputs'] != inputs or result['inventory'] != inventory:
+        raise ValueError('PRODUCER_BINDING')
+    actual = regular_tree(evidence)
+    actual.pop('producer.json')
+    actual.pop('supervisor-producer.log', None)  # independently packaged by supervisor
+    if actual != result['files']:
+        raise ValueError('EVIDENCE_FILE_INVENTORY')
+    runs = [{'dataset': p.entry.dataset, 'schedule_id': p.entry.schedule_id, 'engine': engine, 'exit': 0}
+            for p in prepared for engine in ('clj', 'py')]
+    if result['runs'] != runs:
+        raise ValueError('INCOMPLETE_ENGINE_EXECUTION')
+    return verify_pairs(prepared, evidence / 'recordings', scratch)
+
+
+def verify_pairs(prepared, recordings, scratch):
+    if not prepared:
+        raise ValueError('EMPTY_RECORDINGS')
+    reports = []
+    with contextlib.redirect_stdout(io.StringIO()):
+        controls_pass = g12.self_test() == 0
+    if not controls_pass:
+        raise ValueError('G12_CONTROLS_FAILED')
+    passed = True
+    for p in prepared:
+        rec = store.recording_dir(p.entry.dataset, p.entry.schedule_id, root=recordings)
+        if read(rec / 'schedule.json') != p.spec.to_dict():
+            raise ValueError('RECORDING_SCHEDULE_BINDING')
+        for engine in ('clj', 'py'):
+            certify.validate_recording_inventory(rec / engine, engine, p)
+        strict = certify.compare_recording_pair(rec / 'clj', rec / 'py', cache_root=scratch)
+        metric = g12.measure_main_blob(rec, REPO / 'delphi')
+        ok = bool(all(s['match'] for s in strict['per_step']) and metric.get('authoritative_g12') is True)
+        passed = passed and ok
+        stage_diagnostic = {'status': 'NOT_CAPTURED', 'gate': False}
+        if (rec / 'clj-stages').is_dir() and (rec / 'py-stages').is_dir():
+            try:
+                stage_diagnostic = {'gate': False, 'comparison': g12.measure_stages(rec / 'clj-stages', rec / 'py-stages')}
+            except Exception as exc:
+                stage_diagnostic = {'gate': False, 'status': 'UNAVAILABLE', 'error_type': type(exc).__name__}
+        reports.append({'dataset': p.entry.dataset, 'schedule_id': p.entry.schedule_id,
+                        'strict': strict, 'g12': metric, 'pass': ok, 'stages': stage_diagnostic})
+    controls = checkpoint_controls(prepared[0], recordings, scratch)
+    return {'verdict': 'PASS' if passed else 'FAIL', 'checks': sum(len(p.checkpoints) for p in prepared),
+            'entries': reports, 'negative_controls': {'schema': 'polis-private-controls/1',
+                                  'g12': {'rejected': 17, 'expected': 17}, 'checkpoint': controls},
+            'scope': 'paired-recordings; stages/recovery/consumption are separate diagnostics'}
+
+
+def checkpoint_controls(expected, recordings, scratch):
+    """Exercise the shipped schema/inventory validator on real, valid output."""
+    from dataclasses import replace
+    base = store.recording_dir(expected.entry.dataset, expected.entry.schedule_id, root=recordings)
+    checkpoint = expected.checkpoints[0]
+    one = replace(expected, checkpoints=[checkpoint])
+    source = base / 'py' / f"step-{checkpoint['index']:03d}.json"
+    control_dir = scratch / 'controls'
+    control_dir.mkdir()
+    target = control_dir / source.name
+    original = source.read_bytes()
+    target.write_bytes(original)
+    certify.validate_recording_inventory(control_dir, 'py', one)
+    result = {}
+    for name in ('missing-evidence', 'forged-evidence', 'truncated-evidence', 'short-inventory'):
+        target.write_bytes(original)
+        check = one
+        if name == 'missing-evidence':
+            target.unlink()
+        elif name == 'forged-evidence':
+            malformed = json_bytes(original)
+            malformed['blob']['n'] = True  # same bytes/hash could not legitimize this
+            target.write_bytes(encoded(malformed))
+        elif name == 'truncated-evidence':
+            target.write_bytes(original[:len(original)//2])
+        else:
+            check = replace(one, checkpoints=[checkpoint, {**checkpoint, 'index': checkpoint['index'] + 1}])
+        try:
+            certify.validate_recording_inventory(control_dir, 'py', check)
+        except (ValueError, certify.CertifyError):
+            result[name] = 'REJECTED'
+        else:
+            raise ValueError('CHECKPOINT_CONTROL_FALSE_ACCEPTANCE')
+    return result
+
+
+def verify(evidence=Path('/evidence'), admission_dir=Path('/admission'), verdict_dir=Path('/verdict')):
+    a = read(admission_dir / 'admission.json')
+    inputs = {k: a[k] for k in INPUT_KEYS}
+    report = {'verdict': 'INCOMPLETE', 'checks': 0}
+    try:
+        with tempfile.TemporaryDirectory(prefix='paired-verifier-') as tmp:
+            report = verify_recordings(evidence, inputs, Path(tmp))
+    except Exception as exc:
+        report['private_error_type'] = type(exc).__name__
+    controls = report.get('negative_controls', {'schema': 'polis-private-controls/1', 'status': 'NOT_COMPLETED'})
+    dump(verdict_dir / 'negative-controls.json', controls)
+    dump(verdict_dir / 'details.json', report)
+    verdict = report['verdict']
+    receipt = {'schema': 'polis-private-gate/2', 'negativeControlsSha256': sha(controls), 'admissionSha256': sha(a),
+               'evidenceSha256': (admission_dir / 'evidence-sha256').read_text().strip(),
+               'inventorySha256': a['inventorySha256'], 'scheduleSha256': a['scheduleSha256'],
+               'policySha256': a['policySha256'], 'checks': report['checks'], 'verdict': verdict,
+               'reason': {'PASS': 'COMPLETE', 'FAIL': 'COMPARISON', 'INCOMPLETE': 'MISSING_EVIDENCE'}[verdict]}
+    dump(verdict_dir / 'receipt.json', receipt)
+
+
+if __name__ == '__main__':
+    if sys.argv[1:] == ['produce']:
+        produce()
+    elif sys.argv[1:] == ['verify']:
+        verify()
+    else:
+        raise SystemExit('Expected produce or verify')

--- a/ci/private_cert/images/launcher.py
+++ b/ci/private_cert/images/launcher.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Fixed exec-form ABI; verify the admitted closure before its gate entrypoint.
+
+The gate is separately reviewed code. This launcher intentionally does not
+replace it with certify --strict or turn a build/transport success into PASS.
+"""
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+
+ROOT = Path('/opt/polis-private-image')
+
+
+def main():
+    recipe = json.loads((ROOT / 'recipe.json').read_bytes())
+    action = {'producer': 'produce', 'verifier': 'verify'}[recipe['role']]
+    if sys.argv[1:] != [action]:
+        raise ValueError('IMAGE_ACTION')
+    # Admission is immutable under the supervisor's fixed mount contract.
+    input_path = '/run-spec/inputs.json' if action == 'produce' else '/admission/admission.json'
+    if action == 'produce' and Path('/admission').exists():
+        raise ValueError('PRODUCER_CONTROL_MOUNT')
+    admission = json.loads(Path(input_path).read_bytes())
+    for key in ('candidateSha', 'oracleSha', 'policySha256'):
+        if recipe[key] != admission[key]:
+            raise ValueError('IMAGE_ADMISSION')
+    payload = ROOT / 'payload'
+    actual = set()
+    for path in payload.rglob('*'):
+        if path.is_symlink():
+            raise ValueError('SOURCE_SYMLINK')
+        if path.is_file():
+            rel = str(path.relative_to(payload))
+            actual.add(rel)
+            if hashlib.sha256(path.read_bytes()).hexdigest() != recipe['files'].get(rel):
+                raise ValueError('SOURCE_DIGEST')
+        elif not path.is_dir():
+            raise ValueError('SOURCE_FILE_TYPE')
+    if actual != set(recipe['files']):
+        raise ValueError('SOURCE_CENSUS')
+    # Never import code from the mounted fixture/evidence/admission or an ambient
+    # PYTHONPATH. -I disables caller-controlled Python import/config sources.
+    env = {key: value for key, value in os.environ.items() if key in {
+        'PATH', 'OPENBLAS_NUM_THREADS', 'OMP_NUM_THREADS', 'MKL_NUM_THREADS',
+        'NUMEXPR_NUM_THREADS', 'LANG', 'LC_ALL'}}
+    env.update(HOME='/tmp', PYTHONDONTWRITEBYTECODE='1', PYTHONNOUSERSITE='1',
+               UV_OFFLINE='1', PIP_NO_INDEX='1')
+    os.chdir(payload)
+    os.execve('/opt/venv/bin/python', ['/opt/venv/bin/python', '-I',
+              str(payload / recipe['entrypoint']), action], env)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception:
+        raise SystemExit('INCOMPLETE: admitted image closure or action invalid') from None

--- a/ci/private_cert/images/plan.py
+++ b/ci/private_cert/images/plan.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Bind a reviewed complete plan to actual fixture bytes BEFORE engine output.
+
+plan.json must already contain the reviewed role/directory mapping and freshly
+resolved schedules. This command validates them and emits only data commitments
+for the runtime operator's signed admission; it does not sign, upload or run.
+"""
+import argparse
+from pathlib import Path
+import sys
+import tempfile
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gate
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--fixture', type=Path, required=True)
+    p.add_argument('--candidate', required=True)
+    p.add_argument('--oracle', required=True)
+    p.add_argument('--out', type=Path, required=True)
+    a = p.parse_args()
+    from image_admission import COMMIT
+    if not COMMIT.fullmatch(a.candidate) or not COMMIT.fullmatch(a.oracle):
+        raise ValueError('IMMUTABLE_SOURCE_PINS_REQUIRED')
+    inputs = dict(candidateSha=a.candidate, oracleSha=a.oracle,
+                  policySha256=gate.sha(gate.POLICY), scheduleSha256='', inventorySha256='', expectedChecks=0)
+    with tempfile.TemporaryDirectory(prefix='paired-plan-') as tmp:
+        prepared, inventory = gate.prepare(a.fixture.resolve(), inputs, Path(tmp), bind=False)
+    inputs.update(scheduleSha256=gate.sha([p.spec.to_dict() for p in prepared]),
+                  inventorySha256=gate.sha(inventory),
+                  expectedChecks=sum(len(p.checkpoints) for p in prepared))
+    gate.dump(a.out, inputs)
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/private_cert/images/recipe.py
+++ b/ci/private_cert/images/recipe.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""List the complete source-only image closure from one reviewed checkout.
+
+The subsequent stage command validates committedness and every byte. Verifier
+recipes come from an independently reviewed checkout, not a producer artifact.
+"""
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from control import encoded
+from image_admission import GATES, file_digest, validate_recipe
+
+
+def source_files(root):
+    names = {
+        'ci/private_cert/control.py', 'ci/private_cert/image_admission.py',
+        'ci/private_cert/images/gate.py', 'ci/private_cert/images/g12.py',
+        'delphi/scripts/replay_driver.py', 'delphi/scripts/certify_battery.json',
+        'delphi/scripts/certify_datasets.json', 'delphi/scripts/certify_datasets.schema.json',
+        'math/dev/replay.clj', 'math/deps.edn',
+    }
+    for base, pattern in [('delphi/polismath', '**/*.py'), ('math/src', '**/*'),
+                          ('delphi/scripts/schedules', '*.json'), ('delphi/scripts/schemas', '*.json'),
+                          ('delphi/real_data', '*/*-votes.csv'), ('delphi/real_data', '*/*-comments.csv')]:
+        names.update(str(p.relative_to(root)) for p in (root / base).glob(pattern) if p.is_file())
+    return {name: file_digest(root / name) for name in sorted(names)}
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--source', type=Path, required=True)
+    p.add_argument('--role', choices=['producer', 'verifier'], required=True)
+    p.add_argument('--candidate', required=True)
+    p.add_argument('--oracle', required=True)
+    p.add_argument('--policy-sha256', required=True)
+    p.add_argument('--runtime-image', required=True)
+    p.add_argument('--out', type=Path, required=True)
+    a = p.parse_args()
+    head = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=a.source, text=True).strip()
+    recipe = {'schema': 'polis-private-image-recipe/1', 'role': a.role, 'sourceCommit': head,
+              'candidateSha': a.candidate, 'oracleSha': a.oracle, 'policySha256': a.policy_sha256,
+              'runtimeImage': a.runtime_image, 'files': source_files(a.source),
+              'entrypoint': 'ci/private_cert/images/gate.py', 'gates': sorted(GATES)}
+    validate_recipe(recipe)
+    with a.out.open('xb') as f:
+        f.write(encoded(recipe))
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/private_cert/images/runtime.Dockerfile
+++ b/ci/private_cert/images/runtime.Dockerfile
@@ -1,0 +1,19 @@
+# Build only in the isolated builder. All inputs must be preloaded, reviewed
+# Linux ARM64 digest references. This composes offline dependencies; no source,
+# fixtures, host home, credentials, apt or pip is copied/resolved at runtime.
+ARG NUMERICAL_IMAGE
+ARG CLOJURE_IMAGE
+ARG OS_IMAGE
+FROM ${NUMERICAL_IMAGE} AS numerical
+FROM ${CLOJURE_IMAGE} AS oracle
+FROM ${OS_IMAGE}
+COPY --from=numerical /usr/local/ /usr/local/
+COPY --from=oracle /opt/java/openjdk/ /opt/java/openjdk/
+COPY --from=oracle /root/.m2/repository/ /opt/m2/
+COPY --from=oracle /app/.cpcache/ /opt/oracle-classpath/
+COPY clojure-offline.py /usr/local/bin/clojure
+RUN chmod 0555 /usr/local/bin/clojure && ln -sf /usr/local/bin/python3 /usr/bin/python3 && \
+    mkdir -p /opt/venv/bin && ln -s /usr/local/bin/python3 /opt/venv/bin/python && \
+    chmod -R a+rX /opt/m2 /opt/oracle-classpath
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=/opt/venv/bin:/opt/java/openjdk/bin:/usr/local/bin:/usr/bin:/bin

--- a/ci/private_cert/images/stage.py
+++ b/ci/private_cert/images/stage.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Stage only an explicitly reviewed source closure into a fresh build context.
+
+No git mutation, dependency resolution, image pull/build or cloud action. Source
+pins must describe committed reviewed code; dirty file bytes cannot masquerade
+as that commit. The independent verifier uses its own source checkout/recipe.
+"""
+import argparse
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from control import encoded, sha
+from image_admission import file_digest, json_bytes, validate_recipe
+
+
+def stage(source, recipe, destination):
+    recipe = validate_recipe(recipe)
+    source = source.resolve(strict=True)
+    head = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=source, text=True).strip()
+    if head != recipe['sourceCommit']:
+        raise ValueError('UNREVIEWED_SOURCE_COMMIT')
+    # Content hashes and trackedness are both mandatory. Ignore unrelated edits.
+    for rel, digest in recipe['files'].items():
+        path = source / rel
+        if path.is_symlink() or not path.is_file() or source not in path.resolve().parents:
+            raise ValueError('SOURCE_FILE_BOUNDARY')
+        if any(p.is_symlink() for p in path.parents if p != source and source in p.parents):
+            raise ValueError('SOURCE_DIRECTORY_SYMLINK')
+        tracked = subprocess.check_output(['git', 'ls-files', '--error-unmatch', '--', rel], cwd=source)
+        committed = subprocess.check_output(['git', 'show', f'{head}:{rel}'], cwd=source)
+        import hashlib
+        if (not tracked or file_digest(path) != digest
+                or hashlib.sha256(committed).hexdigest() != digest):
+            raise ValueError('UNREVIEWED_SOURCE_BYTES')
+        if recipe['role'] == 'producer':
+            origin = recipe['candidateSha'] if rel.startswith('delphi/polismath/') else (
+                recipe['oracleSha'] if rel.startswith('math/') else None)
+            if origin is not None:
+                origin_bytes = subprocess.check_output(['git', 'show', f'{origin}:{rel}'], cwd=source)
+                if hashlib.sha256(origin_bytes).hexdigest() != digest:
+                    raise ValueError('ENGINE_SOURCE_COMMIT_BINDING')
+    destination.mkdir(mode=0o700, parents=True, exist_ok=False)
+    for rel in recipe['files']:
+        out = destination / 'payload' / rel
+        out.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source / rel, out)
+        out.chmod(0o444)
+    (destination / 'recipe.json').write_bytes(encoded(recipe))
+    here = Path(__file__).resolve().parent
+    for name in ('Dockerfile', 'launcher.py'):
+        shutil.copyfile(here / name, destination / name)
+    (destination / 'build.json').write_bytes(encoded({
+        'schema': 'polis-private-image-build/1', 'recipeSha256': sha(recipe),
+        'dockerfileSha256': file_digest(here / 'Dockerfile'),
+        'launcherSha256': file_digest(here / 'launcher.py'),
+        'platform': 'linux/arm64', 'network': 'none',
+        'runtimeImage': recipe['runtimeImage'],
+    }))
+    return sha(recipe)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--source', type=Path, required=True)
+    p.add_argument('--recipe', type=Path, required=True)
+    p.add_argument('--out', type=Path, required=True)
+    a = p.parse_args()
+    print(stage(a.source, json_bytes(a.recipe.read_bytes()), a.out))
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/private_cert/operator.py
+++ b/ci/private_cert/operator.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Scoped operator invocation. No SDK client is constructed on import."""
+import argparse
+import json
+import re
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('action', choices=['launch', 'status', 'cancel'])
+    p.add_argument('--admission-id', required=True)
+    p.add_argument('--function', required=True)
+    p.add_argument('--region', required=True)
+    args = p.parse_args()
+    if not re.fullmatch('[a-f0-9]{32}', args.admission_id):
+        raise SystemExit('Invalid admission id')
+    import boto3
+    result = boto3.client('lambda', region_name=args.region).invoke(
+        FunctionName=args.function, InvocationType='RequestResponse',
+        Payload=json.dumps({'action': args.action, 'admissionId': args.admission_id}).encode())
+    if result.get('FunctionError'):
+        raise SystemExit('TEARDOWN_UNKNOWN; reconcile with status; never create another admission to bypass it')
+    raw = result['Payload'].read(4097)
+    if len(raw) > 4096:
+        raise SystemExit('Unexpected control response')
+    parsed = json.loads(raw)
+    if set(parsed) != {'status', 'admissionId'} or parsed['admissionId'] != args.admission_id or parsed['status'] not in ('STAGED', 'RUNNING', 'CLEAN'):
+        raise SystemExit('Unexpected control response')
+    print(json.dumps(parsed))
+
+
+if __name__ == '__main__': main()

--- a/ci/private_cert/sign.py
+++ b/ci/private_cert/sign.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Sign a reviewed private admission, after baking and exact-version staging.
+
+No key generation, key logging, private upload or cloud action. Key and JSON
+paths belong outside the public checkout. Requires cryptography in the operator
+runtime. The corresponding public key is independently admitted in the AMI.
+"""
+import argparse
+import json
+from pathlib import Path
+from control import encoded
+
+
+def main():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    p = argparse.ArgumentParser()
+    p.add_argument('--unsigned', type=Path, required=True)
+    p.add_argument('--private-key', type=Path, required=True)
+    p.add_argument('--output', type=Path, required=True)
+    args = p.parse_args()
+    key = serialization.load_pem_private_key(args.private_key.read_bytes(), password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        raise SystemExit('Ed25519 key required')
+    a = json.loads(args.unsigned.read_bytes())
+    if 'signature' in a:
+        raise SystemExit('Refusing to silently replace an existing signature')
+    public = key.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw).hex()
+    if a['signerPublicKey'] != public:
+        raise SystemExit('Admission public key does not match signer')
+    a['signature'] = key.sign(encoded(a)).hex()
+    # Exclusive write and private mode. No stdout contains admission bytes.
+    import os
+    fd = os.open(args.output, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, 'wb') as f:
+        f.write(encoded(a) + b'\n')
+
+
+if __name__ == '__main__': main()

--- a/ci/private_cert/test_image_admission.py
+++ b/ci/private_cert/test_image_admission.py
@@ -1,0 +1,257 @@
+import copy
+import hashlib
+import io
+import json
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from control import encoded, sha
+import image_admission as images
+
+
+def recipe(role):
+    return {'schema': 'polis-private-image-recipe/1', 'role': role,
+            'sourceCommit': ('a' if role == 'producer' else 'b') * 40,
+            'candidateSha': 'c' * 40, 'oracleSha': 'd' * 40, 'policySha256': 'e' * 64,
+            'runtimeImage': 'localhost/synthetic-runtime@sha256:' + 'f' * 64,
+            'entrypoint': 'gate.py', 'files': {'gate.py': hashlib.sha256(b'# synthetic test only\n').hexdigest()},
+            'gates': sorted(images.GATES)}
+
+
+def config(r):
+    return {'User': '65534:65534',
+            'Entrypoint': ['/usr/bin/python3', '/opt/polis-private-image/launcher.py'],
+            'Cmd': [], 'WorkingDir': '/opt/polis-private-image',
+            'Env': ['HOME=/tmp', 'PATH=/usr/bin'],
+            'Labels': {'org.polis.private.role': r['role'], 'org.polis.private.recipe': sha(r)}}
+
+
+def tar_bytes(files):
+    out = io.BytesIO()
+    with tarfile.open(fileobj=out, mode='w') as t:
+        for name, raw in files.items():
+            m = tarfile.TarInfo(name)
+            m.size = len(raw)
+            t.addfile(m, io.BytesIO(raw))
+    return out.getvalue()
+
+
+def oci(path, r, *, config_patch=None, platform='arm64', source_patch=None, extra=False, corrupt=False):
+    files = {'opt/polis-private-image/recipe.json': encoded(r),
+             'opt/polis-private-image/launcher.py': (Path(images.__file__).parent / 'images/launcher.py').read_bytes(),
+             'opt/polis-private-image/payload/gate.py': b'# synthetic test only\n'}
+    files.update(source_patch or {})
+    layer = tar_bytes(files)
+    image_config = config(r)
+    image_config.update(config_patch or {})
+    cfg = encoded({'architecture': platform, 'os': 'linux', 'config': image_config,
+                   'rootfs': {'type': 'layers', 'diff_ids': ['sha256:' + hashlib.sha256(layer).hexdigest()]}})
+    blobs = {}
+    def desc(raw, media):
+        digest = hashlib.sha256(raw).hexdigest()
+        blobs['blobs/sha256/' + digest] = raw
+        return {'mediaType': media, 'digest': 'sha256:' + digest, 'size': len(raw)}
+    manifest = encoded({'schemaVersion': 2, 'mediaType': images.MANIFEST,
+                        'config': desc(cfg, images.CONFIG), 'layers': [desc(layer, images.LAYER)]})
+    index = encoded({'schemaVersion': 2, 'manifests': [desc(manifest, images.MANIFEST)]})
+    if corrupt:
+        key = next(iter(blobs))
+        blobs[key] = b'X' + blobs[key][1:]
+    if extra:
+        blobs['unexpected'] = b'unknown'
+    path.write_bytes(tar_bytes({'oci-layout': encoded({'imageLayoutVersion': '1.0.0'}),
+                                'index.json': index, **blobs}))
+    return path
+
+
+def review(recipes):
+    return {'schema': 'polis-private-image-review/1',
+            'recipeSha256': {k: sha(v) for k, v in recipes.items()},
+            'controls': {k: 'PASS' for k in images.CONTROLS}, 'gateReviewSha256': '1' * 64}
+
+
+class ImageTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.recipes = {r: recipe(r) for r in images.ROLES}
+        self.paths = {r: oci(self.root / (r + '.tar'), self.recipes[r]) for r in images.ROLES}
+
+    def lock(self):
+        return images.make_lock(self.paths['producer'], self.paths['verifier'], self.recipes, review(self.recipes))
+
+    def admission(self, lock):
+        return {'candidateSha': 'c'*40, 'oracleSha': 'd'*40, 'policySha256': 'e'*64,
+                'runnerImage': 'localhost/producer@' + lock['images']['producer']['manifestDigest'],
+                'verifierImage': 'localhost/verifier@' + lock['images']['verifier']['manifestDigest']}
+
+    def test_real_digest_closure_not_config_or_tar_id(self):
+        lock = self.lock()
+        images.validate_lock(lock, self.admission(lock))
+        for entry in lock['images'].values():
+            self.assertEqual(len({entry['manifestDigest'][7:], entry['configDigest'][7:], entry['archiveSha256']}), 3)
+
+    def test_corrupt_blob_rejected(self):
+        oci(self.paths['producer'], self.recipes['producer'], corrupt=True)
+        with self.assertRaisesRegex(ValueError, 'BLOB_DIGEST'):
+            self.lock()
+
+    def test_extra_archive_member_rejected(self):
+        oci(self.paths['producer'], self.recipes['producer'], extra=True)
+        with self.assertRaisesRegex(ValueError, 'UNREFERENCED'):
+            self.lock()
+
+    def test_wrong_platform_rejected(self):
+        oci(self.paths['producer'], self.recipes['producer'], platform='amd64')
+        with self.assertRaisesRegex(ValueError, 'PLATFORM'):
+            self.lock()
+
+    def test_forged_source_label_cannot_hide_changed_file(self):
+        oci(self.paths['producer'], self.recipes['producer'], source_patch={
+            'opt/polis-private-image/payload/gate.py': b'forged code'})
+        with self.assertRaisesRegex(ValueError, 'SOURCE_CLOSURE'):
+            self.lock()
+
+    def test_unexpected_image_source_rejected(self):
+        oci(self.paths['verifier'], self.recipes['verifier'], source_patch={
+            'opt/polis-private-image/payload/extra.py': b'extra'})
+        with self.assertRaisesRegex(ValueError, 'SOURCE_CLOSURE'):
+            self.lock()
+
+    def test_wrong_entrypoint_user_and_ambient_env_rejected(self):
+        for change in ({'User': '0'}, {'Entrypoint': ['/bin/sh']}, {'Cmd': ['produce']},
+                       {'Volumes': {'/host': {}}}, {'Env': ['AWS_ACCESS_KEY_ID=synthetic']},
+                       {'OnBuild': ['RUN anything']}):
+            with self.subTest(change=change):
+                oci(self.paths['producer'], self.recipes['producer'], config_patch=change)
+                with self.assertRaises(ValueError):
+                    self.lock()
+
+    def test_review_missing_failed_or_wrong_recipe_is_rejected(self):
+        good = review(self.recipes)
+        for mutate in (lambda r: r['controls'].pop('forged-evidence'),
+                       lambda r: r['controls'].update({'forged-evidence': 'FAIL'}),
+                       lambda r: r['recipeSha256'].update({'verifier': '0'*64})):
+            r = copy.deepcopy(good)
+            mutate(r)
+            with self.assertRaises(ValueError):
+                images.make_lock(self.paths['producer'], self.paths['verifier'], self.recipes, r)
+
+    def test_moving_runtime_tag_missing_gate_or_private_source_rejected(self):
+        for change in ({'runtimeImage': 'localhost/runtime:latest'}, {'gates': ['strict']},
+                       {'files': {'real_data/private.json': 'a'*64}}, {'files': {'../gate.py': 'a'*64}},
+                       {'sourceCommit': 'edge'}, {'development': True}):
+            with self.subTest(change=change), self.assertRaises(ValueError):
+                images.validate_recipe({**self.recipes['producer'], **change})
+
+    def test_admission_tuple_and_lock_binding(self):
+        lock = self.lock()
+        a = self.admission(lock)
+        runtime = {'image-lock.json': sha(lock)}
+        a['runtimeSha256'] = sha(runtime)
+        images.bind_runtime_lock(lock, runtime, a)
+        for key in ('candidateSha', 'oracleSha', 'policySha256', 'runnerImage', 'verifierImage'):
+            bad = {**a, key: 'wrong'}
+            with self.subTest(key=key), self.assertRaises(ValueError):
+                images.bind_runtime_lock(lock, runtime, bad)
+        runtime['image-lock.json'] = '0'*64
+        with self.assertRaisesRegex(ValueError, 'RUNTIME_BINDING'):
+            images.bind_runtime_lock(lock, runtime, a)
+
+    def test_preloaded_digest_inspection_never_pulls(self):
+        lock = self.lock()
+        a = self.admission(lock)
+        def inspect(cmd, **kwargs):
+            role = 'verifier' if 'verifier' in cmd[-1] else 'producer'
+            e = lock['images'][role]
+            return subprocess.CompletedProcess(cmd, 0, encoded([{
+                'Digest': e['manifestDigest'], 'Id': e['configDigest'],
+                'Os': 'linux', 'Architecture': 'arm64', 'Config': config(e['recipe'])}]))
+        with patch('image_admission.subprocess.run', side_effect=inspect) as run:
+            images.check_preloaded(lock, a, verifier_only=True)
+            self.assertEqual(run.call_count, 1)
+            self.assertEqual(run.call_args.args[0][:3], ['podman', 'image', 'inspect'])
+        with patch('image_admission.subprocess.run', return_value=subprocess.CompletedProcess([], 0, b'[]')):
+            with self.assertRaisesRegex(ValueError, 'MISSING'):
+                images.check_preloaded(lock, a)
+
+    def test_docker_export_is_deterministic_and_preserves_source_closure(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location('export_oci', Path(images.__file__).parent / 'images/export_oci.py')
+        exporter = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(exporter)
+        with tarfile.open(self.paths['producer']) as src:
+            index = images.json_bytes(src.extractfile('index.json').read())
+            manifest = images.json_bytes(src.extractfile('blobs/sha256/' + index['manifests'][0]['digest'][7:]).read())
+            config_bytes = src.extractfile('blobs/sha256/' + manifest['config']['digest'][7:]).read()
+            layer_bytes = src.extractfile('blobs/sha256/' + manifest['layers'][0]['digest'][7:]).read()
+        docker = self.root / 'docker.tar'
+        docker.write_bytes(tar_bytes({'manifest.json': encoded([{'Config': 'config.json', 'Layers': ['layer.tar']}]),
+                                     'config.json': config_bytes, 'layer.tar': layer_bytes}))
+        a, b = self.root / 'a.oci.tar', self.root / 'b.oci.tar'
+        self.assertEqual(exporter.convert(docker, a), exporter.convert(docker, b))
+        self.assertEqual(a.read_bytes(), b.read_bytes())
+        self.assertEqual(images.inspect_oci(a)['privateFiles'], images.inspect_oci(self.paths['producer'])['privateFiles'])
+        with self.assertRaises(FileExistsError):
+            exporter.convert(docker, a)
+
+    def test_stager_rejects_dirty_bytes_even_with_matching_recipe_hash(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location('image_stage', Path(images.__file__).parent / 'images/stage.py')
+        stage = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(stage)
+        source = self.root / 'source'
+        source.mkdir()
+        (source / 'gate.py').write_bytes(b'changed code')
+        r = self.recipes['producer']
+        r['files']['gate.py'] = images.file_digest(source / 'gate.py')
+        with patch.object(stage.subprocess, 'check_output', side_effect=[r['sourceCommit'], b'gate.py', b'committed code']):
+            with self.assertRaisesRegex(ValueError, 'UNREVIEWED_SOURCE_BYTES'):
+                stage.stage(source, r, self.root / 'context')
+        self.assertFalse((self.root / 'context').exists())
+
+    def test_stager_rejects_mismatched_engine_commit(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location('image_stage', Path(images.__file__).parent / 'images/stage.py')
+        stage = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(stage)
+        source = self.root / 'source'
+        path = source / 'delphi/polismath/gate.py'
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b'committed code')
+        r = {**self.recipes['producer'], 'entrypoint': 'delphi/polismath/gate.py',
+             'files': {'delphi/polismath/gate.py': images.file_digest(path)}}
+        with patch.object(stage.subprocess, 'check_output', side_effect=[r['sourceCommit'], b'tracked', b'committed code', b'other engine commit']):
+            with self.assertRaisesRegex(ValueError, 'ENGINE_SOURCE_COMMIT_BINDING'):
+                stage.stage(source, r, self.root / 'context')
+        self.assertFalse((self.root / 'context').exists())
+
+    def test_stager_copies_only_reviewed_files_and_requires_new_context(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location('image_stage', Path(images.__file__).parent / 'images/stage.py')
+        stage = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(stage)
+        source = self.root / 'source'
+        source.mkdir()
+        raw = b'# synthetic test only\n'
+        (source / 'gate.py').write_bytes(raw)
+        (source / 'ambient.txt').write_bytes(b'must not enter image')
+        r = self.recipes['verifier']
+        with patch.object(stage.subprocess, 'check_output', side_effect=[r['sourceCommit'], b'gate.py', raw]*2):
+            stage.stage(source, r, self.root / 'context')
+            with self.assertRaises(FileExistsError):
+                stage.stage(source, r, self.root / 'context')
+        self.assertEqual(list((self.root / 'context/payload').iterdir()), [self.root / 'context/payload/gate.py'])
+
+    def test_duplicate_json_rejected(self):
+        with self.assertRaisesRegex(ValueError, 'DUPLICATE'):
+            images.json_bytes(b'{"schema":1,"schema":1}')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ci/private_cert/test_paired_gate.py
+++ b/ci/private_cert/test_paired_gate.py
@@ -1,0 +1,162 @@
+"""Gate intake controls. Requires the lossless-ingress change in the source tree.
+
+The existing bundle test factory makes explicitly synthetic role metadata; no
+private data or engine run is part of these intake tests. Public CSVs are the
+committed fixtures and are verified against the independent source copy.
+"""
+import copy
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).parent / 'images'))
+import gate
+from polismath.replay import fixture_config, fixture_bundle
+from tests.test_certify_bundle import _generate, _manifest
+
+
+class PairedGateTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.old_mapping = os.environ.pop('POLIS_REPLAY_INPUT_MAP', None)
+        self.addCleanup(self.restore_mapping)
+        config = fixture_config.load_config()
+        payload, summaries = _generate(config, self.root)
+        self.fixture = payload.parent
+        manifest = _manifest(config, payload, generated_summaries=summaries)
+        self.entries = [e for e in gate.certify.load_battery() if e.dataset in {'vw', 'biodiversity'}]
+        plan_entries = []
+        import shutil
+        for alias in {'vw', 'biodiversity'}:
+            source = gate.real_data.dataset_dir(alias)
+            dest = payload / ('public-' + alias)
+            dest.mkdir()
+            for pattern in ('*-votes.csv', '*-comments.csv'):
+                for f in source.glob(pattern):
+                    shutil.copyfile(f, dest / f.name)
+        for e in self.entries:
+            expected = gate.certify.prepare_entry(e)
+            plan_entries.append({'dataset': e.dataset, 'schedule_id': e.schedule_id,
+                                 'role': next(x['role'] for x in config['public_fixtures'] if x['slug'] == e.dataset),
+                                 'directory': 'public-' + e.dataset, 'schedule': expected.spec.to_dict()})
+        manifest['files'] = fixture_bundle.scan_files(payload)
+        manifest['root_digest'] = fixture_bundle.root_digest(manifest['files'])
+        (self.fixture / 'config.json').write_bytes(fixture_config.DEFAULT_CONFIG_PATH.read_bytes())
+        gate.dump(self.fixture / 'manifest.json', manifest)
+        self.plan = {'schema': 'polis-private-paired-plan/1', 'scope': 'public',
+                     'manifestSha256': gate.file_digest(self.fixture / 'manifest.json'),
+                     'configSha256': gate.file_digest(self.fixture / 'config.json'), 'entries': plan_entries}
+        gate.dump(self.fixture / 'plan.json', self.plan)
+        self.inputs = dict(candidateSha='c'*40, oracleSha='d'*40, policySha256=gate.sha(gate.POLICY),
+                           scheduleSha256='', inventorySha256='', expectedChecks=0)
+        scratch = self.root / 'derive'
+        scratch.mkdir()
+        prepared, inventory = gate.prepare(self.fixture, self.inputs, scratch, bind=False)
+        self.inputs.update(scheduleSha256=gate.sha([p.spec.to_dict() for p in prepared]),
+                           inventorySha256=gate.sha(inventory), expectedChecks=sum(len(p.checkpoints) for p in prepared))
+
+    def restore_mapping(self):
+        os.environ.pop('POLIS_REPLAY_INPUT_MAP', None)
+        if self.old_mapping is not None:
+            os.environ['POLIS_REPLAY_INPUT_MAP'] = self.old_mapping
+
+    def run_prepare(self, inputs=None):
+        scratch = self.root / 'verify'
+        scratch.mkdir()
+        return gate.prepare(self.fixture, inputs or self.inputs, scratch)
+
+    def write_plan(self):
+        (self.fixture / 'plan.json').write_bytes(gate.encoded(self.plan))
+
+    def test_complete_public_fixture_inventory(self):
+        prepared, inventory = self.run_prepare()
+        self.assertEqual(len(prepared), 6)
+        self.assertEqual(self.inputs['expectedChecks'], 87)
+        self.assertEqual(gate.sha(inventory), self.inputs['inventorySha256'])
+
+    def test_producer_uses_separate_schedule_input_and_fresh_serial_engines(self):
+        from unittest.mock import patch
+        output = self.root / 'output'
+        output.mkdir()
+        input_path = self.root / 'inputs.json'
+        gate.dump(input_path, self.inputs)
+        engines = []
+        def run(cmd, cwd, log):
+            source = Path(cmd[cmd.index('--schedule') + 1])
+            raw = source.read_bytes()
+            self.assertTrue(raw)
+            if cmd[0] == 'clojure':
+                engines.append('clj')
+                target = Path(cmd[cmd.index('--out') + 1]) / 'schedule.json'
+                self.assertNotEqual(source, target)
+                target.write_bytes(raw)
+            else:
+                engines.append('py')
+                json.loads(raw)
+            log.write_bytes(b'synthetic driver control')
+            return 0
+        with patch.object(gate, 'run_engine', side_effect=run):
+            gate.produce(self.fixture, output, input_path)
+        self.assertEqual(engines, ['clj', 'py'] * 6)
+        self.assertEqual(len(gate.read(output / 'producer.json')['runs']), 12)
+        with self.assertRaisesRegex(ValueError, 'FRESH_OUTPUT'):
+            gate.produce(self.fixture, output, input_path)
+
+    def test_wrong_policy_fails_before_execution(self):
+        with self.assertRaisesRegex(ValueError, 'POLICY'):
+            self.run_prepare({**self.inputs, 'policySha256': '0'*64})
+
+    def test_wrong_input_inventory_fails(self):
+        with self.assertRaisesRegex(ValueError, 'INVENTORY_BINDING'):
+            self.run_prepare({**self.inputs, 'inventorySha256': '0'*64})
+
+    def test_short_entry_inventory_fails(self):
+        self.plan['entries'].pop()
+        self.write_plan()
+        with self.assertRaisesRegex(ValueError, 'INCOMPLETE_ENTRY'):
+            self.run_prepare()
+
+    def test_duplicate_entry_fails(self):
+        self.plan['entries'].append(copy.deepcopy(self.plan['entries'][0]))
+        self.write_plan()
+        with self.assertRaisesRegex(ValueError, 'ENTRY_INVENTORY'):
+            self.run_prepare()
+
+    def test_role_substitution_fails(self):
+        self.plan['entries'][0]['role'] = 'wrong'
+        self.write_plan()
+        with self.assertRaisesRegex(ValueError, 'ROLE_BINDING'):
+            self.run_prepare()
+
+    def test_short_checkpoint_schedule_fails(self):
+        self.plan['entries'][0]['schedule']['cuts']['at'].pop(0)
+        self.write_plan()
+        with self.assertRaisesRegex(ValueError, 'CHECKPOINT_COUNT'):
+            self.run_prepare()
+
+    def test_restart_recipe_cannot_be_removed(self):
+        row = next(r for r in self.plan['entries'] if 'restart' in r['schedule_id'])
+        row['schedule']['restart_after'] = None
+        self.write_plan()
+        with self.assertRaisesRegex(ValueError, 'RECIPE_CHANGED'):
+            self.run_prepare()
+
+    def test_extra_fixture_file_fails(self):
+        (self.fixture / 'extra').write_text('unlisted')
+        with self.assertRaisesRegex(ValueError, 'EXTRA_FILES'):
+            self.run_prepare()
+
+    def test_corrupt_fixture_file_fails(self):
+        csv = next((self.fixture / 'payload/public-vw').glob('*-votes.csv'))
+        csv.write_bytes(csv.read_bytes()[:-1])
+        with self.assertRaises(fixture_bundle.VerificationError):
+            self.run_prepare()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ci/private_cert/test_private_cert.py
+++ b/ci/private_cert/test_private_cert.py
@@ -1,0 +1,323 @@
+"""Offline fault injection: no boto3 construction, credentials or network."""
+import copy
+import datetime as dt
+import hashlib
+import io
+import json
+from pathlib import Path
+import tarfile
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from control import Control, Unknown, encoded, sha
+from worker import safe_extract, validate_receipt, upload_chunks, sandbox, CHUNK
+from dns import question
+from verify import verify
+
+
+class ApiError(Exception):
+    def __init__(self, code):
+        self.response = {'Error': {'Code': code}}
+
+
+class Pages:
+    def __init__(self, call): self.call = call
+    def paginate(self, **kwargs): return iter(self.call(**kwargs))
+
+
+class S3:
+    def __init__(self):
+        self.objects, self.versions, self.uploads = {}, [], []
+        self.deleted, self.aborted, self.puts = [], [], []
+        self.leave_versions = False
+    def get_object(self, Bucket, Key, VersionId=None):
+        if (Bucket, Key) not in self.objects: raise ApiError('NoSuchKey')
+        return {'Body': io.BytesIO(self.objects[Bucket, Key]), 'VersionId': VersionId or 'v1'}
+    def put_object(self, **kw):
+        k = kw['Bucket'], kw['Key']
+        if kw.get('IfNoneMatch') == '*' and k in self.objects: raise ApiError('PreconditionFailed')
+        self.objects[k] = kw['Body']
+        self.puts.append(kw)
+        return {'VersionId': 'v1'}
+    def head_object(self, **kw): raise ApiError('404')
+    def get_paginator(self, name):
+        if name == 'list_object_versions': return Pages(lambda **kw: [{'Versions': list(self.versions)}])
+        if name == 'list_multipart_uploads': return Pages(lambda **kw: [{'Uploads': list(self.uploads)}])
+        raise AssertionError(name)
+    def delete_object(self, **kw):
+        self.deleted.append(kw)
+        if not self.leave_versions: self.versions = [v for v in self.versions if v['VersionId'] != kw['VersionId']]
+    def abort_multipart_upload(self, **kw):
+        self.aborted.append(kw)
+        self.uploads = [u for u in self.uploads if u['UploadId'] != kw['UploadId']]
+
+
+class EC2:
+    def __init__(self):
+        self.instances, self.disks, self.runs, self.terminated, self.deleted = [], [], [], [], []
+        self.run_fails = False
+    def get_paginator(self, name):
+        if name == 'describe_instances': return Pages(lambda **kw: [{'Reservations': [{'Instances': self.instances}]}])
+        if name == 'describe_volumes': return Pages(lambda **kw: [{'Volumes': self.disks}])
+        raise AssertionError(name)
+    def describe_images(self, **kw):
+        return {'Images': [{'Architecture': 'arm64', 'State': 'available', 'OwnerId': '111111111111'}]}
+    def run_instances(self, **kw):
+        self.runs.append(kw)
+        if self.run_fails: raise ApiError('RequestTimeout')
+        return {'Instances': self.instances}
+    def terminate_instances(self, **kw): self.terminated += kw['InstanceIds']
+    def delete_volume(self, **kw): self.deleted.append(kw['VolumeId'])
+    def describe_volumes(self, VolumeIds):
+        found = [d for d in self.disks if d['VolumeId'] in VolumeIds]
+        if not found: raise ApiError('InvalidVolume.NotFound')
+        return {'Volumes': found}
+
+
+def admission():
+    return {'id': 'a'*32, 'account': '111111111111', 'region': 'us-east-1', 'ami': 'ami-'+'1'*17,
+            'stagingExpiresAt': '2030-01-01T09:00:00Z', 'expiresAt': '2030-01-01T12:00:00Z', 'inventorySha256': 'a'*64,
+            'scheduleSha256': 'b'*64, 'policySha256': 'c'*64, 'expectedChecks': 3,
+            'candidateSha': 'd'*40, 'verifierImage': 'localhost/polis-verifier@sha256:'+'e'*64}
+
+
+def setup(now=1893492000):  # 2030-01-01 10:00 UTC
+    a = admission()
+    cfg = {'ADMISSION': encoded(a).decode(), 'ADMISSION_SHA256': sha(a), 'CONTROL_BUCKET': 'control',
+           'FIXTURE_BUCKET': 'fixtures', 'EVIDENCE_BUCKET': 'evidence', 'CONTROL_KEY': 'key', 'TEMPLATE': 'lt-test',
+           'TEMPLATE_VERSION': '1', 'PROFILE': 'profile', 'SUBNET': 'subnet', 'SECURITY_GROUP': 'sg', 'ENDPOINT': 'vpce'}
+    e, s = EC2(), S3()
+    c = Control(e, s, cfg, now)
+    i = {'InstanceId': 'i-test', 'ClientToken': c.token, 'LaunchTemplate': {'LaunchTemplateId': 'lt-test', 'LaunchTemplateName': 'test', 'Version': '1'},
+         'IamInstanceProfile': {'Arn': 'profile'}, 'ImageId': a['ami'], 'SubnetId': 'subnet', 'InstanceType': 'r8g.4xlarge',
+         'Tags': [{'Key': 'polis:private-cert', 'Value': a['id']}], 'SecurityGroups': [{'GroupId': 'sg'}],
+         'State': {'Name': 'running'}, 'BlockDeviceMappings': [{'Ebs': {'VolumeId': v}} for v in ('vol-a', 'vol-b')]}
+    e.instances = [i]
+    return c, e, s, i
+
+
+class ControlTests(unittest.TestCase):
+    def test_launch_fixed_template_and_token_only(self):
+        c, e, s, i = setup()
+        self.assertEqual(c.launch()['status'], 'RUNNING')
+        self.assertEqual(set(e.runs[0]), {'LaunchTemplate', 'MinCount', 'MaxCount', 'ClientToken'})
+        self.assertEqual(e.runs[0]['LaunchTemplate'], {'LaunchTemplateId': 'lt-test', 'Version': '1'})
+        self.assertIsNotNone(c.read('boot/' + c.a['id'] + '.json'))
+    def test_duplicate_launch_does_not_launch_again(self):
+        c, e, s, i = setup(); c.launch(); c.launch()
+        self.assertEqual(len(e.runs), 1)
+    def test_lost_ack_reconciles_by_client_token(self):
+        c, e, s, i = setup(); e.run_fails = True
+        with self.assertRaises(ApiError): c.launch()
+        self.assertEqual(c.launch()['status'], 'RUNNING'); self.assertEqual(len(e.runs), 1)
+    def test_lost_ack_blank_describe_is_unknown(self):
+        c, e, s, i = setup(); e.instances = []; e.run_fails = True
+        with self.assertRaises(ApiError): c.launch()
+        with self.assertRaisesRegex(Unknown, 'LAUNCH_ACK_UNKNOWN'): c.launch()
+        self.assertEqual(len(e.runs), 1)
+    def test_tag_alone_never_authorizes_mutation(self):
+        for change in ({'ClientToken': 'forged'}, {'IamInstanceProfile': {'Arn': 'prod'}}, {'ImageId': 'prod'}, {'SubnetId': 'prod'},
+                       {'PublicIpAddress': '1.2.3.4'}, {'SecurityGroups': [{'GroupId': 'prod'}]}, {'LaunchTemplate': {'LaunchTemplateId': 'prod', 'Version': '1'}}):
+            c, e, s, i = setup(); c.launch(); i.update(change)
+            with self.subTest(change=change), self.assertRaisesRegex(Unknown, 'OWNERSHIP'): c.reconcile(cancel=True)
+            self.assertEqual(e.terminated, [])
+    def test_terminate_ack_is_not_clean(self):
+        c, e, s, i = setup(); c.launch()
+        with self.assertRaisesRegex(Unknown, 'TERMINATION_PENDING'): c.reconcile(cancel=True)
+        self.assertEqual(e.terminated, ['i-test']); self.assertIsNone(c.read(c.prefix + 'clean.json'))
+    def test_terminated_disks_and_all_versions_must_be_gone(self):
+        c, e, s, i = setup(); c.launch(); i['State']['Name'] = 'terminated'
+        s.versions = [{'Key': 'staging/a/bundle.tar', 'VersionId': v} for v in ('v1', 'v2')]
+        s.uploads = [{'Key': 'staging/a/bundle.tar', 'UploadId': 'u1'}]
+        self.assertEqual(c.reconcile()['status'], 'CLEAN'); self.assertEqual(len(s.deleted), 2); self.assertEqual(len(s.aborted), 1)
+        with self.assertRaisesRegex(Unknown, 'RUN_CLOSED'): c.launch()
+    def test_disk_delete_ack_is_not_clean(self):
+        c, e, s, i = setup(); c.launch(); i['State']['Name'] = 'terminated'
+        e.disks = [{'VolumeId': 'vol-a', 'State': 'available', 'Attachments': []}]
+        with self.assertRaisesRegex(Unknown, 'DISK_REMAINS'): c.reconcile()
+        self.assertEqual(e.deleted, ['vol-a']); self.assertIsNone(c.read(c.prefix + 'clean.json'))
+    def test_unknown_tagged_disk_never_deleted(self):
+        c, e, s, i = setup(); c.launch(); i['State']['Name'] = 'terminated'
+        e.disks = [{'VolumeId': 'vol-prod', 'State': 'available', 'Attachments': []}]
+        with self.assertRaisesRegex(Unknown, 'UNKNOWN_DISK'): c.reconcile()
+        self.assertFalse(e.deleted)
+    def test_failed_disk_describe_is_unknown(self):
+        c, e, s, i = setup(); c.launch(); i['State']['Name'] = 'terminated'
+        e.describe_volumes = lambda **kw: (_ for _ in ()).throw(ApiError('UnauthorizedOperation'))
+        with self.assertRaisesRegex(Unknown, 'DISK_DESCRIBE_UNKNOWN'): c.reconcile()
+    def test_empty_disk_describe_is_unknown(self):
+        c, e, s, i = setup(); c.launch(); i['State']['Name'] = 'terminated'
+        e.describe_volumes = lambda **kw: {'Volumes': []}
+        with self.assertRaisesRegex(Unknown, 'DISK_DESCRIBE_EMPTY'): c.reconcile()
+    def test_versions_remaining_blocks_clean(self):
+        c, e, s, i = setup(); c.launch(); i['State']['Name'] = 'terminated'
+        s.versions = [{'Key': 'staging/a/bundle.tar', 'VersionId': 'v'}]; s.leave_versions = True
+        with self.assertRaisesRegex(Unknown, 'FIXTURE_REMAINS'): c.reconcile()
+    def test_missing_heartbeat_terminates_after_grace(self):
+        c, e, s, i = setup(); c.launch(); c.now += 601
+        with self.assertRaisesRegex(Unknown, 'TERMINATION_PENDING'): c.reconcile()
+        self.assertEqual(e.terminated, ['i-test'])
+    def test_expiry_removes_staging_even_if_no_instance_observed(self):
+        c, e, s, i = setup(); c.launch(); c.now += 9000; e.instances = []
+        s.versions = [{'Key': 'staging/a/bundle.tar', 'VersionId': 'v'}]
+        with self.assertRaisesRegex(Unknown, 'LAUNCH_ACK_UNKNOWN'): c.reconcile()
+        self.assertFalse(s.versions)
+    def test_no_launch_ever_clean_on_expiry(self):
+        c, e, s, i = setup(); c.now += 9000
+        self.assertEqual(c.reconcile()['status'], 'CLEAN'); self.assertFalse(e.runs)
+    def test_open_ingestion_launch_denied(self):
+        c, e, s, i = setup(now=1893400000)
+        with self.assertRaisesRegex(Unknown, 'INGESTION_STILL_OPEN'): c.launch()
+    def test_campaign_over_twelve_hours_denied(self):
+        c, e, s, i = setup()
+        c.expiry = c.now + 12 * 3600 + 1
+        with self.assertRaisesRegex(Unknown, 'OVER_BUDGET'): c.launch()
+        self.assertFalse(e.runs)
+    def test_expired_launch_denied(self):
+        c, e, s, i = setup(); c.now = c.expiry
+        with self.assertRaisesRegex(Unknown, 'EXPIRED'): c.launch()
+        self.assertFalse(e.runs)
+    def test_control_record_cannot_be_replaced(self):
+        c, e, s, i = setup(); c.record('test', {'a': 1}); c.record('test', {'a': 1})
+        with self.assertRaisesRegex(Unknown, 'RECORD_CONFLICT'): c.record('test', {'a': 2})
+    def test_failed_control_read_is_not_absence(self):
+        c, e, s, i = setup()
+        s.get_object = lambda **kw: (_ for _ in ()).throw(ApiError('AccessDenied'))
+        with self.assertRaisesRegex(Unknown, 'CONTROL_READ_UNKNOWN'): c.launch()
+        self.assertFalse(e.runs)
+    def test_duplicate_instance_blocks(self):
+        c, e, s, i = setup(); c.launch(); e.instances.append(copy.deepcopy(i))
+        with self.assertRaisesRegex(Unknown, 'OWNERSHIP'): c.reconcile(cancel=True)
+        self.assertFalse(e.terminated)
+
+
+class WorkerTests(unittest.TestCase):
+    def tar(self, entries):
+        raw = io.BytesIO()
+        with tarfile.open(fileobj=raw, mode='w') as t:
+            for name, kind, value in entries:
+                i = tarfile.TarInfo(name); i.type = kind
+                if kind == tarfile.REGTYPE: i.size = len(value)
+                else: i.linkname = value.decode()
+                t.addfile(i, io.BytesIO(value) if kind == tarfile.REGTYPE else None)
+        return raw.getvalue()
+    def extract(self, entries, size=100, members=10):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp); (p/'a.tar').write_bytes(self.tar(entries))
+            return safe_extract(p/'a.tar', p/'output', size, members)
+    def test_safe_nested_file(self): self.assertEqual(self.extract([('a/b', tarfile.REGTYPE, b'123')]), (1, 3))
+    def test_strict_host_umask_still_gives_container_readable_fixture(self):
+        import os
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp); (p/'a.tar').write_bytes(self.tar([('a/b', tarfile.REGTYPE, b'123')]))
+            prior = os.umask(0o077)
+            try: safe_extract(p/'a.tar', p/'fixture', 100, 10)
+            finally: os.umask(prior)
+            self.assertEqual((p/'fixture').stat().st_mode & 0o777, 0o555)
+            self.assertEqual((p/'fixture/a').stat().st_mode & 0o777, 0o555)
+            self.assertEqual((p/'fixture/a/b').stat().st_mode & 0o777, 0o444)
+            # Restore owner write only for TemporaryDirectory cleanup as nonroot.
+            (p/'fixture').chmod(0o755); (p/'fixture/a').chmod(0o755)
+    def test_traversal_absolute_duplicate_and_links(self):
+        for entries in ([('../x', tarfile.REGTYPE, b'1')], [('/x', tarfile.REGTYPE, b'1')],
+                        [('x', tarfile.REGTYPE, b'1')]*2, [('link', tarfile.SYMTYPE, b'/etc/passwd')],
+                        [('link', tarfile.LNKTYPE, b'x')], [('dir', tarfile.DIRTYPE, b'')]):
+            with self.subTest(entries=entries), self.assertRaises(ValueError): self.extract(entries)
+    def test_expansion_and_member_limits(self):
+        with self.assertRaises(ValueError): self.extract([('x', tarfile.REGTYPE, b'123')], size=2)
+        with self.assertRaises(ValueError): self.extract([('x', tarfile.REGTYPE, b'1')], members=0)
+    def receipt(self):
+        a = admission()
+        return {'schema': 'polis-private-gate/1', 'admissionSha256': sha(a), 'evidenceSha256': 'f'*64,
+                'inventorySha256': a['inventorySha256'], 'scheduleSha256': a['scheduleSha256'], 'policySha256': a['policySha256'],
+                'checks': 3, 'verdict': 'PASS', 'reason': 'COMPLETE'}
+    def test_complete_bound_receipt(self): self.assertEqual(validate_receipt(self.receipt(), admission(), 'f'*64)['verdict'], 'PASS')
+    def test_short_forged_free_text_receipts_rejected(self):
+        for changes in ({'checks': 2}, {'checks': True}, {'policySha256': 'x'}, {'admissionSha256': 'x'},
+                        {'evidenceSha256': 'x'}, {'reason': 'secret'}, {'extra': 'private-path'}, {'verdict': 'UNKNOWN'}):
+            with self.subTest(changes=changes), self.assertRaises(ValueError): validate_receipt({**self.receipt(), **changes}, admission(), 'f'*64)
+    def test_chunks_are_bounded_versioned_and_create_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp)/'archive'; p.write_bytes(b'x'*(CHUNK+1)); s = S3()
+            prefix, m = upload_chunks(s, p, {'admission': admission(), 'evidenceBucket': 'evidence', 'evidenceKey': 'key'}, 'instance')
+            self.assertEqual([c['bytes'] for c in m['chunks']], [CHUNK, 1])
+            self.assertTrue(all(c['version'] == 'v1' for c in m['chunks']))
+            self.assertTrue(all(p['IfNoneMatch'] == '*' for p in s.puts))
+            self.assertFalse(any(p['Key'].endswith('manifest.json') for p in s.puts))
+    def test_sandbox_command_has_no_host_network_credentials_or_socket(self):
+        with tempfile.TemporaryDirectory() as tmp, patch('worker.subprocess.run') as run:
+            run.side_effect = [type('R', (), {'returncode': 0})(), type('R', (), {'stdout': b'[{"State":{"ExitCode":0,"OOMKilled":false}}]'})(), None]
+            sandbox('localhost/image@sha256:123', 'produce', [(Path(tmp), '/fixture', 'ro')], Path(tmp)/'log', 10)
+            cmd = run.call_args_list[0].args[0]
+            for value in ('--network=none', '--read-only', '--cap-drop=ALL', '--pull=never', '--memory-swap=112g', '--user=65534:65534'): self.assertIn(value, cmd)
+            self.assertNotIn('docker.sock', ' '.join(cmd)); self.assertNotIn('AWS_', ' '.join(cmd))
+    def test_timeout_still_kills_container(self):
+        with tempfile.TemporaryDirectory() as tmp, patch('worker.subprocess.run', side_effect=[TimeoutError(), None]) as run:
+            with self.assertRaises(TimeoutError): sandbox('image', 'produce', [], Path(tmp)/'log', 1)
+            self.assertEqual(run.call_args_list[-1].args[0], ['podman', 'rm', '--force', 'polis-private-produce'])
+    def test_dns_only_one_plain_address_question(self):
+        packet = b'\x00\x01\x01\x00\x00\x01' + b'\x00'*6 + b'\x03s3a\x03com\x00\x00\x01\x00\x01'
+        self.assertEqual(question(packet), 's3a.com')
+        for bad in (packet[:-1], packet + b'junk', packet[:12] + b'\xc0\x0c\x00\x01\x00\x01'):
+            with self.assertRaises((ValueError, IndexError)): question(bad)
+
+
+class VerifyTests(unittest.TestCase):
+    def fixture(self, tmp):
+        a = admission(); s = S3(); arn = 'arn:aws:ec2:us-east-1:111111111111:instance/i-test'
+        prefix = f'runs/{a["id"]}/{arn}/'
+        bucket = f'ppc-{a["account"]}-{a["id"]}-evidence'
+        raw = WorkerTests().tar([('output.json', tarfile.REGTYPE, b'{}')])
+        digest = hashlib.sha256(raw).hexdigest()
+        receipt = {**WorkerTests().receipt(), 'evidenceSha256': digest}
+        m = {'schema': 'polis-private-evidence/1', 'admissionSha256': sha(a), 'archiveSha256': digest,
+             'archiveBytes': len(raw), 'instanceArn': arn,
+             'chunks': [{'key': prefix+'chunks/00000000', 'version': 'v1', 'bytes': len(raw), 'sha256': digest}], 'gateReceipt': receipt}
+        s.objects[bucket, prefix+'chunks/00000000'] = raw
+        s.objects[bucket, prefix+'manifest.json'] = encoded(m)
+        control = f'ppc-{a["account"]}-{a["id"]}-control'
+        s.objects[control, f'control/{a["id"]}/clean.json'] = encoded({'status': 'CLEAN', 'admissionSha256': sha(a),
+                    'instanceId': 'i-test', 'fixtureVersions': 0, 'volumes': ['vol-a', 'vol-b']})
+        def gate(*args): (Path(tmp)/'verdict'/'receipt.json').write_bytes(encoded(receipt))
+        return a, s, m, prefix, bucket, control, gate
+    def test_private_reverification_and_cleanup_allow_only_closed_public_schema(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            a, s, m, prefix, bucket, control, gate = self.fixture(tmp)
+            with patch('verify.sandbox', side_effect=gate) as called:
+                result = verify(s, a, prefix+'manifest.json', 'v1', Path(tmp))
+            self.assertEqual(called.call_count, 1)
+            self.assertEqual(set(result), {'schema', 'admissionId', 'candidateSha', 'verdict', 'reason', 'checks'})
+            self.assertEqual(result['verdict'], 'PASS')
+            self.assertNotIn('fixture', encoded(result).decode())
+    def test_missing_cleanup_cannot_publish_pass(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            a, s, m, prefix, bucket, control, gate = self.fixture(tmp)
+            del s.objects[control, f'control/{a["id"]}/clean.json']
+            with patch('verify.sandbox', side_effect=gate), self.assertRaises(ApiError):
+                verify(s, a, prefix+'manifest.json', 'v1', Path(tmp))
+    def test_wrong_instance_cleanup_cannot_publish(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            a, s, m, prefix, bucket, control, gate = self.fixture(tmp)
+            key = control, f'control/{a["id"]}/clean.json'
+            record = json.loads(s.objects[key]); record['instanceId'] = 'i-other'; s.objects[key] = encoded(record)
+            with patch('verify.sandbox', side_effect=gate), self.assertRaisesRegex(ValueError, 'TEARDOWN_UNKNOWN'):
+                verify(s, a, prefix+'manifest.json', 'v1', Path(tmp))
+    def test_forged_chunk_bytes_rejected_before_semantic_gate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            a, s, m, prefix, bucket, control, gate = self.fixture(tmp)
+            s.objects[bucket, prefix+'chunks/00000000'] = b'forged'
+            with patch('verify.sandbox') as called, self.assertRaisesRegex(ValueError, 'CHUNK_BINDING'):
+                verify(s, a, prefix+'manifest.json', 'v1', Path(tmp))
+            called.assert_not_called()
+    def test_independent_gate_disagreement_rejects_worker_receipt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            a, s, m, prefix, bucket, control, gate = self.fixture(tmp)
+            def changed(*args):
+                gate(); p = Path(tmp)/'verdict'/'receipt.json'; r = json.loads(p.read_bytes())
+                r.update(verdict='FAIL', reason='COMPARISON'); p.write_bytes(encoded(r))
+            with patch('verify.sandbox', side_effect=changed), self.assertRaisesRegex(ValueError, 'DISAGREEMENT'):
+                verify(s, a, prefix+'manifest.json', 'v1', Path(tmp))
+
+
+if __name__ == '__main__': unittest.main()

--- a/ci/private_cert/test_private_cert.py
+++ b/ci/private_cert/test_private_cert.py
@@ -229,7 +229,7 @@ class WorkerTests(unittest.TestCase):
         with self.assertRaises(ValueError): self.extract([('x', tarfile.REGTYPE, b'1')], members=0)
     def receipt(self):
         a = admission()
-        return {'schema': 'polis-private-gate/1', 'admissionSha256': sha(a), 'evidenceSha256': 'f'*64,
+        return {'schema': 'polis-private-gate/2', 'negativeControlsSha256': 'a'*64, 'admissionSha256': sha(a), 'evidenceSha256': 'f'*64,
                 'inventorySha256': a['inventorySha256'], 'scheduleSha256': a['scheduleSha256'], 'policySha256': a['policySha256'],
                 'checks': 3, 'verdict': 'PASS', 'reason': 'COMPLETE'}
     def test_complete_bound_receipt(self): self.assertEqual(validate_receipt(self.receipt(), admission(), 'f'*64)['verdict'], 'PASS')
@@ -270,7 +270,7 @@ class VerifyTests(unittest.TestCase):
         bucket = f'ppc-{a["account"]}-{a["id"]}-evidence'
         raw = WorkerTests().tar([('output.json', tarfile.REGTYPE, b'{}')])
         digest = hashlib.sha256(raw).hexdigest()
-        receipt = {**WorkerTests().receipt(), 'evidenceSha256': digest}
+        receipt = {**WorkerTests().receipt(), 'evidenceSha256': digest, 'negativeControlsSha256': sha({'synthetic': True})}
         m = {'schema': 'polis-private-evidence/1', 'admissionSha256': sha(a), 'archiveSha256': digest,
              'archiveBytes': len(raw), 'instanceArn': arn,
              'chunks': [{'key': prefix+'chunks/00000000', 'version': 'v1', 'bytes': len(raw), 'sha256': digest}], 'gateReceipt': receipt}
@@ -279,7 +279,9 @@ class VerifyTests(unittest.TestCase):
         control = f'ppc-{a["account"]}-{a["id"]}-control'
         s.objects[control, f'control/{a["id"]}/clean.json'] = encoded({'status': 'CLEAN', 'admissionSha256': sha(a),
                     'instanceId': 'i-test', 'fixtureVersions': 0, 'volumes': ['vol-a', 'vol-b']})
-        def gate(*args): (Path(tmp)/'verdict'/'receipt.json').write_bytes(encoded(receipt))
+        def gate(*args):
+            (Path(tmp)/'verdict'/'receipt.json').write_bytes(encoded(receipt))
+            (Path(tmp)/'verdict'/'negative-controls.json').write_bytes(encoded({'synthetic': True}))
         return a, s, m, prefix, bucket, control, gate
     def test_private_reverification_and_cleanup_allow_only_closed_public_schema(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/ci/private_cert/verify.py
+++ b/ci/private_cert/verify.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Private reviewer CLI: re-read exact S3 versions, run admitted independent gate,
+then permit a minimal public summary ONLY after a bound CLEAN control receipt.
+Raw artifacts and configuration never belong in the public repository.
+"""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+
+from control import encoded, sha
+from worker import CHUNK, file_sha, safe_extract, sandbox, validate_receipt
+
+
+def verify(s3, admission, manifest_key, manifest_version, workspace):
+    a = admission
+    bucket = f'ppc-{a["account"]}-{a["id"]}-evidence'
+    obj = s3.get_object(Bucket=bucket, Key=manifest_key, VersionId=manifest_version)
+    raw = obj['Body'].read(16 * 1024 * 1024 + 1)
+    if len(raw) > 16 * 1024 * 1024 or obj.get('VersionId') != manifest_version:
+        raise ValueError('MANIFEST_VERSION_OR_SIZE')
+    m = json.loads(raw)
+    if set(m) != {'schema', 'admissionSha256', 'archiveSha256', 'archiveBytes', 'instanceArn', 'chunks', 'gateReceipt'} or m['schema'] != 'polis-private-evidence/1' or m['admissionSha256'] != sha(a):
+        raise ValueError('MANIFEST_BINDING')
+    prefix = f'runs/{a["id"]}/{m["instanceArn"]}/'
+    if manifest_key != prefix + 'manifest.json' or not m['instanceArn'].startswith(f'arn:aws:ec2:{a["region"]}:{a["account"]}:instance/i-'):
+        raise ValueError('MANIFEST_PATH')
+    if type(m['archiveBytes']) is not int or not 0 < m['archiveBytes'] <= 180 * 1024 ** 3:
+        raise ValueError('EVIDENCE_SIZE')
+    if not isinstance(m['chunks'], list) or not 1 <= len(m['chunks']) <= 11520:
+        raise ValueError('CHUNK_COUNT')
+    archive = workspace / 'evidence.tar'
+    with archive.open('xb') as out:
+        total = 0
+        for idx, c in enumerate(m['chunks']):
+            if (set(c) != {'key', 'version', 'bytes', 'sha256'} or c['key'] != prefix + f'chunks/{idx:08d}'
+                    or not c['version'] or c['version'] == 'null' or type(c['bytes']) is not int or not 0 < c['bytes'] <= CHUNK):
+                raise ValueError('CHUNK_PATH_OR_SIZE')
+            obj = s3.get_object(Bucket=bucket, Key=c['key'], VersionId=c['version'])
+            data = obj['Body'].read(CHUNK + 1)
+            if obj.get('VersionId') != c['version'] or len(data) != c['bytes'] or hashlib.sha256(data).hexdigest() != c['sha256']:
+                raise ValueError('CHUNK_BINDING')
+            total += len(data)
+            if total > m['archiveBytes']:
+                raise ValueError('EXCESS_EVIDENCE')
+            out.write(data)
+    if total != m['archiveBytes'] or file_sha(archive) != m['archiveSha256']:
+        raise ValueError('ARCHIVE_BINDING')
+    validate_receipt(m['gateReceipt'], a, m['archiveSha256'])
+    safe_extract(archive, workspace / 'evidence', 180 * 1024 ** 3, 1000000)
+    inputs, output = workspace / 'inputs', workspace / 'verdict'
+    inputs.mkdir(mode=0o755)
+    output.mkdir(mode=0o777)
+    output.chmod(0o777)
+    (inputs / 'admission.json').write_bytes(encoded(a))
+    (inputs / 'evidence-sha256').write_text(m['archiveSha256'])
+    (inputs / 'admission.json').chmod(0o444)
+    (inputs / 'evidence-sha256').chmod(0o444)
+    inputs.chmod(0o555)
+    sandbox(a['verifierImage'], 'verify', [(workspace / 'evidence', '/evidence', 'ro'), (inputs, '/admission', 'ro'), (output, '/verdict', 'rw')], workspace / 'verifier.log', 12 * 3600)
+    receipt_path = output / 'receipt.json'
+    if receipt_path.is_symlink() or receipt_path.stat().st_size > 8192:
+        raise ValueError('RECEIPT_SIZE')
+    receipt = validate_receipt(json.loads(receipt_path.read_bytes()), a, m['archiveSha256'])
+    if receipt != m['gateReceipt']:
+        raise ValueError('INDEPENDENT_GATE_DISAGREEMENT')
+    control = f'ppc-{a["account"]}-{a["id"]}-control'
+    clean = json.loads(s3.get_object(Bucket=control, Key=f'control/{a["id"]}/clean.json')['Body'].read(65536))
+    if (clean.get('status') != 'CLEAN' or clean.get('admissionSha256') != sha(a)
+            or clean.get('instanceId') != m['instanceArn'].rsplit('/', 1)[1]
+            or clean.get('fixtureVersions') != 0 or len(clean.get('volumes', [])) != 2):
+        raise ValueError('TEARDOWN_UNKNOWN')
+    # No bundle hash, object key/version, private inventory, free text, path,
+    # row id or raw exception reaches the public result. Local file only.
+    return {'schema': 'polis-private-summary/1', 'admissionId': a['id'], 'candidateSha': a['candidateSha'],
+            'verdict': receipt['verdict'], 'reason': receipt['reason'], 'checks': receipt['checks']}
+
+
+def main():
+    import boto3
+    p = argparse.ArgumentParser()
+    p.add_argument('--admission', type=Path, required=True)
+    p.add_argument('--trusted-public-key', type=Path, required=True)
+    p.add_argument('--manifest-key', required=True)
+    p.add_argument('--manifest-version', required=True)
+    p.add_argument('--private-workspace', type=Path, required=True)
+    p.add_argument('--summary', type=Path, required=True)
+    args = p.parse_args()
+    a = json.loads(args.admission.read_bytes())
+    # Operator must independently admit the public key; a substituted admission
+    # file is not made trustworthy merely by carrying a self-supplied signature.
+    p2 = a['signature']
+    if args.trusted_public_key.read_text().strip() != a['signerPublicKey']:
+        raise ValueError('UNTRUSTED_ADMISSION_KEY')
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    Ed25519PublicKey.from_public_bytes(bytes.fromhex(a['signerPublicKey'])).verify(bytes.fromhex(p2), encoded({k: v for k, v in a.items() if k != 'signature'}))
+    args.private_workspace.mkdir(mode=0o700, parents=True, exist_ok=False)
+    result = verify(boto3.client('s3', region_name=a['region']), a, args.manifest_key, args.manifest_version, args.private_workspace)
+    with args.summary.open('xb') as f:
+        f.write(encoded(result) + b'\n')
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception:
+        raise SystemExit('INCOMPLETE: private verification or cleanup failed; no public summary written') from None

--- a/ci/private_cert/verify.py
+++ b/ci/private_cert/verify.py
@@ -63,6 +63,9 @@ def verify(s3, admission, manifest_key, manifest_version, workspace):
     if receipt_path.is_symlink() or receipt_path.stat().st_size > 8192:
         raise ValueError('RECEIPT_SIZE')
     receipt = validate_receipt(json.loads(receipt_path.read_bytes()), a, m['archiveSha256'])
+    controls_path = output / 'negative-controls.json'
+    if controls_path.is_symlink() or controls_path.stat().st_size > 8192 or file_sha(controls_path) != receipt['negativeControlsSha256']:
+        raise ValueError('NEGATIVE_CONTROLS_BINDING')
     if receipt != m['gateReceipt']:
         raise ValueError('INDEPENDENT_GATE_DISAGREEMENT')
     control = f'ppc-{a["account"]}-{a["id"]}-control'
@@ -82,6 +85,8 @@ def main():
     p = argparse.ArgumentParser()
     p.add_argument('--admission', type=Path, required=True)
     p.add_argument('--trusted-public-key', type=Path, required=True)
+    p.add_argument('--image-lock', type=Path, required=True)
+    p.add_argument('--runtime-lock', type=Path, required=True)
     p.add_argument('--manifest-key', required=True)
     p.add_argument('--manifest-version', required=True)
     p.add_argument('--private-workspace', type=Path, required=True)
@@ -95,6 +100,11 @@ def main():
         raise ValueError('UNTRUSTED_ADMISSION_KEY')
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
     Ed25519PublicKey.from_public_bytes(bytes.fromhex(a['signerPublicKey'])).verify(bytes.fromhex(p2), encoded({k: v for k, v in a.items() if k != 'signature'}))
+    # Independent reviewer checks the admitted verifier BEFORE evidence downloads.
+    from image_admission import bind_runtime_lock, check_preloaded, json_bytes
+    image_lock = json_bytes(args.image_lock.read_bytes())
+    bind_runtime_lock(image_lock, json_bytes(args.runtime_lock.read_bytes()), a)
+    check_preloaded(image_lock, a, verifier_only=True)
     args.private_workspace.mkdir(mode=0o700, parents=True, exist_ok=False)
     result = verify(boto3.client('s3', region_name=a['region']), a, args.manifest_key, args.manifest_version, args.private_workspace)
     with args.summary.open('xb') as f:

--- a/ci/private_cert/worker.py
+++ b/ci/private_cert/worker.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Baked P-053 supervisor. No downloads of executable code at boot.
+
+The admitted runner/verifier OCI images are preloaded and run without host
+network, credentials or sockets. Their ABI is documented in docs/private-cert.md.
+Only the independently pinned verifier may produce a private gate receipt.
+"""
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import subprocess
+import tarfile
+import threading
+import time
+import urllib.request
+
+from control import encoded, sha
+
+CHUNK = 16 * 1024 * 1024
+ROOT = Path('/opt/polis-private')
+SCRATCH = Path('/private-cert')
+
+
+def file_sha(p):
+    h = hashlib.sha256()
+    with Path(p).open('rb') as f:
+        for b in iter(lambda: f.read(CHUNK), b''):
+            h.update(b)
+    return h.hexdigest()
+
+
+def safe_extract(archive, destination, max_bytes, max_members):
+    """Uncompressed tar only; complete census before extraction, no link types."""
+    seen, total = set(), 0
+    with tarfile.open(archive, mode='r:') as t:
+        members = []
+        for m in t:
+            p = PurePosixPath(m.name)
+            if (not m.isfile() or p.is_absolute() or '..' in p.parts or not p.parts
+                    or str(p) != m.name or m.name in seen or '\\' in m.name
+                    or any(ord(c) < 32 for c in m.name)):
+                raise ValueError('UNSAFE_ARCHIVE')
+            seen.add(m.name)
+            total += m.size
+            if total > max_bytes or len(seen) > max_members or m.size < 0:
+                raise ValueError('ARCHIVE_LIMIT')
+            members.append(m)
+        if not members:
+            raise ValueError('EMPTY_ARCHIVE')
+        destination = Path(destination)
+        destination.mkdir(mode=0o755, parents=True, exist_ok=False)
+        for m in members:
+            output = destination / m.name
+            output.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+            with output.open('xb') as f:
+                shutil.copyfileobj(t.extractfile(m), f, CHUNK)
+            output.chmod(0o444)
+    # systemd uses UMask=0077; explicit chmod keeps the read-only bind view
+    # readable by the unprivileged container without opening the private parent.
+    for p in destination.rglob('*'):
+        if p.is_dir():
+            p.chmod(0o555)
+    destination.chmod(0o555)
+    return len(seen), total
+
+
+def metadata():
+    # No proxy: admission identity cannot be supplied by an ambient HTTP proxy.
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    base = 'http://169.254.169.254/latest/'
+    req = urllib.request.Request(base + 'api/token', method='PUT', headers={'X-aws-ec2-metadata-token-ttl-seconds': '300'})
+    with opener.open(req, timeout=5) as r:
+        token = r.read(1024).decode()
+    req = urllib.request.Request(base + 'dynamic/instance-identity/document', headers={'X-aws-ec2-metadata-token': token})
+    with opener.open(req, timeout=5) as r:
+        return json.loads(r.read(8192))
+
+
+def sandbox(image, action, mounts, log, timeout):
+    # podman is used only by the trusted supervisor. There is no daemon socket
+    # and no host socket, host PID namespace or credential mount in the child.
+    cmd = ['podman', 'run', '--name', 'polis-private-' + action, '--pull=never',
+           '--network=none', '--read-only', '--cap-drop=ALL',
+           '--security-opt=no-new-privileges', '--user=65534:65534',
+           '--pids-limit=4096', '--memory=112g', '--memory-swap=112g', '--cpus=14',
+           '--ulimit=core=0:0', '--tmpfs=/tmp:rw,nosuid,nodev,noexec,size=4g',
+           '--env=OPENBLAS_NUM_THREADS=1', '--env=OMP_NUM_THREADS=1',
+           '--env=MKL_NUM_THREADS=1', '--env=NUMEXPR_NUM_THREADS=1']
+    for source, target, access in mounts:
+        cmd += ['--volume', f'{source}:{target}:{access},nosuid,nodev']
+    # exec-form ABI: no caller-provided argv, shell expression or mount.
+    cmd += [image, action]
+    try:
+        with Path(log).open('wb') as f:
+            result = subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, timeout=timeout, check=False)
+        inspected = subprocess.run(['podman', 'inspect', 'polis-private-' + action], capture_output=True, check=True)
+        state = json.loads(inspected.stdout)[0]['State']
+        if result.returncode != 0 or state.get('OOMKilled') or state.get('ExitCode') != 0:
+            raise ValueError('PRODUCER_INCOMPLETE')
+    finally:
+        # Removal kills leftover children even if the producer command timed out.
+        subprocess.run(['podman', 'rm', '--force', 'polis-private-' + action], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+
+
+def validate_receipt(receipt, admission, evidence_sha):
+    """Closed, bounded schema. Only trusted verifier output reaches this check.
+
+    The verifier must recompute inventory/checkpoints/polarity/recovery and the
+    strict comparison. This transport validator is deliberately not that gate.
+    """
+    keys = {'schema', 'admissionSha256', 'evidenceSha256', 'inventorySha256',
+            'scheduleSha256', 'policySha256', 'checks', 'verdict', 'reason'}
+    if type(receipt) is not dict or set(receipt) != keys:
+        raise ValueError('RECEIPT_SCHEMA')
+    if (receipt['schema'] != 'polis-private-gate/1' or receipt['admissionSha256'] != sha(admission)
+            or receipt['evidenceSha256'] != evidence_sha):
+        raise ValueError('RECEIPT_BINDING')
+    for key in ('inventorySha256', 'scheduleSha256', 'policySha256'):
+        if receipt[key] != admission[key]:
+            raise ValueError('RECEIPT_BINDING')
+    if type(receipt['checks']) is not int or not 0 <= receipt['checks'] <= admission['expectedChecks']:
+        raise ValueError('RECEIPT_COUNTS')
+    allowed = {'PASS': 'COMPLETE', 'FAIL': 'COMPARISON', 'INCOMPLETE': 'MISSING_EVIDENCE', 'INCONCLUSIVE': 'UNRESOLVED_POLICY'}
+    if receipt['verdict'] not in allowed or receipt['reason'] != allowed[receipt['verdict']]:
+        raise ValueError('RECEIPT_VERDICT')
+    if receipt['verdict'] == 'PASS' and receipt['checks'] != admission['expectedChecks']:
+        raise ValueError('SHORT_INVENTORY')
+    return receipt
+
+
+def upload_chunks(s3, path, boot, instance_arn):
+    a = boot['admission']
+    prefix = f'runs/{a["id"]}/{instance_arn}/'
+    chunks = []
+    with Path(path).open('rb') as f:
+        for index, block in enumerate(iter(lambda: f.read(CHUNK), b'')):
+            digest = hashlib.sha256(block).hexdigest()
+            key = prefix + f'chunks/{index:08d}'
+            result = s3.put_object(Bucket=boot['evidenceBucket'], Key=key, Body=block,
+                                   IfNoneMatch='*', ServerSideEncryption='aws:kms', SSEKMSKeyId=boot['evidenceKey'])
+            version = result.get('VersionId')
+            if not version or version == 'null':
+                raise ValueError('MISSING_VERSION')
+            chunks.append({'key': key, 'version': version, 'bytes': len(block), 'sha256': digest})
+    manifest = {'schema': 'polis-private-evidence/1', 'admissionSha256': sha(a),
+                'archiveSha256': file_sha(path), 'archiveBytes': Path(path).stat().st_size,
+                'instanceArn': instance_arn, 'chunks': chunks}
+    return prefix, manifest
+
+
+def run():
+    import boto3
+    # Bootstrap is baked BEFORE an AMI ID exists. The admission (which binds
+    # that resulting AMI) is signed afterwards by the admitted curator key.
+    # Reading this tiny untrusted control record precedes fixture access.
+    bootstrap = json.loads((ROOT / 'bootstrap.json').read_bytes())
+    identity = metadata()
+    if identity['accountId'] != bootstrap['account'] or identity['region'] != bootstrap['region']:
+        raise ValueError('BOOT_ACCOUNT')
+    from botocore.config import Config
+    s3 = boto3.client('s3', region_name=bootstrap['region'],
+                      config=Config(s3={'us_east_1_regional_endpoint': 'regional', 'addressing_style': 'virtual'}))
+    control_bucket = f'ppc-{bootstrap["account"]}-{bootstrap["id"]}-control'
+    boot = None
+    for _ in range(48):
+        try:
+            obj = s3.get_object(Bucket=control_bucket, Key=f'boot/{bootstrap["id"]}.json')
+            raw = obj['Body'].read(65537)
+            if len(raw) > 65536:
+                raise ValueError('BOOT_OVERSIZE')
+            boot = json.loads(raw)
+            break
+        except Exception:
+            time.sleep(5)
+    if not boot:
+        raise ValueError('NO_BOOT_RECORD')
+    a = boot['admission']
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    signature = a['signature']
+    signed = {k: v for k, v in a.items() if k != 'signature'}
+    Ed25519PublicKey.from_public_bytes(bytes.fromhex(bootstrap['signerPublicKey'])).verify(bytes.fromhex(signature), encoded(signed))
+    if (a['signerPublicKey'] != bootstrap['signerPublicKey'] or a['id'] != bootstrap['id']
+            or a['account'] != bootstrap['account'] or a['region'] != bootstrap['region']
+            or a['ami'] != identity['imageId'] or boot['instanceId'] != identity['instanceId']
+            or boot['admissionSha256'] != sha(a)):
+        raise ValueError('BOOT_ADMISSION')
+    lock = json.loads((ROOT / 'runtime-lock.json').read_bytes())
+    if set(lock) != {'bootstrap.json', 'control.py', 'dns.py', 'start.sh', 'firewall.nft'} or sha(lock) != a['runtimeSha256'] or file_sha(ROOT / 'worker.py') != a['supervisorSha256']:
+        raise ValueError('RUNTIME_BINDING')
+    for rel, digest in lock.items():
+        p = ROOT / rel
+        if p.resolve().parent != ROOT or file_sha(p) != digest:
+            raise ValueError('RUNTIME_FILE')
+    expires = __import__('datetime').datetime.fromisoformat(a['expiresAt'].replace('Z', '+00:00')).timestamp()
+    if time.time() >= expires or expires - boot['started'] > 12 * 3600:
+        raise ValueError('EXPIRED_OR_OVER_BUDGET')
+    instance_arn = f'arn:aws:ec2:{a["region"]}:{a["account"]}:instance/{identity["instanceId"]}'
+    stop = threading.Event()
+    def heartbeat():
+        while not stop.is_set():
+            try:
+                s3.put_object(Bucket=control_bucket, Key=f'heartbeats/{a["id"]}/{instance_arn}.json', Body=b'{}',
+                              ServerSideEncryption='aws:kms', SSEKMSKeyId=boot['evidenceKey'])
+            except Exception:
+                # Sweeper uses S3 LastModified, never this process's claim.
+                pass
+            stop.wait(60)
+    threading.Thread(target=heartbeat, daemon=True).start()
+    try:
+        if not SCRATCH.is_mount() or shutil.disk_usage(SCRATCH).free < a['fixtureBytes'] + a['expandedBytes'] + 32 * 1024 ** 3:
+            raise ValueError('DISK_CAPACITY')
+        work = SCRATCH / 'work'
+        work.mkdir(mode=0o700)
+        bundle = work / 'bundle.tar'
+        obj = s3.get_object(Bucket=boot['fixtureBucket'], Key=a['fixtureKey'], VersionId=a['fixtureVersion'])
+        if obj.get('VersionId') != a['fixtureVersion'] or obj['ContentLength'] != a['fixtureBytes']:
+            raise ValueError('FIXTURE_VERSION_OR_SIZE')
+        with bundle.open('xb') as f:
+            remaining = a['fixtureBytes']
+            while remaining:
+                data = obj['Body'].read(min(CHUNK, remaining))
+                if not data:
+                    raise ValueError('TRUNCATED_FIXTURE')
+                f.write(data)
+                remaining -= len(data)
+            if obj['Body'].read(1):
+                raise ValueError('OVERSIZE_FIXTURE')
+        if file_sha(bundle) != a['fixtureSha256']:
+            raise ValueError('FIXTURE_DIGEST')
+        safe_extract(bundle, work / 'fixture', a['expandedBytes'], a['maxMembers'])
+        bundle.unlink()
+        output, verify, inputs = work / 'output', work / 'verify', work / 'inputs'
+        for d in (output, verify, inputs):
+            d.mkdir(mode=0o755)
+        # Full immutable admission is visible to the TRUSTED driver/verifier.
+        # Their candidate subprocess ABI forbids passing these control inputs.
+        (inputs / 'admission.json').write_bytes(encoded(a))
+        (inputs / 'admission.json').chmod(0o444)
+        inputs.chmod(0o555)
+        for d in (output, verify):
+            os.chown(d, 65534, 65534)
+        sandbox(a['runnerImage'], 'produce', [(work / 'fixture', '/fixture', 'ro'), (inputs, '/admission', 'ro'), (output, '/output', 'rw')],
+                work / 'producer.log', max(1, int(expires - time.time() - 300)))
+        # Trusted root repackages only regular output; candidate-created links,
+        # devices and duplicate paths cannot select host files for publication.
+        archive = work / 'evidence.tar'
+        with tarfile.open(archive, 'w') as t:
+            for p in sorted(output.rglob('*')):
+                if p.is_symlink() or (not p.is_file() and not p.is_dir()):
+                    raise ValueError('UNSAFE_EVIDENCE')
+                if p.is_file():
+                    t.add(p, arcname=str(p.relative_to(output)), recursive=False)
+            t.add(work / 'producer.log', arcname='supervisor-producer.log', recursive=False)
+        evidence_sha = file_sha(archive)
+        (inputs / 'evidence-sha256').write_text(evidence_sha)
+        (inputs / 'evidence-sha256').chmod(0o444)
+        sandbox(a['verifierImage'], 'verify', [(output, '/evidence', 'ro'), (inputs, '/admission', 'ro'), (verify, '/verdict', 'rw')],
+                work / 'verifier.log', max(1, int(expires - time.time() - 120)))
+        receipt_path = verify / 'receipt.json'
+        if receipt_path.is_symlink() or receipt_path.stat().st_size > 8192:
+            raise ValueError('UNSAFE_RECEIPT')
+        receipt = validate_receipt(json.loads(receipt_path.read_bytes()), a, evidence_sha)
+        prefix, manifest = upload_chunks(s3, archive, boot, instance_arn)
+        manifest['gateReceipt'] = receipt
+        # Manifest LAST. Private verifier re-downloads each version and re-runs
+        # the semantic gate; this envelope never directly enables public PASS.
+        s3.put_object(Bucket=boot['evidenceBucket'], Key=prefix + 'manifest.json', Body=encoded(manifest),
+                      IfNoneMatch='*', ServerSideEncryption='aws:kms', SSEKMSKeyId=boot['evidenceKey'])
+    except Exception:
+        # Missing complete gate evidence remains INCOMPLETE, even if this lands.
+        try:
+            failure = encoded({'schema': 'polis-private-failure/1', 'admissionSha256': sha(a),
+                               'status': 'INCOMPLETE', 'reason': 'EXECUTION_OR_COLLECTION'})
+            s3.put_object(Bucket=boot['evidenceBucket'], Key=f'runs/{a["id"]}/{instance_arn}/failure.json',
+                          Body=failure, IfNoneMatch='*', ServerSideEncryption='aws:kms', SSEKMSKeyId=boot['evidenceKey'])
+            for label in ('producer.log', 'verifier.log'):
+                path = SCRATCH / 'work' / label
+                if path.is_file() and not path.is_symlink():
+                    with path.open('rb') as stream:
+                        for index, block in enumerate(iter(lambda: stream.read(CHUNK), b'')):
+                            s3.put_object(Bucket=boot['evidenceBucket'], Key=f'runs/{a["id"]}/{instance_arn}/failure/{label}/{index:08d}',
+                                          Body=block, IfNoneMatch='*', ServerSideEncryption='aws:kms', SSEKMSKeyId=boot['evidenceKey'])
+        except Exception:
+            pass
+        raise
+    finally:
+        stop.set()
+
+
+if __name__ == '__main__':
+    try:
+        run()
+    except Exception:
+        # Raw tracebacks/paths never go to serial console or cloud logs.
+        pass
+    finally:
+        subprocess.run(['systemctl', 'poweroff'], check=False)

--- a/ci/private_cert/worker.py
+++ b/ci/private_cert/worker.py
@@ -112,15 +112,17 @@ def validate_receipt(receipt, admission, evidence_sha):
     strict comparison. This transport validator is deliberately not that gate.
     """
     keys = {'schema', 'admissionSha256', 'evidenceSha256', 'inventorySha256',
-            'scheduleSha256', 'policySha256', 'checks', 'verdict', 'reason'}
+            'scheduleSha256', 'policySha256', 'checks', 'verdict', 'reason', 'negativeControlsSha256'}
     if type(receipt) is not dict or set(receipt) != keys:
         raise ValueError('RECEIPT_SCHEMA')
-    if (receipt['schema'] != 'polis-private-gate/1' or receipt['admissionSha256'] != sha(admission)
+    if (receipt['schema'] != 'polis-private-gate/2' or receipt['admissionSha256'] != sha(admission)
             or receipt['evidenceSha256'] != evidence_sha):
         raise ValueError('RECEIPT_BINDING')
     for key in ('inventorySha256', 'scheduleSha256', 'policySha256'):
         if receipt[key] != admission[key]:
             raise ValueError('RECEIPT_BINDING')
+    if not isinstance(receipt['negativeControlsSha256'], str) or not __import__('re').fullmatch(r'[a-f0-9]{64}', receipt['negativeControlsSha256']):
+        raise ValueError('NEGATIVE_CONTROLS_BINDING')
     if type(receipt['checks']) is not int or not 0 <= receipt['checks'] <= admission['expectedChecks']:
         raise ValueError('RECEIPT_COUNTS')
     allowed = {'PASS': 'COMPLETE', 'FAIL': 'COMPARISON', 'INCOMPLETE': 'MISSING_EVIDENCE', 'INCONCLUSIVE': 'UNRESOLVED_POLICY'}
@@ -188,12 +190,18 @@ def run():
             or boot['admissionSha256'] != sha(a)):
         raise ValueError('BOOT_ADMISSION')
     lock = json.loads((ROOT / 'runtime-lock.json').read_bytes())
-    if set(lock) != {'bootstrap.json', 'control.py', 'dns.py', 'start.sh', 'firewall.nft'} or sha(lock) != a['runtimeSha256'] or file_sha(ROOT / 'worker.py') != a['supervisorSha256']:
+    if set(lock) != {'bootstrap.json', 'control.py', 'dns.py', 'start.sh', 'firewall.nft',
+                     'image_admission.py', 'image-lock.json'} or sha(lock) != a['runtimeSha256'] or file_sha(ROOT / 'worker.py') != a['supervisorSha256']:
         raise ValueError('RUNTIME_BINDING')
     for rel, digest in lock.items():
         p = ROOT / rel
         if p.resolve().parent != ROOT or file_sha(p) != digest:
             raise ValueError('RUNTIME_FILE')
+    # Before fixture access, require the reviewed lock and both local OCI closures.
+    from image_admission import bind_runtime_lock, check_preloaded
+    image_lock = json.loads((ROOT / 'image-lock.json').read_bytes())
+    bind_runtime_lock(image_lock, lock, a)
+    check_preloaded(image_lock, a)
     expires = __import__('datetime').datetime.fromisoformat(a['expiresAt'].replace('Z', '+00:00')).timestamp()
     if time.time() >= expires or expires - boot['started'] > 12 * 3600:
         raise ValueError('EXPIRED_OR_OVER_BUDGET')
@@ -242,7 +250,17 @@ def run():
         inputs.chmod(0o555)
         for d in (output, verify):
             os.chown(d, 65534, 65534)
-        sandbox(a['runnerImage'], 'produce', [(work / 'fixture', '/fixture', 'ro'), (inputs, '/admission', 'ro'), (output, '/output', 'rw')],
+        # Producer/candidate processes receive data commitments only. The full
+        # control admission, identity, signature and object coordinates are never
+        # mounted in their filesystem; only the independent verifier gets them.
+        run_spec = work / 'run-spec'
+        run_spec.mkdir(mode=0o755)
+        projection = {k: a[k] for k in ('candidateSha', 'oracleSha', 'policySha256',
+                      'scheduleSha256', 'inventorySha256', 'expectedChecks')}
+        (run_spec / 'inputs.json').write_bytes(encoded(projection))
+        (run_spec / 'inputs.json').chmod(0o444)
+        run_spec.chmod(0o555)
+        sandbox(a['runnerImage'], 'produce', [(work / 'fixture', '/fixture', 'ro'), (run_spec, '/run-spec', 'ro'), (output, '/output', 'rw')],
                 work / 'producer.log', max(1, int(expires - time.time() - 300)))
         # Trusted root repackages only regular output; candidate-created links,
         # devices and duplicate paths cannot select host files for publication.
@@ -263,6 +281,9 @@ def run():
         if receipt_path.is_symlink() or receipt_path.stat().st_size > 8192:
             raise ValueError('UNSAFE_RECEIPT')
         receipt = validate_receipt(json.loads(receipt_path.read_bytes()), a, evidence_sha)
+        controls_path = verify / 'negative-controls.json'
+        if controls_path.is_symlink() or controls_path.stat().st_size > 8192 or file_sha(controls_path) != receipt['negativeControlsSha256']:
+            raise ValueError('NEGATIVE_CONTROLS_BINDING')
         prefix, manifest = upload_chunks(s3, archive, boot, instance_arn)
         manifest['gateReceipt'] = receipt
         # Manifest LAST. Private verifier re-downloads each version and re-runs

--- a/docs/private-cert.md
+++ b/docs/private-cert.md
@@ -7,10 +7,12 @@ function. **It does not launch an instance or stage private data during deploy.*
 Only a scoped operator invocation launches the one admitted instance. There is
 no GitHub/OIDC role, SSM access, SSH key, public IP, NAT or production connection.
 
-This is infrastructure and the trusted execution/collection boundary, not a new
-mathematical certification gate. The admitted producer and independent verifier
-images must implement the ABI below using the reviewed current certify/strict
-gate interfaces. An arbitrary image that prints PASS is not admissible. No private
+The trusted execution/collection boundary uses the step-2 paired-recording gate
+(certify + G12, absolute 1e-6, relative 1e-4, zero outliers), per the orchestrator
+ruling in BOARD [677]. Stage comparisons are diagnostic only; recovery and
+consumption inference belong to the separate shadow-run diagnostic. The
+[image implementation and admission](../ci/private_cert/images/README.md) defines
+the producer, independent verifier, offline dependency closure and digest pins. An arbitrary image that prints PASS is not admissible. No private
 certificate, ARM boot, capacity fit, IAM simulation or cloud canary is established
 by the local unit tests and synth comparison.
 
@@ -44,9 +46,10 @@ security group, instance type and tag. A tag by itself never authorizes cleanup.
 Use the existing private ARM64 image-builder process. `ci/private_cert/bake.sh`
 performs offline installation/hardening only; it does not build an AMI or download
 packages. Preinstall and independently pin Linux/systemd, Python 3.12, boto3,
-cryptography, podman, nftables, ebsnvme-id, and all engine/JVM/BLAS/local-Postgres
-runtime dependencies in the OCI images. Preload the OCI images and verify their
-manifest digests. Verify the base image's root mapping is `/dev/xvda` and its root
+cryptography, podman, nftables and ebsnvme-id on the host. Put the pinned
+engine/JVM/BLAS dependency closure in the OCI images; paired replay needs no
+Postgres service. Preload the OCI images and verify their manifest digests against the reviewed
+`image-lock.json`; pass its path to the bake as `PRIVATE_CERT_IMAGE_LOCK`. Verify the base image's root mapping is `/dev/xvda` and its root
 filesystem accommodates those dependencies in 32 GiB. No credentials or fixture
 bytes belong in the AMI or image-builder snapshots.
 
@@ -57,7 +60,10 @@ Run the bake script as root only on that disposable builder. It installs the
 supervisor/service, masks cloud-init/SSM/SSH/serial login/swap, disables cores,
 installs the DNS/IMDS firewall and outputs the actual supervisor/runtime digests.
 Save those digests in the private admission. The runtime lock hashes the installed
-bootstrap, control module, DNS forwarder, start script and firewall. The AMI itself
+bootstrap, control module, DNS forwarder, start script, firewall,
+`image_admission.py` and canonical `image-lock.json`. Before fetching fixtures the
+supervisor checks preloaded manifest/config digests, platform and execution
+configuration against this signed runtime binding. The AMI itself
 binds all other installed bytes; admit its provenance before signing.
 
 The supervisor cannot have a final AMI ID baked into itself: that ID does not
@@ -181,27 +187,32 @@ private run record until disposal is verified.
 
 ## Admitted image ABI and independent publication
 
-The producer image entrypoint accepts the literal `produce`, with `/fixture`
-read-only, `/admission/admission.json` read-only, and `/output` writable. It owns a
-fresh local Postgres and sequential engine processes inside the disconnected
-container. It must validate the manifest/census and schedule **contents**, use the
-current strict certify driver/admission APIs, run every admitted entry/checkpoint,
-polarity/approved-difference checks and declared recovery/consumption gates, and
-emit complete raw evidence, producer exits and peak-memory/disk/OOM evidence.
-`delphi/scripts/certify.py run --strict --workers 1` is the current battery CLI;
-its success alone does not substitute for the other private admission obligations.
-Do not use `--only`, permissive mode, reused recordings, shortened schedules or a
-hand-built inventory as a private certificate. The driver must not expose its
-trusted verifier/control inputs to untrusted candidate subprocesses.
+The producer accepts `produce`, with `/fixture` read-only, only the six data
+commitments in `/run-spec/inputs.json` read-only, and `/output` writable. It has no
+admission/control mount, credentials, object keys, signatures, host sockets or
+verifier output. It validates the original bundle manifest/configuration and the
+complete planned scope, resolves lossless private event inputs, and runs the two
+engines serially from a fresh directory. It retains every raw checkpoint, engine
+exit and child peak RSS/output byte count. Nonzero exits or missing evidence are
+INCOMPLETE. An OOM that kills the collector is retained by the supervisor's
+failure path; capacity still needs measurement on the admitted host.
 
-The separately admitted verifier image accepts `verify`, with the complete
-`/evidence` read-only, `/admission` read-only (including `evidence-sha256`), and
-`/verdict` writable. It recomputes the gate from complete evidence and writes one
-bounded `receipt.json` with the exact `polis-private-gate/1` schema enforced by
-`validate_receipt`. This schema has fixed reason enums, count and digest bindings;
-it cannot independently prove the mathematics. The verifier implementation and
-its negative controls are part of the admitted runtime review, not a candidate's
-self-assertion. Missing images/receipts/checkpoints cannot yield a public PASS.
+The verifier is built separately from independently reviewed source, and pinned
+by its own OCI manifest digest. It accepts `verify`, with `/evidence` read-only,
+`/admission` read-only (including `evidence-sha256`), and `/verdict` writable. It
+independently admits the bundle, derives schedules/checkpoints and file inventory,
+validates both raw schemas, and runs certify + G12. Stage comparisons cannot
+change the verdict. The bounded `receipt.json` uses `polis-private-gate/2`, with
+fixed reasons, count and admission/evidence/inventory/schedule/policy digests plus
+`negativeControlsSha256`. The corresponding `negative-controls.json` contains the
+17 G12 controls and four checkpoint schema/inventory controls. The supervisor
+checks that artifact's actual bytes against the receipt. Missing checkpoints,
+short entry inventories or failed controls cannot yield PASS.
+
+Image release admission additionally requires the reviewed source closure and
+synthetic wrapper/isolation controls described in the image README. Labels and
+a successful build cannot establish correctness or reviewer independence. A
+paired-recording PASS does not confer writer transfer or close shadow diagnostics.
 
 The supervisor uploads bounded create-only 16-MiB chunks, records exact VersionIds
 and SHA256s, and uploads the private manifest last. Failure envelopes/log chunks
@@ -212,7 +223,10 @@ The private reviewer retrieves the exact manifest key/version from its private r
 record. It runs `ci/private_cert/verify.py` on an isolated private Linux verifier
 host with the admitted verifier image preloaded, passing `--admission`,
 `--trusted-public-key` (file containing the independently admitted hex key),
-`--manifest-key`, `--manifest-version`, a fresh `--private-workspace`, and `--summary`.
+`--manifest-key`, `--manifest-version`, the reviewed `--image-lock` and
+`--runtime-lock`, a fresh `--private-workspace`, and `--summary`. The CLI binds the
+image lock to the signed runtime digest and inspects the preloaded verifier
+before it downloads evidence.
 This downloads and hashes every exact chunk version, safely extracts the complete
 evidence, **reruns** the independent gate, requires agreement with the bound private
 receipt, and reads the matching immutable CLEAN record before writing any summary.

--- a/docs/private-cert.md
+++ b/docs/private-cert.md
@@ -1,0 +1,265 @@
+# Disposable private certification (P-053)
+
+`enablePrivateCertBox` is **off by default**. It adds a separate `PrivateCertStack`,
+without changing the existing `CdkStack` or the synthetic CI worker. Enabling it
+creates the isolated network, private storage, pinned launch template and control
+function. **It does not launch an instance or stage private data during deploy.**
+Only a scoped operator invocation launches the one admitted instance. There is
+no GitHub/OIDC role, SSM access, SSH key, public IP, NAT or production connection.
+
+This is infrastructure and the trusted execution/collection boundary, not a new
+mathematical certification gate. The admitted producer and independent verifier
+images must implement the ABI below using the reviewed current certify/strict
+gate interfaces. An arbitrary image that prints PASS is not admissible. No private
+certificate, ARM boot, capacity fit, IAM simulation or cloud canary is established
+by the local unit tests and synth comparison.
+
+## One-time operator decisions and prerequisites
+
+Colin chooses the payer account/region and distinct existing operator, curator and
+private-reviewer role ARNs, the admission-signing public key, the maintainer SNS
+topic, retention (30 days routine or 90 days failure), and the exact image/source/
+policy/schedule/inventory tuple. The public key is independently reviewed; a key
+inside an untrusted admission does not establish its own trust. Private key,
+admission JSON, manifests, object keys, data and all synth output from a real
+admission stay **outside this public checkout and public Actions artifacts**.
+
+The deployment principal is privileged infrastructure administration. The runtime
+operator receives only the function invocation and control-record reads from this
+stack. Curator receives one exact staging-object PutObject/KMS GenerateDataKey;
+reviewer receives exact-version evidence reads. Existing principals should not
+carry broader deployment/session policies. Never attach the synthetic CI role.
+Environment-form OIDC subjects do not identify a workflow; neither unsupported
+STS claims nor root SSM commands are an acceptable future private-data boundary.
+
+The trusted lifecycle function must DescribeInstances/DescribeVolumes in the
+payer account because these EC2 APIs cannot be resource-scoped. This exposes
+account metadata to that trusted function, **not** to candidates, workers, public
+CI or the operator response. Mutation checks additionally require the stored
+admission digest/client token, template version, image, instance profile, subnet,
+security group, instance type and tag. A tag by itself never authorizes cleanup.
+
+## Bake, then sign
+
+Use the existing private ARM64 image-builder process. `ci/private_cert/bake.sh`
+performs offline installation/hardening only; it does not build an AMI or download
+packages. Preinstall and independently pin Linux/systemd, Python 3.12, boto3,
+cryptography, podman, nftables, ebsnvme-id, and all engine/JVM/BLAS/local-Postgres
+runtime dependencies in the OCI images. Preload the OCI images and verify their
+manifest digests. Verify the base image's root mapping is `/dev/xvda` and its root
+filesystem accommodates those dependencies in 32 GiB. No credentials or fixture
+bytes belong in the AMI or image-builder snapshots.
+
+Bake `/opt/polis-private/bootstrap.json` via `PRIVATE_CERT_BOOTSTRAP` with exactly
+these public bootstrap fields: `id` (32 lowercase hex opaque random characters),
+`account`, `region`, `signerPublicKey` (32-byte Ed25519 public key as lowercase hex).
+Run the bake script as root only on that disposable builder. It installs the
+supervisor/service, masks cloud-init/SSM/SSH/serial login/swap, disables cores,
+installs the DNS/IMDS firewall and outputs the actual supervisor/runtime digests.
+Save those digests in the private admission. The runtime lock hashes the installed
+bootstrap, control module, DNS forwarder, start script and firewall. The AMI itself
+binds all other installed bytes; admit its provenance before signing.
+
+The supervisor cannot have a final AMI ID baked into itself: that ID does not
+exist until image creation. After baking, the signed admission binds the returned
+AMI ID. At boot the supervisor reads only its tiny control record, verifies it
+against the **baked** public key, checks its own IMDS identity and runtime hashes,
+and only then fetches the admitted bundle VersionId. User-data is absent and no
+boot service executes it. The instance profile has no user-data/launch permissions.
+
+The host resolver forwards only the three exact bucket hostnames to the VPC DNS
+resolver. nftables blocks all other direct DNS and non-root IMDS. Containers run
+without a connected network, host PID namespace, credentials or host sockets;
+SGs alone do not filter Amazon-provided DNS. Synthetic canaries must verify these
+host and container boundaries on the actual admitted AMI.
+
+## Private admission and two-phase staging
+
+`PrivateAdmission` in `cdk/privateCertBox.ts` is the authoritative field list.
+Besides bootstrap fields it requires:
+
+- `schema: polis-private-admission/1`, `ami`, and the public-key `signature`;
+- the one `fixtureKey`, exactly `staging/ID/bundle.tar`, its non-null `fixtureVersion`,
+  SHA256 and byte length, plus maximum expanded bytes/member count;
+- 40-character `candidateSha`/`oracleSha`, 64-character supervisor/runtime/policy/
+  schedule/inventory digests, and complete expected check count;
+- `runnerImage` and `verifierImage`, preloaded names of the form
+  `localhost/polis-NAME@sha256:DIGEST` (no mutable tag or boot pull);
+- absolute UTC `stagingExpiresAt` and later `expiresAt`;
+- the three distinct role ARNs, existing notification topic ARN, regional S3
+  managed `s3PrefixListId`, and 30/90-day evidence retention.
+
+Storage is encrypted gp3: 32-GiB root plus 256-GiB scratch, DeleteOnTermination on
+both. Instance class is fixed at ARM64 r8g.4xlarge (128 GiB); the container ceiling
+is 112 GiB, 14 CPUs, 4,096 processes, no swap and fixed single-thread BLAS. The
+worker checks available disk space before extraction; the admitted producer must
+check the complete manifest dimensions and record peak RSS/disk/OOM before a full
+largest-entry run. If these bounds do not fit, the result is INCOMPLETE. Do not
+silently resize, sample, shorten schedules or replace entries.
+
+A bucket must exist before S3 can assign a VersionId. Therefore staging is two
+reviewed deployments, **with no launch between them**:
+
+1. Sign an initial staging admission using a conspicuously synthetic placeholder
+   VersionId/hash/size, the real baked AMI and a future ingestion cutoff. Synthesize
+   and review the isolated stack; deploy it under the scoped deployment session.
+   The placeholder grants no access to the subsequently uploaded real version.
+   Launch refuses while ingestion is open. No instance starts during deploy.
+2. The authorized curator packages an uncompressed tar containing only uniquely
+   named regular files with relative paths (no explicit directory entries, links,
+   traversal, duplicate paths or devices). Validate the owned bundle and full
+   lossless inventory in its private source environment. Upload the single object with a **single-part PutObject** (admission
+   maximum 4 GiB; larger bundles require a reviewed staging extension),
+   with explicit `aws:kms` encryption and the **FixtureKey ARN**. The deployment
+   operator supplies that ARN from the deployed private stack resource inventory. Capture the actual
+   VersionId, SHA256 and byte length locally. This adds no extraction/prod grant.
+3. Replace the placeholder with those exact values, choose the immutable schedule,
+   policy and complete inventory, sign the final admission, and update only the
+   private stack. Ingestion closes before launch; bucket policy denies all later
+   uploads, so cleanup cannot be invalidated by a curator restaging after CLEAN.
+   Launch must fall after `stagingExpiresAt` and before `expiresAt`, with at most
+   12 instance-hours remaining. The sweeper's clock and IAM expiry enforce the
+   same absolute admission deadline.
+
+Sign locally using the already admitted private key (never commit it):
+
+```sh
+python3 ci/private_cert/sign.py --unsigned /private/path/admission-unsigned.json \
+  --private-key /private/path/signing-key.pem --output /private/path/admission.json
+```
+
+In `cdk/`, the reviewed operator's synth/deploy input is
+`PRIVATE_CERT_CONFIG=/private/path/admission.json` and context
+`-c enablePrivateCertBox=true`. Missing/invalid signatures, pins, identities,
+versions, bounds and expiry fields fail synthesis. Synthesize `PrivateCertStack`
+with `--no-lookups`; the S3 prefix list is explicitly supplied from the reviewed
+regional inventory. No lookup or deployment is performed by the local tests.
+`enablePrivateCertBox=false` or omission reads no private admission at all.
+
+Never update the template/admission, remove the flag, replace roles/keys, or destroy
+this stack while an admission has a launch claim or unknown teardown. Such
+privileged changes can remove its active sweeper; they are outside the runtime
+isolation boundary. One immutable admission and one launch attempt per stack;
+create a fresh stack only after the previous admission's verified disposal.
+
+## Launch, reconcile, cancel
+
+The operator uses `ci/private_cert/operator.py` with `--function` set to the
+private stack's `ControlFunctionName` output, `--region`, `--admission-id`, and
+one of `launch`, `status`, `cancel`. The payload accepts **only** the action and
+admission ID. All template, profile, image and network arguments come from the
+reviewed function configuration. The function has reserved concurrency one.
+
+The function writes a create-only claim before calling RunInstances, with a fixed
+ClientToken and MinCount/MaxCount of one. Repeated launch requests reconcile that
+token; they never blindly reissue the launch. Lost acknowledgement plus an empty
+Describe stays TEARDOWN_UNKNOWN. Operator failure/cancellation does not stop the
+independent five-minute sweep. Missing S3-observed heartbeat after a bounded boot
+grace also requests termination; worker-supplied timestamps cannot renew it.
+
+A terminate/delete API acknowledgement is not a disposal receipt. CLEAN requires
+observed `terminated`, exact stored volume ownership, explicit absence of both
+volume IDs, and fresh empty staging-version and multipart inventories. Failed or
+empty volume Describe is UNKNOWN. Unknown tagged disks are never deleted. If a
+launch disappeared before its disks were inventoried, manual privileged review is
+required; the function keeps this uncertainty visible instead of declaring CLEAN.
+Absolute fixture expiry is enforced even when EC2 reconciliation fails.
+
+All staging versions, delete markers and multipart uploads are removed; the
+curator's original source bundle is outside this stack. Control records, evidence
+buckets and KMS keys are retained on stack removal. Routine/failure evidence
+prefixes expire after the admitted 30/90 days, including noncurrent versions.
+Release evidence requiring longer rollback/support retention must be transferred
+by the separate governed private archive process before that deadline; this
+worker receives no release-archive permission. No Object Lock is set on staging.
+
+Wire and test both maintainer alarms: control errors/UNKNOWN and missing sweep
+invocations. Control logs contain fixed health counts and fixed errors only.
+Never work around UNKNOWN by starting another admission. Investigate the exact
+owned resources, restore the sweeper if needed, and retain the uncertainty in the
+private run record until disposal is verified.
+
+## Admitted image ABI and independent publication
+
+The producer image entrypoint accepts the literal `produce`, with `/fixture`
+read-only, `/admission/admission.json` read-only, and `/output` writable. It owns a
+fresh local Postgres and sequential engine processes inside the disconnected
+container. It must validate the manifest/census and schedule **contents**, use the
+current strict certify driver/admission APIs, run every admitted entry/checkpoint,
+polarity/approved-difference checks and declared recovery/consumption gates, and
+emit complete raw evidence, producer exits and peak-memory/disk/OOM evidence.
+`delphi/scripts/certify.py run --strict --workers 1` is the current battery CLI;
+its success alone does not substitute for the other private admission obligations.
+Do not use `--only`, permissive mode, reused recordings, shortened schedules or a
+hand-built inventory as a private certificate. The driver must not expose its
+trusted verifier/control inputs to untrusted candidate subprocesses.
+
+The separately admitted verifier image accepts `verify`, with the complete
+`/evidence` read-only, `/admission` read-only (including `evidence-sha256`), and
+`/verdict` writable. It recomputes the gate from complete evidence and writes one
+bounded `receipt.json` with the exact `polis-private-gate/1` schema enforced by
+`validate_receipt`. This schema has fixed reason enums, count and digest bindings;
+it cannot independently prove the mathematics. The verifier implementation and
+its negative controls are part of the admitted runtime review, not a candidate's
+self-assertion. Missing images/receipts/checkpoints cannot yield a public PASS.
+
+The supervisor uploads bounded create-only 16-MiB chunks, records exact VersionIds
+and SHA256s, and uploads the private manifest last. Failure envelopes/log chunks
+are private and explicitly INCOMPLETE; upload failure leaves incomplete evidence.
+The worker has no evidence read/list/delete or public publication permissions.
+
+The private reviewer retrieves the exact manifest key/version from its private run
+record. It runs `ci/private_cert/verify.py` on an isolated private Linux verifier
+host with the admitted verifier image preloaded, passing `--admission`,
+`--trusted-public-key` (file containing the independently admitted hex key),
+`--manifest-key`, `--manifest-version`, a fresh `--private-workspace`, and `--summary`.
+This downloads and hashes every exact chunk version, safely extracts the complete
+evidence, **reruns** the independent gate, requires agreement with the bound private
+receipt, and reads the matching immutable CLEAN record before writing any summary.
+A zero producer exit, valid transport hash or worker PASS is insufficient.
+
+The resulting local summary has only schema, opaque admission ID, candidate SHA,
+fixed verdict/reason and check count. It includes no bundle hash, object key,
+VersionId, private name/path, free text, log or raw JUnit. Sharing that reviewed
+summary is a separate authorized publication step; the tool does not upload it.
+No public certificate is emitted while cleanup or verification is unknown.
+
+## Acceptance before private bytes
+
+Run the entire canary matrix on synthetic bundles in the admitted payer account:
+wrong version/object/endpoint/principal; public/synthetic role reads; candidate
+DNS/internet/prod/IMDS access; cross-instance write/delete; missing conditional
+write; image/profile/network/user-data overrides; unsigned/forged boot; traversal,
+symlink and expansion bombs; absent/forged/truncated/short-inventory evidence;
+cancel, lost launch acknowledgement, dead boot, killed supervisor and expired
+credentials. Verify actual terminal EC2 state, both disks absent, every staged
+version/delete marker/upload absent, and maintainer notification for unknown or
+missing sweep. Local tests are not substitutes for IAM or ARM canaries.
+
+After those pass, run the complete largest private entry and report capacity
+separately. Existing public recording/schedule coverage and private gate admission
+remain required; provisioning this box does not waive them.
+
+## Local checks and cost accounting
+
+Run `npm test -- --runInBand` and `npx tsc --noEmit` from `cdk/`, and
+`python3 -m unittest discover -s ci/private_cert -p 'test_*.py' -v` from the root.
+Synthesize the same base and edited checkout with identical environment/context,
+then use `ci/private_cert/check_synth.py BASE_TEMPLATE OFF_TEMPLATE`. It compares
+**all** resource fields and the complete template, with no normalization exceptions.
+The opt-in stack should also synthesize under a signed synthetic admission and be
+checked for dependency cycles. Never place a real admission in a test fixture.
+
+Use measured EC2 hours, attached gp3 GiB-hours, retained S3 GiB-months, requests,
+KMS and control costs. No NAT/public IPv4/interface-endpoint hourly fee is designed
+in. A 12-hour campaign ceiling is a budget, not a completion estimate. Pin the
+current regional rate at activation and measure actual largest-entry capacity;
+local tests make no cost or runtime measurement claim.
+
+IAM references: [S3 conditional write enforcement](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes-enforce.html),
+[EC2 instance credential source condition](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-policies-for-amazon-ec2.html).
+
+Multipart inventory is bucket-scoped metadata in this dedicated per-admission
+staging bucket: IAM does not support `s3:prefix` for ListBucketMultipartUploads.
+The API call still filters the staging prefix, and abort/deletion grants are
+prefix-scoped. [S3 action authorization reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_s3.html).


### PR DESCRIPTION
Implements the Q24 decision: real-data certification runs on a disposable box in the payer account with no route to production.

A separate, default-off stack: signed admission of exactly one bundle version; isolated ARM launch template and network; exact-version fixture role; private versioned KMS-encrypted storage; baked supervisor with DNS/OCI isolation; digest- and version-bound evidence; an independent verifier publication boundary; a fixed-input lifecycle function; confirmed cleanup plus a sweeper. Operator steps in `docs/private-cert.md`.

**Nothing changes while the flag is off.** `cdk synth` with the flag absent, explicitly false, and true-with-admission: the existing stack stays at 127 resources with a byte-identical template (sha256 `fc692601…`). The opt-in sibling adds 28 resources.

**Tests.** cdk 70/70 (3 suites), `tsc --noEmit` clean, `ci/private_cert` unit tests 36/36, `bash -n` and AST checks clean.

**Not claimed here, and required before activation:** an admitted ARM AMI, the producer and independent-verifier images, cloud/IAM/boot canaries, the complete private gate, and the largest-entry capacity measurement. Draft until those are planned.

Written by the second reviewer; reviewed by the orchestrator. Schema impact: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s