### PR TITLE
feat(replay): ingest the extraction's millisecond event stream directly in both engines

### DIFF
--- a/delphi/docs/EVENT_INGRESS.md
+++ b/delphi/docs/EVENT_INGRESS.md
@@ -1,0 +1,86 @@
+# Authoritative event ingress
+
+`certify` and `replay_driver.py` prefer `events.jsonl` whenever it is present in
+the selected fixture directory. Its sibling `events.meta.json` is required;
+malformed/missing metadata fails instead of falling back to CSV. CSV-only public
+fixtures retain the existing path. Both engines accept an explicit file:
+
+```sh
+# From delphi/
+uv run python scripts/replay_driver.py run --schedule /private/schedule.json \
+  --events /private/fixture/events.jsonl --out /private/replays
+# From math/
+clojure -M:replay --schedule /private/schedule.json \
+  --events /private/fixture/events.jsonl --out /private/replays/dataset/schedule
+```
+
+For certification of opaque extracted directories, set `POLIS_REPLAY_INPUT_MAP`
+to a JSON object mapping **every selected battery dataset alias** to one existing
+absolute directory. A missing binding is an error; it cannot silently select a
+public dataset or another private extraction. This local mapping is not an
+admission: the private producer/verifier must derive it from the reviewed
+manifest's role/directory binding and verify the manifest files before running.
+Never commit a real mapping, private fixtures or results.
+
+Ingress validates `certify-events/2`, the declared storage sign (integer -1 or
++1), strict integer types, ordinal/source-row continuity, vote-before-comment
+ordering, monotone vote milliseconds, unique ascending comment IDs, counts and
+the logical digest. Both engines preserve every vote slot, including duplicates,
+revotes and NULLs. Equal-millisecond rows retain their frozen extraction order;
+no new tie-break or deduplication is applied. Python retains the original event
+rows (including current comment state and provenance) in `input_events`.
+
+Only non-null votes undergo the declared storage-to-semantic sign mapping;
+Clojure then maps semantic signs into its native raw convention. Null votes stay
+null; zero weights stay zero and null weights stay null through the engine call
+and restart. This is an ingress guarantee, not a new mathematical policy:
+Python's existing update skips null votes, Clojure receives nil, and both current
+engines ignore `weight_x_32767`. Their existing disagreement/failure is evidence,
+not permission to turn null into pass, drop the event, or waive the gate. The
+existing fixture admission's null policy still applies independently.
+
+Current comment rows provide latest state and `modified`, not a historical
+moderation log. Interleaving uses their integer-millisecond modification times
+and counts absent `modified` values as unavailable. Moderation remains schedule
+controlled; no initial participant/comment flags or historical actions are
+invented. Full original events and metadata are hashed into both recording cache
+keys; event metadata is also in the run's resolved schedules. Source is recorded
+as `events-jsonl`. Changing convention, weight, null or comment state invalidates
+the caches even when engine output happens to be unchanged.
+
+## Historical schedules and CSV loss
+
+A cut remains a **one-based vote slot**, not the mixed JSONL `ord` (which also
+counts comment records). All vote events count, including NULLs. A historical
+CSV cut after a dropped NULL addresses a different prefix. Even without drops,
+subsecond timestamps change timestamp-based cuts and moderation weaving. Absolute
+vote-count cuts are reusable only after proving identical vote identities/order
+and the intended full-stream endpoint against the new manifest. Do not silently
+reuse, truncate, rescale or repin historical private schedules. Freeze newly
+reviewed recipe resolutions before inspecting candidate output.
+
+`event_ingress.compatibility_accounting(events_path, csv_path)` emits exact
+per-ordinal milliseconds lost, omitted NULLs, absent weights, old/new slot mapping
+and whether the CSV equals the declared projection. It is a **private** diagnostic
+and does not bless a lossy input. Missing original public facts are unavailable,
+not evidence of zero loss.
+
+## Reproducible public proof
+
+```sh
+PYTHONPATH=delphi python delphi/scripts/prove_event_ingress.py --out /private/fresh-proof
+```
+
+This enumerates public entries from the committed config and battery, lifts the
+known CSV data into the authoritative format, runs both engines under both paths,
+and compares SHA256s of every raw `step-*.json` file (including Clojure metadata).
+It does not regenerate private inputs, rewrite schedules or compare provenance
+files that intentionally record different inputs. The public export supplies no
+original millisecond/weight/null-drop record; the lift cannot reconstruct one.
+
+Two independent nondeterministic inputs are controlled **only by the proof**:
+Python's output `math_tick` clock is fixed, and Clojure's `rand` is seeded 671.
+The latter matters when a previously missing PCA axis is initialized on a later
+every-vote tick: the normal cold-start pin alone does not cover that path. The
+production engines and normal replay drivers keep their existing behavior.
+An uncontrolled process-to-process axis sign change is not CSV information loss.

--- a/delphi/polismath/replay/certify.py
+++ b/delphi/polismath/replay/certify.py
@@ -815,6 +815,8 @@ def votes_csv_path(dataset: str) -> Path | None:
     d = real_data.dataset_dir(dataset)
     if d is None:
         return None
+    if (d / "events.jsonl").exists():
+        return d / "events.jsonl"
     hits = sorted(d.glob("*-votes.csv"))
     return hits[0] if hits else None
 
@@ -1083,7 +1085,7 @@ def _run_subprocess(cmd: list[str], *, cwd: Path, env: dict[str, str],
                           text=True, timeout=timeout)
 
 
-def run_py_driver(spec_path: Path, *, out_root: Path) -> subprocess.CompletedProcess:
+def run_py_driver(spec_path: Path, *, out_root: Path, events: Path | None = None) -> subprocess.CompletedProcess:
     """Runs ``scripts/replay_driver.py run --schedule <spec_path> --out
     <out_root>`` in a SUBPROCESS (cwd=delphi/) with ``OMP_NUM_THREADS`` /
     ``OPENBLAS_NUM_THREADS`` pinned to 1."""
@@ -1092,6 +1094,8 @@ def run_py_driver(spec_path: Path, *, out_root: Path) -> subprocess.CompletedPro
     env["OPENBLAS_NUM_THREADS"] = "1"
     cmd = ["uv", "run", "python", "scripts/replay_driver.py", "run",
            "--schedule", str(spec_path), "--out", str(out_root)]
+    if events is not None:
+        cmd += ["--events", str(events)]
     try:
         return _run_subprocess(cmd, cwd=_DELPHI_ROOT, env=env)
     except OSError as exc:
