### PR TITLE
ci(characterization): dispatchable corpus re-record job with accounting

### DIFF
--- a/.github/workflows/characterization-rerecord.yml
+++ b/.github/workflows/characterization-rerecord.yml
@@ -1,0 +1,100 @@
+name: Characterization corpus re-record
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Target commit or ref (empty uses the immutable dispatch SHA)
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: characterization-rerecord-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  record:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    env:
+      COMPOSE_PROJECT_NAME: p027-rerecord-${{ github.run_id }}-${{ github.run_attempt }}
+      P027_PORT_MIN: '55930'
+      P027_PORT_MAX: '55939'
+      POLIS_RECOVERY_PG_PORT: '55930'
+      RECOVERY_PG_PORT: '55930'
+      P027_HTTP_PORT: '55931'
+      P027_CONTROL_PORT: '55932'
+    steps:
+      # Keep the job/accounting code from the dispatch separately from the target.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.sha }}
+          path: control
+          persist-credentials: false
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ inputs.target || github.sha }}
+          path: target
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '22'
+      - name: Install accounting dependencies and linters
+        working-directory: target
+        run: |
+          npm ci --prefix server --ignore-scripts
+          sudo apt-get update
+          sudo apt-get install -y shellcheck yamllint
+      - name: Validate the dispatch tools
+        working-directory: control
+        env:
+          P027_ACCOUNTING_REPO: ${{ github.workspace }}/target
+        run: |
+          shellcheck ci/p027_rerecord.sh ci/p027_rerecord_build.sh
+          yamllint -d '{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}}' .github/workflows/characterization-rerecord.yml
+          node --test server/characterization/rerecord-accounting.test.cjs
+      - name: Record, account, fresh replay, controls and repack
+        working-directory: target
+        run: bash ../control/ci/p027_rerecord.sh
+      - name: Remove only this job's stack
+        if: always()
+        working-directory: target
+        run: python3 server/characterization/run.py down
+      - name: Show review summary
+        if: always()
+        working-directory: target
+        run: |
+          python3 - <<'PYCODE'
+          import json, os
+          from pathlib import Path
+          root = Path('server/characterization/artifacts/rerecord-job')
+          summary = root / 'summary.json'
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as out:
+              if summary.exists():
+                  out.write('```json\n' + summary.read_text() + '```\n')
+              else:
+                  out.write('No eligible candidate summary; inspect the stage logs in the artifact.\n')
+              stages = {p.stem: int(p.read_text()) for p in root.glob('*.exit')}
+              out.write('Stage exit codes: `' + json.dumps(stages, sort_keys=True) + '`\n')
+          PYCODE
+      - name: Upload candidate and review evidence (including failed runs)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: characterization-rerecord-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            target/server/characterization/artifacts/rerecord-job/*.json
+            target/server/characterization/artifacts/rerecord-job/*.jsonl
+            target/server/characterization/artifacts/rerecord-job/*.log
+            target/server/characterization/artifacts/rerecord-job/*.exit
+            target/server/characterization/artifacts/rerecord-job/baseline.json.gz
+            target/server/characterization/artifacts/rerecord-job/baseline.sha256
+            target/server/characterization/artifacts/rerecord-job/previous.json.gz
+            target/server/characterization/artifacts/rerecord-job/previous.sha256
+          retention-days: 14
+          if-no-files-found: error

--- a/ci/p027_rerecord.sh
+++ b/ci/p027_rerecord.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Invoked from the immutable target checkout. The driver may come from another ref.
+set -euo pipefail
+control_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+target_root=$(pwd)
+harness=server/characterization
+out=$harness/artifacts/rerecord-job
+: "${COMPOSE_PROJECT_NAME:?set a unique p027 project}"
+: "${POLIS_RECOVERY_PG_PORT:?set the isolated port window}"
+export BUILDX_CONFIG=${BUILDX_CONFIG:-${TMPDIR:-/tmp}/$COMPOSE_PROJECT_NAME-buildx}
+export P027_NEGATIVE_CONTROLS=0 P027_MARKERS=1
+unset P027_ONLY P027_PARITY_ONLY P027_RECORDING P027_STOP_ON_DIFF
+if [[ -e "$out" ]]; then
+  echo 'Refusing to reuse an existing job output directory' >&2
+  exit 1
+fi
+for directory in recording rerecord-fresh rerecord-fresh-replay; do
+  if [[ -e "$harness/artifacts/$directory" ]]; then
+    echo "Refusing stale recording/replay directory: $directory" >&2
+    exit 1
+  fi
+done
+mkdir -p "$out"
+cp "$harness/artifacts/baseline.json.gz" "$out/previous.json.gz"
+cp "$harness/artifacts/baseline.sha256" "$out/previous.sha256"
+# Local and workflow teardown both go through the same ownership guard.
+cleanup() {
+  local rc=$?
+  python3 "$harness/run.py" down >"$out/cleanup.log" 2>&1 || rc=1
+  cp "$out/previous.json.gz" "$harness/artifacts/baseline.json.gz"
+  cp "$out/previous.sha256" "$harness/artifacts/baseline.sha256"
+  exit "$rc"
+}
+trap cleanup EXIT
+stage() {
+  local label=$1 rc=0
+  shift
+  "$@" >"$out/$label.log" 2>&1 || rc=$?
+  printf '%s\n' "$rc" >"$out/$label.exit"
+  tail -n 8 "$out/$label.log"
+  return "$rc"
+}
+if [[ ${1:-} != --reuse-images ]]; then
+  # Fixed historical image names are safe only on an ephemeral hosted runner.
+  [[ ${GITHUB_ACTIONS:-} == true && ${RUNNER_ENVIRONMENT:-} == github-hosted ]]
+  stage build bash "$control_root/ci/p027_rerecord_build.sh"
+fi
+node "$harness/baseline.cjs" "$out/previous"
+# A failed/partial record is diagnostic only; do not pack it as a candidate.
+stage record python3 "$harness/run.py" record recording round6
+stage accounting node "$control_root/server/characterization/rerecord-accounting.cjs" \
+  "$target_root" "$out/previous" "$harness/artifacts/recording" "$out/accounting.json"
+stage pack node "$harness/baseline.cjs" pack "$harness/artifacts/recording"
+cp "$harness/artifacts/baseline.json.gz" "$out/baseline.json.gz"
+cp "$harness/artifacts/baseline.sha256" "$out/baseline.sha256"
+# Exact round trip of the candidate, independently of the baseline unit suite.
+node "$harness/baseline.cjs" "$out/repacked"
+node - "$target_root" "$out" <<'JS'
+const fs = require('node:fs'), path = require('node:path');
+const [root, out] = process.argv.slice(2);
+const {pack} = require(path.join(root, 'server/characterization/baseline.cjs'));
+const digest = pack(path.join(out, 'repacked'), path.join(out, 'repacked.json.gz'));
+if (digest !== fs.readFileSync(path.join(out, 'baseline.sha256'), 'utf8').trim()) throw Error('non-deterministic repack');
+fs.writeFileSync(path.join(out, 'repack.json'), JSON.stringify({sha256: digest, identical: true}) + '\n');
+JS
+stage record-down python3 "$harness/run.py" down
+failed=0
+# Preserve any replay differences (including r19/r20) and still run the controls.
+stage replay python3 "$harness/run.py" replay rerecord-fresh round6 || failed=1
+if [[ -f "$harness/artifacts/rerecord-fresh-replay/results.json" ]]; then
+  cp "$harness/artifacts/rerecord-fresh-replay/results.json" "$out/replay-results.json"
+  cp "$harness/artifacts/rerecord-fresh-replay/comparisons.actual.jsonl" "$out/replay-comparisons.jsonl"
+fi
+cp "$harness/artifacts/recording/results.json" "$out/record-results.json"
+stage node-tests python3 "$harness/run.py" test || failed=1
+stage python-tests python3 -m unittest discover -s "$harness" -p 'test_*.py' || failed=1
+stage negative python3 "$harness/negative.py" || failed=1
+if [[ -f "$harness/artifacts/negative-controls.json" ]]; then
+  cp "$harness/artifacts/negative-controls.json" "$out/negative-controls.json"
+fi
+node - "$out" "$failed" <<'JS'
+const fs = require('node:fs'), path = require('node:path');
+const [out, failed] = process.argv.slice(2);
+const a = JSON.parse(fs.readFileSync(path.join(out, 'accounting.json')));
+const checks = Object.fromEntries(['record','accounting','pack','record-down','replay','node-tests','python-tests','negative'].map(k =>
+  [k, Number(fs.readFileSync(path.join(out, k + '.exit'), 'utf8'))]));
+const readJson = name => JSON.parse(fs.readFileSync(path.join(out, name + '.json')));
+const record = readJson('record-results'), replay = readJson('replay-results');
+const controls = readJson('negative-controls');
+const expectedControls = ['response','effect','remove-route','hang-route','error-route','exit-route','real-email-loop','unobserved-network-egress'];
+const evidencePass = record.cases > 0 && record.failures === 0 &&
+  record.cases === a.counts.unchanged + a.counts.changed + a.counts.added &&
+  replay.cases === record.cases && replay.failures === 0 && replay.differences === 0 &&
+  replay.coverage.missing === 0 && controls.length === expectedControls.length &&
+  controls.every((c,i) => c.control === expectedControls[i] && c.exit === (i < 6 ? 1 : 0));
+const result = {target: a.target, base: a.base, record: {cases: record.cases, failures: record.failures},
+  replay: {cases: replay.cases, failures: replay.failures, differences: replay.differences},
+  negativeControls: controls.length, evidencePass, archiveSha256: fs.readFileSync(path.join(out,'baseline.sha256'),'utf8').trim(),
+  counts: a.counts, checks, reviewEligible: a.reviewEligible && failed === '0' && evidencePass, autoMerge: false};
+fs.writeFileSync(path.join(out, 'summary.json'), JSON.stringify(result,null,2)+'\n');
+console.log(JSON.stringify(result));
+if (!result.reviewEligible) process.exitCode = 1;
+JS

--- a/ci/p027_rerecord_build.sh
+++ b/ci/p027_rerecord_build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Fresh-machine builds for the sealed p027 stack. Never start the general test stack.
+set -euo pipefail
+[[ ${GITHUB_ACTIONS:-} == true && ${RUNNER_ENVIRONMENT:-} == github-hosted ]]
+export DOCKER_BUILDKIT=1
+# Sequential builds bound peak memory; inspect disk receipts when sizing the runner.
+df -h .
+docker build --target prod --build-arg NODE_ENV=production -t p027-server -f server/Dockerfile server
+docker build -t p027-postgres -f server/Dockerfile-db server
+docker build -t p027-oidc-simulator oidc-simulator
+docker build -t p027-file-server --build-arg NODE_ENV=production \
+  --build-arg AUTH_AUDIENCE=users --build-arg AUTH_CLIENT_ID=dev-client-id \
+  --build-arg AUTH_ISSUER=https://localhost:3000/ --build-arg AUTH_NAMESPACE=https://pol.is/ \
+  --build-arg EMBED_SERVICE_HOSTNAME=localhost --build-arg GIT_HASH=characterization \
+  -f file-server/Dockerfile .
+docker build --target final --build-arg USE_CPU_TORCH=true -t p011-delphi-test:latest delphi
+docker pull amazon/dynamodb-local:latest
+docker image inspect p027-server p027-postgres p027-oidc-simulator p027-file-server \
+  p011-delphi-test:latest amazon/dynamodb-local:latest --format '{{.Id}} {{.Size}}'
+df -h .

--- a/server/characterization/README.md
+++ b/server/characterization/README.md
@@ -322,3 +322,74 @@ The six-file Node command remains the runner/README source of truth; round 6 add
 two comments tests within the existing pca2.test.cjs file. The round-5 maintenance
 alone passed 80/80 before this expansion. Host audit commands require the existing
 server Node dependencies (or run their equivalents inside the sealed driver).
+
+## Dispatchable corpus re-record
+
+The **Characterization corpus re-record** Actions workflow accepts `target`, a
+commit or ref in this repository. Empty means the immutable SHA of the dispatching
+ref. The workflow must first be present on the default branch for dispatch to be
+available. It keeps its dispatch tools separate from the resolved target checkout,
+uses read-only repository permissions, and persists no checkout credentials.
+It does not create or merge a PR.
+
+The job builds the test images explicitly on an ephemeral `ubuntu-24.04` runner,
+including the CPU Delphi `final` image used only by `math-seed`. It builds the
+repository's Postgres, server, file-server and OIDC images, then starts the existing
+six-service internal-network topology. Build-time package downloads precede sealed
+execution. No EC2 worker, production data, provider job or cloud credentials are
+needed. Sequential builds limit peak resource use; the build log records image
+sizes and available disk. The public runner has 4 CPUs, 16 GB RAM and 14 GB SSD
+([GitHub runner reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)).
+A hosted cold-build capacity measurement is still required; local image reuse is
+not evidence that the whole build fits that disk budget.
+
+`ci/p027_rerecord.sh` runs the complete `round6` profile, verifies and retains the
+committed archive, and writes `artifacts/rerecord-job/`. It records, computes the
+offline old/new accounting, packs the candidate, verifies an exact unpack/repack,
+destroys the owned stack, then replays the candidate on a fresh stack. Node and
+Python characterization tests and all eight live negative controls follow even
+when replay reports differences. r19/r20 remain exact-order-sensitive: either
+residual makes the job red. No difference is waived by this automation.
+
+The upload retains the old/new archives and SHA files, accounting, replay results
+and comparisons, repack receipt, per-stage logs/exit codes and final summary for
+14 days, including failed runs. Ordinary failures stop before packing a partial
+recording. Teardown runs on failure/cancellation, only for the unique `p027` project.
+The script restores the original tracked archive and SHA file on exit; the new
+candidate lives only in the artifact. Reviewers apply its two candidate files
+explicitly after reviewing the evidence.
+
+`rerecord-accounting.cjs` reads both P-025 recordings with integrity and inventory
+admission (the historical reader is loaded from its recorded commit, preserving
+its own required inventory). Cases are keyed by identity, with independent
+unchanged/changed/added/removed counts, serial-order and exact request-artifact
+checks. The served comparator is `compare.cjs::firstDifference`; checker changes
+are reported and prevent automatic eligibility. Shared-file hashes remain visible.
+The archive's source commit must be an ancestor of the target HEAD.
+
+The census preserves registration/verb identities, ordered callbacks and global
+middleware. A changed callback is attributed only when both runtime hashes match
+one named function in the old and new TypeScript output. Its parent/commit hash
+transitions are listed from Git history, without executing historical application
+code. Anonymous/dependency wrappers, ambiguous function identities and unavailable
+history remain explicitly unattributed. Commit subjects alone never justify a
+fingerprint. `reviewEligible` requires unchanged cases and requests, unchanged
+route structure/middleware/runtime, attributed callback changes, unchanged
+checkers and shared fixtures/schema, and all live checks passing. New fixtures or
+schema still produce an artifact for review; their presence makes the job red. It is a review convenience, not API migration admission.
+
+For a local check with already reviewed images, use fresh ports/project per the
+isolation section and `bash ci/p027_rerecord.sh --reuse-images`. The optional
+`P027_POSTGRES_IMAGE` selects a uniquely named local test image without retagging
+another agent's shared image. The fresh-image builder deliberately refuses to run
+outside an ephemeral GitHub-hosted runner because its historical tags are shared.
+Do not reuse an existing `rerecord-job` directory.
+
+The former recording catalog described 423 columns and no `polis_queue` tables.
+A fresh database with migration `000019` exposed 71 additional columns in six
+queue/provenance tables. The catalog now includes those columns; all 423 existing
+entries are unchanged. The shared historical Postgres image omitted that migration
+and masked the incompatibility. The hosted job therefore always builds Postgres
+from the target's migrations; it never reuses a historical database image or
+regenerates the catalog automatically. Any future schema mismatch still requires
+an explicit catalog review before recording.

--- a/server/characterization/catalog.json
+++ b/server/characterization/catalog.json
@@ -1620,6 +1620,432 @@
     "udt_name": "int8"
   },
   {
+    "table_name": "polis_queue_attempts",
+    "column_name": "env",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_attempts",
+    "column_name": "attempt_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_attempts",
+    "column_name": "job_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_attempts",
+    "column_name": "owner_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_attempts",
+    "column_name": "lease_epoch",
+    "data_type": "bigint",
+    "udt_name": "int8"
+  },
+  {
+    "table_name": "polis_queue_attempts",
+    "column_name": "started_at",
+    "data_type": "timestamp with time zone",
+    "udt_name": "timestamptz"
+  },
+  {
+    "table_name": "polis_queue_attempts",
+    "column_name": "ended_at",
+    "data_type": "timestamp with time zone",
+    "udt_name": "timestamptz"
+  },
+  {
+    "table_name": "polis_queue_attempts",
+    "column_name": "outcome",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_attempts",
+    "column_name": "error_code",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_attempts",
+    "column_name": "output_sha256",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_heads",
+    "column_name": "env",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_heads",
+    "column_name": "product_key",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_heads",
+    "column_name": "zid",
+    "data_type": "integer",
+    "udt_name": "int4"
+  },
+  {
+    "table_name": "polis_queue_heads",
+    "column_name": "requested_generation",
+    "data_type": "bigint",
+    "udt_name": "int8"
+  },
+  {
+    "table_name": "polis_queue_heads",
+    "column_name": "desired_run_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_heads",
+    "column_name": "published_run_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_heads",
+    "column_name": "published_generation",
+    "data_type": "bigint",
+    "udt_name": "int8"
+  },
+  {
+    "table_name": "polis_queue_heads",
+    "column_name": "published_sha256",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_heads",
+    "column_name": "version",
+    "data_type": "bigint",
+    "udt_name": "int8"
+  },
+  {
+    "table_name": "polis_queue_install",
+    "column_name": "singleton",
+    "data_type": "boolean",
+    "udt_name": "bool"
+  },
+  {
+    "table_name": "polis_queue_install",
+    "column_name": "created_roles",
+    "data_type": "ARRAY",
+    "udt_name": "_text"
+  },
+  {
+    "table_name": "polis_queue_install",
+    "column_name": "adopted_roles",
+    "data_type": "ARRAY",
+    "udt_name": "_text"
+  },
+  {
+    "table_name": "polis_queue_install",
+    "column_name": "added_grants",
+    "data_type": "jsonb",
+    "udt_name": "jsonb"
+  },
+  {
+    "table_name": "polis_queue_install",
+    "column_name": "applied_at",
+    "data_type": "timestamp with time zone",
+    "udt_name": "timestamptz"
+  },
+  {
+    "table_name": "polis_queue_install",
+    "column_name": "catalog_fingerprint",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "env",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "job_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "run_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "stage",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "stage_instance",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "state",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "priority",
+    "data_type": "smallint",
+    "udt_name": "int2"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "eligible_at",
+    "data_type": "timestamp with time zone",
+    "udt_name": "timestamptz"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "udt_name": "timestamptz"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "updated_at",
+    "data_type": "timestamp with time zone",
+    "udt_name": "timestamptz"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "attempt_count",
+    "data_type": "integer",
+    "udt_name": "int4"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "parked_attempt_count",
+    "data_type": "integer",
+    "udt_name": "int4"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "max_attempts",
+    "data_type": "integer",
+    "udt_name": "int4"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "lease_epoch",
+    "data_type": "bigint",
+    "udt_name": "int8"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "version",
+    "data_type": "bigint",
+    "udt_name": "int8"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "mgmt_version",
+    "data_type": "bigint",
+    "udt_name": "int8"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "owner_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "attempt_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "locked_until",
+    "data_type": "timestamp with time zone",
+    "udt_name": "timestamptz"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "terminal_attempt_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "first_parked_at",
+    "data_type": "timestamp with time zone",
+    "udt_name": "timestamptz"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "last_error_code",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_jobs",
+    "column_name": "output_sha256",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_requests",
+    "column_name": "env",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_requests",
+    "column_name": "actor_scope",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_requests",
+    "column_name": "product_key",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_requests",
+    "column_name": "request_key",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_requests",
+    "column_name": "request_sha256",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_requests",
+    "column_name": "run_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_requests",
+    "column_name": "job_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_requests",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "udt_name": "timestamptz"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "env",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "run_id",
+    "data_type": "uuid",
+    "udt_name": "uuid"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "zid",
+    "data_type": "integer",
+    "udt_name": "int4"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "product_key",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "requested_generation",
+    "data_type": "bigint",
+    "udt_name": "int8"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "input_uri",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "input_sha256",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "expected_output_uri",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "expected_output_sha256",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "config_sha256",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "code_image_digest",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "contract_version",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "state",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "output_sha256",
+    "data_type": "text",
+    "udt_name": "text"
+  },
+  {
+    "table_name": "polis_queue_runs",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "udt_name": "timestamptz"
+  },
+  {
     "table_name": "pwreset_tokens",
     "column_name": "uid",
     "data_type": "integer",

--- a/server/characterization/compose.yml
+++ b/server/characterization/compose.yml
@@ -3,7 +3,7 @@
 name: ${COMPOSE_PROJECT_NAME:?unique project required}
 services:
   postgres:
-    image: p027-postgres
+    image: ${P027_POSTGRES_IMAGE:-p027-postgres}
     environment:
       POSTGRES_DB: p027
       POSTGRES_USER: postgres

--- a/server/characterization/rerecord-accounting.cjs
+++ b/server/characterization/rerecord-accounting.cjs
@@ -1,0 +1,423 @@
+"use strict";
+// Offline review only. Never relax the live replay census or normalize new fields.
+const fs = require("node:fs");
+const path = require("node:path");
+const cp = require("node:child_process");
+const crypto = require("node:crypto");
+const os = require("node:os");
+const sha = (x) => crypto.createHash("sha256").update(x).digest("hex");
+const equal = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+const read = (dir, name) => fs.readFileSync(path.join(dir, name));
+const json = (dir, name) => JSON.parse(read(dir, name));
+function git(repo, ...args) {
+  return cp.execFileSync("git", args, {
+    cwd: repo,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+}
+function commit(repo, value) {
+  if (!/^[a-f0-9]{40}$/.test(value)) throw Error("expected full commit SHA");
+  if (git(repo, "rev-parse", "--verify", `${value}^{commit}`).trim() !== value)
+    throw Error("commit unavailable");
+  return value;
+}
+function indexed(items, key) {
+  const result = new Map();
+  for (const item of items) {
+    const id = key(item);
+    if (result.has(id)) throw Error(`duplicate identity: ${id}`);
+    result.set(id, item);
+  }
+  return result;
+}
+function caseDelta(before, after, compare) {
+  const a = indexed(before, (x) => x.caseId),
+    b = indexed(after, (x) => x.caseId);
+  const result = {
+    unchanged: [],
+    changed: [],
+    added: [],
+    removed: [],
+    requestChanges: [],
+    sequenceChanged: !equal([...a.keys()], [...b.keys()]),
+    oracleFailures: [],
+  };
+  for (const [id, c] of b) {
+    if (c.oracle?.pass !== true) result.oracleFailures.push(id);
+    if (!a.has(id)) {
+      result.added.push(id);
+      continue;
+    }
+    if (!equal(a.get(id).request, c.request)) result.requestChanges.push(id);
+    const field = compare(a.get(id), c);
+    if (field) result.changed.push({ caseId: id, field });
+    else result.unchanged.push(id);
+  }
+  for (const id of a.keys()) if (!b.has(id)) result.removed.push(id);
+  return result;
+}
+const routeKey = (r) => JSON.stringify([r.registrationIndex, r.method]);
+function censusDelta(before, after, attribute) {
+  if (!before.ready || !after.ready) throw Error("census not ready");
+  const a = indexed(before.routes, routeKey),
+    b = indexed(after.routes, routeKey);
+  const result = {
+    before: a.size,
+    after: b.size,
+    added: [],
+    removed: [],
+    structureChanges: [],
+    callbacks: [],
+    middlewareChanged: !equal(before.middleware, after.middleware),
+    orderChanged: !equal([...a.keys()], [...b.keys()]),
+    runtimeChanged: !equal(before.runtime, after.runtime),
+    serializationChanged: !equal(before.serialization, after.serialization),
+  };
+  for (const [id, r] of b) {
+    if (!a.has(id)) {
+      result.added.push(r);
+      continue;
+    }
+    const old = a.get(id);
+    const shape = (x) => {
+      const { ordered_callback_fingerprints: _fingerprints, ...rest } = x;
+      return rest;
+    };
+    if (
+      !equal(shape(old), shape(r)) ||
+      old.ordered_callback_fingerprints.length !==
+        r.ordered_callback_fingerprints.length
+    )
+      result.structureChanges.push({ before: old, after: r });
+    r.ordered_callback_fingerprints.forEach((fingerprint, slot) => {
+      const previous = old.ordered_callback_fingerprints[slot];
+      if (previous !== fingerprint)
+        result.callbacks.push({
+          registrationIndex: r.registrationIndex,
+          method: r.method,
+          path: r.path,
+          slot,
+          before: previous ?? null,
+          after: fingerprint,
+          attribution: previous
+            ? attribute(previous, fingerprint)
+            : { status: "unattributed", reason: "new callback slot" },
+        });
+    });
+  }
+  for (const [id, r] of a) if (!b.has(id)) result.removed.push(r);
+  return result;
+}
+// Hash the exact emitted function text: the runtime census hashes Function#toString.
+// No application module is imported/executed during history inspection.
+function functions(source, file, ts, options) {
+  const code = ts.transpileModule(source, {
+    compilerOptions: options,
+    fileName: file,
+  }).outputText;
+  const ast = ts.createSourceFile(
+    file + ".js",
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS
+  );
+  const out = [];
+  function visit(node) {
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node)
+    ) {
+      let name = node.name?.text;
+      if (!name && ts.isVariableDeclaration(node.parent))
+        name = node.parent.name.getText(ast);
+      // Anonymous wrappers and dependency-generated functions remain explicitly unattributed.
+      if (name) out.push({ file, name, sha256: sha(node.getText(ast)) });
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(ast);
+  return out;
+}
+function attributor(repo, base, target) {
+  const ts = require(path.join(repo, "server/node_modules/typescript"));
+  const config = ts.readConfigFile(
+    path.join(repo, "server/tsconfig.json"),
+    ts.sys.readFile
+  );
+  if (config.error) throw Error("invalid TypeScript config");
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    path.join(repo, "server")
+  );
+  if (parsed.errors.length) throw Error("invalid TypeScript options");
+  const cache = new Map();
+  function snapshot(pin, file) {
+    const key = pin + ":" + file;
+    if (!cache.has(key)) {
+      let source;
+      try {
+        source = git(repo, "show", key);
+      } catch {
+        cache.set(key, []);
+        return [];
+      }
+      cache.set(key, functions(source, file, ts, parsed.options));
+    }
+    return cache.get(key);
+  }
+  function inventory(pin) {
+    return git(
+      repo,
+      "ls-tree",
+      "-r",
+      "--name-only",
+      pin,
+      "--",
+      "server/app.ts",
+      "server/index.ts",
+      "server/src"
+    )
+      .trim()
+      .split("\n")
+      .filter((f) => f.endsWith(".ts"))
+      .flatMap((f) => snapshot(pin, f));
+  }
+  const old = inventory(base),
+    current = inventory(target);
+  const memo = new Map();
+  return (before, after) => {
+    const pair = before + after;
+    if (memo.has(pair)) return memo.get(pair);
+    const matches = old
+      .filter((x) => x.sha256 === before)
+      .flatMap((a) =>
+        current
+          .filter(
+            (b) => b.sha256 === after && a.file === b.file && a.name === b.name
+          )
+          .map((b) => [a, b])
+      );
+    let result = {
+      status: "unattributed",
+      reason: "no unique named source function matching both runtime hashes",
+    };
+    if (matches.length === 1) {
+      const [a] = matches[0];
+      const range = git(
+        repo,
+        "rev-list",
+        "--reverse",
+        "--ancestry-path",
+        `${base}..${target}`
+      )
+        .trim()
+        .split("\n")
+        .filter(Boolean);
+      const transitions = [];
+      for (const pin of range) {
+        const parents = git(repo, "rev-list", "--parents", "-n", "1", pin)
+          .trim()
+          .split(" ")
+          .slice(1);
+        const one = (at) =>
+          snapshot(at, a.file).filter((f) => f.name === a.name);
+        const now = one(pin);
+        if (now.length !== 1) continue;
+        // Report parent edges, including merge edges; do not guess from commit subjects.
+        for (const parent of parents) {
+          const was = one(parent);
+          if (was.length === 1 && was[0].sha256 !== now[0].sha256)
+            transitions.push({
+              commit: pin,
+              parent,
+              before: was[0].sha256,
+              after: now[0].sha256,
+            });
+        }
+      }
+      if (transitions.length)
+        result = {
+          status: "attributed",
+          file: a.file,
+          function: a.name,
+          before,
+          after,
+          transitions,
+        };
+    }
+    memo.set(pair, result);
+    return result;
+  };
+}
+function cleanDelta(d) {
+  return (
+    !d.changed.length &&
+    !d.added.length &&
+    !d.removed.length &&
+    !d.requestChanges.length &&
+    !d.sequenceChanged &&
+    !d.oracleFailures.length
+  );
+}
+function eligible(report) {
+  const c = report.census;
+  return (
+    cleanDelta(report.cases) &&
+    !report.requestArtifactChanges.length &&
+    !c.added.length &&
+    !c.removed.length &&
+    !c.structureChanges.length &&
+    !c.middlewareChanged &&
+    !c.orderChanged &&
+    !c.runtimeChanged &&
+    !c.serializationChanged &&
+    c.callbacks.every((x) => x.attribution.status === "attributed") &&
+    !report.checkerChanges.length &&
+    !report.sharedFiles.some(
+      (file) => !["index.json", "run.json", "routes.json"].includes(file.path)
+    )
+  );
+}
+function historicalRecording(repo, pin, dir) {
+  // Preserve the old generator's required inventory when a target adds cases.
+  // This does not alter admission or the comparator used for live target replay.
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "p027-historical-reader-")
+  );
+  try {
+    const files = git(
+      repo,
+      "ls-tree",
+      "-r",
+      "--name-only",
+      pin,
+      "--",
+      "server/characterization"
+    )
+      .trim()
+      .split("\n")
+      .filter((f) => /\.(cjs|json)$/.test(f) && !f.includes("/artifacts/"));
+    for (const file of files) {
+      const destination = path.join(root, file);
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.writeFileSync(destination, git(repo, "show", `${pin}:${file}`));
+    }
+    fs.symlinkSync(
+      path.join(repo, "server/node_modules"),
+      path.join(root, "server/node_modules"),
+      "dir"
+    );
+    return require(path.join(
+      root,
+      "server/characterization/recording.cjs"
+    )).readRecording(dir);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+function account(repo, beforeDir, afterDir) {
+  const harness = path.join(repo, "server/characterization");
+  const { readRecording } = require(path.join(harness, "recording.cjs"));
+  const { firstDifference } = require(path.join(harness, "compare.cjs"));
+  const base = commit(repo, json(beforeDir, "index.json").meta.appCommit);
+  const a = historicalRecording(repo, base, beforeDir),
+    b = readRecording(afterDir);
+  const target = commit(repo, b.manifest.appCommit);
+  if (target !== git(repo, "rev-parse", "HEAD").trim())
+    throw Error("recording does not pin target HEAD");
+  git(repo, "merge-base", "--is-ancestor", base, target);
+  if (
+    json(beforeDir, "run.json").commit !== base ||
+    json(afterDir, "run.json").commit !== target
+  )
+    throw Error("archive run/source pin mismatch");
+  if (firstDifference(a.cases[0], a.cases[0]) !== null)
+    throw Error("self comparison failed");
+  const mutant = structuredClone(a.cases[0]);
+  mutant.response.status = 599;
+  mutant.wire.response.status = 599;
+  if (!firstDifference(a.cases[0], mutant))
+    throw Error("status mutation was not detected");
+  const report = {
+    version: "p027-rerecord-accounting/1",
+    base,
+    target,
+    cases: caseDelta(a.cases, b.cases, firstDifference),
+    requestArtifactChanges: [],
+    census: censusDelta(
+      json(beforeDir, "routes.json"),
+      json(afterDir, "routes.json"),
+      attributor(repo, base, target)
+    ),
+    sharedFiles: [],
+    checkerChanges: [],
+  };
+  const oldCases = indexed(a.index.cases, (x) => x.case_id);
+  for (const c of b.index.cases)
+    if (
+      oldCases.has(c.case_id) &&
+      !read(beforeDir, oldCases.get(c.case_id).path + "/request.json").equals(
+        read(afterDir, c.path + "/request.json")
+      )
+    )
+      report.requestArtifactChanges.push(c.case_id);
+  const oldFiles = indexed(a.index.files, (x) => x.path),
+    newFiles = indexed(b.index.files, (x) => x.path);
+  for (const name of new Set([...oldFiles.keys(), ...newFiles.keys()])) {
+    const before = oldFiles.get(name)?.sha256 ?? null,
+      after = newFiles.get(name)?.sha256 ?? null;
+    if (before !== after)
+      report.sharedFiles.push({ path: name, before, after });
+  }
+  // A changed comparator/seed/profile needs explicit review, even if its own comparison says equal.
+  const checkers = git(
+    repo,
+    "diff",
+    "--name-only",
+    base,
+    target,
+    "--",
+    "server/characterization",
+    "server/package-lock.json",
+    "server/tsconfig.json"
+  )
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .filter((f) => !f.includes("/artifacts/") && !f.endsWith("README.md"));
+  report.checkerChanges = checkers;
+  report.reviewEligible = eligible(report);
+  report.counts = Object.fromEntries(
+    ["unchanged", "changed", "added", "removed", "oracleFailures"].map((k) => [
+      k,
+      report.cases[k].length,
+    ])
+  );
+  return report;
+}
+if (require.main === module) {
+  const [repo, before, after, output] = process.argv.slice(2);
+  if (!output)
+    throw Error("usage: rerecord-accounting.cjs REPO BEFORE AFTER OUTPUT");
+  const result = account(path.resolve(repo), before, after);
+  fs.writeFileSync(output, JSON.stringify(result, null, 2) + "\n");
+  console.log(
+    JSON.stringify({
+      counts: result.counts,
+      census: result.census.callbacks.length,
+      reviewEligible: result.reviewEligible,
+    })
+  );
+}
+module.exports = {
+  caseDelta,
+  censusDelta,
+  functions,
+  eligible,
+  account,
+  attributor,
+};

--- a/server/characterization/rerecord-accounting.test.cjs
+++ b/server/characterization/rerecord-accounting.test.cjs
@@ -1,0 +1,322 @@
+"use strict";
+const test = require("node:test"),
+  assert = require("node:assert/strict");
+const path = require("node:path");
+const {
+  caseDelta,
+  censusDelta,
+  functions,
+  eligible,
+  attributor,
+} = require("./rerecord-accounting.cjs");
+const repo =
+  process.env.P027_ACCOUNTING_REPO || path.resolve(__dirname, "../..");
+const ts = require(path.join(repo, "server/node_modules/typescript"));
+const diff = (a, b) =>
+  JSON.stringify(a) === JSON.stringify(b) ? null : "$.changed";
+const c = (id) => ({
+  caseId: id,
+  request: { path: "/a" },
+  response: { status: 200 },
+  oracle: { pass: true },
+});
+const route = (hash = "old", index = 0) => ({
+  registrationIndex: index,
+  method: "GET",
+  path: "/a",
+  ordered_callback_fingerprints: [hash],
+});
+const census = (routes) => ({ ready: true, routes, middleware: [["m"]] });
+const attribution = () => ({ status: "attributed" });
+for (const [label, transform, field] of [
+  [
+    "response status",
+    (x) => {
+      x.response.status = 401;
+    },
+    "changed",
+  ],
+  [
+    "request bytes",
+    (x) => {
+      x.request.path = "/b";
+    },
+    "requestChanges",
+  ],
+  [
+    "oracle failure",
+    (x) => {
+      x.oracle.pass = false;
+    },
+    "oracleFailures",
+  ],
+])
+  test(label + " remains visible", () => {
+    const after = c("one");
+    transform(after);
+    assert.equal(caseDelta([c("one")], [after], diff)[field].length, 1);
+  });
+test("complete unchanged inventory", () => {
+  const d = caseDelta([c("one"), c("two")], [c("one"), c("two")], diff);
+  assert.deepEqual(d.unchanged, ["one", "two"]);
+  assert.equal(d.sequenceChanged, false);
+});
+test("added and removed cases never zip into false equality", () => {
+  const d = caseDelta([c("one")], [c("two")], diff);
+  assert.deepEqual(d.added, ["two"]);
+  assert.deepEqual(d.removed, ["one"]);
+  assert.equal(d.unchanged.length, 0);
+});
+test("reordered serial cases cannot qualify", () => {
+  assert.equal(
+    caseDelta([c("one"), c("two")], [c("two"), c("one")], diff).sequenceChanged,
+    true
+  );
+});
+test("duplicates rejected on either side", () => {
+  assert.throws(
+    () => caseDelta([c("one"), c("one")], [c("one")], diff),
+    /duplicate/
+  );
+  assert.throws(
+    () => caseDelta([c("one")], [c("one"), c("one")], diff),
+    /duplicate/
+  );
+});
+test("callback slot and route are attributed individually", () => {
+  const d = censusDelta(census([route()]), census([route("new")]), (a, b) => ({
+    status: "attributed",
+    before: a,
+    after: b,
+  }));
+  assert.equal(d.callbacks.length, 1);
+  assert.equal(d.callbacks[0].slot, 0);
+  assert.equal(d.callbacks[0].attribution.before, "old");
+});
+test("ALL fanout keeps verb identities", () => {
+  const a = route(),
+    b = { ...a, method: "POST" };
+  assert.equal(
+    censusDelta(census([a, b]), census([route("new"), b]), attribution)
+      .callbacks.length,
+    1
+  );
+});
+test("route reorder or metadata changes remain structural", () => {
+  const d = censusDelta(
+    census([route()]),
+    census([{ ...route(), path: "/b" }]),
+    attribution
+  );
+  assert.equal(d.structureChanges.length, 1);
+});
+test("new/deleted registrations and middleware are visible", () => {
+  const a = census([route()]),
+    b = census([route("new", 1)]);
+  b.middleware = [["changed"]];
+  const d = censusDelta(a, b, attribution);
+  assert.equal(d.added.length, 1);
+  assert.equal(d.removed.length, 1);
+  assert.equal(d.middlewareChanged, true);
+});
+test("callback arity changes are structural, new slot is unattributed", () => {
+  const b = route();
+  b.ordered_callback_fingerprints.push("new");
+  const d = censusDelta(census([route()]), census([b]), attribution);
+  assert.equal(d.structureChanges.length, 1);
+  assert.equal(d.callbacks[0].attribution.status, "unattributed");
+});
+test("not-ready and duplicate census rejected", () => {
+  assert.throws(
+    () => censusDelta({ ready: false }, census([]), attribution),
+    /ready/
+  );
+  assert.throws(
+    () => censusDelta(census([route(), route()]), census([]), attribution),
+    /duplicate/
+  );
+});
+function good() {
+  return {
+    cases: caseDelta([c("one")], [c("one")], diff),
+    census: censusDelta(census([route()]), census([route("new")]), attribution),
+    requestArtifactChanges: [],
+    checkerChanges: [],
+    sharedFiles: [],
+  };
+}
+test("eligible only for unchanged cases with attributed fingerprints", () =>
+  assert.equal(eligible(good()), true));
+for (const [label, mutate] of [
+  ["changed cases", (r) => r.cases.changed.push({ caseId: "one" })],
+  ["missing cases", (r) => r.cases.removed.push("one")],
+  ["request artifacts", (r) => r.requestArtifactChanges.push("one")],
+  ["checker drift", (r) => r.checkerChanges.push("compare.cjs")],
+  [
+    "middleware",
+    (r) => {
+      r.census.middlewareChanged = true;
+    },
+  ],
+  [
+    "unattributed function",
+    (r) => {
+      r.census.callbacks[0].attribution.status = "unattributed";
+    },
+  ],
+])
+  test(label + " prevents eligibility", () => {
+    const r = good();
+    mutate(r);
+    assert.equal(eligible(r), false);
+  });
+test("fingerprints use emitted function text without executing source", () => {
+  const source =
+    'throw new Error("MUST NOT EXECUTE"); export function handler(x: number) { return x+1; }';
+  const rows = functions(source, "example.ts", ts, {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.CommonJS,
+  });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].name, "handler");
+  const source2 = source.replace("x+1", "x+2");
+  assert.notEqual(
+    rows[0].sha256,
+    functions(source2, "example.ts", ts, {
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.CommonJS,
+    })[0].sha256
+  );
+});
+test("real round-7 callback hash is reproduced from committed source", () => {
+  const cp = require("node:child_process");
+  const source = cp.execFileSync(
+    "git",
+    [
+      "show",
+      "ed64b457f893116abb471bf4eeea51799f7c2787:server/src/routes/delphi/topicMod.ts",
+    ],
+    { cwd: repo, encoding: "utf8" }
+  );
+  const config = ts.parseJsonConfigFileContent(
+    ts.readConfigFile(path.join(repo, "server/tsconfig.json"), ts.sys.readFile)
+      .config,
+    ts.sys,
+    path.join(repo, "server")
+  ).options;
+  const rows = functions(
+    source,
+    "server/src/routes/delphi/topicMod.ts",
+    ts,
+    config
+  );
+  assert.equal(
+    rows.find((x) => x.name === "handle_POST_topicMod_moderate").sha256,
+    "6fe495dd3b3292582e747d38f0b2de86ed9b181ab8ccfa3113c950dc08285d0f"
+  );
+});
+
+test("committed moderation callback is attributed to its changing commit", () => {
+  const cp = require("node:child_process");
+  const after = "a5dfcd6f404d8a58f844d7480b8d209eda488675";
+  const before = cp
+    .execFileSync("git", ["rev-parse", after + "^"], {
+      cwd: repo,
+      encoding: "utf8",
+    })
+    .trim();
+  const file = "server/src/routes/delphi/topicMod.ts";
+  const config = ts.parseJsonConfigFileContent(
+    ts.readConfigFile(path.join(repo, "server/tsconfig.json"), ts.sys.readFile)
+      .config,
+    ts.sys,
+    path.join(repo, "server")
+  ).options;
+  const hashAt = (pin) =>
+    functions(
+      cp.execFileSync("git", ["show", pin + ":" + file], {
+        cwd: repo,
+        encoding: "utf8",
+      }),
+      file,
+      ts,
+      config
+    ).find((x) => x.name === "handle_POST_topicMod_moderate").sha256;
+  const attribute = attributor(repo, before, after);
+  const result = attribute(hashAt(before), hashAt(after));
+  assert.equal(result.status, "attributed");
+  assert.equal(result.file, file);
+  assert.ok(result.transitions.some((x) => x.commit === after));
+  assert.equal(
+    attribute("0".repeat(64), "f".repeat(64)).status,
+    "unattributed"
+  );
+});
+
+test("census array reorder, runtime and serialization changes block eligibility", () => {
+  const a = census([route(), route("other", 1)]);
+  for (const mutate of [
+    (b) => b.routes.reverse(),
+    (b) => {
+      b.runtime = { node: "changed" };
+    },
+    (b) => {
+      b.serialization = { profile: "changed" };
+    },
+  ]) {
+    const b = structuredClone(a);
+    mutate(b);
+    const r = good();
+    r.census = censusDelta(a, b, attribution);
+    assert.equal(eligible(r), false);
+  }
+});
+
+test("real archive admission precedes target-pin rejection", () => {
+  const { testBaseline } = require(path.join(
+    repo,
+    "server/characterization/baseline.cjs"
+  ));
+  const { account } = require("./rerecord-accounting.cjs");
+  const dir = testBaseline();
+  assert.throws(
+    () => account(repo, dir, dir),
+    /recording does not pin target HEAD/
+  );
+});
+
+test("real served comparator counts one status mutation without losing the inventory", () => {
+  const { testBaseline } = require(path.join(
+    repo,
+    "server/characterization/baseline.cjs"
+  ));
+  const { readRecording } = require(path.join(
+    repo,
+    "server/characterization/recording.cjs"
+  ));
+  const { firstDifference } = require(path.join(
+    repo,
+    "server/characterization/compare.cjs"
+  ));
+  const baseline = readRecording(testBaseline()).cases;
+  const actual = structuredClone(baseline);
+  actual[0].response.status = 599;
+  actual[0].wire.response.status = 599;
+  const d = caseDelta(baseline, actual, firstDifference);
+  assert.equal(d.changed.length, 1);
+  assert.equal(d.unchanged.length, baseline.length - 1);
+  assert.equal(d.changed[0].caseId, baseline[0].caseId);
+});
+
+test("changed shared schema or fixture requires review even with unchanged outcomes", () => {
+  for (const file of [
+    "schema.json",
+    "normalization.json",
+    "pca2-seed.json",
+    "new-fixture.json",
+  ]) {
+    const r = good();
+    r.sharedFiles.push({ path: file, before: "old", after: "new" });
+    assert.equal(eligible(r), false);
+  }
+});


### PR DESCRIPTION
Two commits.

**1. Catalog regeneration.** A fresh Postgres built from all 20 migrations includes the queue tables that 000019 adds; the recorder's schema catalog predated them and its unknown-schema gate refused to record. The shared historical Postgres image had masked this. Regenerated with the harness's generator: only the 000019 objects added, no existing column changed. Not a database schema change.

**2. The job.** Re-recording the corpus was manual and took three round trips today. `workflow_dispatch` with a target ref (default: the immutable dispatch SHA): builds the sealed compose stack on an ephemeral runner with a fresh Postgres from all migrations, records the corpus, runs the offline accounting against the committed archive (cases unchanged/changed/added/removed; census delta with per-callback attribution), the fresh replay, the negative controls, and the deterministic repack, and uploads the old and new archives with review evidence. Read-only permissions; it never opens or merges a PR; the driver exits 1 whenever the result is not review-eligible, so a reviewer always decides.

**Validated end to end locally:** record and fresh replay 1,265 / 0 / 0; accounting 1,265 unchanged; census 302→302, zero changes; deterministic candidate sha256 `0af8d791…`; accounting tests 27/27; Node 85/85; Python 17/17; live controls 8/8; shellcheck, actionlint, yamllint, eslint, prettier clean. Hosted cold-build fit is not yet measured; the first dispatch will show it.

Written by the second reviewer; reviewed by the orchestrator. Schema impact: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s