### PR TITLE
feat(delphi): representative conversation selection for the private battery (opt-in, box-only provenance)

### DIFF
--- a/delphi/docs/representative-selection.md
+++ b/delphi/docs/representative-selection.md
@@ -1,0 +1,123 @@
+# Representative snapshot selection
+
+The optional `representative_selection` config block selects up to 20 distinct
+conversations and produces a numeric census report. This is a **selection-only
+stage**: it does not extract extra sample payloads, add replay/schedule/battery
+entries, or change payload admission. Existing coverage recipes remain intact.
+A later reviewed extension must materialize and admit the sampled conversations
+before a full representative private campaign can run.
+
+The shipped `scripts/certify_datasets.json` and battery are unchanged. Make a
+reviewed new config version before inspecting candidate outputs, adding:
+
+```json
+"representative_selection": {
+  "algorithm": "representative-logpv/1",
+  "target": 20,
+  "seed": "0101010101010101010101010101010101010101010101010101010101010101"
+}
+```
+
+The seed above is a synthetic example, not an operator's chosen production seed.
+The schema requires exactly these three fields, this version/target and 64
+lowercase hexadecimal seed characters. Absence disables this stage; null or
+malformed declarations refuse. No activity, outcome, resource-fit or old-role
+exclusion is applied. Changing the seed/config or snapshot changes the sample;
+do not reroll after a failure.
+
+## Allocation
+
+Use the existing full snapshot metrics: P is distinct voting participants, V
+counts all vote rows including revotes/null-valued votes, C is distinct voted
+comments and U is distinct participant/comment cells. Registered participants
+remain a separate count. Integer size data must be nonnegative and consistent;
+unsupported/null identities are refused rather than silently excluded.
+
+Both P and V use `[0]`, `[1,9]`, `[10,99]`, `[100,999]`, ... with bin index zero
+for zero and `len(str(count))` for positive counts. No floating logarithms or
+upper-tail clipping. Quotas cover lower/upper P and V tails first (most populous
+cell, seeded tie-break, reusing a cell that already covers a tail), then the
+largest unrepresented cells until up to eight cells are covered. Remaining slots
+maximize the integer deficit `20*cell_population - total_population*cell_quota`,
+with capacity limits and seeded ties. Within each cell, take the quota's first
+HMAC-SHA256-ranked identities without replacement. Ranking messages are compact
+UTF-8 JSON arrays `[version,"conversation",zid]` or
+`[version,"cell",p_bin,v_bin]`; the seed bytes are the HMAC key. Private final
+collision ties use zid/cell coordinates ascending. Neither identity nor rank is
+part of the report.
+
+For fewer than 20 conversations, select the complete census and report the
+shortfall. Zero population is reported by the selection command with exit2 and
+cannot admit a campaign; whole-config extraction refuses before generating any
+payload. More than 20 occupied cells can leave cells uncovered: the report
+explicitly counts them. A complete rectangle of bins includes zero-count gaps.
+Independent cardinality/tail/coverage checks reject a defective allocator.
+This deliberately stratified sample's unweighted failure fraction is not an
+unbiased production failure-rate estimate.
+
+## Run inside the private snapshot box
+
+From `delphi/`, using the already authorized restored-clone connection and a
+reviewed config. All real values, credentials, raw surveys and sidecars stay in
+that box; the certification worker gets no database or snapshot permission.
+
+```sh
+uv run python scripts/prodclone_extract.py select-representative \
+  --database-url "$PRIVATE_CLONE_DATABASE_URL" \
+  --from-config "$PRIVATE_SELECTION_CONFIG" \
+  --out "$PRIVATE_SELECTION_PROVENANCE" \
+  --snapshot-id "$PRIVATE_SNAPSHOT_ID"
+```
+
+`--out` must be a box-only file below `real_data/.local/`, never inside a bundle
+payload or an Actions artifact. The file is written mode0600 and contains the
+report, private ordinal→zid map and transaction guarantee. The source metric rows,
+topics and rank hashes are not copied into it. stdout is only the validated JSON
+report; errors contain fixed codes, not database URLs, source values or private
+paths. A successful nonempty census exits0 even when short; this is selection
+completion, not a certificate. Missing/malformed config, invalid counts, unsafe
+path or report fields fail. An empty census exits2 after writing/reporting zero
+counts. No existing recipe is resolved by this command, so a small population can
+be surveyed without pretending it satisfies every existing edge-role predicate.
+
+Omit `--snapshot-id` for a new local snapshot. For repeat selections/extraction of
+the same state, keep a `pg_export_snapshot()` exporter transaction open and supply
+its ID to each command; reusing a seed on a new snapshot is insufficient. The
+code begins read-only repeatable-read before querying the census. The optional
+`--writers-disabled` records an independently established clone condition; it
+does not disable writers or relax transaction isolation.
+
+Alternatively, the existing `from-config` extraction command with that same
+optional config performs selection over the **same fetched census and transaction**
+as its unchanged old-role resolution/extraction. It writes
+`representative_selection.private.json` beside the payload, under the existing
+`.private` sidecar directory. `certify_extract.json` contains the safe report but
+excludes the representative identity map. Existing survey/role provenance stays
+in its own restricted sidecars. With selection enabled stdout contains only the
+new report; without the block, original extraction behavior/output is retained.
+Failures never substitute the sample for a missing old recipe.
+
+## Report boundary and measurements
+
+The report has exactly `seed`, `bucket_counts` and `chosen_entry_sizes`.
+`bucket_counts` contains numeric population, target, selected, shortfall, occupied,
+covered and uncovered counts, plus `cells`: P/V bin, population and selected count.
+Each size row contains only P, V, C, U, matrix_area, registered_participants,
+all_comments and P/V bins. All values except the seed are integer counts or lists
+of such records. Size rows sort by numeric size only and do not expose a link to
+the private ordinal. Duplicate sizes are legitimate. The validator rejects
+extra fields at every level and checks totals, coverage, bin/grid consistency
+and size census before publication.
+
+No zid, report ID, role/alias, directory/path, snapshot/timestamp, rank/hash,
+source text, outcome or raw exception belongs in this report. Sidecars remain
+in the extraction box and are excluded from tar/log/public outputs. This stage
+measures database cardinalities only. It does **not** claim extracted byte sizes,
+RSS or scratch capacity for the sampled conversations. Those require the later
+payload/capacity stage; unknown byte measurements are not reported as zero.
+No change is made to the private box's independent public-summary policy.
+
+The tests use synthetic populations, including a deliberately defective allocator,
+small/empty/uncovered populations, reordered inputs, ignored outcome fields,
+report leakage/tampering and whole-extraction/CLI wiring. Selection evidence
+cannot replace actual private payload, replay, capacity or cleanup admission.