@@ -1109,7 +1113,8 @@ def run_clj_driver(
     item 5). Omitted (``None``, the default) for every schedule that doesn't
     request moderation interleaving, so existing recordings' invocation is
     byte-for-byte unchanged."""
-    cmd = ["clojure", "-M:replay", "--schedule", str(spec_path), "--votes", str(votes_csv),
+    cmd = ["clojure", "-M:replay", "--schedule", str(spec_path),
+           "--events" if votes_csv.name == "events.jsonl" else "--votes", str(votes_csv),
            "--out", str(out_dir)]
     if comments_csv is not None:
         cmd += ["--comments", str(comments_csv)]
@@ -1298,6 +1303,7 @@ def ensure_py_recording(
     entry: BatteryEntry, spec: sched.ScheduleSpec, votes_sha: str, *, root: Path,
     refresh: bool = False, comments_csv: Path | None = None,
     conventions: ConventionDescriptor = DEFAULT_CONVENTIONS,
+    events: Path | None = None,
 ) -> tuple[Path, bool]:
     """Reuse ``<root>/<ds>/<sid>/py/`` iff its cache manifest matches (votes
     sha256, schedule hash, ENGINE-scoped tree hash, and — when ``comments_csv``
@@ -1327,6 +1333,9 @@ def ensure_py_recording(
         "engine_tree_sha256": _engine_tree_hash_cached(),
         **conventions.cache_fields(),
     }
+    if events is not None:
+        from polismath.replay.event_ingress import input_hashes
+        expected.update(input_hashes(events))
     if comments_csv is not None:
         expected["comments_csv_sha256"] = sha256_file(comments_csv)
     if not refresh and _manifest_matches(manifest_path, expected):
@@ -1334,7 +1343,8 @@ def ensure_py_recording(
 
     tmp_schedule = _write_temp_schedule(spec, root)
     _clear_recording(py_dir)
-    result = run_py_driver(tmp_schedule, out_root=root)
+    result = (run_py_driver(tmp_schedule, out_root=root, events=events) if events is not None
+              else run_py_driver(tmp_schedule, out_root=root))
     if result.returncode != 0:
         raise CertifyError(
             "py-driver", (result.stderr or result.stdout or "non-zero exit").strip()[:1000]
@@ -1372,6 +1382,9 @@ def ensure_clj_recording(
         "math_src_sha256": math_src_sha256,
         **conventions.cache_fields(),
     }
+    if votes_csv.name == "events.jsonl":
+        from polismath.replay.event_ingress import input_hashes
+        expected.update(input_hashes(votes_csv))
     if comments_csv is not None:
         expected["comments_csv_sha256"] = sha256_file(comments_csv)
     if not refresh and _manifest_matches(manifest_path, expected):
@@ -1539,6 +1552,7 @@ class ExpectedEntry:
     comments_sha: str | None
     stream_end: int
     checkpoints: list[dict[str, int]]
+    events_meta_sha: str | None = None
 
     def inventory(self) -> list[dict[str, Any]]:
         return [{
@@ -1582,8 +1596,9 @@ def prepare_entry(entry: BatteryEntry) -> ExpectedEntry:
             raise CertifyError("inventory", "zero checkpoint requires a nonempty empty_output contract")
         if not set(spec.empty_output) <= ACCEPTANCE_KEYS:
             raise CertifyError("inventory", "empty_output must name acceptance fields")
-    comments = comments_csv_path(entry.dataset) if spec.moderation != "none" else None
-    if spec.moderation == "interleave-by-timestamp" and comments is None:
+    is_events = votes_csv.name == "events.jsonl"
+    comments = comments_csv_path(entry.dataset) if spec.moderation != "none" and not is_events else None
+    if spec.moderation == "interleave-by-timestamp" and comments is None and not is_events:
         raise CertifyError("dataset-unavailable", "moderation schedule requires comments CSV")
     checkpoints = [{"index": s.index, "prev_slot": s.prev_slot, "cut_slot": s.cut_slot,
                     "batch_size": len(s.vote_events), "cut_time_ms": s.cut_time_ms}
@@ -1591,11 +1606,14 @@ def prepare_entry(entry: BatteryEntry) -> ExpectedEntry:
     # Pass resolved absolute cursors to BOTH engines. Neither driver gets to
     # independently round fractions or silently change the expected inventory.
     resolved = spec.to_dict()
+    if is_events:
+        resolved["source"] = "events-jsonl"
     resolved["cuts"] = {"mode": "vote-count", "at": [s.cut_slot for s in steps]}
     if steps[0].cut_slot == 0:
         resolved["cuts"]["empty_checkpoint"] = True
     return ExpectedEntry(entry, sched.ScheduleSpec.from_dict(resolved), votes_csv, votes_sha,
-                         comments, sha256_file(comments) if comments else None, ds.n, checkpoints)
+                         comments, sha256_file(comments) if comments else None, ds.n, checkpoints,
+                         sha256_file(votes_csv.with_name("events.meta.json")) if is_events else None)
 
 
 def validate_recording_inventory(directory: Path, engine: str, expected: ExpectedEntry) -> None:
@@ -1679,11 +1697,16 @@ def _certify_entry_heavy(
         # M3 (P-019): the comments CSV is an input to the PYTHON replay too, so it
         # must be part of the py cache key, mirroring the clj side above.
         py_dir, py_cached = ensure_py_recording(entry, spec, votes_sha, root=root,
-                                                refresh=refresh_py, comments_csv=comments_csv)
+                                                refresh=refresh_py, comments_csv=comments_csv,
+                                                **({"events": votes_csv} if expected.events_meta_sha else {}))
         # Recorded in the run manifest: a verdict reached entirely from cache is
         # a different provenance claim than one that re-ran both engines.
         cache = {"clj": "hit" if clj_cached else "miss",
                  "py": "hit" if py_cached else "miss"}
+        if expected.events_meta_sha and sha256_file(
+            votes_csv.with_name("events.meta.json")
+        ) != expected.events_meta_sha:
+            raise CertifyError("input-changed", "event metadata changed after inventory")
         if sha256_file(votes_csv) != votes_sha or (
             comments_csv is not None and sha256_file(comments_csv) != expected.comments_sha
         ):
@@ -1888,7 +1911,9 @@ def run_battery(
                      "status": "INCONCLUSIVE", "reason": "not completed"} for e in entries],
         "resolved_schedules": [{"dataset": p.entry.dataset, "schedule_id": p.entry.schedule_id,
                                 "schedule": p.spec.to_dict(), "votes_sha256": p.votes_sha,
-                                "comments_sha256": p.comments_sha} for p in prepared.values()],
+                                "comments_sha256": p.comments_sha,
+                                **({"events_meta_sha256": p.events_meta_sha} if p.events_meta_sha else {})}
+                               for p in prepared.values()],
     }
     manifest_path = _write_run_manifest(root, manifest)
 

--- a/delphi/polismath/replay/driver.py
+++ b/delphi/polismath/replay/driver.py
@@ -169,7 +169,8 @@ def _votes_dict(step: ReplayStep) -> dict[str, Any]:
     deterministically. Signs pass through in Delphi convention (see module doc).
     """
     votes = [
-        {"pid": v.pid, "tid": v.tid, "vote": v.sign, "created": v.t_ms}
+        {"pid": v.pid, "tid": v.tid, "vote": v.sign, "created": v.t_ms,
+         **({"weight_x_32767": v.weight_x_32767} if v.source_ord is not None else {})}
         for v in step.vote_events
     ]
     return {"votes": votes, "lastVoteTimestamp": step.cut_time_ms}
@@ -215,7 +216,8 @@ def _restart_conversation(
     restored = Conversation.from_dict(blob)
 
     all_votes = [
-        {"pid": v.pid, "tid": v.tid, "vote": v.sign, "created": v.t_ms}
+        {"pid": v.pid, "tid": v.tid, "vote": v.sign, "created": v.t_ms,
+         **({"weight_x_32767": v.weight_x_32767} if v.source_ord is not None else {})}
         for v in dataset.votes[:cut_slot]
     ]
     restored = restored.update_votes(

--- a/delphi/polismath/replay/event_ingress.py
+++ b/delphi/polismath/replay/event_ingress.py
@@ -1,0 +1,146 @@
+"""Authoritative certify-events/2 ingress; CSV is only a compatibility view.
+
+NULL is retained and passed to the engines, never converted to a semantic
+vote or pass. Existing engine NULL behavior is deliberately not repaired here.
+Weights reach each engine unchanged; neither current engine uses this column.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+
+from polismath.replay.types import ModEvent, ReplayDataset
+from polismath.utils.vote_convention import semantic_vote, validate_storage_agree_value
+
+
+def _object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _read(text):
+    return json.loads(text, object_pairs_hook=_object,
+                      parse_constant=lambda _: (_ for _ in ()).throw(ValueError("nonfinite JSON")))
+
+
+def _integer(value, *, nullable=False):
+    if nullable and value is None:
+        return
+    if type(value) is not int or not -(2**63) <= value < 2**63:
+        raise ValueError("event integer required (signed 64-bit)")
+
+
+def read_events(path: str | Path):
+    """Validate before feeding either engine; no sorting or row dropping."""
+    path = Path(path)
+    meta = _read(path.with_name("events.meta.json").read_text())
+    if meta.get("schema_version") != "certify-events/2":
+        raise ValueError("unsupported events schema")
+    convention = validate_storage_agree_value(meta.get("polarity", {}).get("storage_agree_value"))
+    events = []
+    votes = []
+    comments = []
+    digest = hashlib.sha256()
+    for line in path.read_text().splitlines():
+        e = _read(line)
+        if not isinstance(e, dict) or type(e.get("ord")) is not int or e["ord"] != len(events):
+            raise ValueError("event ord must be contiguous from zero")
+        kind = e.get("kind")
+        fields = {"ord", "kind", "created", "pid", "tid", "src"}
+        fields |= {"vote", "weight_x_32767"} if kind == "vote" else {"modified", "mod", "is_meta"}
+        if kind not in ("vote", "comment") or set(e) != fields:
+            raise ValueError("unknown/missing event fields")
+        for key in ("created", "pid", "tid"):
+            _integer(e[key])
+        src = e["src"]
+        rows = votes if kind == "vote" else comments
+        if (not isinstance(src, dict) or set(src) != {"table", "row"}
+                or src["table"] != ("votes" if kind == "vote" else "comments")
+                or type(src["row"]) is not int or src["row"] != len(rows)):
+            raise ValueError("event source row does not match frozen order")
+        if kind == "vote":
+            if comments or (votes and e["created"] < votes[-1]["created"]):
+                raise ValueError("votes must precede comments in created order")
+            _integer(e["vote"], nullable=True)
+            if e["vote"] not in (None, -1, 0, 1):
+                raise ValueError("unknown vote")
+            _integer(e["weight_x_32767"], nullable=True)
+        else:
+            _integer(e["modified"], nullable=True)
+            _integer(e["mod"])
+            if e["mod"] not in (-1, 0, 1) or type(e["is_meta"]) is not bool:
+                raise ValueError("invalid comment state")
+            if comments and e["tid"] <= comments[-1]["tid"]:
+                raise ValueError("comments must be unique in tid order")
+        rows.append(e)
+        events.append(e)
+        digest.update((json.dumps({k: v for k, v in e.items() if k != "src"},
+                                 sort_keys=True, separators=(",", ":")) + "\n").encode())
+    counts = meta.get("counts", {})
+    for key, count in (("events", len(events)), ("vote_events", len(votes)), ("comment_events", len(comments))):
+        if type(counts.get(key)) is not int or counts[key] != count:
+            raise ValueError("event census mismatch")
+    if meta.get("logical_digest_sha256") != digest.hexdigest():
+        raise ValueError("event logical digest mismatch")
+    return events, convention
+
+
+def load_events(path: str | Path) -> ReplayDataset:
+    events, convention = read_events(path)
+    votes = [e for e in events if e["kind"] == "vote"]
+    comments = [e for e in events if e["kind"] == "comment"]
+    ds = ReplayDataset.build([
+        (e["created"], e["pid"], e["tid"],
+         None if e["vote"] is None else semantic_vote(e["vote"], convention))
+        for e in votes
+    ], mod_events=[ModEvent(e["modified"], e["tid"], e["mod"], e["is_meta"])
+                   for e in comments if e["modified"] is not None])
+    ds.votes = [replace(v, weight_x_32767=e["weight_x_32767"], source_ord=e["ord"])
+                for v, e in zip(ds.votes, votes)]
+    ds.input_events = tuple(events)
+    ds.mod_events_skipped = sum(e["modified"] is None for e in comments)
+    return ds
+
+
+def input_hashes(path: str | Path) -> dict[str, str]:
+    path = Path(path)
+    return {name: hashlib.sha256(p.read_bytes()).hexdigest() for name, p in (
+        ("events_sha256", path), ("events_meta_sha256", path.with_name("events.meta.json")))}
+
+
+def compatibility_accounting(events_path: str | Path, csv_path: str | Path) -> dict:
+    """Exact private diagnostic: every lost vote fact and its ordinal.
+
+    A checkpoint in the old CSV addresses a different prefix after a NULL drop.
+    This does not attempt to infer unavailable original facts from public CSVs.
+    """
+    from polismath.replay.real_data import read_export_vote_rows
+    events, convention = read_events(events_path)
+    votes = [e for e in events if e['kind'] == 'vote']
+    retained = [e for e in votes if e['vote'] is not None]
+    actual = read_export_vote_rows(csv_path)
+    expected = [(e['created'] // 1000 * 1000, e['pid'], e['tid'],
+                 semantic_vote(e['vote'], convention)) for e in retained]
+    losses = []
+    csv_slot = 0
+    for slot, e in enumerate(votes, 1):
+        if e['vote'] is not None:
+            csv_slot += 1
+        losses.append({'ord': e['ord'], 'event_vote_slot': slot,
+                       'csv_vote_slot': csv_slot if e['vote'] is not None else None,
+                       'null_vote_dropped': e['vote'] is None,
+                       'milliseconds_lost': e['created'] % 1000,
+                       'weight_lost': e['weight_x_32767'],
+                       'weight_column_absent': True})
+    return {'schema': 'polis-csv-loss/1', 'events': len(votes), 'csv_rows': len(actual),
+            'csv_matches_declared_projection': actual == expected,
+            'null_votes_dropped': sum(e['vote'] is None for e in votes),
+            'subsecond_rows': sum(e['created'] % 1000 != 0 for e in votes),
+            'non_null_weights_lost': sum(e['weight_x_32767'] is not None for e in votes),
+            'rows': losses}

--- a/delphi/polismath/replay/real_data.py
+++ b/delphi/polismath/replay/real_data.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import csv
 import hashlib
 import json
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -105,9 +106,20 @@ def dataset_dir(slug: str) -> Path | None:
     match wins a slug collision."""
     if not _SLUG_RE.match(slug):
         return None
+    mapping = os.environ.get("POLIS_REPLAY_INPUT_MAP")
+    if mapping:
+        bindings = json.loads(Path(mapping).read_text())
+        if not isinstance(bindings, dict) or slug not in bindings:
+            raise ValueError("input map must bind every requested dataset")
+        path = Path(bindings[slug])
+        if not path.is_absolute() or not path.is_dir():
+            raise ValueError("input map values must be existing absolute directories")
+        return path
     hits = sorted(REAL_DATA_ROOT.glob(f"*-{slug}"))
     if not hits:
         hits = sorted(REAL_DATA_ROOT.glob(f".local/*-{slug}"))
+    if len(hits) > 1:
+        raise ValueError("ambiguous dataset directory")
     return hits[0] if hits else None
 
 
@@ -127,6 +139,9 @@ def load_export_votes(slug: str) -> ReplayDataset:
     d = dataset_dir(slug)
     if d is None:
         raise FileNotFoundError(f"no dataset directory matching *-{slug}")
+    if (d / "events.jsonl").exists():
+        from polismath.replay.event_ingress import load_events
+        return load_events(d / "events.jsonl")
     votes_csvs = sorted(d.glob("*-votes.csv"))
     if not votes_csvs:
         raise FileNotFoundError(f"no *-votes.csv in {d.name}")

--- a/delphi/polismath/replay/types.py
+++ b/delphi/polismath/replay/types.py
@@ -40,8 +40,10 @@ class VoteEvent:
     t_ms: int
     pid: int
     tid: int
-    sign: int
+    sign: int | None
     is_revote: bool
+    weight_x_32767: int | None = None
+    source_ord: int | None = None
 
 
 @dataclass(frozen=True)
@@ -90,6 +92,8 @@ class ReplayDataset:
     # no moderation-history columns at all (nothing was skipped — there was
     # nothing to parse).
     mod_events_skipped: int = 0
+    # Original authoritative rows, including comments and source provenance.
+    input_events: tuple[dict, ...] = ()
 
     @property
     def n(self) -> int:

--- a/delphi/scripts/prove_event_ingress.py
+++ b/delphi/scripts/prove_event_ingress.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Compare both ingress paths on every public battery entry.
+
+The public source is CSV-only. Lifting it proves no change to its known content;
+it cannot recover private/original subsecond timestamps, weights or NULL rows.
+Python's recording-only math_tick clock and Clojure rand are fixed in both runs.
+Provenance/schedule files intentionally differ and are not numerical recordings.
+"""
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from polismath.replay import certify, event_ingress, fixture_extract, real_data
+
+
+def sha(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def lift(slug, target):
+    """Lift only known CSV facts; NULL weight means unavailable, not recovered."""
+    csv = certify.votes_csv_path(slug)
+    rows = sorted(real_data.read_export_vote_rows(csv), key=lambda v: v[0])
+    events = fixture_extract.build_events([
+        dict(created=t, pid=p, tid=c, vote=-v, weight_x_32767=None) for t, p, c, v in rows
+    ], [])
+    target.mkdir(parents=True, exist_ok=True)
+    fixture_extract.write_events_jsonl(target / 'events.jsonl', events)
+    meta = {'schema_version': 'certify-events/2', 'polarity': {'storage_agree_value': -1},
+            'counts': {'events': len(events), 'vote_events': len(events), 'comment_events': 0},
+            'logical_digest_sha256': fixture_extract.logical_digest(events),
+            'derivation': {'source': 'public-csv-lift', 'csv_sha256': sha(csv),
+                           'unavailable': ['original milliseconds', 'original weights', 'dropped NULL votes']}}
+    (target / 'events.meta.json').write_text(json.dumps(meta, sort_keys=True) + '\n')
+    ds = event_ingress.load_events(target / 'events.jsonl')
+    old = real_data.load_export_votes(slug)
+    assert [(v.t_ms, v.pid, v.tid, v.sign, v.is_revote) for v in old.votes] == [
+        (v.t_ms, v.pid, v.tid, v.sign, v.is_revote) for v in ds.votes]
+    return csv, target / 'events.jsonl'
+
+
+def run_proof(out):
+    delphi = Path(__file__).resolve().parents[1]
+    config = json.loads((delphi / 'scripts/certify_datasets.json').read_text())
+    # Use the battery's established public classification, not slug substrings.
+    public = {entry["slug"] for entry in config["public_fixtures"]}
+    entries = [e for e in certify.load_battery() if e.dataset in public]
+    sources = {slug: lift(slug, out / 'inputs' / slug) for slug in sorted({e.dataset for e in entries})}
+    env = dict(os.environ, OMP_NUM_THREADS='1', OPENBLAS_NUM_THREADS='1', MKL_NUM_THREADS='1',
+               PYTHONPATH=str(delphi), PYTHONHASHSEED='0')
+    env.pop('POLIS_REPLAY_INPUT_MAP', None)
+    wrapper = out / 'fixed-clj.clj'
+    wrapper.write_text("(load-file \"dev/replay.clj\")\n"
+                       "(let [rng (java.util.Random. 671)]\n"
+                       "  (with-redefs [clojure.core/rand (fn ([] (.nextDouble rng)) ([n] (* n (.nextDouble rng))))]\n"
+                       "    (apply replay/-main *command-line-args*)))\n")
+    tasks = []
+    for entry in entries:
+        expected = certify.prepare_entry(entry)
+        spec = out / 'schedules' / entry.dataset / (entry.schedule_id + '.json')
+        spec.parent.mkdir(parents=True, exist_ok=True)
+        expected.spec.write_json(spec)
+        for mode in ('csv', 'events'):
+            root = out / mode
+            rec = root / entry.dataset / entry.schedule_id
+            source = sources[entry.dataset][mode == 'events']
+            clj = ['clojure', '-M', str(wrapper), '--schedule', str(spec), '--out', str(rec),
+                   '--events' if mode == 'events' else '--votes', str(source)]
+            py = [sys.executable, '-c',
+                  "import runpy,time; time.time=lambda:1700000000.0; runpy.run_path('scripts/replay_driver.py',run_name='__main__')",
+                  'run', '--schedule', str(spec), '--out', str(root)]
+            if mode == 'events':
+                py += ['--events', str(source)]
+            for engine, cmd, cwd in [('clj', clj, delphi.parent / 'math'), ('py', py, delphi)]:
+                log = out / 'logs' / f'{entry.dataset}-{entry.schedule_id}-{mode}-{engine}.log'
+                tasks.append((cmd, cwd, log, env))
+    def execute(task):
+        cmd, cwd, log, env = task
+        log.parent.mkdir(parents=True, exist_ok=True)
+        with log.open('w') as fh:
+            p = subprocess.run(cmd, cwd=cwd, env=env, stdout=fh, stderr=subprocess.STDOUT, timeout=3600)
+        print(f'{log.stem}: exit {p.returncode}', flush=True)
+        if p.returncode:
+            raise RuntimeError(f'driver failed; see {log}')
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        list(pool.map(execute, tasks))
+    results = []
+    for e in entries:
+        for engine in ('py', 'clj'):
+            a = out / 'csv' / e.dataset / e.schedule_id / engine
+            b = out / 'events' / e.dataset / e.schedule_id / engine
+            files_a = {p.name: sha(p) for p in a.glob('step-*.json')}
+            files_b = {p.name: sha(p) for p in b.glob('step-*.json')}
+            different = sorted(k for k in files_a.keys() | files_b.keys() if files_a.get(k) != files_b.get(k))
+            results.append(dict(dataset=e.dataset, schedule_id=e.schedule_id, engine=engine,
+                                files=len(files_a), byte_identical=not different, different=different,
+                                csv_sha256=files_a, events_sha256=files_b))
+    report = dict(schema='polis-event-ingress-proof/1',
+                  scope='CSV-only public lift; fixed Python wall clock and Clojure rand seed 671; raw step files compared',
+                  entries=len(entries), engine_runs=len(tasks), results=results,
+                  passed=all(r['byte_identical'] for r in results))
+    (out / 'proof.json').write_text(json.dumps(report, indent=2, sort_keys=True) + '\n')
+    return report['passed']
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--out', required=True, type=Path)
+    args = parser.parse_args()
+    args.out.mkdir(parents=True, exist_ok=False)
+    raise SystemExit(0 if run_proof(args.out.resolve()) else 1)

--- a/delphi/scripts/replay_driver.py
+++ b/delphi/scripts/replay_driver.py
@@ -81,19 +81,24 @@ def cli() -> None:
 @click.option("--out", "out_root", type=click.Path(path_type=Path), default=None,
               help="Store root (default: real_data/.local/replays).")
 @click.option("--verbose", is_flag=True, help="Show driver progress logging.")
-def run(dataset, schedule_path, preset, n_cuts, schedule_id, out_root, verbose):
+@click.option("--events", type=click.Path(exists=True, path_type=Path), default=None,
+              help="Exact events.jsonl; requires sibling events.meta.json.")
+def run(dataset, schedule_path, preset, n_cuts, schedule_id, out_root, verbose, events):
     """Run a (dataset, schedule) replay and write the recording store."""
     if not verbose:
         # logging.disable is process-global: restore it in _run's finally so an
         # in-process caller (CliRunner tests) isn't silenced past this command.
         logging.disable(logging.CRITICAL)
     try:
-        _run_impl(dataset, schedule_path, preset, n_cuts, schedule_id, out_root, verbose)
+        _run_impl(dataset, schedule_path, preset, n_cuts, schedule_id, out_root, verbose, events)
     finally:
         logging.disable(logging.NOTSET)
 
 
-def _run_impl(dataset, schedule_path, preset, n_cuts, schedule_id, out_root, verbose):
+def _run_impl(dataset, schedule_path, preset, n_cuts, schedule_id, out_root, verbose, events=None):
+    from polismath.replay.event_ingress import load_events, input_hashes
+    def load(slug):
+        return load_events(events) if events else load_export_votes(slug)
     ds: ReplayDataset | None = None
     loaded_slug: str | None = None
     if schedule_path is not None:
@@ -102,7 +107,7 @@ def _run_impl(dataset, schedule_path, preset, n_cuts, schedule_id, out_root, ver
     elif preset is not None:
         if not dataset:
             raise click.UsageError("--dataset is required with --preset")
-        ds = load_export_votes(dataset)
+        ds = load(dataset)
         loaded_slug = dataset
         spec = _spec_from_preset(preset, dataset, ds, n_cuts=n_cuts,
                                  schedule_id=schedule_id)
@@ -112,14 +117,26 @@ def _run_impl(dataset, schedule_path, preset, n_cuts, schedule_id, out_root, ver
     # Reuse the dataset already loaded to build a preset spec instead of loading
     # it a second time; only the --schedule path (or a slug mismatch) needs a load.
     if ds is None or loaded_slug != spec.dataset:
-        ds = load_export_votes(spec.dataset)
+        ds = load(spec.dataset)
+    if events is None:
+        from polismath.replay.real_data import dataset_dir
+        directory = dataset_dir(spec.dataset)
+        if directory is not None and (directory / "events.jsonl").exists():
+            events = directory / "events.jsonl"
+    if spec.source == "events-jsonl" and events is None:
+        raise click.UsageError("events-jsonl schedule requires authoritative events")
+    if events is not None:
+        raw = spec.to_dict()
+        raw["source"] = "events-jsonl"
+        spec = sched.ScheduleSpec.from_dict(raw)
     click.echo(f"dataset={spec.dataset} n_votes={ds.n} schedule={spec.schedule_id}", err=True)
 
     def _progress(i: int, total: int) -> None:
         click.echo(f"  step {i + 1}/{total} …", err=True)
 
     records = run_replay(ds, spec, progress=_progress if verbose else None)
-    out_dir = st.write_recording(records, spec, root=out_root)
+    out_dir = st.write_recording(records, spec, root=out_root,
+                                 **({"extra_provenance": input_hashes(events)} if events else {}))
     click.echo(f"wrote {len(records)} steps → {out_dir}")
 
 

--- a/delphi/tests/replay_harness/event_ingress_test.clj
+++ b/delphi/tests/replay_harness/event_ingress_test.clj
@@ -1,0 +1,59 @@
+;; From math/: clojure -M ../delphi/tests/replay_harness/event_ingress_test.clj
+(load-file "dev/replay.clj")
+(require '[clojure.test :refer :all] '[cheshire.core :as json] '[clojure.java.io :as io])
+
+(def vote-events [{"ord" 0 "kind" "vote" "created" 1001 "pid" 1 "tid" 2 "vote" -1
+                   "weight_x_32767" 0 "src" {"table" "votes" "row" 0}}
+                  {"ord" 1 "kind" "vote" "created" 1001 "pid" 1 "tid" 2 "vote" 1
+                   "weight_x_32767" nil "src" {"table" "votes" "row" 1}}
+                  {"ord" 2 "kind" "vote" "created" 1999 "pid" 1 "tid" 2 "vote" nil
+                   "weight_x_32767" 123 "src" {"table" "votes" "row" 2}}])
+
+(defn with-stream [events sign f]
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory "ingress-test-" (make-array java.nio.file.attribute.FileAttribute 0)))
+        path (io/file dir "events.jsonl")
+        meta (io/file dir "events.meta.json")]
+    (try
+      (spit path (apply str (map #(str (json/generate-string %) "\n") events)))
+      (spit meta (json/generate-string
+                   {"schema_version" "certify-events/2" "polarity" {"storage_agree_value" sign}
+                    "counts" {"events" (count events) "vote_events" (count events) "comment_events" 0}
+                    "logical_digest_sha256" (#'replay/sha256-hex
+                       (apply str (map #(str (json/generate-string (into (sorted-map) (dissoc % "src"))) "\n") events)))}))
+      (f path)
+      (finally (.delete path) (.delete meta) (.delete dir)))))
+
+(deftest millisecond-null-weight-and-tie-order
+  (with-stream vote-events -1
+    (fn [path]
+      (let [votes (:votes (replay/read-event-stream path))]
+        (is (= [1001 1001 1999] (mapv :t-ms votes)))
+        (is (= [1 -1 nil] (mapv :sign votes)))
+        (is (= [0 nil 123] (mapv :weight_x_32767 votes)))
+        (is (= [0 1 2] (mapv :source-ord votes)))
+        (is (= [{:pid 1 :tid 2 :vote -1 :created 1001 :weight_x_32767 0}
+                {:pid 1 :tid 2 :vote 1 :created 1001 :weight_x_32767 nil}
+                {:pid 1 :tid 2 :vote nil :created 1999 :weight_x_32767 123}]
+               (replay/->conv-votes votes)))))))
+
+(deftest corrupt-events-rejected
+  (doseq [events [(assoc-in vote-events [1 "ord"] 0)
+                  (assoc-in vote-events [0 "vote"] false)
+                  (assoc-in vote-events [0 "weight_x_32767"] false)
+                  (assoc-in vote-events [1 "created"] 999)
+                  (assoc-in vote-events [0 "src" "row"] 3)
+                  (assoc-in vote-events [0 "pid"] 1.5)
+                  (assoc-in vote-events [0 "vote"] 2)]]
+    (with-stream events -1 #(is (thrown? Exception (replay/read-event-stream %))))))
+
+(deftest bad-conventions-rejected
+  (doseq [s [true nil 0 -1.0 "-1"]]
+    (with-stream vote-events s #(is (thrown? Exception (replay/read-event-stream %))))))
+
+(deftest duplicate-json-rejected
+  (is (thrown? Exception (replay/parse-event-json "{\"ord\":0,\"ord\":0}"))))
+
+(deftest zero-events-retained
+  (with-stream [] -1 #(is (= [] (:votes (replay/read-event-stream %))))))
+
+(let [r (run-tests)] (System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))

--- a/delphi/tests/replay_harness/test_event_ingress.py
+++ b/delphi/tests/replay_harness/test_event_ingress.py
@@ -1,0 +1,185 @@
+"""Lossless ingress rejects corrupt streams and preserves engine-boundary facts."""
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from polismath.replay import event_ingress as ei, real_data, schedule
+from polismath.replay.driver import _votes_dict
+from polismath.replay.fixture_extract import build_events, logical_digest
+
+
+def write_stream(directory, events=None, sign=-1):
+    directory.mkdir(parents=True, exist_ok=True)
+    if events is None:
+        events = build_events([
+            dict(created=1001, pid=1, tid=2, vote=-1, weight_x_32767=0),
+            dict(created=1001, pid=1, tid=2, vote=1, weight_x_32767=None),
+            dict(created=1999, pid=1, tid=2, vote=None, weight_x_32767=123),
+        ], [dict(created=900, modified=1500, pid=1, tid=2, mod=-1, is_meta=True)])
+    path = directory / 'events.jsonl'
+    path.write_text(''.join(json.dumps(e) + '\n' for e in events))
+    meta = {'schema_version': 'certify-events/2', 'polarity': {'storage_agree_value': sign},
+            'logical_digest_sha256': logical_digest(events), 'counts': {
+                'events': len(events), 'vote_events': sum(e['kind'] == 'vote' for e in events),
+                'comment_events': sum(e['kind'] == 'comment' for e in events)}}
+    path.with_name('events.meta.json').write_text(json.dumps(meta))
+    return path
+
+
+def test_lossless_boundary_and_cut_indices(tmp_path):
+    path = write_stream(tmp_path)
+    ds = ei.load_events(path)
+    assert [(v.k, v.t_ms, v.sign, v.weight_x_32767, v.is_revote, v.source_ord) for v in ds.votes] == [
+        (1, 1001, 1, 0, False, 0), (2, 1001, -1, None, True, 1), (3, 1999, None, 123, True, 2)]
+    assert ds.input_events == tuple(json.loads(line) for line in path.read_text().splitlines())
+    spec = schedule.ScheduleSpec('fixture', 'cuts', {'mode': 'vote-count', 'at': [1, 2, 3]},
+                                 moderation='interleave-by-timestamp')
+    steps = schedule.slice_schedule(ds, spec)
+    assert [len(s.mod_events) for s in steps] == [0, 0, 1]
+    assert _votes_dict(steps[2]) == {'votes': [dict(pid=1, tid=2, vote=None, created=1999,
+                                                 weight_x_32767=123)], 'lastVoteTimestamp': 1999}
+    assert _votes_dict(steps[0])['votes'][0]['weight_x_32767'] == 0
+    assert schedule.resolve_cut_slots(ds, {'mode': 'timestamp', 'at': [1001, 1999]}) == (2, 3)
+
+
+@pytest.mark.parametrize('mutation', [
+    lambda e: e[0].update(ord=True), lambda e: e[1].update(ord=0),
+    lambda e: e[0].update(created=1.5), lambda e: e[0].update(created=2**63),
+    lambda e: e[0].update(pid=True), lambda e: e[0].update(vote=False),
+    lambda e: e[0].update(vote=2), lambda e: e[0].pop('weight_x_32767'),
+    lambda e: e[0].update(weight_x_32767=False), lambda e: e[1].update(created=999),
+    lambda e: e[0].update(src={'table': 'votes', 'row': 1}),
+    lambda e: e[3].update(is_meta=1), lambda e: e[3].update(mod=None),
+    lambda e: e[0].update(extra='unknown'), lambda e: e[3].update(kind='other'),
+])
+def test_reject_corrupt_events(tmp_path, mutation):
+    p = write_stream(tmp_path)
+    events, _ = ei.read_events(p)
+    mutation(events)
+    write_stream(tmp_path, events)
+    with pytest.raises(ValueError):
+        ei.load_events(p)
+
+
+@pytest.mark.parametrize('sign', [True, 0, '-1', -1.0, None])
+def test_reject_undeclared_convention(tmp_path, sign):
+    with pytest.raises(ValueError):
+        ei.load_events(write_stream(tmp_path, sign=sign))
+
+
+def test_compensated_polarity_preserves_nulls_weights(tmp_path):
+    p = write_stream(tmp_path / 'a')
+    events, _ = ei.read_events(p)
+    flipped = copy.deepcopy(events)
+    for e in flipped:
+        if e['kind'] == 'vote' and e['vote'] is not None:
+            e['vote'] *= -1
+    q = write_stream(tmp_path / 'b', flipped, sign=1)
+    assert ei.load_events(p).votes == ei.load_events(q).votes
+
+
+def test_empty_stream_and_hashes(tmp_path):
+    p = write_stream(tmp_path, [])
+    assert ei.load_events(p).n == 0
+    h = ei.input_hashes(p)
+    p.with_name('events.meta.json').write_text('{}')
+    assert ei.input_hashes(p)['events_meta_sha256'] != h['events_meta_sha256']
+    with pytest.raises(ValueError):
+        ei.load_events(p)
+
+
+@pytest.mark.parametrize('corruption', ['digest', 'count', 'duplicate'])
+def test_meta_and_json_binding(tmp_path, corruption):
+    p = write_stream(tmp_path)
+    meta_path = p.with_name('events.meta.json')
+    meta = json.loads(meta_path.read_text())
+    if corruption == 'digest':
+        meta['logical_digest_sha256'] = '0' * 64
+    elif corruption == 'count':
+        meta['counts']['vote_events'] = 2
+    else:
+        p.write_text(p.read_text().replace('"ord": 0', '"ord": 0, "ord": 0'))
+    meta_path.write_text(json.dumps(meta))
+    with pytest.raises(ValueError):
+        ei.load_events(p)
+
+
+def test_exact_input_map_and_prefer_events(tmp_path, monkeypatch):
+    p = write_stream(tmp_path / 'opaque')
+    bindings = tmp_path / 'map.json'
+    bindings.write_text(json.dumps({'fixture': str(p.parent)}))
+    monkeypatch.setenv('POLIS_REPLAY_INPUT_MAP', str(bindings))
+    assert real_data.load_export_votes('fixture').n == 3
+    with pytest.raises(ValueError, match='every requested'):
+        real_data.dataset_dir('unbound')
+    # A malformed authoritative input must never fall back to compatibility CSV.
+    p.write_text('{}\n')
+    with pytest.raises(ValueError):
+        real_data.load_export_votes('fixture')
+
+
+def test_compatibility_loss_is_exact_and_detects_stale_csv(tmp_path):
+    from polismath.replay.fixture_extract import compat_rows_from_events
+    from polismath.replay.prodclone import write_votes_csv
+    p = write_stream(tmp_path)
+    events, _ = ei.read_events(p)
+    rows, _, _ = compat_rows_from_events(events)
+    csv_path = tmp_path / 'fixture-votes.csv'
+    write_votes_csv(csv_path, rows)
+    report = ei.compatibility_accounting(p, csv_path)
+    assert report['csv_matches_declared_projection']
+    assert (report['events'], report['csv_rows'], report['null_votes_dropped'],
+            report['subsecond_rows'], report['non_null_weights_lost']) == (3, 2, 1, 3, 2)
+    assert [r['csv_vote_slot'] for r in report['rows']] == [1, 2, None]
+    assert [r['milliseconds_lost'] for r in report['rows']] == [1, 1, 999]
+    csv_path.write_text(csv_path.read_text().replace(',1\n', ',-1\n'))
+    # Explicitly truncate, independent of CSV newline conventions.
+    write_votes_csv(csv_path, rows[:1])
+    assert not ei.compatibility_accounting(p, csv_path)['csv_matches_declared_projection']
+
+
+def test_event_metadata_is_bound_to_prepared_inventory(tmp_path, monkeypatch):
+    from polismath.replay import certify
+    p = write_stream(tmp_path)
+    monkeypatch.setattr(real_data, 'dataset_dir', lambda _: tmp_path)
+    e = certify.BatteryEntry('fixture', 'one', preset='single-cut')
+    prepared = certify.prepare_entry(e)
+    assert prepared.votes_csv == p
+    assert prepared.events_meta_sha == ei.input_hashes(p)['events_meta_sha256']
+    assert prepared.spec.source == 'events-jsonl'
+    assert prepared.stream_end == 3
+    assert prepared.checkpoints[-1]['cut_time_ms'] == 1999
+
+
+def test_subprocesses_receive_exact_events_file(tmp_path, monkeypatch):
+    from polismath.replay import certify
+    import subprocess
+    seen = []
+    def invoke(cmd, **kwargs):
+        seen.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, '', '')
+    monkeypatch.setattr(certify, '_run_subprocess', invoke)
+    events = tmp_path / 'events.jsonl'
+    certify.run_py_driver(tmp_path / 'schedule.json', out_root=tmp_path, events=events)
+    certify.run_clj_driver(tmp_path / 'schedule.json', events, out_dir=tmp_path)
+    for cmd in seen:
+        assert cmd[cmd.index('--events') + 1] == str(events)
+        assert '--votes' not in cmd
+
+
+def test_restart_keeps_null_and_zero_weight(tmp_path, monkeypatch):
+    from polismath.replay import driver
+    ds = ei.load_events(write_stream(tmp_path))
+    seen = []
+    class Restored:
+        def update_votes(self, payload, recompute):
+            seen.append(payload)
+            return self
+        def mod_update(self, rows):
+            return self
+    monkeypatch.setattr(driver.Conversation, 'from_dict', lambda _: Restored())
+    driver._restart_conversation(ds, cut_slot=3, cut_time_ms=1999, blob={}, mod_events=())
+    assert [v['weight_x_32767'] for v in seen[0]['votes']] == [0, None, 123]
+    assert [v['vote'] for v in seen[0]['votes']] == [1, -1, None]

--- a/math/dev/replay.clj
+++ b/math/dev/replay.clj
@@ -62,6 +62,7 @@
             [clojure.string :as str]
             [clojure.tools.cli :as cli]
             [cheshire.core :as json]
+            [cheshire.factory :as json-factory]
             [com.stuartsierra.component :as component]
             [clojure.core.matrix :as matrix]
             [polismath.math.conversation :as conv]
@@ -95,6 +96,66 @@
                :tid  (Long/parseLong (str/trim (nth r ci)))
                :sign (Long/parseLong (str/trim (nth r si)))})
             (rest rows)))))
+
+(declare sha256-hex)
+
+(defn parse-event-json [text]
+  (binding [json-factory/*json-factory*
+            (json-factory/make-json-factory {:strict-duplicate-detection true
+                                            :allow-unquoted-control-chars false})]
+    (json/parse-string text)))
+
+(defn read-event-stream
+  "Read extraction order and nullable raw storage fields without CSV conversion."
+  [path]
+  (let [meta (parse-event-json (slurp (io/file (.getParentFile (io/file path)) "events.meta.json")))
+        s (get-in meta ["polarity" "storage_agree_value"])
+        events (with-open [r (io/reader path)] (mapv parse-event-json (line-seq r)))
+        votes (filterv #(= "vote" (get % "kind")) events)
+        comments (filterv #(= "comment" (get % "kind")) events)
+        int64? #(and (integer? %) (<= Long/MIN_VALUE % Long/MAX_VALUE))
+        nullable? #(or (nil? %) (int64? %))]
+    (when-not (and (= "certify-events/2" (get meta "schema_version"))
+                   (integer? s) (#{-1 1} s))
+      (throw (ex-info "invalid event schema/convention" {})))
+    (doseq [[i e] (map-indexed vector events)]
+      (let [kind (get e "kind")
+            fields (into #{"ord" "kind" "created" "pid" "tid" "src"}
+                         (if (= kind "vote") ["vote" "weight_x_32767"] ["modified" "mod" "is_meta"]))]
+        (when-not (and (= fields (set (keys e))) (= i (get e "ord"))
+                       (integer? (get e "ord")) (#{"vote" "comment"} kind)
+                       (every? #(int64? (get e %)) ["created" "pid" "tid"])
+                       (if (= kind "vote")
+                         (and (nullable? (get e "vote"))
+                              (contains? #{nil -1 0 1} (get e "vote"))
+                              (nullable? (get e "weight_x_32767")))
+                         (and (nullable? (get e "modified"))
+                              (integer? (get e "mod")) (#{-1 0 1} (get e "mod"))
+                              (instance? Boolean (get e "is_meta")))))
+          (throw (ex-info "invalid event fields/order" {})))))
+    (doseq [[rows table] [[votes "votes"] [comments "comments"]]]
+      (doseq [[i e] (map-indexed vector rows)]
+        (when-not (and (= {"table" table "row" i} (get e "src"))
+                       (integer? (get-in e ["src" "row"])))
+          (throw (ex-info "invalid event source order" {})))))
+    (when-not (and (= events (into votes comments))
+                   (apply <= (cons Long/MIN_VALUE (map #(get % "created") votes)))
+                   (or (empty? comments) (apply < (map #(get % "tid") comments)))
+                   (every? (fn [[k n]] (and (integer? (get-in meta ["counts" k]))
+                                            (= n (get-in meta ["counts" k]))))
+                           [["events" (count events)] ["vote_events" (count votes)]
+                            ["comment_events" (count comments)]]))
+      (throw (ex-info "event order/census mismatch" {})))
+    (let [logical (apply str (map #(str (json/generate-string (into (sorted-map) (dissoc % "src"))) "\n") events))]
+      (when-not (= (sha256-hex logical) (get meta "logical_digest_sha256"))
+        (throw (ex-info "event logical digest mismatch" {}))))
+    {:votes (mapv (fn [e] {:t-ms (get e "created") :pid (get e "pid") :tid (get e "tid")
+                           :sign (when-some [v (get e "vote")] (* v s))
+                           :weight_x_32767 (get e "weight_x_32767") :source-ord (get e "ord")}) votes)
+     :mods {:events (mapv (fn [e] {:tid (get e "tid") :mod (get e "mod")
+                                  :is_meta (get e "is_meta") :modified (get e "modified")})
+                         (filter #(some? (get % "modified")) comments))
+            :n-skipped (count (filter #(nil? (get % "modified")) comments))}}))
 
 (defn build-dataset
   "Sort raw file-order vote maps stably by (t_ms, input index) and 1-index them.
@@ -210,8 +271,9 @@
 
 (defn ->conv-votes
   [batch]
-  (mapv (fn [{:keys [pid tid sign t-ms]}]
-          {:pid pid :tid tid :vote (- (long sign)) :created t-ms})
+  (mapv (fn [{:keys [pid tid sign t-ms source-ord weight_x_32767]}]
+          (cond-> {:pid pid :tid tid :vote (when (some? sign) (- (long sign))) :created t-ms}
+            (some? source-ord) (assoc :weight_x_32767 weight_x_32767)))
         batch))
 
 ;; ---------------------------------------------------------------------------
@@ -272,7 +334,7 @@
         (assoc :raw-rating-mat
                (nm/update-nmat (nm/named-matrix)
                                (mapv (fn [{:keys [pid tid sign]}]
-                                       [pid tid (- (long sign))])
+                                       [pid tid (when (some? sign) (- (long sign)))])
                                      votes-so-far)))
         (conv/mod-update (vec mods-so-far)))))
 
@@ -595,7 +657,7 @@
   slicer's stable order); booleans are 0/1."
   [step]
   (let [votes (mapv (fn [{:keys [pid tid sign t-ms]}]
-                      [(long pid) (long tid) (long sign) (long t-ms)])
+                      [(long pid) (long tid) (when (some? sign) (long sign)) (long t-ms)])
                     (:votes step))
         mods  (mapv (fn [{:keys [tid is_meta mod modified]}]
                       [(long tid) (if is_meta 1 0) (long mod) (long modified)])
@@ -798,6 +860,7 @@
 (def cli-options
   [["-s" "--schedule PATH" "Path to the schedule JSON (§4)."]
    ["-v" "--votes PATH" "Path to the export votes CSV."]
+   [nil "--events PATH" "Authoritative events.jsonl with sibling events.meta.json."]
    ["-o" "--out DIR" "Recording dir (…/<dataset>/<schedule_id>); clj/ is written under it."]
    [nil "--comments PATH" "Optional comments CSV (meta-tids via is-meta column)."]
    [nil "--zid ZID" "Conversation id to seed (default: schedule dataset name)."]
@@ -820,9 +883,11 @@
       (do (binding [*out* *err*] (doseq [e errors] (println e)) (println summary))
           (System/exit 1))
 
-      (some nil? [(:schedule options) (:votes options) (:out options)])
+      (or (some nil? [(:schedule options) (:out options)])
+          (= (boolean (:votes options)) (boolean (:events options)))
+          (and (:events options) (:comments options)))
       (do (binding [*out* *err*]
-            (println "ERROR: --schedule, --votes and --out are all required.")
+            (println "ERROR: --schedule, --out and exactly one of --votes/--events required; --events excludes --comments.")
             (println summary))
           (System/exit 1))
 
@@ -845,6 +910,8 @@
             ;; 1283) and store.load_step_blobs globs step-*.json there.
             stage-root  (io/file out "clj-stages")]
 
+        (when (and (= source "events-jsonl") (nil? (:events options)))
+          (throw (ex-info "events-jsonl schedule requires --events" {})))
         (when-not (contains? #{"none" "interleave-by-timestamp" nil} moderation)
           (throw (ex-info
                    (str "Unknown moderation mode " (pr-str moderation)
@@ -852,7 +919,7 @@
                         "(mod rows from --comments, woven by modified timestamp).")
                    {:moderation moderation})))
         (when (and (= moderation "interleave-by-timestamp")
-                   (nil? (:comments options)))
+                   (nil? (:comments options)) (nil? (:events options)))
           (throw (ex-info "moderation=interleave-by-timestamp requires --comments"
                           {:moderation moderation})))
 
@@ -873,13 +940,14 @@
         (component/start
           (cmb/create-core-matrix-booter {:config {:math {:matrix-implementation :vectorz}}}))
 
-        (let [raw   (read-votes-csv (:votes options))
+        (let [event-input (when (:events options) (read-event-stream (:events options)))
+              raw   (if event-input (:votes event-input) (read-votes-csv (:votes options)))
               votes (build-dataset raw)
               slots (resolve-cut-slots votes cuts)
               restart-after (get schedule "restart_after")
               {mod-events :events n-mod-skipped :n-skipped}
               (if (= moderation "interleave-by-timestamp")
-                (read-mod-events (:comments options))
+                (if event-input (:mods event-input) (read-mod-events (:comments options)))
                 {:events [] :n-skipped 0})
               steps (slice-schedule votes slots mod-events)
               ;; Under interleave moderation, meta-tids enter EXCLUSIVELY via
@@ -944,8 +1012,8 @@
           ;; Provenance (recording dir + a clj/ mirror so a later Python run's
           ;; provenance.json cannot clobber ours).
           (let [prov (build-provenance
-                       {:schedule schedule :schedule-id schedule-id :source source
-                        :votes-path (:votes options) :comments-path (:comments options)
+                       {:schedule schedule :schedule-id schedule-id :source (if (:events options) "events-jsonl" source)
+                        :votes-path (or (:events options) (:votes options)) :comments-path (:comments options)
                         :zid zid :meta-tids meta-tids :meta-tids-source meta-src
                         :warm-start warm-start :repeats repeats
                         :n-steps (count steps) :edn? edn? :stage-json? stage-json?
@@ -953,6 +1021,10 @@
                         :n-mod-events (count mod-events)
                         :n-mod-skipped n-mod-skipped
                         :restart-after restart-after})
+                prov (if (:events options)
+                       (assoc prov :events_meta_sha256
+                              (sha256-file (io/file (.getParentFile (io/file (:events options))) "events.meta.json")))
+                       prov)
                 prov-json (json/generate-string prov {:pretty true})]
             (spit (io/file out "provenance.json") prov-json)
             (spit (io/file clj-dir "provenance.json") prov-json))


### PR DESCRIPTION
Step-2 prerequisite from the private-run plan. The replay drivers and certify read second-resolution compatibility CSVs while the fixture extraction retains millisecond events with nulls, weights, and revotes. Both drivers and certify now ingest the validated `events.jsonl` directly through an exact opaque-directory input map, preserving millisecond order, nulls, weights, and revotes through the engine calls and the restart seam, with the metadata cache and inventory bound to the ingress. The CSV path's information loss is accounted exactly; the historical schedule files' explicit cuts are documented as not copyable onto newly selected roles. No schedule re-pins.

**Public proof.** 6/6 entries, 24 engine processes, 261/261 raw step files byte-identical between the CSV and event paths (87 paired checkpoints each), with the proof-only fixed Python clock and Clojure random seed. The public source is CSV-only, so this proves known-content equivalence, not recovery of information the CSVs never had.

**Two observations kept on record, no waiver.** An uncontrolled first proof showed a second-axis sign difference on every-vote steps 32–55 from later-axis random initialisation (the same axis-orientation sensitivity the axis-continuity diagnostic measures). On a generated 3-vote input, Python completes 3 checkpoints while Clojure fails with divide by zero.

**Tests.** Focused 262 passed / 1 existing skip; adjacent 232 / 0; ingress 31 / 0; Clojure 5 tests / 19 assertions clean. Docs: `delphi/docs/EVENT_INGRESS.md`.

Written by the second reviewer; reviewed by the orchestrator. Schema impact: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s