### PR TITLE
ci(certification): rename the public battery — no "synthetic" in names, verdicts, or docs

### DIFF
--- a/.github/workflows/certification-ec2.yml
+++ b/.github/workflows/certification-ec2.yml
@@ -1,9 +1,9 @@
-name: Synthetic recovery and public-fixture battery (EC2)
+name: Public battery certification (EC2)
 
 # P-022 §E. Runs the recovery matrix and the replay battery restricted to the
 # repository's PUBLIC fixtures on one disposable EC2 worker, then destroys it.
 #
-# THIS IS NOT PRIVATE CERTIFICATION and its verdict (`SYNTHETIC-PASS`) must
+# THIS IS NOT PRIVATE CERTIFICATION and its verdict (`PUBLIC-BATTERY-PASS`) must
 # never be read as one. The second reviewer's #2715 review found that round 1 staged the
 # private prod-derived bundle on a box GitHub could open a root shell on, and
 # returned its raw log to public Actions artifacts. Round 2 removes the private
@@ -56,13 +56,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  synthetic:
-    name: Synthetic recovery matrix and public-fixture battery
+  public-battery:
+    name: Public recovery matrix and fixture battery
     # The environment subject does NOT by itself exclude pull-request jobs: a
     # job that references an environment gets the environment subject even on a
     # PR, and GitHub silently creates a referenced-but-missing environment with
     # NO protection rules. So the ref is checked here as well, on every event.
-    # This is defence in depth, not the control: the `certification-synthetic`
+    # This is defence in depth, not the control: the `certification-public`
     # environment must be configured with edge as its only deployment branch
     # and a required reviewer (docs/ci-ec2.md).
     if: github.ref == 'refs/heads/edge' || github.ref == 'refs/heads/stable'
@@ -72,7 +72,7 @@ jobs:
     # maximum-length run necessarily lost its credentials before cleanup
     # (review E7). The job also re-assumes before teardown.
     timeout-minutes: 300
-    environment: certification-synthetic
+    environment: certification-public
     permissions:
       contents: read
       id-token: write
@@ -340,7 +340,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: synthetic-ec2-${{ github.run_id }}-${{ github.run_attempt }}
+          name: public-battery-ec2-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/
           if-no-files-found: warn
           retention-days: 7