--- a/delphi/polismath/replay/fixture_config.py
+++ b/delphi/polismath/replay/fixture_config.py
@@ -118,6 +118,24 @@ def served_math_options(config: dict[str, Any]) -> ServedMathOptions:
     )
 
 
+def representative_seed(config: dict[str, Any]) -> str | None:
+    """Optional, frozen selection-only declaration; reject malformed direct calls.
+
+    The shipped recipes/config remain byte-identical. A reviewed opt-in creates
+    a new config version; it does not admit additional payloads or battery rows.
+    """
+    if "representative_selection" not in config:
+        return None
+    block = config["representative_selection"]
+    schema = load_schema()["properties"]["representative_selection"]
+    if validate_against_schema(block, schema):
+        raise ConfigError("Invalid representative selection declaration")
+    # JSON Schema's/Python's $ anchor also matches before a final newline.
+    if re.fullmatch(r"[0-9a-f]{64}", block["seed"]) is None:
+        raise ConfigError("Invalid representative selection seed")
+    return block["seed"]
+
+
 # ---------------------------------------------------------------------------
 # Minimal JSON Schema (Draft-07 subset) interpreter.
 # ---------------------------------------------------------------------------
@@ -386,6 +404,11 @@ def _semantic_errors(config: dict[str, Any]) -> list[str]:
                 errors.append(
                     f"$.served_math.math_envs: duplicate entries "
                     f"{sorted({e for e in names if names.count(e) > 1})}")
+
+    try:
+        representative_seed(config)
+    except ConfigError:
+        errors.append("$.representative_selection: invalid declaration or seed")
 
     return errors
 

