### PR TITLE
ci(certification): launch the disposable worker from the latest launch-template version

### DIFF
--- a/.github/workflows/certification-ec2.yml
+++ b/.github/workflows/certification-ec2.yml
@@ -181,11 +181,13 @@ jobs:
           # The run tag goes on the volume as well as the instance: an orphan
           # volume with no owner is as hard to reconcile as an orphan instance.
           VOLTAGS="ResourceType=volume,Tags=[{Key=polis:ci,Value=disposable},{Key=polis:ci-run,Value=$RUN_TAG}]"
-          # Version=1 is pinned here; note that this is a caller choice, not an
-          # IAM restriction -- the role could select another version of the same
-          # template if one ever existed. Only the CDK deploy creates versions.
+          # $Latest: every CDK deploy of the construct creates a new launch-template
+          # version (user data, packages) and does not move the default, so a
+          # fixed version number would boot stale user data forever. This is a
+          # caller choice, not an IAM restriction. Only the CDK deploy creates
+          # versions, so $Latest is always the last deployed one.
           INSTANCE_ID=$(aws ec2 run-instances \
-            --launch-template "LaunchTemplateId=${LAUNCH_TEMPLATE_ID},Version=1" \
+            --launch-template "LaunchTemplateId=${LAUNCH_TEMPLATE_ID},Version=\$Latest" \
             --instance-type "$INSTANCE_TYPE" \
             --count 1 \
             --client-token "$TOKEN" \


### PR DESCRIPTION
Attempts three and four of the disposable certification worker (runs 34425826458, 34427627513) failed with the identical bootstrap error even though the fixes were deployed. Cause: the workflow pinned `Version=1` of the launch template, and each CDK deploy created a new version (now 1, 2, 3) without moving the default, so the box kept booting the original user data. Confirmed from `describe-launch-template-versions` and from the returned bootstrap log, which shows no toolchain install.

One-line fix: `Version=$Latest`. Only the CDK deploy creates versions, so it is always the last deployed one. No redeploy needed: version 3 already carries the arm64 package fix and the C toolchain.

Workflow file: browser merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s