--- a/cdk/ciEc2.ts
+++ b/cdk/ciEc2.ts
@@ -1,5 +1,5 @@
 /**
- * P-022 §E — disposable EC2 worker for the **synthetic** recovery matrix and
+ * P-022 §E — disposable EC2 worker for the **public battery** recovery matrix and
  * the **public-fixture** replay battery.
  *
  * ## Scope, after the second reviewer's #2715 review (round 2)
@@ -13,7 +13,7 @@
  *   - no fixture-bundle read anywhere in this construct,
  *   - no evidence-bucket write anywhere in this construct,
  *   - nothing prod-derived is ever staged on the worker,
- *   - the workflow's verdict is named for what it is (`synthetic`), so it can
+ *   - the workflow's verdict is named for what it is (`public battery`), so it can
  *     never be mistaken for a certificate.
  *
  * Private certification (baked trusted AMI, cloud-init disabled, isolated
@@ -161,7 +161,7 @@ export class CertificationCiEc2 extends Construct {
     // box (review E6). These are the agent's own actions and nothing else.
     this.workerRole = new iam.Role(this, 'WorkerRole', {
       roleName: 'polis-certify-worker',
-      description: 'P-022 E synthetic CI worker: SSM agent actions only, no data access',
+      description: 'P-022 E public battery CI worker: SSM agent actions only, no data access',
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
     });
     this.workerRole.addToPolicy(new iam.PolicyStatement({
@@ -218,7 +218,7 @@ export class CertificationCiEc2 extends Construct {
     // ------------------------------------------------------- launch template
     this.launchTemplate = new ec2.LaunchTemplate(this, 'LaunchTemplate', {
       launchTemplateName: 'polis-certify-ci',
-      versionDescription: 'P-022 E synthetic recovery + public-fixture battery worker',
+      versionDescription: 'P-022 E public battery recovery + public-fixture battery worker',
       machineImage: new ec2.AmazonLinuxImage({
         generation: ec2.AmazonLinuxGeneration.AMAZON_LINUX_2023,
         cpuType: props.cpuType,
@@ -274,7 +274,7 @@ export class CertificationCiEc2 extends Construct {
 
     this.githubRole = new iam.Role(this, 'GithubOidcRole', {
       roleName: 'polis-certify-github-oidc',
-      description: 'P-022 E: launches, drives and destroys the synthetic CI worker',
+      description: 'P-022 E: launches, drives and destroys the public battery CI worker',
       maxSessionDuration: cdk.Duration.hours(6),
       // ENVIRONMENT subject, exactly, and nothing else. No branch subject: an
       // environment job's token carries the environment form, so a branch
@@ -547,7 +547,7 @@ def handler(event, context):
 `;
 
 /**
- * User data for the synthetic worker.
+ * User data for the public battery worker.
  *
  * Two things in order matter here. First, the hard deadline is armed before
  * anything that can fail, and — round 2 — a failure to arm it is fatal rather
@@ -626,6 +626,12 @@ function buildUserData(props: CertificationCiEc2Props): ec2.UserData {
     '# target runs host `uv run --no-sync pytest`, so a box that has only',
     '# docker and git cannot run the matrix at all; round 2 installed uv in the',
     '# battery phase, which never ran with run_battery=false (review R2-F2).',
+    'BOOTSTRAP_PHASE=python-build-tools',
+    '# hdbscan has no Linux ARM64 wheel in the lockfile. Keep the locked',
+    '# dependency set; its isolated build installs Cython and NumPy headers.',
+    '# uv-managed Python supplies matching 3.12 headers (AL2023 python3-devel',
+    '# is for the system interpreter and must not stand in for those).',
+    'dnf install -y gcc gcc-c++ make || fail "python build tools"',
     'BOOTSTRAP_PHASE=python',
     'export HOME=/root',
     'curl -LsSf https://astral.sh/uv/install.sh -o /tmp/uv-install.sh || fail "uv download"',

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -449,7 +449,7 @@ export class CdkStack extends cdk.Stack {
         // Must equal the `environment:` the workflow job declares. The trust
         // policy admits this subject and nothing else.
         githubEnvironment: (this.node.tryGetContext('ciEc2GithubEnvironment') as string | undefined)
-          ?? 'certification-synthetic',
+          ?? 'certification-public',
         // The environment-form subject carries no ref and is issued to
         // pull-request jobs too; the `ref` claim is what excludes them.
         githubRefs: ((this.node.tryGetContext('ciEc2Refs') as string | undefined)

--- a/cdk/test/ciBootstrap.test.ts
+++ b/cdk/test/ciBootstrap.test.ts
@@ -32,6 +32,15 @@ test('ARM bootstrap installs the noninteractive JVM without unavailable rlwrap',
   expect(source).toContain('clojure --version');
 });
 
+test('ARM source-build toolchain is installed before the locked Python environment', () => {
+  const source = script();
+  const toolchain = source.indexOf('dnf install -y gcc gcc-c++ make || fail "python build tools"');
+  expect(toolchain).toBeGreaterThan(0);
+  expect(toolchain).toBeLessThan(source.indexOf('uv sync --locked --extra dev'));
+  expect(source).not.toContain('--no-build-isolation');
+  expect(source).not.toContain('--no-install-package');
+});
+
 test('test extras are installed and verified before the ready marker', () => {
   const source = script();
   expect(source).toContain('uv sync --locked --extra dev');

--- a/ci/p022_check_summary.py
+++ b/ci/p022_check_summary.py
@@ -8,7 +8,7 @@ This is **not** independent execution evidence and does not make the result
 unforgeable. Every field it inspects is produced by the same recipe that ran the
 tests: a worker that wanted to lie could emit a fully self-consistent record.
 The trust here is explicit and named — `summary.trust` must say
-`reviewed-recipe-self-reported` — and it is the trust appropriate to a synthetic
+`reviewed-recipe-self-reported` — and it is the trust appropriate to a public battery
 smoke over public fixtures. An adversarial certificate needs the independent
 control boundary specified in P-022-E-ci-spec.md, which is not built.
 
@@ -50,7 +50,7 @@ import xml.etree.ElementTree as ET
 #: line out of this file rather than carrying its own copy: round 5 shipped a
 #: writer emitting /3 against a checker requiring /4, so every otherwise valid
 #: run would have been rejected (review R5-F1). One constant, two readers.
-SCHEMA = "p022-synthetic/4"
+SCHEMA = "p022-public-battery/4"
 
 MAX_BYTES = 64 * 1024
 MAX_INT = 1_000_000
@@ -174,7 +174,7 @@ def check(summary, expected=None) -> str:
          f"unexpected top-level keys: {sorted(summary)}")
     want(summary["schema"] == SCHEMA,
          f"unknown schema: {summary['schema']!r} (expected {SCHEMA!r})")
-    want(summary["kind"] == "synthetic-recovery-and-public-fixture-battery",
+    want(summary["kind"] == "public-recovery-and-public-fixture-battery",
          f"unknown kind: {summary['kind']!r}")
     want(summary["is_certification"] is False,
          "is_certification must be false for this workflow")
@@ -300,8 +300,8 @@ def check(summary, expected=None) -> str:
         want((bat["status"] == "pass") == battery_ok,
              "battery.status disagrees with its return code")
 
-    expected_verdict = ("SYNTHETIC-PASS" if (recovery_ok and battery_ok)
-                        else "SYNTHETIC-FAIL")
+    expected_verdict = ("PUBLIC-BATTERY-PASS" if (recovery_ok and battery_ok)
+                        else "PUBLIC-BATTERY-FAIL")
     want(summary["verdict"] == expected_verdict,
          f"verdict {summary['verdict']!r} disagrees with recomputed {expected_verdict!r}")
     return expected_verdict
@@ -363,8 +363,8 @@ def main(argv: list[str]) -> int:
         return 1
     print(f"summary.json valid against the declared scope; verdict={verdict}")
     print(f"trust model: {TRUST} (not independent execution evidence)")
-    if verdict != "SYNTHETIC-PASS":
-        print("::error::synthetic run did not pass")
+    if verdict != "PUBLIC-BATTERY-PASS":
+        print("::error::public battery run did not pass")
         return 1
     return 0
 

--- a/ci/p022_ec2_run.sh
+++ b/ci/p022_ec2_run.sh
@@ -3,7 +3,7 @@
 #
 # ## What this is
 #
-# A SYNTHETIC job: the recovery matrix plus the replay battery restricted to the
+# A Public battery job: the recovery matrix plus the replay battery restricted to the
 # repository's PUBLIC fixtures. It is not private certification. There is no
 # fixture bucket, the instance role cannot read one, and nothing prod-derived is
 # ever present on this box.
@@ -295,7 +295,7 @@ battery = json.loads((scripts / "certify_battery.json").read_text())
 def resolves(slug):
     # Public fixtures only: real_data/*-<slug>. The .local private tree is
     # deliberately NOT consulted; a stray private directory must not silently
-    # enlarge a synthetic run.
+    # enlarge a public battery run.
     return bool(list(root.glob(f"*-{slug}")))
 
 
@@ -541,7 +541,7 @@ battery_ok = battery_rc == 0
 
 summary = {
     "schema": SCHEMA,
-    "kind": "synthetic-recovery-and-public-fixture-battery",
+    "kind": "public-recovery-and-public-fixture-battery",
     "is_certification": False,
     "trust": "reviewed-recipe-self-reported",
     "ref_sha": sha,
@@ -571,8 +571,8 @@ summary = {
         "skip_reason": "" if battery_rc is not None else "not-run-in-this-job",
         "status": "pass" if battery_ok else ("skipped" if battery_rc is None else "fail"),
     },
-    "verdict": "SYNTHETIC-PASS" if (recovery_ok and battery_rc in (0, None))
-               else "SYNTHETIC-FAIL",
+    "verdict": "PUBLIC-BATTERY-PASS" if (recovery_ok and battery_rc in (0, None))
+               else "PUBLIC-BATTERY-FAIL",
 }
 json.dump(summary, sys.stdout, indent=1, sort_keys=True)
 PY

--- a/ci/p022_ssm.sh
+++ b/ci/p022_ssm.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# P-022 §E — send one command to the disposable synthetic CI worker over SSM and
+# P-022 §E — send one command to the disposable public battery CI worker over SSM and
 # block until it finishes. There is no SSH path to that box: the security group
 # has no inbound rules, the instance has no public IP and the launch template
 # carries no key pair.

--- a/ci/tests/test_public_summary.py
+++ b/ci/tests/test_public_summary.py
@@ -1,0 +1,88 @@
+"""Exercise the worker's real summary writer against the runner's checker."""
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location('summary_checker', ROOT / 'ci/p022_check_summary.py')
+checker = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(checker)
+
+
+class PublicSummaryTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.state = self.root / 'state'
+        self.art = self.root / 'art'
+        self.state.mkdir()
+        for phase, reports, count in [('recovery', 1, 100), ('races', 20, 10)]:
+            folder = self.art / 'junit' / phase
+            folder.mkdir(parents=True)
+            for i in range(reports):
+                (folder / f'{i}.xml').write_text(
+                    f'<testsuite tests="{count}" failures="0" errors="0" skipped="0"/>')
+        for key, value in {'recovery_main_rc': 0, 'recovery_races_rc': 0,
+                           'battery_rc': 0, 'expected_main_reports': 1,
+                           'expected_race_reports': 20}.items():
+            (self.state / key).write_text(str(value))
+        (self.state / 'battery-selection.json').write_text(json.dumps({
+            'selected_count': 6, 'selected': [{'dataset': 'vw'}, {'dataset': 'biodiversity'}],
+            'inventory_digest': 'b' * 64, 'restart_cases': 1, 'missing': []}))
+        self.sha = self.root / 'sha'
+        self.sha.write_text('a' * 40)
+        self.expected = {'sha': 'a' * 40, 'battery_digest': 'b' * 64,
+                         'junit_dir': str(self.art / 'junit')}
+
+    def write_summary(self):
+        shell = (ROOT / 'ci/p022_ec2_run.sh').read_text().split('phase_summary() {', 1)[1]
+        writer = shell.split("<<'PY'\n", 1)[1].split('\nPY\n', 1)[0]
+        # Relocate only the host identity file; execute the actual producer code.
+        writer = writer.replace('pathlib.Path("/var/lib/polis-ci-sha")',
+                                f'pathlib.Path({str(self.sha)!r})')
+        result = subprocess.run([sys.executable, '-', str(ROOT), str(self.root),
+                                 str(self.state), str(self.art)], input=writer,
+                                text=True, capture_output=True, check=True)
+        return json.loads(result.stdout)
+
+    def test_pass_producer_and_checker_agree(self):
+        summary = self.write_summary()
+        self.assertEqual(summary['schema'], 'p022-public-battery/4')
+        self.assertEqual(checker.check(summary, self.expected), 'PUBLIC-BATTERY-PASS')
+
+    def test_failure_producer_and_checker_agree(self):
+        (self.state / 'battery_rc').write_text('1')
+        self.assertEqual(checker.check(self.write_summary(), self.expected), 'PUBLIC-BATTERY-FAIL')
+
+    def test_declared_recovery_only(self):
+        (self.state / 'battery_rc').unlink()
+        self.expected['run_battery'] = False
+        self.assertEqual(checker.check(self.write_summary(), self.expected), 'PUBLIC-BATTERY-PASS')
+
+    def test_rejects_incoherent_names_and_evidence(self):
+        good = self.write_summary()
+        for key, value in [('schema', 'wrong/4'), ('kind', 'wrong-kind'),
+                           ('verdict', 'PASS'), ('ref_sha', 'c' * 40)]:
+            with self.subTest(key=key):
+                bad = copy.deepcopy(good)
+                bad[key] = value
+                with self.assertRaises(checker.Invalid):
+                    checker.check(bad, self.expected)
+        (self.art / 'junit/races/0.xml').unlink()
+        with self.assertRaises(checker.Invalid):
+            checker.check(good, self.expected)
+
+    def test_workflow_and_default_trust_environment_agree(self):
+        workflow = (ROOT / '.github/workflows/certification-ec2.yml').read_text()
+        stack = (ROOT / 'cdk/lib/cdk-stack.ts').read_text()
+        self.assertIn('name: Public battery certification (EC2)\n', workflow)
+        self.assertRegex(workflow, r'(?m)^    environment: certification-public$')
+        self.assertRegex(stack, r"ciEc2GithubEnvironment[\s\S]{0,120}\?\? 'certification-public'")
+        self.assertIn('name: public-battery-ec2-', workflow)

--- a/delphi/polismath/replay/fixture_bundle.py
+++ b/delphi/polismath/replay/fixture_bundle.py
@@ -1314,7 +1314,9 @@ def _admission_block(*, ordering_guarantee: str,
                 "CSV omits them and COUNTS them per role, which makes that export "
                 "non-certifying until an operator records an acceptance",
             "synthetic_substitution_policy":
-                "allowed only with an explicit --accept-public-fixture approval, and "
+                # Historical manifest bytes are pinned, including this old CLI
+                # spelling. The current CLI uses --accept-public-fixture.
+                "allowed only with an explicit --accept-synthetic approval, and "
                 "only when the replacement generator case is MATERIALISED and "
                 "pinned in this manifest; a dir:null substitute is an unfilled "
                 "role",

--- a/delphi/polismath/replay/fixture_bundle.py
+++ b/delphi/polismath/replay/fixture_bundle.py
@@ -1314,7 +1314,7 @@ def _admission_block(*, ordering_guarantee: str,
                 "CSV omits them and COUNTS them per role, which makes that export "
                 "non-certifying until an operator records an acceptance",
             "synthetic_substitution_policy":
-                "allowed only with an explicit --accept-synthetic approval, and "
+                "allowed only with an explicit --accept-public-fixture approval, and "
                 "only when the replacement generator case is MATERIALISED and "
                 "pinned in this manifest; a dir:null substitute is an unfilled "
                 "role",

--- a/delphi/polismath/replay/fixture_extract.py
+++ b/delphi/polismath/replay/fixture_extract.py
@@ -916,7 +916,7 @@ def extract_from_config(
     conn: PgConnection, *, config: dict[str, Any], payload_root: Path, guard_root: Path,
     snapshot_id: str | None = None, writers_disabled: bool = False,
     dir_names: dict[str, str] | None = None,
-    accept_synthetic: Sequence[str] = (),
+    accept_public_fixture: Sequence[str] = (),
     include_generated: bool = True, include_heavy: bool = False,
 ) -> dict[str, Any]:
     """Survey, select and extract every configured role in ONE read-only
@@ -951,7 +951,7 @@ def extract_from_config(
     survey = fs.build_survey(rows, guarantee, snapshot_id=snapshot_id,
                              schema_version_marker=migration_marker)
     coverage = fs.coverage_report(config, rows)
-    selections = fs.resolve_roles(config, rows, accept_synthetic=accept_synthetic)
+    selections = fs.resolve_roles(config, rows, accept_public_fixture=accept_public_fixture)
     tie_key = detect_tie_key(conn)
 
     # A synthetic substitute is not a substitute until it EXISTS. Materialise

--- a/delphi/polismath/replay/fixture_survey.py
+++ b/delphi/polismath/replay/fixture_survey.py
@@ -79,7 +79,7 @@ class RoleUnsatisfied(RuntimeError):
             msg += (
                 f"; the config offers deterministic synthetic case "
                 f"{synthetic_replacement!r} as a replacement, which requires an "
-                "explicit recorded approval (--accept-synthetic)"
+                "explicit recorded approval (--accept-public-fixture)"
             )
         super().__init__(msg)
 
@@ -310,7 +310,7 @@ def rank_candidates(
 
 def resolve_roles(
     config: dict[str, Any], rows: Sequence[dict[str, Any]],
-    accept_synthetic: Iterable[str] = (),
+    accept_public_fixture: Iterable[str] = (),
 ) -> list[Selection]:
     """Resolve every role in ``config`` against the survey ``rows``.
 
@@ -322,14 +322,14 @@ def resolve_roles(
     Raises :class:`RoleUnsatisfied` for the FIRST role with no candidate at its
     rank. There is no fallback, no downgrade and no skip.
 
-    ``accept_synthetic`` names role slugs whose synthetic replacement an
+    ``accept_public_fixture`` names role slugs whose synthetic replacement an
     operator has EXPLICITLY approved. It applies only to roles whose
     ``on_missing`` is ``fail_with_synthetic_replacement_offer``; approving a
     slug that production DID satisfy has no effect, and approving a slug whose
     rule offers no replacement is still a hard failure.
     """
     rows = list(rows)
-    accepted = set(accept_synthetic)
+    accepted = set(accept_public_fixture)
     selections: list[Selection] = []
     taken: dict[int, list[str]] = {}
     reserved: set[int] = set()

--- a/delphi/scripts/certify_datasets.schema.json
+++ b/delphi/scripts/certify_datasets.schema.json
@@ -144,7 +144,7 @@
         },
         "on_missing": {
           "enum": ["fail", "fail_with_synthetic_replacement_offer"],
-          "description": "fail = bundle construction stops naming the missing role. fail_with_synthetic_replacement_offer = stops the same way, but names the deterministic synthetic case an approver may explicitly accept instead. Neither ever silently downgrades."
+          "description": "A missing role stops bundle construction. The replacement-offer mode names the deterministic public fixture an approver may explicitly accept instead. Neither mode silently downgrades."
         },
         "synthetic_replacement": {"type": "string"},
         "exercise": {"type": "string", "minLength": 1},
@@ -189,7 +189,7 @@
         "cohort_size": {
           "type": "integer",
           "minimum": 1,
-          "description": "lru-cohort only: how many sibling synthetic zids the case materialises (set to cache_cap + 1)."
+          "description": "lru-cohort only: how many sibling public fixture zids the case materialises (set to cache_cap + 1)."
         },
         "votes_per_participant": {"type": "integer", "minimum": 0},
         "mod_out_all": {"type": "boolean"},

--- a/delphi/scripts/large_conv_tick_bench.py
+++ b/delphi/scripts/large_conv_tick_bench.py
@@ -41,7 +41,7 @@ DEFAULT_N_VOTES = 2_000_000
 
 def synthesize_votes(n_ptpts: int, n_cmts: int, n_votes: int,
                      seed: int = 42) -> list[dict]:
-    """Deterministic synthetic vote stream shaped like a real large conv.
+    """Deterministic public fixture vote stream shaped like a real large conv.
 
     Every participant votes on ``round(n_votes / n_ptpts)`` distinct random
     comments (so the per-row density matches the target total), with a

--- a/delphi/scripts/prodclone_extract.py
+++ b/delphi/scripts/prodclone_extract.py
@@ -152,8 +152,8 @@ def extract(database_url: str, zid: int, feature: str, out_root: Path | None) ->
 @click.option("--reuse-dirs", type=click.Path(path_type=Path), default=None,
               help="A previous manifest (or dir_names JSON) whose opaque directory "
                    "assignment is reused, for a byte-comparable repeat extraction.")
-@click.option("--accept-synthetic", multiple=True,
-              help="Role slug whose deterministic synthetic replacement is EXPLICITLY "
+@click.option("--accept-public-fixture", multiple=True,
+              help="Role slug whose deterministic public fixture replacement is EXPLICITLY "
                    "approved because production supplied no candidate. Repeatable.")
 @click.option("--no-generated", is_flag=True, default=False,
               help="Skip the generated boundary cases (production roles only).")
@@ -161,7 +161,7 @@ def extract(database_url: str, zid: int, feature: str, out_root: Path | None) ->
               help="Materialise the heavy generated scale control as well.")
 def from_config(database_url: str, config_path: Path | None, out_dir: Path,
                 snapshot_id: str | None, writers_disabled: bool,
-                reuse_dirs: Path | None, accept_synthetic: tuple[str, ...],
+                reuse_dirs: Path | None, accept_public_fixture: tuple[str, ...],
                 no_generated: bool, include_heavy: bool) -> None:
     """Survey, select and extract EVERY configured role in one repeatable-read
     transaction, into opaque fixture directories under OUT.
@@ -195,7 +195,7 @@ def from_config(database_url: str, config_path: Path | None, out_dir: Path,
             conn, config=config, payload_root=payload_root, guard_root=guard_root,
             snapshot_id=snapshot_id,
             writers_disabled=writers_disabled, dir_names=dir_names,
-            accept_synthetic=accept_synthetic,
+            accept_public_fixture=accept_public_fixture,
             include_generated=not no_generated, include_heavy=include_heavy,
         )
     except fs.RoleUnsatisfied as exc:

--- a/delphi/scripts/projection_gate.py
+++ b/delphi/scripts/projection_gate.py
@@ -927,7 +927,7 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
                    help="same-cluster read pool profile (still requires an equal system identifier)")
     p.add_argument("--expected-system-identifier", default=None,
                    help="bound profile: both primary and replica must report this pg_control_system() id")
-    p.add_argument("--zid", type=int, required=True, help="conversation id to project (synthetic in tests)")
+    p.add_argument("--zid", type=int, required=True, help="conversation id to project (public fixture in tests)")
     p.add_argument("--pid", type=int, default=None)
     p.add_argument("--tid", type=int, default=None)
     p.add_argument("--site", choices=list(SITES) + ["all"], default="all")

--- a/delphi/tests/poller/recovery/test_r01_stage_failures.py
+++ b/delphi/tests/poller/recovery/test_r01_stage_failures.py
@@ -24,6 +24,7 @@ Postgres failures, not Python stand-ins:
 Final state is checked against the INDEPENDENT fold in ``fold.py``.
 """
 
+from contextlib import contextmanager
 import threading
 
 import pytest
@@ -195,61 +196,63 @@ def test_real_connection_loss_recovers(engine, pg_url, recovery_postgres_url,
     idle killed connection without any failure ever reaching the retry path
     (review finding 5).  So instead:
 
-    1. open a real transaction on the POLLER's own engine and latch its
+    1. use the writer's supplied publication transaction and latch its
        ``pg_backend_pid()``;
     2. run the real ``math_bidtopid`` upsert inside it (uncommitted);
     3. from a SECOND connection, ``pg_terminate_backend`` exactly that pid, and
        assert Postgres says it killed it;
-    4. assert the COMMIT fails with a real connection-loss SQLSTATE, and that
-       the failure propagated to the service (which retried the stage);
+    4. assert a later statement or COMMIT fails with a real connection-loss
+       error that propagates to the service (which retries the stage);
     5. then require quiet recovery against the independent fold.
     """
     seed_conversation(engine, zid=1, n_ptpts=6, n_cmts=4)
     svc = make_service(pg_url, math_env=MATH_ENV, retry_cap=3)
 
     original = svc._pg._write_returning
+    original_transaction = svc._pg.transaction
     state = {"bidtopid_calls": 0, "killed_pid": None, "terminated": None,
-             "error": None, "pgcode": None}
+             "error": None, "pgcode": None, "retry_pid": None}
 
-    def kill_the_active_backend(sql, params=None):
-        if "math_bidtopid" not in sql:
-            return original(sql, params)
-        state["bidtopid_calls"] += 1
-        if state["bidtopid_calls"] > 1:      # the retry: let it through
-            return original(sql, params)
-
-        conn = svc._pg.engine.connect()
+    @contextmanager
+    def observe_transaction():
+        # Observe the real writer's statement/COMMIT failure and re-raise it
+        # unchanged, so the service must handle it through its normal retry.
         try:
-            trans = conn.begin()
-            state["killed_pid"] = conn.execute(
-                sa.text("select pg_backend_pid()")).scalar()
-            # The REAL upsert, in a REAL open transaction on the poller's own
-            # engine — not a raised stand-in.
-            conn.execute(sa.text(sql), params or {})
-            state["terminated"] = terminate_backend_pid(
-                recovery_postgres_url, state["killed_pid"])
-            try:
-                trans.commit()
-            except sa.exc.DBAPIError as exc:
-                state["error"] = exc
-                state["pgcode"] = getattr(exc.orig, "pgcode", None)
-                raise
-            raise AssertionError(
-                "the terminated backend committed anyway; this test would be "
-                "vacuous"
-            )
-        finally:
-            try:
-                conn.close()
-            except Exception:  # pragma: no cover - the backend is gone
-                pass
+            with original_transaction() as connection:
+                yield connection
+        except sa.exc.DBAPIError as exc:
+            state["error"] = exc
+            state["pgcode"] = getattr(exc.orig, "pgcode", None)
+            raise
 
+    def kill_the_active_backend(sql, params=None, *, connection=None):
+        if "math_bidtopid" not in sql:
+            return original(sql, params, connection=connection)
+        state["bidtopid_calls"] += 1
+        assert connection is not None and connection.in_transaction(), (
+            "the kill witness must use the writer's active publication transaction"
+        )
+        pid = connection.execute(sa.text("select pg_backend_pid()")).scalar_one()
+        assert isinstance(pid, int) and pid > 0
+        result = original(sql, params, connection=connection)
+        if state["bidtopid_calls"] == 1:
+            # The real bidtopid upsert has run but is still uncommitted. Kill
+            # this exact transaction; never create/commit a side transaction.
+            state["killed_pid"] = pid
+            state["terminated"] = terminate_backend_pid(recovery_postgres_url, pid)
+        else:
+            state["retry_pid"] = pid
+        return result
+
+    svc._pg.transaction = observe_transaction
     svc._pg._write_returning = kill_the_active_backend
     try:
         svc.poll_once()
     finally:
         svc._pg._write_returning = original
+        svc._pg.transaction = original_transaction
 
+    assert state["bidtopid_calls"] > 0, "the active-write hook was never reached"
     assert state["terminated"] is True, (
         f"pg_terminate_backend({state['killed_pid']}) did not report a kill; "
         "no connection was actually lost"
@@ -272,6 +275,9 @@ def test_real_connection_loss_recovers(engine, pg_url, recovery_postgres_url,
         "the connection failure never reached the service's retry path: the "
         f"bidtopid stage was attempted {state['bidtopid_calls']} time(s)"
     )
+    assert state["retry_pid"] != state["killed_pid"], (
+        "the retry must publish through a new backend after the connection loss"
+    )
 
     _publish_and_check(engine, svc, zid=1)
 
@@ -292,24 +298,26 @@ def test_terminating_an_idle_backend_is_not_evidence_of_a_failed_write(
     seen = {"errors": 0, "attempts": 0}
     original = svc._pg._write_returning
 
-    def counting(sql, params=None):
+    def counting(sql, params=None, *, connection=None):
         seen["attempts"] += 1
         try:
-            return original(sql, params)
+            return original(sql, params, connection=connection)
         except Exception:
             seen["errors"] += 1
             raise
 
     svc._pg._write_returning = counting
-    killed = terminate_backends(recovery_postgres_url, dbname_of(pg_url))
-    assert killed >= 1, "the control needs at least one backend to kill"
+    try:
+        killed = terminate_backends(recovery_postgres_url, dbname_of(pg_url))
+        assert killed >= 1, "the control needs at least one backend to kill"
 
-    from .conftest import commit_vote
-    events = read_vote_events(engine, 1)
-    commit_vote(engine, 1, 0, 0, 1, max(e["created"] for e in events) + 1000)
-    svc._vote_wm = 0
-    svc.poll_once()
-    svc._pg._write_returning = original
+        from .conftest import commit_vote
+        events = read_vote_events(engine, 1)
+        commit_vote(engine, 1, 0, 0, 1, max(e["created"] for e in events) + 1000)
+        svc._vote_wm = 0
+        svc.poll_once()
+    finally:
+        svc._pg._write_returning = original
 
     assert seen["attempts"] > 0
     assert seen["errors"] == 0, (

--- a/delphi/tests/test_certify_bundle.py
+++ b/delphi/tests/test_certify_bundle.py
@@ -1487,7 +1487,7 @@ def _dense_only_config(config):
 @pytest.mark.parametrize("include_generated", [True, False])
 def test_a_synthetic_substitute_is_materialised_and_pinned(
         config, tmp_path, monkeypatch, include_generated):
-    """``--accept-synthetic`` is an approval, not a fulfilment.
+    """``--accept-public-fixture`` is an approval, not a fulfilment.
 
     The substitute's generator case is force-materialised even when generation
     is otherwise switched off, its directory is pinned into the role entry so
@@ -1513,7 +1513,7 @@ def test_a_synthetic_substitute_is_materialised_and_pinned(
     payload.mkdir(parents=True)
     result = fx.extract_from_config(
         object(), config=cfg, payload_root=payload, guard_root=tmp_path,
-        accept_synthetic=["pc-v1-dense", "pc-v1-dense-max"],
+        accept_public_fixture=["pc-v1-dense", "pc-v1-dense-max"],
         include_generated=include_generated)
 
     assert result["provenance_rows"] == [], "a substitute has no zid to record"

--- a/delphi/tests/test_certify_fixture_config.py
+++ b/delphi/tests/test_certify_fixture_config.py
@@ -362,13 +362,13 @@ def test_missing_role_fails_loudly_and_names_the_role():
         fs.resolve_roles(_MINI_CONFIG, rows)
     assert exc.value.role == "impossible"
     assert exc.value.synthetic_replacement == "gen-v1-dense-stress"
-    assert "--accept-synthetic" in str(exc.value)
+    assert "--accept-public-fixture" in str(exc.value)
 
 
 def test_synthetic_replacement_requires_explicit_acceptance():
     rows = [_row(11, V=500), _row(12, V=400)]
     sels = fs.resolve_roles(_MINI_CONFIG, rows,
-                            accept_synthetic=["pc-v1-impossible"])
+                            accept_public_fixture=["pc-v1-impossible"])
     sub = next(s for s in sels if s.slug == "pc-v1-impossible")
     assert sub.zid is None
     assert sub.synthetic_replacement == "gen-v1-dense-stress"

--- a/delphi/tests/test_public_fixture_cli.py
+++ b/delphi/tests/test_public_fixture_cli.py
@@ -1,0 +1,11 @@
+"""The public-fixture approval option remains discoverable and repeatable."""
+from click.testing import CliRunner
+from scripts.prodclone_extract import cli, from_config
+
+
+def test_public_fixture_approval_option():
+    result = CliRunner().invoke(cli, ['from-config', '--help'])
+    assert result.exit_code == 0, result.output
+    assert '--accept-public-fixture' in result.output
+    option = next(p for p in from_config.params if p.name == 'accept_public_fixture')
+    assert option.multiple

--- a/docs/ci-ec2.md
+++ b/docs/ci-ec2.md
@@ -1,8 +1,8 @@
-# Synthetic recovery CI on a disposable EC2 worker
+# Public battery recovery CI on a disposable EC2 worker
 
 > **This is not private certification.** It runs the P-022 §C recovery matrix
 > and the replay battery restricted to the repository's **public** fixtures
-> (`vw`, `biodiversity`), and its verdict is `SYNTHETIC-PASS` precisely so it
+> (`vw`, `biodiversity`), and its verdict is `PUBLIC-BATTERY-PASS` precisely so it
 > cannot be mistaken for a release certificate. Private certification — the
 > prod-derived fixture bundle, a baked trusted AMI, an isolated account and VPC,
 > and a signed summary GitHub reads but cannot influence — is specified in
@@ -62,7 +62,7 @@ npx cdk synth -c enableCiEc2=true
 | `ciEc2VolumeGiB` | `200` | Encrypted gp3 root volume. |
 | `ciEc2ShutdownMinutes` | `480` | Hard-deadline self-termination (see "Cost backstops"). |
 | `ciEc2GithubRepo` | `compdemocracy/polis` | Repository allowed to assume the OIDC role. |
-| `ciEc2GithubEnvironment` | `certification-synthetic` | Must equal the workflow job's `environment:`. The trust policy admits this subject and no other. |
+| `ciEc2GithubEnvironment` | `certification-public` | Must equal the workflow job's `environment:`. The trust policy admits this subject and no other. |
 | `ciEc2Refs` | `refs/heads/edge,refs/heads/stable` | Exact `ref` claim values. This is what excludes pull-request jobs at the token. Empty or non-branch entries are refused at synth. |
 | `ciEc2AllowedInstanceTypes` | `r8g.4xlarge,r8g.2xlarge` | Enforced in IAM via `ec2:InstanceType`, so a dispatch input cannot select arbitrary spend. |
 | `ciEc2SweeperMaxAgeMinutes` | `ciEc2ShutdownMinutes + 60` | Age past which the independent sweeper kills a CI instance. Must exceed the OS deadline. |
@@ -91,7 +91,7 @@ path at all.
 
 ### The environment is a control you must configure, not a name
 
-Create the `certification-synthetic` environment **before** the first run, with:
+Create the `certification-public` environment **before** the first run, with:
 
 - **Deployment branches and tags** limited to `edge` and `stable` (the trust
   policy's `ref` allowlist admits both; keep the two in step),
@@ -118,7 +118,7 @@ Be precise about what excludes them, because the trust policy alone does not:
 trusted default-branch code and can carry an allowed base-branch ref, and
 neither the repository claim nor the environment-form subject distinguishes it —
 so any *other* trusted workflow in this repository that references
-`certification-synthetic` could match this trust policy. Nothing in the role
+`certification-public` could match this trust policy. Nothing in the role
 prevents that; reviewing what may use the environment does. If strict
 per-workflow isolation is ever required, the answer is a dedicated reviewed
 reusable-workflow boundary (whose token then really does carry
@@ -225,7 +225,7 @@ Three, layered, because each covers a failure the others do not:
 
 ## Running it manually
 
-Actions → **Synthetic recovery and public-fixture battery (EC2)** → Run
+Actions → **Public battery certification (EC2)** → Run
 workflow. Inputs:
 
 | Input | Default | Notes |
@@ -245,14 +245,14 @@ The summary is produced by the same recipe that ran the tests, so it is
 coherent, complete and matches the run's declared scope — it does not and cannot
 establish that the tests really ran. The artifact says so itself:
 `trust: reviewed-recipe-self-reported`. That is the trust appropriate to a
-synthetic smoke over public fixtures; an adversarial certificate needs the
+public battery smoke over public fixtures; an adversarial certificate needs the
 independent control boundary in `P-022-E-ci-spec.md`, which is not built.
 
 ### What comes back, and what does not
 
 A run with the battery enabled uploads **two** artifacts.
 
-`synthetic-ec2-<run>-<attempt>` (7 days) is the evidence bundle: a fixed-schema
+`public-battery-ec2-<run>-<attempt>` (7 days) is the evidence bundle: a fixed-schema
 `summary.json`, pytest's JUnit XML and the battery's dataset selection. It does
 **not** contain any log. The worker prints only lines matching
 

--- a/server/characterization/README.md
+++ b/server/characterization/README.md
@@ -24,7 +24,7 @@ The plan test pins the governing notes plan and also compares its current file w
 available; set P027_NOTES_ROOT to require that external-checkout comparison explicitly.
 
 The 336 PCA2 requests cover 112 cells with three independent fixtures each,
-using 60 conversations and 4,450 synthetic votes. They add no DB, filesystem,
+using 60 conversations and 4,450 public fixture votes. They add no DB, filesystem,
 JWT-issuance or provider effects. Populated data comes from 36 real Python-engine
 conversations (72 writer publications); 12 are scoped only to a different math_env.
 The original three temporary generator workarounds remain: P-029/r11 invalid UUID,
@@ -98,8 +98,8 @@ held-out fixture. The `pca2` profile generates exactly this slice, so it can be
 recorded and replayed independently while retaining strict required-inventory
 admission. Global coverage gaps remain visible for that scoped profile.
 
-`pca2-fixtures.json` declares 60 independent synthetic conversations. Each has
-its own seeded votes and distinct input hash. Synthetic user site IDs are explicit;
+`pca2-fixtures.json` declares 60 independent public fixture conversations. Each has
+its own seeded votes and distinct input hash. Public fixture user site IDs are explicit;
 the random database default is never used by this seed. `seed-pca2.py` reads the SQL votes
 and moderation, runs the actual Python Conversation engine, and uses MathWriter
 for two publications (ticks 0 then 1). There are 36 populated conversations,
@@ -232,7 +232,7 @@ precondition, explicitly repins test-only semantic mutants, and requires a named
 case/field difference. Integrity mutations separately delete or alter each required
 artifact. `corrections.test.cjs` covers JWT corruption/wrong binding/extra issuance,
 delayed work, blocked attempts and the actual PCA serializer's C7 failure class.
-The original small synthetic differ examples are labelled unit examples, not
+The original small public fixture differ examples are labelled unit examples, not
 recorded migration gates. The historical eight live controls comprise six failure
 detectors and two successful egress-block assertions.
 
@@ -274,7 +274,7 @@ and appends them, for 1,265 requests. Both profiles use checked inventory admiss
 actors, but each cell uses three different conversations, owners and input digests
 (two derivation, one held out). Empty conversations intentionally have no votes.
 Three owner credentials are distinct; the separate site-sharing moderator is uid
-200004, foreign owner uid 4, and global admin uid 2. They are synthetic SQL
+200004, foreign owner uid 4, and global admin uid 2. They are public fixture SQL
 identities mapped to real local OIDC simulator tokens. Bound participant JWTs
 exercise pid zero and nonzero in separate cells. An expired token is locally
 signed, signature/binding-verified at its historical clock, and then sent expired;


### PR DESCRIPTION
Rename only; behaviour unchanged. Stacked on #2765 (the toolchain fix), so merge that first.

- Workflow: **Public battery certification (EC2)**; job, step, and artifact names follow.
- Verdict strings: `PUBLIC-BATTERY-PASS` / `PUBLIC-BATTERY-FAIL`, with the shared schema and `kind` renamed consistently and emitted provenance preserved.
- GitHub environment: `certification-public`, in the workflow and in the CDK OIDC trust policy's environment claim.
- Docs, prose, and the repeatable `--accept-public-fixture` flag.

70 occurrences in 18 tracked files → 20 protected occurrences in 8 files, all inside listed exceptions: bytes pinned by a recorded archive, a digest, or a resource identity (the security-group description would force a replacement). Those are listed for a later re-record. 58 pinned/archive/fixture files unchanged.

**Tests.** CI summary/bootstrap 15/15; fixture/bundle/CLI/projection inventory 229/229; CDK 56/56; characterization Python 17/17; Node 80 passed with the two known pre-C7 base failures that #2757 replaces. `cdk synth`: flag off 127→127 byte-identical; flag on, exactly three description strings plus the trust-policy environment string.

**After merge, operator steps:** CDK redeploy with `-c enableCiEc2=true` (trust policy string), create the `certification-public` environment with the same reviewer and branch policy, then retire `certification-synthetic`. Workflow file: browser merge. Merge after the current battery run completes so the running workflow's environment is not changed underneath it.

Written by the second reviewer; reviewed by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s