--- a/delphi/polismath/replay/fixture_extract.py
+++ b/delphi/polismath/replay/fixture_extract.py
@@ -912,6 +912,30 @@ def extract_conversation(
 # ---------------------------------------------------------------------------
 
 
+def select_representative_from_config(
+    conn: PgConnection, *, config: dict[str, Any], snapshot_id: str | None = None,
+    writers_disabled: bool = False,
+) -> dict[str, Any]:
+    """Selection-only entry point; private provenance never belongs in payload.
+
+    Reads one snapshot, without resolving/changing any existing coverage recipe
+    or extracting new sample payloads. Zero population is reported as a census,
+    never accepted as a representative campaign.
+    """
+    from polismath.replay import fixture_config as fcfg
+    from polismath.replay import fixture_survey as fs
+    from polismath.replay.fixture_selection import SelectionError, select_representative
+
+    seed = fcfg.representative_seed(config)
+    if seed is None:
+        raise SelectionError("SELECTION_NOT_CONFIGURED")
+    guarantee = fs.open_readonly_repeatable_read(
+        conn, snapshot_id=snapshot_id, writers_disabled=writers_disabled)
+    selected = select_representative(fs.fetch_metrics(conn), seed)
+    return {"report": selected.report, "provenance_rows": list(selected.provenance),
+            "transaction_guarantee": guarantee}
+
+
 def extract_from_config(
     conn: PgConnection, *, config: dict[str, Any], payload_root: Path, guard_root: Path,
     snapshot_id: str | None = None, writers_disabled: bool = False,
@@ -943,10 +967,17 @@ def extract_from_config(
     # reviewed edit that mints a new bundle version rather than an operator
     # flag. Absent from the config means off.
     served_math = fcfg.served_math_options(config)
+    representative_seed = fcfg.representative_seed(config)
     dir_names = dict(dir_names or {})
     guarantee = fs.open_readonly_repeatable_read(
         conn, snapshot_id=snapshot_id, writers_disabled=writers_disabled)
     rows = fs.fetch_metrics(conn)
+    representative = None
+    if representative_seed is not None:
+        from polismath.replay.fixture_selection import SelectionError, select_representative
+        representative = select_representative(rows, representative_seed)
+        if not rows:
+            raise SelectionError("EMPTY_POPULATION")
     migration_marker = None  # probing rolls back; do it outside this txn
     survey = fs.build_survey(rows, guarantee, snapshot_id=snapshot_id,
                              schema_version_marker=migration_marker)
@@ -1029,7 +1060,7 @@ def extract_from_config(
         provenance_rows.append({
             "role": sel.role, "slug": sel.slug, "dir": dir_name, "zid": sel.zid})
 
-    return {
+    result = {
         "survey": survey,
         "coverage_report": coverage,
         "transaction_guarantee": guarantee,
@@ -1045,3 +1076,8 @@ def extract_from_config(
         "dir_names": dir_names,
         "provenance_rows": provenance_rows,
     }
+
+    if representative is not None:
+        result["representative_selection"] = representative.report
+        result["representative_provenance"] = list(representative.provenance)
+    return result

--- a/delphi/polismath/replay/fixture_selection.py
+++ b/delphi/polismath/replay/fixture_selection.py
@@ -1,0 +1,186 @@
+"""Seeded representative selection inside the private snapshot box.
+
+No payload or battery admission: this stage returns a counts-only report and a
+separate private identity map. Raw rows and rank hashes must never be logged.
+"""
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+import hashlib
+import hmac
+import json
+import re
+from typing import Any, Iterable, Sequence
+
+VERSION = "representative-logpv/1"
+TARGET = 20
+SIZE_FIELDS = ("P", "V", "C", "U", "matrix_area", "registered_participants", "all_comments")
+CELL_FIELDS = frozenset({"p_bin", "v_bin", "population", "selected"})
+TOTAL_FIELDS = frozenset({"population", "target", "selected", "shortfall", "occupied", "covered", "uncovered", "cells"})
+
+
+class SelectionError(ValueError):
+    """A fixed error code, never an interpolated source value or row."""
+
+
+def _require(condition: bool, code: str) -> None:
+    if not condition:
+        raise SelectionError(code)
+
+
+def _count(value: Any) -> bool:
+    return type(value) is int and 0 <= value <= 2**63 - 1
+
+
+def log_bin(count: int) -> int:
+    _require(_count(count), "INVALID_COUNT")
+    return len(str(count)) if count else 0
+
+
+def validate_seed(seed: str) -> None:
+    _require(type(seed) is str and re.fullmatch(r"[0-9a-f]{64}", seed) is not None,
+             "INVALID_SEED")
+
+
+def _rank(seed: str, kind: str, *values: int) -> bytes:
+    message = json.dumps([VERSION, kind, *values], separators=(",", ":")).encode()
+    return hmac.new(bytes.fromhex(seed), message, hashlib.sha256).digest()
+
+
+def _population(rows: Sequence[dict[str, Any]]) -> dict[int, dict[str, int]]:
+    population: dict[int, dict[str, int]] = {}
+    for row in rows:
+        _require(type(row) is dict, "INVALID_METRICS")
+        zid = row.get("zid")
+        _require(_count(zid) and zid not in population, "INVALID_IDENTITY_CENSUS")
+        _require(all(_count(row.get(k)) for k in SIZE_FIELDS), "INVALID_METRICS")
+        sizes = {k: row[k] for k in SIZE_FIELDS}
+        _require(sizes["matrix_area"] == sizes["P"] * sizes["C"] and
+                 sizes["U"] <= sizes["V"] and sizes["U"] <= sizes["matrix_area"] and
+                 sizes["P"] <= sizes["U"] and sizes["C"] <= sizes["U"] and
+                 ((sizes["V"] == 0) == (sizes["P"] == sizes["C"] == sizes["U"] == 0)),
+                 "INCONSISTENT_METRICS")
+        sizes.update(p_bin=log_bin(sizes["P"]), v_bin=log_bin(sizes["V"]))
+        population[zid] = sizes
+    return population
+
+
+def _cell(sizes: dict[str, int]) -> tuple[int, int]:
+    return sizes["p_bin"], sizes["v_bin"]
+
+
+def _tails(cells: set[tuple[int, int]]) -> list[set[tuple[int, int]]]:
+    if not cells:
+        return []
+    return [{c for c in cells if c[axis] == extreme(c[axis] for c in cells)}
+            for axis in (0, 1) for extreme in (min, max)]
+
+
+def _check_selection(population: dict[int, dict[str, int]], selected: Sequence[int]) -> None:
+    """Independent cardinality/coverage oracle, also applied to the allocator."""
+    _require(len(selected) == min(TARGET, len(population)) and
+             len(set(selected)) == len(selected) and all(z in population for z in selected),
+             "SELECTION_CENSUS")
+    cells = {_cell(s) for s in population.values()}
+    chosen = {_cell(population[z]) for z in selected}
+    _require(all(tail & chosen for tail in _tails(cells)), "TAIL_NOT_COVERED")
+    _require(len(chosen) >= min(8, len(cells), len(population)), "CELL_COVERAGE")
+
+
+def _allocate(cells: dict[tuple[int, int], list[int]], seed: str) -> dict[tuple[int, int], int]:
+    quotas = dict.fromkeys(cells, 0)
+    total = sum(map(len, cells.values()))
+    if total < TARGET:
+        return {c: len(ids) for c, ids in cells.items()}
+    ranks = {c: (_rank(seed, "cell", *c), c) for c in cells}
+    def largest(options: Iterable[tuple[int, int]]) -> tuple[int, int]:
+        return min(options, key=lambda c: (-len(cells[c]), ranks[c]))
+    for tail in _tails(set(cells)):
+        if not any(quotas[c] for c in tail):
+            quotas[largest(tail)] = 1
+    while sum(q > 0 for q in quotas.values()) < min(8, len(cells), TARGET):
+        quotas[largest(c for c in cells if not quotas[c])] = 1
+    while sum(quotas.values()) < TARGET:
+        available = [c for c in cells if quotas[c] < len(cells[c])]
+        chosen = min(available, key=lambda c: (-(TARGET * len(cells[c]) - total * quotas[c]), ranks[c]))
+        quotas[chosen] += 1
+    return quotas
+
+
+@dataclass(frozen=True)
+class RepresentativeSelection:
+    report: dict[str, Any]
+    # Identity-bearing output is deliberately absent from repr/diagnostics.
+    provenance: tuple[dict[str, int], ...] = field(repr=False)
+
+
+def select_representative(rows: Sequence[dict[str, Any]], seed: str) -> RepresentativeSelection:
+    validate_seed(seed)
+    population = _population(rows)
+    cells: dict[tuple[int, int], list[int]] = defaultdict(list)
+    for zid, sizes in population.items():
+        cells[_cell(sizes)].append(zid)
+    quotas = _allocate(cells, seed)
+    selected = [z for c in sorted(cells)
+                for z in sorted(cells[c], key=lambda z: (_rank(seed, "conversation", z), z))[:quotas[c]]]
+    _check_selection(population, selected)
+    # Report order is numeric sizes only; no link to private ordinal or identity.
+    sizes = sorted((dict(population[z]) for z in selected),
+                   key=lambda s: tuple(s[k] for k in ("p_bin", "v_bin", *SIZE_FIELDS)))
+    cell_rows = []
+    if cells:
+        for p_bin in range(max(c[0] for c in cells) + 1):
+            for v_bin in range(max(c[1] for c in cells) + 1):
+                c = (p_bin, v_bin)
+                cell_rows.append(dict(p_bin=p_bin, v_bin=v_bin,
+                                      population=len(cells.get(c, ())), selected=quotas.get(c, 0)))
+    covered = sum(q > 0 for q in quotas.values())
+    report = {"seed": seed, "bucket_counts": {
+        "population": len(population), "target": TARGET, "selected": len(selected),
+        "shortfall": TARGET-len(selected), "occupied": len(cells), "covered": covered,
+        "uncovered": len(cells)-covered, "cells": cell_rows}, "chosen_entry_sizes": sizes}
+    validate_report(report)
+    private = tuple({"ordinal": i, "zid": z} for i, z in enumerate(selected, 1))
+    return RepresentativeSelection(report, private)
+
+
+def validate_report(report: dict[str, Any]) -> None:
+    """Reject unknown fields/types before any report reaches stdout or a file."""
+    _require(type(report) is dict and set(report) == {"seed", "bucket_counts", "chosen_entry_sizes"},
+             "REPORT_FIELDS")
+    validate_seed(report["seed"])
+    counts, sizes = report["bucket_counts"], report["chosen_entry_sizes"]
+    _require(type(counts) is dict and set(counts) == TOTAL_FIELDS, "REPORT_FIELDS")
+    _require(all(_count(counts[k]) for k in TOTAL_FIELDS-{"cells"}), "REPORT_COUNT")
+    cell_rows = counts["cells"]
+    _require(type(cell_rows) is list and type(sizes) is list, "REPORT_FIELDS")
+    seen = set()
+    for row in cell_rows:
+        _require(type(row) is dict and set(row) == CELL_FIELDS and
+                 all(_count(v) for v in row.values()), "REPORT_CELL")
+        c = _cell(row)
+        _require(c not in seen and row["selected"] <= row["population"] and
+                 max(c) <= 19, "REPORT_CELL")
+        seen.add(c)
+    for row in sizes:
+        _require(type(row) is dict and set(row) == set(SIZE_FIELDS) | {"p_bin", "v_bin"} and
+                 all(_count(v) for v in row.values()), "REPORT_SIZE")
+        # Use the same numeric consistency checks without accepting an identity.
+        checked = _population([dict(row, zid=0)])[0]
+        _require(checked == row, "REPORT_SIZE")
+    actual = Counter(_cell(row) for row in sizes)
+    _require(all(actual[_cell(row)] == row["selected"] for row in cell_rows) and
+             set(actual) <= seen and sum(row["population"] for row in cell_rows) == counts["population"] and
+             sum(row["selected"] for row in cell_rows) == counts["selected"] == len(sizes) and
+             counts["target"] == TARGET and counts["selected"] == min(TARGET, counts["population"]) and
+             counts["shortfall"] == TARGET-counts["selected"] and
+             counts["occupied"] == sum(row["population"] > 0 for row in cell_rows) and
+             counts["covered"] == len(actual) and counts["uncovered"] == counts["occupied"]-len(actual),
+             "REPORT_CENSUS")
+    occupied = {_cell(row) for row in cell_rows if row["population"]}
+    _require(all(tail & set(actual) for tail in _tails(occupied)) and
+             len(actual) >= min(8, len(occupied), counts["population"]), "REPORT_COVERAGE")
+    expected = ({(p, v) for p in range(max(c[0] for c in occupied)+1)
+                 for v in range(max(c[1] for c in occupied)+1)} if occupied else set())
+    _require(seen == expected, "REPORT_CELL_GRID")

--- a/delphi/scripts/certify_datasets.schema.json
+++ b/delphi/scripts/certify_datasets.schema.json
@@ -49,6 +49,17 @@
         }
       }
     },
+    "representative_selection": {
+      "type": "object",
+      "description": "Optional snapshot selection/report stage only. Does not add payloads, change existing recipes or admit representative replay. A reviewed config/version fixes the seed before candidate output is inspected; absence preserves existing extraction behavior.",
+      "additionalProperties": false,
+      "required": ["algorithm", "target", "seed"],
+      "properties": {
+        "algorithm": {"type": "string", "const": "representative-logpv/1"},
+        "target": {"type": "integer", "const": 20},
+        "seed": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
     "served_math": {
       "type": "object",
       "description": "OPTIONAL (P-052 section 4.5). When present with capture=true, each extracted conversation additionally captures what the Clojure engine actually SERVED: the math_main row per math_env (blob verbatim, last_vote_timestamp, math_tick, caching_tick, modified) and the math_ticks row. This is an EXTRACTION change only - two additional SELECTs against tables that already exist, no migration, no new column, no trigger, no write. The block is ABSENT from the shipped config, which is what keeps the capture off by default and keeps certify_datasets.json byte-identical (and therefore every published manifest's commits.config_sha256 unchanged). Turning it on is a reviewed edit that mints a new config version.",

--- a/delphi/scripts/prodclone_extract.py
+++ b/delphi/scripts/prodclone_extract.py
@@ -39,6 +39,7 @@ from polismath.replay import fixture_bundle as fb
 from polismath.replay import fixture_config as fc
 from polismath.replay import fixture_extract as fx
 from polismath.replay import fixture_survey as fs
+from polismath.replay.fixture_selection import validate_report
 from polismath.replay import prodclone as pc
 from polismath.replay.real_data import REAL_DATA_ROOT
 
@@ -133,6 +134,48 @@ def extract(database_url: str, zid: int, feature: str, out_root: Path | None) ->
 # ---------------------------------------------------------------------------
 
 
+@cli.command("select-representative")
+@click.option("--database-url", required=True)
+@click.option("--from-config", "config_path", type=click.Path(path_type=Path), required=True)
+@click.option("--out", "out_path", type=click.Path(path_type=Path), required=True,
+              help="Box-only provenance file, beneath real_data/.local/; never a payload member.")
+@click.option("--snapshot-id", default=None)
+@click.option("--writers-disabled", is_flag=True, default=False)
+def select_representative(database_url: str, config_path: Path, out_path: Path,
+                          snapshot_id: str | None, writers_disabled: bool) -> None:
+    """Emit only seed/bucket counts/selected sizes; retain identities in the box.
+
+    Selection-only: no new payload, recipe, schedule or battery is admitted.
+    Exit 2 with an empty census report when the snapshot has no conversations.
+    """
+    try:
+        config = fc.load_config(config_path)
+        if fc.representative_seed(config) is None:
+            raise ValueError("SELECTION_NOT_CONFIGURED")
+        target = out_path.resolve()
+        parts = target.parts
+        if ".local" not in parts:
+            raise ValueError("PRIVATE_PATH_REQUIRED")
+        guard = Path(*parts[:parts.index(".local")])
+        target = pc.assert_under_local(target, guard)
+        conn = psycopg2.connect(database_url)
+        try:
+            result = fx.select_representative_from_config(
+                conn, config=config, snapshot_id=snapshot_id,
+                writers_disabled=writers_disabled)
+        finally:
+            conn.close()
+        validate_report(result["report"])
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fb.os_umask_safe_write(target, fb.canonical_json(result))
+    except Exception:
+        # Connection/config/path/raw database errors can contain private data.
+        raise click.ClickException("REPRESENTATIVE_SELECTION_FAILED") from None
+    click.echo(fb.canonical_json(result["report"]).decode().strip())
+    if result["report"]["bucket_counts"]["population"] == 0:
+        raise click.exceptions.Exit(2)
+
+
 @cli.command("from-config")
 @click.option("--database-url", required=True,
               help="Postgres connection URL for the prodclone database.")
@@ -168,7 +211,23 @@ def from_config(database_url: str, config_path: Path | None, out_dir: Path,
 
     Prints counts only — no zid, no report id, no directory-to-role mapping.
     """
-    config = fc.load_config(config_path)
+    try:
+        config = fc.load_config(config_path)
+    except Exception:
+        raise click.ClickException("INVALID_SELECTION_CONFIG") from None
+    try:
+        _extract_config(config, database_url, out_dir, snapshot_id, writers_disabled,
+                        reuse_dirs, accept_public_fixture, no_generated, include_heavy)
+    except Exception:
+        if "representative_selection" in config:
+            raise click.ClickException("REPRESENTATIVE_EXTRACTION_FAILED") from None
+        raise
+
+
+def _extract_config(config: dict, database_url: str, out_dir: Path,
+                    snapshot_id: str | None, writers_disabled: bool,
+                    reuse_dirs: Path | None, accept_public_fixture: tuple[str, ...],
+                    no_generated: bool, include_heavy: bool) -> None:
     payload_root = Path(out_dir).resolve()
     # Derive the real_data root from the caller's path so assert_under_local can
     # re-check every single write. --out may be "<root>/.local" itself or a
@@ -189,7 +248,12 @@ def from_config(database_url: str, config_path: Path | None, out_dir: Path,
         else:
             dir_names = dict(loaded)
 
-    conn = psycopg2.connect(database_url)
+    try:
+        conn = psycopg2.connect(database_url)
+    except Exception:
+        if "representative_selection" in config:
+            raise click.ClickException("REPRESENTATIVE_EXTRACTION_FAILED") from None
+        raise
     try:
         result = fx.extract_from_config(
             conn, config=config, payload_root=payload_root, guard_root=guard_root,
@@ -198,10 +262,22 @@ def from_config(database_url: str, config_path: Path | None, out_dir: Path,
             accept_public_fixture=accept_public_fixture,
             include_generated=not no_generated, include_heavy=include_heavy,
         )
-    except fs.RoleUnsatisfied as exc:
-        raise click.ClickException(str(exc)) from exc
+    except Exception as exc:
+        if "representative_selection" in config:
+            raise click.ClickException("REPRESENTATIVE_EXTRACTION_FAILED") from None
+        if isinstance(exc, fs.RoleUnsatisfied):
+            raise click.ClickException(str(exc)) from exc
+        raise
     finally:
         conn.close()
+
+    if "representative_selection" in config:
+        try:
+            if "representative_provenance" not in result:
+                raise ValueError("MISSING_SELECTION_PROVENANCE")
+            validate_report(result["representative_selection"])
+        except Exception:
+            raise click.ClickException("REPRESENTATIVE_REPORT_INVALID") from None
 
     # Side-car artefacts live BESIDE the payload, never inside it: the payload
     # tree is what gets hashed into the bundle, and the survey/provenance files
@@ -215,7 +291,18 @@ def from_config(database_url: str, config_path: Path | None, out_dir: Path,
     fb.os_umask_safe_write(provenance_path, fb.canonical_json(result["provenance_rows"]))
     extract_path = pc.assert_under_local(sidecar / "certify_extract.json", guard_root)
     fb.os_umask_safe_write(extract_path, fb.canonical_json({
-        k: v for k, v in result.items() if k not in ("survey", "provenance_rows")}))
+        k: v for k, v in result.items() if k not in ("survey", "provenance_rows", "representative_provenance")}))
+
+    if "representative_selection" in result:
+        representative_path = pc.assert_under_local(
+            sidecar / "representative_selection.private.json", guard_root)
+        fb.os_umask_safe_write(representative_path, fb.canonical_json({
+            "report": result["representative_selection"],
+            "provenance_rows": result["representative_provenance"],
+            "transaction_guarantee": result["transaction_guarantee"],
+        }))
+        click.echo(fb.canonical_json(result["representative_selection"]).decode().strip())
+        return
 
     click.echo(
         f"transaction: {result['transaction_guarantee']['isolation_level']} / "

--- a/delphi/tests/test_representative_selection.py
+++ b/delphi/tests/test_representative_selection.py
@@ -1,0 +1,337 @@
+"""Synthetic-only snapshot selection, disclosure boundary and extraction wiring.
+
+Selection is not admission of extra payloads or battery recipes.
+"""
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import stat
+
+from click.testing import CliRunner
+import pytest
+
+from polismath.replay import fixture_config as fc
+from polismath.replay import fixture_extract as fx
+from polismath.replay import fixture_generate as fg
+from polismath.replay import fixture_selection as sel
+from polismath.replay import fixture_survey as fs
+
+SEED = "01" * 32
+
+
+def metric(index, p=1, v=3):
+    return {"zid": 910000000 + index, "P": p, "V": v, "C": int(v > 0),
+            "U": p, "matrix_area": p, "registered_participants": p + 1,
+            "all_comments": 1}
+
+
+def configured():
+    config = fc.load_config()
+    config["config_version"] = "synthetic-representative-v1"
+    config["representative_selection"] = dict(algorithm=sel.VERSION, target=20, seed=SEED)
+    return config
+
+
+def _cli():
+    path = Path(__file__).resolve().parents[1] / "scripts/prodclone_extract.py"
+    spec = importlib.util.spec_from_file_location("synthetic_selection_cli", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def chosen(result):
+    return [row["zid"] for row in result.provenance]
+
+
+@pytest.mark.parametrize("n", [0, 1, 19, 20, 21, 45])
+def test_population_shortfall_is_reported_without_duplicates(n):
+    result = sel.select_representative([metric(i) for i in range(n)], SEED)
+    counts = result.report["bucket_counts"]
+    assert counts["population"] == n
+    assert counts["selected"] == min(n, 20)
+    assert counts["shortfall"] == max(0, 20-n)
+    assert len(set(chosen(result))) == min(n, 20)
+    if n < 20:
+        assert set(chosen(result)) == {metric(i)["zid"] for i in range(n)}
+    assert counts["uncovered"] == 0
+    sel.validate_report(result.report)
+
+
+@pytest.mark.parametrize("count,expected", [(0,0),(1,1),(9,1),(10,2),(99,2),(100,3),(999,3),(1000,4),(2**63-1,19)])
+def test_integer_log_boundaries(count, expected):
+    assert sel.log_bin(count) == expected
+
+
+@pytest.mark.parametrize("value", [-1, True, None, 1.0, "10", 2**63])
+def test_invalid_numeric_counts_fail_closed(value):
+    rows = [metric(1)]
+    rows[0]["V"] = value
+    with pytest.raises(sel.SelectionError):
+        sel.select_representative(rows, SEED)
+
+
+@pytest.mark.parametrize("change", [dict(P=4),dict(U=0),dict(matrix_area=2),dict(V=0),dict(C=3)])
+def test_inconsistent_population_fails_before_reporting(change):
+    row = metric(1)
+    row.update(change)
+    with pytest.raises(sel.SelectionError, match="INCONSISTENT_METRICS"):
+        sel.select_representative([row], SEED)
+
+
+def test_duplicate_or_missing_identity_refused_without_rendering_it():
+    row = metric(123)
+    for rows in [[row, row], [{k:v for k,v in row.items() if k != "zid"}]]:
+        with pytest.raises(sel.SelectionError) as exc:
+            sel.select_representative(rows, SEED)
+        assert str(exc.value) == "INVALID_IDENTITY_CENSUS"
+        assert str(row["zid"]) not in str(exc.value)
+
+
+def test_permuted_population_and_unrelated_outcomes_do_not_change_selection():
+    rows = [metric(i, 10**(i % 4), 10**(i % 4 + 1)) for i in range(120)]
+    before = copy.deepcopy(rows)
+    expected = sel.select_representative(rows, SEED)
+    variant = [dict(row, outcome="FAIL", topic="SYNTHETIC_PRIVATE_TEXT") for row in reversed(rows)]
+    assert sel.select_representative(variant, SEED) == expected
+    assert rows == before
+    assert "SYNTHETIC_PRIVATE_TEXT" not in json.dumps(expected.report)
+    assert "910000" not in repr(expected)
+    assert chosen(sel.select_representative(rows, "02"*32)) != chosen(expected)
+
+
+def test_tails_dense_middle_and_full_rectangular_grid_are_present():
+    rows = [metric(0,0,0), metric(1,100000,1000000)]
+    rows += [metric(i+2,100,10000) for i in range(100)]
+    result = sel.select_representative(rows, SEED)
+    assert {metric(0)["zid"], metric(1)["zid"]} <= set(chosen(result))
+    assert sum(s["P"] == 100 for s in result.report["chosen_entry_sizes"]) == 18
+    counts = result.report["bucket_counts"]
+    assert len(counts["cells"]) == 7 * 8
+    assert any(r["population"] == r["selected"] == 0 for r in counts["cells"])
+    assert counts["covered"] == counts["occupied"] == 3
+
+
+def test_more_than_twenty_occupied_cells_reports_uncovered_cells():
+    rows = [metric(0,0,0)]
+    rows += [metric(i+1,10**p,10**v) for i,(p,v) in enumerate(
+        (p,v) for p in range(6) for v in range(p,7))]
+    report = sel.select_representative(rows, SEED).report
+    counts = report["bucket_counts"]
+    assert counts["population"] == counts["occupied"] == 28
+    assert counts["covered"] == 20 and counts["uncovered"] == 8
+    assert len([r for r in counts["cells"] if r["population"] and not r["selected"]]) == 8
+    assert counts["shortfall"] == 0
+
+
+def test_exhausted_tail_cell_is_not_reused_for_remaining_quota():
+    rows = [metric(0,0,0)] + [metric(i+1,100,1000) for i in range(30)]
+    report = sel.select_representative(rows, SEED).report
+    assert sum(r["P"] == 0 for r in report["chosen_entry_sizes"]) == 1
+    assert sum(r["P"] == 100 for r in report["chosen_entry_sizes"]) == 19
+
+
+def test_allocator_mutant_omitting_upper_tail_hits_independent_oracle(monkeypatch):
+    rows = [metric(i) for i in range(30)] + [metric(50,100,1000)]
+    monkeypatch.setattr(sel, "_allocate", lambda cells, seed: {c:20 if c==(1,1) else 0 for c in cells})
+    with pytest.raises(sel.SelectionError, match="TAIL_NOT_COVERED"):
+        sel.select_representative(rows, SEED)
+
+
+@pytest.mark.parametrize("level", ["root","counts","cell","size"])
+@pytest.mark.parametrize("forbidden", ["zid","path","rank","topic"])
+def test_report_allowlist_rejects_every_unknown_field(level, forbidden):
+    report = sel.select_representative([metric(1)],SEED).report
+    target = {"root":report,"counts":report["bucket_counts"],
+              "cell":report["bucket_counts"]["cells"][0],"size":report["chosen_entry_sizes"][0]}[level]
+    target[forbidden] = "SYNTHETIC_PRIVATE_VALUE"
+    with pytest.raises(sel.SelectionError) as exc:
+        sel.validate_report(report)
+    assert "SYNTHETIC_PRIVATE_VALUE" not in str(exc.value)
+
+
+@pytest.mark.parametrize("change", ["wrong_total","missing_cell","wrong_bin","bool_count","missing_size"])
+def test_report_rejects_tampered_census(change):
+    report = sel.select_representative([metric(1)],SEED).report
+    if change=="wrong_total": report["bucket_counts"]["population"]+=1
+    if change=="missing_cell": report["bucket_counts"]["cells"].pop(0)
+    if change=="wrong_bin": report["chosen_entry_sizes"][0]["p_bin"]+=1
+    if change=="bool_count": report["chosen_entry_sizes"][0]["V"]=True
+    if change=="missing_size": report["chosen_entry_sizes"].clear()
+    with pytest.raises(sel.SelectionError):sel.validate_report(report)
+
+
+@pytest.mark.parametrize("block", [None,{},dict(algorithm=sel.VERSION,target=19,seed=SEED),
+    dict(algorithm="unknown",target=20,seed=SEED),dict(algorithm=sel.VERSION,target=True,seed=SEED),
+    dict(algorithm=sel.VERSION,target=20,seed="A"*64),dict(algorithm=sel.VERSION,target=20,seed="01"),
+    dict(algorithm=sel.VERSION,target=20,seed=SEED+"\n"),
+    dict(algorithm=sel.VERSION,target=20,seed=SEED,ids=[1])])
+def test_config_refuses_bad_selection_declarations(block):
+    config=configured();config["representative_selection"]=block
+    with pytest.raises(fc.ConfigError):fc.validate_config(config)
+    with pytest.raises(fc.ConfigError):fc.representative_seed(config)
+
+
+def test_opt_in_leaves_original_roles_battery_and_config_unchanged():
+    original=fc.load_config();config=configured()
+    fc.validate_config(config)
+    assert fc.representative_seed(original) is None
+    assert fc.representative_seed(config)==SEED
+    for key in original.keys()-{"config_version"}:assert config[key]==original[key]
+    assert "representative_selection" not in json.loads(fc.DEFAULT_CONFIG_PATH.read_text())
+    battery=json.loads((fc.SCRIPTS_DIR/'certify_battery.json').read_text())
+    assert len([r for r in battery if r['dataset'] in original['coverage_role_map']])==14
+
+
+def mock_snapshot(monkeypatch, rows):
+    calls=[]
+    def opened(conn,**kw):
+        calls.append(('open',kw))
+        return dict(isolation_level='repeatable read',access_mode='read only',single_transaction=True,
+                    imported_snapshot_id=kw['snapshot_id'])
+    def fetch(conn):
+        assert len(calls)==1
+        calls.append(('fetch',None))
+        return rows
+    monkeypatch.setattr(fs,'open_readonly_repeatable_read',opened)
+    monkeypatch.setattr(fs,'fetch_metrics',fetch)
+    return calls
+
+
+def test_selection_only_reads_one_snapshot_without_resolving_recipes(monkeypatch):
+    rows=[metric(i) for i in range(22)]
+    calls=mock_snapshot(monkeypatch,rows)
+    monkeypatch.setattr(fs,'resolve_roles',lambda *a,**kw:pytest.fail('selection-only resolved recipes'))
+    result=fx.select_representative_from_config(object(),config=configured(),snapshot_id='synthetic-snapshot',writers_disabled=True)
+    assert calls==[('open',{'snapshot_id':'synthetic-snapshot','writers_disabled':True}),('fetch',None)]
+    assert len(result['provenance_rows'])==20
+    assert result['report']['bucket_counts']['population']==22
+    assert result['transaction_guarantee']['imported_snapshot_id']=='synthetic-snapshot'
+
+
+def test_missing_opt_in_refuses_before_database_access(monkeypatch):
+    monkeypatch.setattr(fs,'open_readonly_repeatable_read',lambda *a,**kw:pytest.fail('unconfigured DB access'))
+    with pytest.raises(sel.SelectionError,match='SELECTION_NOT_CONFIGURED'):
+        fx.select_representative_from_config(object(),config=fc.load_config())
+
+
+@pytest.mark.parametrize('enabled',[False,True])
+def test_whole_extraction_shares_census_and_keeps_recipe_payloads_unchanged(tmp_path,monkeypatch,enabled):
+    rows=[metric(i) for i in range(25)]
+    calls=mock_snapshot(monkeypatch,rows)
+    config=configured() if enabled else fc.load_config()
+    seen=[]
+    monkeypatch.setattr(fs,'coverage_report',lambda cfg,r: seen.append(('coverage',cfg,r)) or {'unchanged':True})
+    monkeypatch.setattr(fs,'resolve_roles',lambda cfg,r,**kw:seen.append(('roles',cfg,r)) or [])
+    monkeypatch.setattr(fx,'detect_tie_key',lambda conn:{'guarantee':'synthetic'})
+    monkeypatch.setattr(fg,'write_all',lambda *a,**kw:[])
+    result=fx.extract_from_config(object(),config=config,payload_root=tmp_path,guard_root=tmp_path,snapshot_id='synthetic')
+    assert len(calls)==2 and all(cfg is config and r is rows for _,cfg,r in seen)
+    assert result['roles']==result['generated']==result['provenance_rows']==[]
+    assert not list(tmp_path.iterdir())
+    assert ('representative_selection' in result)==enabled
+    assert ('representative_provenance' in result)==enabled
+    if enabled:
+        assert len(result['representative_provenance'])==20
+        assert result['representative_selection']==sel.select_representative(rows,SEED).report
+
+
+@pytest.mark.parametrize('n',[0,1,19,25])
+def test_selection_cli_outputs_only_report_and_stores_private_mapping(tmp_path,monkeypatch,n):
+    cli=_cli();config_path=tmp_path/'config.json';config_path.write_text(json.dumps(configured()))
+    rows=[metric(i) for i in range(n)];mock_snapshot(monkeypatch,rows)
+    class Conn:
+        closed=False
+        def close(self):self.closed=True
+    conn=Conn();monkeypatch.setattr(cli.psycopg2,'connect',lambda *a:conn)
+    output=tmp_path/'real_data/.local/selection.private.json'
+    result=CliRunner().invoke(cli.cli,['select-representative','--database-url','synthetic',
+        '--from-config',str(config_path),'--out',str(output),'--snapshot-id','synthetic-snapshot'])
+    assert result.exit_code==(2 if n==0 else 0),result.output
+    report=json.loads(result.stdout);sel.validate_report(report)
+    private=json.loads(output.read_text())
+    assert report==private['report']
+    assert len(private['provenance_rows'])==min(n,20)
+    assert stat.S_IMODE(output.stat().st_mode)==0o600
+    assert conn.closed
+    assert 'zid' not in result.output and 'synthetic-snapshot' not in result.output and str(tmp_path) not in result.output
+    assert '910000' not in result.output
+
+
+@pytest.mark.parametrize('failure',['database','outside_path','forged_report'])
+def test_cli_errors_never_render_private_details(tmp_path,monkeypatch,failure):
+    cli=_cli();config_path=tmp_path/'config.json';config_path.write_text(json.dumps(configured()))
+    output=tmp_path/'.local/selection.private.json'
+    class Conn:
+        def close(self):pass
+    monkeypatch.setattr(cli.psycopg2,'connect',lambda *a:Conn())
+    if failure=='database':
+        def explode(*a):raise RuntimeError('SYNTHETIC_PRIVATE_CONNECTION')
+        monkeypatch.setattr(cli.psycopg2,'connect',explode)
+    if failure=='outside_path':output=tmp_path/'SYNTHETIC_PRIVATE_PATH'
+    if failure=='forged_report':
+        report=sel.select_representative([metric(1)],SEED).report
+        report['topic']='SYNTHETIC_PRIVATE_TEXT'
+        monkeypatch.setattr(fx,'select_representative_from_config',lambda *a,**kw:{'report':report})
+    result=CliRunner().invoke(cli.cli,['select-representative','--database-url','synthetic',
+        '--from-config',str(config_path),'--out',str(output)])
+    assert result.exit_code==1 and 'REPRESENTATIVE_SELECTION_FAILED' in result.output
+    assert 'SYNTHETIC_PRIVATE' not in result.output and str(tmp_path) not in result.output
+    assert not output.exists()
+
+
+def test_from_config_cli_confines_selection_identity_to_its_private_sidecar(tmp_path,monkeypatch):
+    cli=_cli();config=configured();config_path=tmp_path/'config.json';config_path.write_text(json.dumps(config))
+    selection=sel.select_representative([metric(i) for i in range(25)],SEED)
+    result={'survey':{'private_zid':910000001,'n_conversations':25},
+            'provenance_rows':[{'zid':910000002,'role':'synthetic-old-role'}],
+            'roles':[], 'generated':[], 'dir_names':{}, 'coverage_report':{},
+            'transaction_guarantee':{'imported_snapshot_id':'synthetic-private-snapshot'},
+            'tie_key':{},'representative_selection':selection.report,
+            'representative_provenance':list(selection.provenance)}
+    class Conn:
+        def close(self):pass
+    monkeypatch.setattr(cli.psycopg2,'connect',lambda *a:Conn())
+    monkeypatch.setattr(fx,'extract_from_config',lambda *a,**kw:result)
+    payload=tmp_path/'real_data/.local/payload'
+    output=CliRunner().invoke(cli.cli,['from-config','--database-url','synthetic',
+        '--from-config',str(config_path),'--out',str(payload)])
+    assert output.exit_code==0,output.output
+    assert json.loads(output.stdout)==selection.report
+    assert not list(payload.iterdir())
+    sidecar=payload.with_name('payload.private')
+    extracted=json.loads((sidecar/'certify_extract.json').read_text())
+    assert 'representative_provenance' not in extracted
+    private=json.loads((sidecar/'representative_selection.private.json').read_text())
+    assert private['provenance_rows']==list(selection.provenance)
+    assert stat.S_IMODE((sidecar/'representative_selection.private.json').stat().st_mode)==0o600
+    assert '910000' not in output.output and str(tmp_path) not in output.output
+    assert 'synthetic-private-snapshot' not in output.output
+
+
+@pytest.mark.parametrize('failure',['path','database','role','write','report','missing_report'])
+def test_from_config_selection_failure_is_fixed_text(tmp_path,monkeypatch,failure):
+    cli=_cli();config_path=tmp_path/'config.json';config_path.write_text(json.dumps(configured()))
+    payload=tmp_path/'real_data/.local/payload'
+    class Conn:
+        def close(self):pass
+    monkeypatch.setattr(cli.psycopg2,'connect',lambda *a:Conn())
+    def explode(*a,**kw):raise ValueError('SYNTHETIC_PRIVATE_DETAIL')
+    if failure=='path':payload=tmp_path/'SYNTHETIC_PRIVATE_PATH'
+    if failure=='database':monkeypatch.setattr(cli.psycopg2,'connect',explode)
+    if failure=='role':monkeypatch.setattr(fx,'extract_from_config',explode)
+    if failure=='missing_report':
+        monkeypatch.setattr(fx,'extract_from_config',lambda *a,**kw:{})
+    if failure in ('write','report'):
+        result={'representative_selection':sel.select_representative([metric(1)],SEED).report,
+                'survey':{},'provenance_rows':[]}
+        if failure=='report':result['representative_selection']['path']='SYNTHETIC_PRIVATE_DETAIL'
+        monkeypatch.setattr(fx,'extract_from_config',lambda *a,**kw:result)
+        if failure=='write':monkeypatch.setattr(cli.fb,'os_umask_safe_write',explode)
+    output=CliRunner().invoke(cli.cli,['from-config','--database-url','synthetic',
+        '--from-config',str(config_path),'--out',str(payload)])
+    assert output.exit_code==1 and 'REPRESENTATIVE_EXTRACTION_FAILED' in output.output
+    assert 'SYNTHETIC_PRIVATE' not in output.output and str(tmp_path) not in output.output


### PR DESCRIPTION
Step-2 item 2d.1: the private battery gets a representative sample, not only the five large conversations and eight edge cases.

Opt-in, with a frozen algorithm, target, and seed: integer log buckets over participant and vote counts including zero; tail and middle coverage; capacity-aware proportional quotas; deterministic HMAC selection without replacement. Reports shortfall below twenty, zero or empty gaps, and uncovered cells. A strict numeric allowlist rejects field or census tampering; an allocator mutant fails an independent tail oracle.

**Containment.** The selection-only CLI and the whole-extraction integration share the same read-only snapshot semantics. stdout carries only the seed, bucket counts, and selected sizes; identity and snapshot provenance stay in mode-0600 box-only sidecars excluded from the payload and the extract summary; fixed error messages suppress private DB, path, and source details. An empty census exits 2 standalone, and existing recipes cannot be bypassed to produce a partial bundle.

**Scope boundary, stated in docs and tests.** No sampled payload, schedule, or battery admission is added here; that is the next slice. Shipped config, battery, role resolver, and payload/image-plan admission bytes are unchanged.

**Tests.** Combined pytest 422 passed / 0 failed / 1 optional skip, including 81/81 new; three PostgreSQL witnesses pass. Design note in the private notes folder (P-055); docs in `delphi/docs/representative-selection.md`.

Written by the second reviewer; reviewed by the orchestrator. Schema impact: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s