### PR TITLE
ci(certification): run-instances uses --count (AWS CLI v2)

### DIFF
--- a/.github/workflows/certification-ec2.yml
+++ b/.github/workflows/certification-ec2.yml
@@ -187,7 +187,7 @@ jobs:
           INSTANCE_ID=$(aws ec2 run-instances \
             --launch-template "LaunchTemplateId=${LAUNCH_TEMPLATE_ID},Version=1" \
             --instance-type "$INSTANCE_TYPE" \
-            --min-count 1 --max-count 1 \
+            --count 1 \
             --client-token "$TOKEN" \
             --tag-specifications "$TAGS" "$VOLTAGS" \
             --query 'Instances[0].InstanceId' --output text)


### PR DESCRIPTION
The first dispatch of the disposable certification worker (run 34421958638) failed before reaching EC2. The runner's AWS CLI v2 rejects the v1 flags:

```
aws: [ERROR]: Unknown options: --min-count, --max-count, 1, 1
```

No instance was launched (CloudTrail shows the OIDC role assumed and no `RunInstances` call), and teardown reported ownership unresolved as designed. One-line fix: `--count 1`.

Workflow file: browser merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s