### PR TITLE
feat(delphi): admit the sampled private payloads to the battery through the probe box

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -14,6 +14,9 @@ on:
       - '.github/workflows/python-ci.yml'
       # server/src so a new server-side wildcard runs the projection-gate sweep
       - 'server/src/**'
+      # Representative payload tests execute the probe planner and independent gate.
+      - 'ci/private_cert/**'
+      - 'ci/probe_box/**'
   pull_request:
     branches:
       - edge
@@ -124,8 +127,14 @@ jobs:
         # its first item (observed: only server/src copied).
         # Recordings tests also load the packer and its digest helper from ci/.
         # battery_coverage.py is already included in the declared delphi/scripts.
+        # Representative payload tests import the box planner/gate and their
+        # helpers from this same checkout root; keep their relative paths intact.
         for rel in $(python3 delphi/scripts/projection_inventory.py --print-scan-inputs) \
-          ci/p022_recordings_manifest.py ci/p022_battery_digest.py; do
+          ci/p022_recordings_manifest.py ci/p022_battery_digest.py \
+          ci/private_cert/images/gate.py ci/private_cert/images/probe.py \
+          ci/private_cert/images/g12.py ci/private_cert/control.py \
+          ci/private_cert/image_admission.py ci/probe_box/receipt.py \
+          ci/probe_box/contracts.py; do
           docker compose -f docker-compose.test.yml exec -T delphi mkdir -p "/app/projgate/$(dirname "$rel")"
           docker compose -f docker-compose.test.yml cp "$rel" "delphi:/app/projgate/$rel" \
             || { echo "failed to copy scan input: $rel"; exit 1; }

--- a/ci/private_cert/images/gate.py
+++ b/ci/private_cert/images/gate.py
@@ -30,7 +30,7 @@ sys.path.insert(0, str(HERE.parent))
 from control import encoded, sha
 from image_admission import file_digest, json_bytes, regular_path
 import g12
-from polismath.replay import certify, fixture_bundle, real_data, schedule, store
+from polismath.replay import certify, fixture_bundle, fixture_samples, real_data, schedule, store
 from polismath.replay.event_ingress import input_hashes
 
 POLICY = {'schema': 'polis-private-paired-policy/1', 'absolute': 1e-6,
@@ -66,7 +66,7 @@ def prepare(fixture, inputs, scratch, *, bind=True):
         raise ValueError('PAIRED_POLICY_BINDING')
     plan = read(fixture / 'plan.json')
     if (set(plan) != {'schema', 'scope', 'manifestSha256', 'configSha256', 'entries'}
-            or plan['schema'] != 'polis-private-paired-plan/1'
+            or plan['schema'] not in ('polis-private-paired-plan/1', fixture_samples.PLAN_VERSION)
             or plan['scope'] not in ('public', 'private', 'all')):
         raise ValueError('PLAN_SCHEMA')
     manifest_path, config_path = fixture / 'manifest.json', fixture / 'config.json'
@@ -76,6 +76,11 @@ def prepare(fixture, inputs, scratch, *, bind=True):
     payload = fixture / 'payload'
     fixture_bundle.verify(payload, manifest)
     fixture_bundle.admit_manifest(manifest, config=config, config_bytes=config_path.read_bytes(), payload_root=payload)
+    samples = fixture_samples.admitted_rules(manifest, config)
+    if plan['schema'] != (fixture_samples.PLAN_VERSION if samples else 'polis-private-paired-plan/1'):
+        raise ValueError('SAMPLE_PLAN_VERSION')
+    if samples and plan['scope'] == 'public':
+        raise ValueError('SAMPLE_FULL_CAMPAIGN_REQUIRED')
     if regular_tree(fixture).keys() != {'plan.json', 'manifest.json', 'config.json'} | {
         'payload/' + f['path'] for f in manifest['files']}:
         raise ValueError('FIXTURE_EXTRA_FILES')
@@ -83,6 +88,7 @@ def prepare(fixture, inputs, scratch, *, bind=True):
     battery = certify.load_battery(REPO / 'delphi/scripts/certify_battery.json')
     required = {(e.dataset, e.schedule_id) for e in battery
                 if plan['scope'] == 'all' or (e.dataset in public) == (plan['scope'] == 'public')}
+    required.update((alias, fixture_samples.SCHEDULE_ID) for alias in samples)
     if not required or not isinstance(plan['entries'], list):
         raise ValueError('EMPTY_BATTERY')
     roles = {}
@@ -102,6 +108,8 @@ def prepare(fixture, inputs, scratch, *, bind=True):
         alias = item['dataset']
         expected_role = next((r['role'] for r in config['public_fixtures'] if r['slug'] == alias),
                              config['coverage_role_map'].get(alias))
+        if alias in samples:
+            expected_role = samples[alias]['role']
         role = roles.get(expected_role)
         if item['role'] != expected_role or (alias not in public and (
             role is None or item['directory'] != role['dir'])):
@@ -142,8 +150,13 @@ def prepare(fixture, inputs, scratch, *, bind=True):
         entry = certify.BatteryEntry(item['dataset'], item['schedule_id'], schedule_path=spec_path,
                                      role=item['role'])
         expected = certify.prepare_entry(entry)
-        original = next(e for e in battery if (e.dataset, e.schedule_id) == (entry.dataset, entry.schedule_id))
-        recipe = certify.build_effective_spec(original, real_data.load_export_votes(entry.dataset))
+        if entry.dataset in samples:
+            recipe = fixture_samples.resolved_spec(entry.dataset, real_data.load_export_votes(entry.dataset))
+            if spec.to_dict() != recipe.to_dict():
+                raise ValueError('SAMPLE_SCHEDULE_RECIPE_CHANGED')
+        else:
+            original = next(e for e in battery if (e.dataset, e.schedule_id) == (entry.dataset, entry.schedule_id))
+            recipe = certify.build_effective_spec(original, real_data.load_export_votes(entry.dataset))
         if (spec.moderation != recipe.moderation or spec.restart_after != recipe.restart_after
                 or spec.clojure != recipe.clojure or spec.coverage != recipe.coverage):
             raise ValueError('SCHEDULE_RECIPE_CHANGED')
@@ -153,6 +166,8 @@ def prepare(fixture, inputs, scratch, *, bind=True):
         if expected.spec.coverage != 'full-stream' and plan['scope'] != 'public':
             raise ValueError('PRIVATE_FULL_STREAM_REQUIRED')
         prepared.append(expected)
+    if samples:
+        prepared = fixture_samples.ordered_prepared(prepared)
     full = {p.entry.dataset for p in prepared if p.spec.coverage == 'full-stream'}
     if any(p.entry.dataset not in full for p in prepared):
         raise ValueError('PREFIX_WITHOUT_FULL_COMPANION')

--- a/ci/private_cert/images/probe.py
+++ b/ci/private_cert/images/probe.py
@@ -65,13 +65,28 @@ def extract() -> None:
         transaction_guarantee=result['transaction_guarantee'], tie_key=result['tie_key'],
         schedules=fb.collect_schedule_hashes(gate.REPO / 'delphi/scripts/schedules'),
         owner='probe-box', extraction_commit=recipe['sourceCommit'], source_commit=recipe['sourceCommit'],
-        coverage_report=result.get('coverage_report'))
+        coverage_report=result.get('coverage_report'),
+        representative_report=result.get('representative_selection'))
     gate.dump(fixture / 'manifest.json', manifest)
     (fixture / 'config.json').write_bytes(config_bytes)
+    inputs = {k: recipe[k] for k in ('candidateSha', 'oracleSha', 'policySha256')}
+    prepare_fixture_plan(fixture, config, manifest, private, inputs)
+    gate.dump(out / 'inputs.json', inputs)
+    # Identity mappings and all measured per-entry sizes remain on this box.
+    gate.dump(private / 'provenance.json', result.get('provenance_rows', []))
+    gate.dump(private / 'representative-provenance.json', result.get('representative_provenance', []))
+
+
+def prepare_fixture_plan(fixture, config, manifest, private, inputs):
+    """Freeze the complete old-plus-sample inventory before either engine runs."""
+    from polismath.replay import fixture_samples as samples
+    payload = fixture / 'payload'
+    sampled = samples.admitted_rules(manifest, config, payload)
     roles = {r['role']: r for r in manifest['roles']}
     public = {r['slug'] for r in config['public_fixtures']}
     battery = [e for e in gate.certify.load_battery() if e.dataset not in public]
     mapping = {e.dataset: str(payload / roles[config['coverage_role_map'][e.dataset]]['dir']) for e in battery}
+    mapping.update({alias: str(payload / roles[rule['role']]['dir']) for alias, rule in sampled.items()})
     import os
     mapping_file = private / 'map.json'
     gate.dump(mapping_file, mapping)
@@ -83,18 +98,30 @@ def extract() -> None:
         role = config['coverage_role_map'][entry.dataset]
         entries.append({'dataset': entry.dataset, 'schedule_id': entry.schedule_id,
                         'role': role, 'directory': roles[role]['dir'], 'schedule': spec.to_dict()})
-    gate.dump(fixture / 'plan.json', {'schema': 'polis-private-paired-plan/1', 'scope': 'private',
+    for alias, rule in sampled.items():
+        spec = samples.resolved_spec(alias, gate.real_data.load_export_votes(alias))
+        entries.append(dict(dataset=alias, schedule_id=samples.SCHEDULE_ID, role=rule['role'],
+                            directory=roles[rule['role']]['dir'], schedule=spec.to_dict()))
+    gate.dump(fixture / 'plan.json', {'schema': samples.PLAN_VERSION if sampled else 'polis-private-paired-plan/1', 'scope': 'private',
         'manifestSha256': gate.file_digest(fixture / 'manifest.json'),
         'configSha256': gate.file_digest(fixture / 'config.json'), 'entries': entries})
-    inputs = {k: recipe[k] for k in ('candidateSha', 'oracleSha', 'policySha256')}
     inputs.update(scheduleSha256='', inventorySha256='', expectedChecks=0)
     with tempfile.TemporaryDirectory() as tmp:
         prepared, inventory = gate.prepare(fixture, inputs, Path(tmp), bind=False)
     inputs.update(scheduleSha256=gate.sha([p.spec.to_dict() for p in prepared]), inventorySha256=gate.sha(inventory),
                   expectedChecks=sum(len(p.checkpoints) for p in prepared))
-    gate.dump(out / 'inputs.json', inputs)
-    # Private provenance is never part of producer evidence or an upload tree.
-    gate.dump(private / 'provenance.json', result.get('provenance_rows', []))
+    if sampled:
+        directories = {r['dir'] for r in manifest['roles'] if r['slug'] in sampled}
+        files = manifest['files']
+        gate.dump(private / 'payload-census.json', {
+            'schema': 'polis-probe-payload-census/1',
+            **samples.payload_census(manifest),
+            'sample_directories': len(directories), 'required_entries': len(prepared),
+            'required_checkpoints': sum(len(p.checkpoints) for p in prepared),
+            'samples': [dict(samples.payload_sizes(payload / directory),
+                             payload_bytes=sum(f['size'] for f in files if f['path'].startswith(directory + '/')))
+                        for directory in sorted(directories)]})
+    return prepared, inventory
 
 
 def verify() -> None:
@@ -111,10 +138,12 @@ def verify() -> None:
                         'outliers': roll['g12_outliers'], 'nonfinite': roll['nonfinite']})
     controls = report['negative_controls']
     completed = controls['g12']['rejected'] + sum(v == 'REJECTED' for v in controls['checkpoint'].values())
-    receipt = {'schema': 'polis-probe-receipt/1', 'run_id': job['run_id'], 'job_sha256': sha(job),
+    manifest = gate.read(Path('/fixture/manifest.json'))
+    selection = manifest.get('representative', {}).get('report')
+    receipt = {'schema': 'polis-probe-receipt/2' if selection else 'polis-probe-receipt/1', 'run_id': job['run_id'], 'job_sha256': sha(job),
                'verdict': report['verdict'], 'entries': entries,
                'controls': {'passed': completed, 'expected': 21},
-               'selection': None,
+               'selection': selection,
                'digests': {'producer': job['producer']['image'].split('@sha256:')[1],
                            'verifier': job['verifier']['image'].split('@sha256:')[1],
                            'inputs': sha(inputs), 'recordings': sha(gate.regular_tree(Path('/evidence'))),

--- a/ci/probe_box/receipt.py
+++ b/ci/probe_box/receipt.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import math
 import re
+from collections import Counter
 
 from contracts import Job, validate_job
 
@@ -39,10 +40,73 @@ def finite(value: object) -> float:
     return value
 
 
+def validate_selection(value: object) -> dict:
+    """Independent export boundary for the counts-only selection report.
+
+    This supervisor has no engine/package dependency and never loads a row,
+    ordinal map or path supplied by the candidate.
+    """
+    r = closed(value, {"seed", "bucket_counts", "chosen_entry_sizes"})
+    if type(r["seed"]) is not str or re.fullmatch(r"[a-f0-9]{64}", r["seed"]) is None:
+        raise ValueError("RECEIPT_SELECTION_SEED")
+    totals = {"population", "target", "selected", "shortfall", "occupied", "covered", "uncovered"}
+    c = closed(r["bucket_counts"], totals | {"cells"})
+    def number(n):
+        if type(n) is not int or not 0 <= n <= 2**63 - 1:
+            raise ValueError("RECEIPT_SELECTION_COUNT")
+    for k in totals:
+        number(c[k])
+    cells, sizes = c["cells"], r["chosen_entry_sizes"]
+    if type(cells) is not list or len(cells) > 400 or type(sizes) is not list or not 1 <= len(sizes) <= 20:
+        raise ValueError("RECEIPT_SELECTION_CENSUS")
+    grid = {}
+    for cell in cells:
+        closed(cell, {"p_bin", "v_bin", "population", "selected"})
+        for n in cell.values():
+            number(n)
+        key = cell["p_bin"], cell["v_bin"]
+        if key in grid or max(key) > 19 or cell["selected"] > cell["population"]:
+            raise ValueError("RECEIPT_SELECTION_CELL")
+        grid[key] = cell
+    actual = Counter()
+    for row in sizes:
+        closed(row, {"P", "V", "C", "U", "matrix_area", "registered_participants", "all_comments", "p_bin", "v_bin"})
+        for n in row.values():
+            number(n)
+        p, v, comments, u = (row[k] for k in ("P", "V", "C", "U"))
+        key = row["p_bin"], row["v_bin"]
+        if (key != (len(str(p)) if p else 0, len(str(v)) if v else 0)
+                or row["matrix_area"] != p*comments or u > min(v, p*comments)
+                or max(p, comments) > u or ((v == 0) != (p == comments == u == 0))):
+            raise ValueError("RECEIPT_SELECTION_SIZE")
+        actual[key] += 1
+    if (cells != sorted(cells, key=lambda x: (x["p_bin"], x["v_bin"])) or sizes != sorted(
+            sizes, key=lambda x: tuple(x[k] for k in ("p_bin", "v_bin", "P", "V", "C", "U", "matrix_area", "registered_participants", "all_comments")))):
+        raise ValueError("RECEIPT_SELECTION_ORDER")
+    occupied = {k for k, cell in grid.items() if cell["population"]}
+    expected_grid = {(p, v) for p in range(max(k[0] for k in occupied)+1)
+                     for v in range(max(k[1] for k in occupied)+1)} if occupied else set()
+    if (set(grid) != expected_grid or not set(actual) <= set(grid)
+            or any(actual[k] != cell["selected"] for k, cell in grid.items())
+            or sum(x["population"] for x in cells) != c["population"]
+            or sum(x["selected"] for x in cells) != c["selected"]
+            or c["target"] != 20 or c["selected"] != len(sizes) or len(sizes) != min(20, c["population"])
+            or c["shortfall"] != 20-len(sizes) or c["occupied"] != len(occupied)
+            or c["covered"] != len(actual) or c["uncovered"] != len(occupied)-len(actual)
+            or len(actual) < min(8, len(occupied), c["population"])):
+        raise ValueError("RECEIPT_SELECTION_CENSUS")
+    for axis in (0, 1):
+        for extreme in (min, max):
+            limit = extreme(k[axis] for k in occupied)
+            if not any(k[axis] == limit for k in actual):
+                raise ValueError("RECEIPT_SELECTION_COVERAGE")
+    return r
+
+
 def validate_receipt(value: object, job: Job) -> dict:
     job = validate_job(job)
     r = closed(value, {"schema", "run_id", "job_sha256", "verdict", "entries", "controls", "selection", "digests"})
-    if (r["schema"] != "polis-probe-receipt/1" or r["run_id"] != job["run_id"] or
+    if (r["schema"] not in ("polis-probe-receipt/1", "polis-probe-receipt/2") or r["run_id"] != job["run_id"] or
             r["job_sha256"] != sha(job) or r["verdict"] not in ("PASS", "FAIL", "INCOMPLETE")):
         raise ValueError("RECEIPT_BINDING")
     if type(r["entries"]) is not list or not 1 <= len(r["entries"]) <= 256:
@@ -65,7 +129,9 @@ def validate_receipt(value: object, job: Job) -> dict:
             controls["passed"] != controls["expected"]):
         raise ValueError("RECEIPT_FALSE_PASS")
     selection = r["selection"]
-    if selection is not None:
+    if r["schema"] == "polis-probe-receipt/2":
+        validate_selection(selection)
+    elif selection is not None:
         closed(selection, {"seed", "bucket_counts", "selected_sizes"})
         count(selection["seed"])
         for name in ("bucket_counts", "selected_sizes"):

--- a/ci/probe_box/test_boundaries.py
+++ b/ci/probe_box/test_boundaries.py
@@ -29,7 +29,35 @@ def receipt():
         digests=dict(producer='1'*64,verifier='2'*64,inputs='3'*64,recordings='4'*64,policy='5'*64))
 
 
+def sampled_receipt():
+    r=receipt();r['schema']='polis-probe-receipt/2'
+    r['selection']={'seed':'01'*32,'bucket_counts':{
+        'population':1,'target':20,'selected':1,'shortfall':19,'occupied':1,'covered':1,'uncovered':0,
+        'cells':[dict(p_bin=p,v_bin=v,population=int(p==v==1),selected=int(p==v==1))
+                 for p in range(2) for v in range(2)]},
+        'chosen_entry_sizes':[dict(P=3,V=7,C=2,U=6,matrix_area=6,registered_participants=4,all_comments=2,p_bin=1,v_bin=1)]}
+    return r
+
+
 class BoundaryTests(unittest.TestCase):
+    def test_v2_receipt_retains_full_hex_seed_and_numeric_report(self):
+        r=sampled_receipt()
+        self.assertEqual(validate_receipt(r,job()),r)
+
+    def test_v2_selection_census_tamper_and_private_fields_refuse(self):
+        for mutation in ['missing','extra','seed','count','cell','size','order','old-version']:
+            with self.subTest(mutation=mutation):
+                r=sampled_receipt();s=r['selection']
+                if mutation=='missing':r['selection']=None
+                elif mutation=='extra':s['chosen_entry_sizes'][0]['path']='synthetic private value'
+                elif mutation=='seed':s['seed']=42
+                elif mutation=='count':s['bucket_counts']['population']=True
+                elif mutation=='cell':s['bucket_counts']['cells'].pop()
+                elif mutation=='size':s['chosen_entry_sizes'][0]['V']=0
+                elif mutation=='order':s['bucket_counts']['cells'].reverse()
+                elif mutation=='old-version':r['schema']='polis-probe-receipt/1'
+                with self.assertRaises(ValueError):validate_receipt(r,job())
+
     def test_valid_receipt_and_numeric_selection(self):
         r=receipt();r['selection']={'seed':42,'bucket_counts':[[0,1,20]],'selected_sizes':[[3,8]]}
         self.assertEqual(validate_receipt(r,job()),r)

--- a/delphi/docs/representative-selection.md
+++ b/delphi/docs/representative-selection.md
@@ -1,11 +1,11 @@
 # Representative snapshot selection
 
 The optional `representative_selection` config block selects up to 20 distinct
-conversations and produces a numeric census report. This is a **selection-only
-stage**: it does not extract extra sample payloads, add replay/schedule/battery
-entries, or change payload admission. Existing coverage recipes remain intact.
-A later reviewed extension must materialize and admit the sampled conversations
-before a full representative private campaign can run.
+conversations and produces a numeric census report. Whole-config extraction
+materializes those conversations in the same snapshot as the existing roles.
+Manifest/4 and the probe's paired-plan/2 admit every sampled payload and its
+full-stream recipe alongside the existing private battery. The standalone
+`select-representative` command remains selection-only.
 
 The shipped `scripts/certify_datasets.json` and battery are unchanged. Make a
 reviewed new config version before inspecting candidate outputs, adding:
@@ -59,7 +59,8 @@ unbiased production failure-rate estimate.
 
 From `delphi/`, using the already authorized restored-clone connection and a
 reviewed config. All real values, credentials, raw surveys and sidecars stay in
-that box; the certification worker gets no database or snapshot permission.
+that box. In ProbeBox, only the reader receives the restricted replica socket;
+the producer and verifier receive separate local mounts without network access.
 
 ```sh
 uv run python scripts/prodclone_extract.py select-representative \
@@ -89,13 +90,56 @@ does not disable writers or relax transaction isolation.
 
 Alternatively, the existing `from-config` extraction command with that same
 optional config performs selection over the **same fetched census and transaction**
-as its unchanged old-role resolution/extraction. It writes
+as its unchanged old-role resolution. It extracts each selected identity once,
+reusing those bytes when an existing role overlaps, while retaining every role
+and replay obligation. New sample aliases are private ordinals `sample-001`
+through `sample-020`; directories retain random prefixes. It writes
 `representative_selection.private.json` beside the payload, under the existing
 `.private` sidecar directory. `certify_extract.json` contains the safe report but
 excludes the representative identity map. Existing survey/role provenance stays
 in its own restricted sidecars. With selection enabled stdout contains only the
 new report; without the block, original extraction behavior/output is retained.
 Failures never substitute the sample for a missing old recipe.
+
+## Payload and replay admission
+
+The opt-in config requires manifest `certify-fixture-manifest/4` with a closed
+`representative` block binding the unchanged numeric report. Every selected
+ordinal must have a distinct materialized directory; an old role may share that
+directory. Admission recounts P, V, C, U, registered participants and comments
+from lossless events and participant rows and compares the complete size census
+with the report. Missing, substituted, duplicated, unknown or unconfigured sample
+roles fail. Existing role predicates, synthetic approval, generated cases and
+NULL-drop policy still apply. Configs without sampling retain manifest/3 and
+the original battery; historical manifest/2 remains supported.
+
+The box freezes all 14 existing private entries plus the selected sample entries
+(normally 34 total). Each sample uses `representative-uniform6-clojure-legacy`,
+with distinct integer cuts `ceil(k*V/6)` for k=1..6. Tiny inputs have fewer than
+six cuts; zero votes have one explicit bootstrap checkpoint and the existing
+strict empty-output contract. The independent gate reconstructs every required
+entry, schedule and checkpoint from the original read-only fixture. Omitting a
+sample, dropping a checkpoint, truncating a stream or declaring a public-only
+subset cannot pass this campaign. Ordinary/restart obligations remain separate.
+Execution sorts by actual V, then actual P×C, then the private dataset key;
+ordinary/restart schedules stay adjacent, ordinary first.
+
+Sample schedules use the explicit `source-final-state` moderation mode in both
+replay drivers. All captured current comment flags enter only the final step,
+including timestamps after the last vote and missing timestamps. Tied vote times
+cannot move these rows to an earlier checkpoint. Known modification timestamps
+are retained; unknown timestamps use the empty watermark sentinel 0 while the
+original NULL remains in the bound events. This is a declared snapshot-state
+application, not a reconstructed moderation history. The established engine
+batch order remains votes/recompute, then moderation sets/watermark; the final
+math is therefore not claimed to have recomputed under those newly applied flags.
+Existing interleaved moderation and restart recipes are unchanged.
+
+Sampled payloads and identity maps are box-only. The legacy object-store
+push/pull and public-pin paths refuse manifest/4, including admission-bypass
+pushes. The box verifier exports only a closed `polis-probe-receipt/2` with the
+validated numeric selection report; ordinary unsampled receipts retain /1.
+Public dispatch output remains exactly run ID plus PASS/FAIL.
 
 ## Report boundary and measurements
 
@@ -112,10 +156,14 @@ and size census before publication.
 No zid, report ID, role/alias, directory/path, snapshot/timestamp, rank/hash,
 source text, outcome or raw exception belongs in this report. Sidecars remain
 in the extraction box and are excluded from tar/log/public outputs. This stage
-measures database cardinalities only. It does **not** claim extracted byte sizes,
-RSS or scratch capacity for the sampled conversations. Those require the later
-payload/capacity stage; unknown byte measurements are not reported as zero.
-No change is made to the private box's independent public-summary policy.
+keeps its database-cardinality schema. A separate box-only payload census records
+actual unique file bytes/member count, per-sample payload bytes, entry count and
+checkpoint count. Admission rejects over 180 GiB expanded payload or 1,000,000
+files without replacing the sample. No archive is exported by this box ABI.
+These are input measurements and ceilings, not proof of production fit: host and
+container memory peaks, retained recording growth, scratch high-water and OOM
+evidence still require the actual private capacity run. Unknown resource
+measurements are not reported as zero. No public output policy is widened.
 
 The tests use synthetic populations, including a deliberately defective allocator,
 small/empty/uncovered populations, reordered inputs, ignored outcome fields,

--- a/delphi/polismath/replay/fixture_bundle.py
+++ b/delphi/polismath/replay/fixture_bundle.py
@@ -79,6 +79,7 @@ from polismath.utils.vote_convention import (
 #: manifest IS, unchanged, on its original bytes — see
 #: :data:`ADMISSIBLE_MANIFEST_SCHEMA_VERSIONS`.
 MANIFEST_SCHEMA_VERSION = "certify-fixture-manifest/3"
+SAMPLED_MANIFEST_SCHEMA_VERSION = "certify-fixture-manifest/4"
 #: The PREVIOUS closed manifest schema. It stays verifiable and admissible
 #: BYTE-FOR-BYTE (review #2730 F-compat): a /2 manifest carries no
 #: ``transform`` key at all and its polarity block already spells out the -1 it
@@ -87,7 +88,7 @@ MANIFEST_SCHEMA_VERSION = "certify-fixture-manifest/3"
 #: bundles are always written at /3; nothing re-issues an existing bundle.
 LEGACY_MANIFEST_SCHEMA_VERSION = "certify-fixture-manifest/2"
 ADMISSIBLE_MANIFEST_SCHEMA_VERSIONS = (
-    LEGACY_MANIFEST_SCHEMA_VERSION, MANIFEST_SCHEMA_VERSION)
+    LEGACY_MANIFEST_SCHEMA_VERSION, MANIFEST_SCHEMA_VERSION, SAMPLED_MANIFEST_SCHEMA_VERSION)
 PROVENANCE_SCHEMA_VERSION = "certify-fixture-provenance/1"
 PINS_SCHEMA_VERSION = "certify-fixture-pins/1"
 #: Bumped to /2 by the r2 admission correction: the policy fields carry CLOSED
@@ -271,6 +272,7 @@ def build_manifest(
     accepted_null_vote_drops: bool = False,
     storage_agree_value: int = STORAGE_AGREE_VALUE,
     transform: dict[str, Any] | None = None,
+    representative_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """The PRIVATE manifest. It records everything P-022 A lists EXCEPT the
     role -> zid mapping, which lives in the separate restricted provenance
@@ -285,6 +287,8 @@ def build_manifest(
     binds the original's digests, never the other way round.
     """
     validate_storage_agree_value(storage_agree_value)
+    from polismath.replay import fixture_samples
+    representative = fixture_samples.block(config, representative_report)
     # P-052 §4.5. Derived from the role summaries rather than passed in, so no
     # caller has to remember it and no caller can misdeclare it. When no role
     # captured the served rows the manifest is byte-for-byte what it was before
@@ -298,7 +302,8 @@ def build_manifest(
             raise BundleError("; ".join(bad))
     files = scan_files(payload_root)
     return {
-        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "schema_version": SAMPLED_MANIFEST_SCHEMA_VERSION if representative else MANIFEST_SCHEMA_VERSION,
+        **({"representative": representative} if representative else {}),
         "bundle_id": bundle_id,
         "created_at": datetime.now(timezone.utc).isoformat(),
         "owner": owner,
@@ -629,7 +634,8 @@ def build_derived_manifest(
     files = scan_files(payload_root)
     derived = dict(source_manifest)
     derived.update(
-        schema_version=MANIFEST_SCHEMA_VERSION,
+        schema_version=(SAMPLED_MANIFEST_SCHEMA_VERSION if "representative" in source_manifest
+                        else MANIFEST_SCHEMA_VERSION),
         bundle_id=bundle_id,
         created_at=datetime.now(timezone.utc).isoformat(),
         owner=owner or source_manifest["owner"],
@@ -992,6 +998,8 @@ def push(
        conflicting upload leaves an INCOMPLETE, unadmitted prefix rather than a
        mixed bundle that looks published.
     """
+    if manifest.get("schema_version") == SAMPLED_MANIFEST_SCHEMA_VERSION or "representative" in manifest:
+        raise BundleError("SAMPLED_PAYLOADS_BOX_ONLY")
     if manifest["bundle_id"] != bundle_id or provenance["bundle_id"] != bundle_id:
         raise BundleError("bundle_id mismatch between arguments and manifest/provenance")
 
@@ -1180,6 +1188,7 @@ MANIFEST_KEYS_ADDED_IN_V3 = frozenset({"transform"})
 MANIFEST_TOP_LEVEL_KEYS_BY_VERSION: dict[str, frozenset[str]] = {
     LEGACY_MANIFEST_SCHEMA_VERSION: MANIFEST_TOP_LEVEL_KEYS - MANIFEST_KEYS_ADDED_IN_V3,
     MANIFEST_SCHEMA_VERSION: MANIFEST_TOP_LEVEL_KEYS,
+    SAMPLED_MANIFEST_SCHEMA_VERSION: MANIFEST_TOP_LEVEL_KEYS | {"representative"},
 }
 
 #: Ordering guarantee -> the ONE tie-order policy token that guarantee permits.
@@ -1364,7 +1373,9 @@ def admit_manifest(
     checks the downloaded payload before making it available to consumers.
     """
     _admit_manifest_structure(manifest, config=config, config_bytes=config_bytes,
-                              config_path=config_path)
+                              config_path=config_path, payload_root=payload_root)
+    if "representative" in manifest and payload_root is None:
+        raise AdmissionError("representative payload admission requires payload_root")
     if any("served_math" in row for row in manifest["roles"]):
         if payload_root is None:
             raise AdmissionError("served_math admission requires payload_root")
@@ -1377,6 +1388,7 @@ def admit_manifest(
 def _admit_manifest_structure(
     manifest: dict[str, Any], *, config: dict[str, Any] | None = None,
     config_bytes: bytes | None = None, config_path: Path | None = None,
+    payload_root: Path | None = None,
 ) -> None:
     """SEMANTIC admission. Raises :class:`AdmissionError` listing every defect.
 
@@ -1671,6 +1683,13 @@ def _admit_manifest_structure(
         P(slug not in by_slug, f"role slug {slug!r} appears twice")
         by_slug[str(slug)] = entry
     config_roles = {r["slug"]: r for r in config["roles"]}
+    from polismath.replay import fixture_samples
+    try:
+        config_roles.update(fixture_samples.admitted_rules(manifest, config, payload_root))
+    except (ValueError, KeyError, TypeError, OSError) as exc:
+        P(False, f"representative payload admission: {type(exc).__name__}")
+        # Do not interpolate source values or private paths from lower layers.
+        raise AdmissionError(_admission_message(manifest, problems)) from None
     for slug in sorted(set(config_roles) - set(by_slug)):
         P(False, f"required role {slug!r} ({config_roles[slug]['role']}) is not in "
                  "the manifest")
@@ -2083,6 +2102,8 @@ def pull(
     if sha256_bytes(manifest_bytes) != pins["manifest_sha256"]:
         raise VerificationError("manifest hash does not match the pinned value")
     manifest = json.loads(manifest_bytes)
+    if manifest.get("schema_version") == SAMPLED_MANIFEST_SCHEMA_VERSION or "representative" in manifest:
+        raise BundleError("SAMPLED_PAYLOADS_BOX_ONLY")
     if manifest["root_digest"] != pins["root_digest"]:
         raise VerificationError("manifest root digest does not match the pinned value")
 
@@ -2157,6 +2178,8 @@ def public_pin(manifest: dict[str, Any]) -> dict[str, Any]:
     hashes, role names and coverage obligations. NO zid, report id, participant
     id, timeline, vote row, blob or error dump — and no measured metric, which
     could fingerprint a conversation."""
+    if manifest.get("schema_version") == SAMPLED_MANIFEST_SCHEMA_VERSION or "representative" in manifest:
+        raise BundleError("SAMPLED_PAYLOADS_BOX_ONLY")
     return {
         "bundle_id": manifest["bundle_id"],
         "root_digest": manifest["root_digest"],

--- a/delphi/polismath/replay/fixture_config.py
+++ b/delphi/polismath/replay/fixture_config.py
@@ -119,7 +119,7 @@ def served_math_options(config: dict[str, Any]) -> ServedMathOptions:
 
 
 def representative_seed(config: dict[str, Any]) -> str | None:
-    """Optional, frozen selection-only declaration; reject malformed direct calls.
+    """Optional, frozen representative selection; reject malformed direct calls.
 
     The shipped recipes/config remain byte-identical. A reviewed opt-in creates
     a new config version; it does not admit additional payloads or battery rows.

--- a/delphi/polismath/replay/fixture_extract.py
+++ b/delphi/polismath/replay/fixture_extract.py
@@ -1013,6 +1013,25 @@ def extract_from_config(
 
     role_summaries: list[dict[str, Any]] = []
     provenance_rows: list[dict[str, Any]] = []
+    extracted = {}
+    def capture(zid, slug, role, metrics):
+        import copy
+        if representative is not None and zid in extracted:
+            summary = copy.deepcopy(extracted[zid])
+            summary.update(slug=slug, role=role)
+            dir_names[slug] = summary["dir"]
+            return summary
+        directory = dir_names.setdefault(slug, mint_opaque_dir(slug))
+        summary = extract_conversation(
+            conn, zid=zid, slug=slug, role=role,
+            payload_root=payload_root, guard_root=guard_root,
+            dir_name=directory, tie_key=tie_key, measured=metrics,
+            capture_served_math=served_math.capture,
+            served_math_envs=served_math.math_envs,
+        )
+        extracted[zid] = copy.deepcopy(summary)
+        return summary
+
     for sel in selections:
         if sel.zid is None:
             case_id = sel.synthetic_replacement
@@ -1044,21 +1063,27 @@ def extract_from_config(
                 "n_candidates": sel.n_candidates,
             })
             continue
-        dir_name = dir_names.setdefault(sel.slug, mint_opaque_dir(sel.slug))
-        summary = extract_conversation(
-            conn, zid=sel.zid, slug=sel.slug, role=sel.role,
-            payload_root=payload_root, guard_root=guard_root,
-            dir_name=dir_name, tie_key=tie_key, measured=sel.metrics,
-            capture_served_math=served_math.capture,
-            served_math_envs=served_math.math_envs,
-        )
+        summary = capture(sel.zid, sel.slug, sel.role, sel.metrics)
         summary.update({
             "group": sel.group, "rank": sel.rank, "source": "production",
             "n_candidates": sel.n_candidates, "overlaps_with": sel.overlaps_with,
         })
         role_summaries.append(summary)
         provenance_rows.append({
-            "role": sel.role, "slug": sel.slug, "dir": dir_name, "zid": sel.zid})
+            "role": sel.role, "slug": sel.slug, "dir": summary["dir"], "zid": sel.zid})
+
+    if representative is not None:
+        from polismath.replay import fixture_samples as samples
+        metrics_by_zid = {row["zid"]: row for row in rows}
+        if {samples.slug(p["ordinal"]) for p in representative.provenance} & {s.slug for s in selections}:
+            raise SelectionError("SAMPLE_ROLE_COLLISION")
+        for chosen in representative.provenance:
+            zid = chosen["zid"]
+            name = samples.slug(chosen["ordinal"])
+            summary = capture(zid, name, name, metrics_by_zid[zid])
+            summary.update(group="representative", rank=None, source="production")
+            role_summaries.append(summary)
+            provenance_rows.append(dict(role=name, slug=name, dir=summary["dir"], zid=zid))
 
     result = {
         "survey": survey,

--- a/delphi/polismath/replay/fixture_samples.py
+++ b/delphi/polismath/replay/fixture_samples.py
@@ -1,0 +1,154 @@
+"""Box-local sampled payload admission and the frozen full-stream recipe.
+
+The numeric selection report remains unchanged. Ordinals, directories, events
+and resolved moderation belong only to the box-local manifest and plan.
+"""
+from collections import Counter
+import csv
+import json
+from pathlib import Path
+
+from polismath.replay import fixture_config, fixture_selection as selection
+
+MANIFEST_VERSION = "certify-fixture-manifest/4"
+BLOCK_VERSION = "certify-representative-payloads/1"
+PLAN_VERSION = "polis-private-paired-plan/2"
+SCHEDULE_ID = "representative-uniform6-clojure-legacy"
+MAX_PAYLOAD_BYTES = 180 * 1024**3
+MAX_PAYLOAD_FILES = 1_000_000
+
+
+def payload_census(manifest):
+    files = manifest["files"]
+    if type(files) is not list or any(type(f.get("size")) is not int or f["size"] < 0 for f in files):
+        raise selection.SelectionError("SAMPLE_PAYLOAD_CENSUS")
+    size = sum(f["size"] for f in files)
+    if len(files) > MAX_PAYLOAD_FILES or size > MAX_PAYLOAD_BYTES:
+        raise selection.SelectionError("SAMPLE_PAYLOAD_CAPACITY")
+    return dict(unique_payload_bytes=size, payload_files=len(files))
+
+
+def slug(ordinal):
+    if type(ordinal) is not int or not 1 <= ordinal <= selection.TARGET:
+        raise selection.SelectionError("SAMPLE_ORDINAL")
+    return f"sample-{ordinal:03d}"
+
+
+def rule(ordinal):
+    name = slug(ordinal)
+    return dict(slug=name, role=name, group="representative", rank=None,
+                predicates=[], on_missing="fail")
+
+
+def block(config, report):
+    seed = fixture_config.representative_seed(config)
+    if seed is None:
+        if report is not None:
+            raise selection.SelectionError("UNCONFIGURED_SAMPLE_PAYLOADS")
+        return None
+    selection.validate_report(report)
+    if report["seed"] != seed or not report["bucket_counts"]["selected"]:
+        raise selection.SelectionError("SAMPLE_REPORT_BINDING")
+    return {"schema": BLOCK_VERSION, "report": report}
+
+
+def payload_sizes(directory):
+    """Recount source rows, including NULL votes, without using compatibility CSV."""
+    from polismath.replay.event_ingress import read_events
+    events, _ = read_events(Path(directory) / "events.jsonl")
+    votes = [e for e in events if e["kind"] == "vote"]
+    p = len({e["pid"] for e in votes})
+    c = len({e["tid"] for e in votes})
+    with (Path(directory) / "participants.csv").open(newline="") as stream:
+        reader = csv.DictReader(stream)
+        if reader.fieldnames != ["participant-id", "moderation", "created"]:
+            raise selection.SelectionError("SAMPLE_PARTICIPANT_SCHEMA")
+        participants = list(reader)
+    ids = [int(row["participant-id"]) for row in participants]
+    if len(set(ids)) != len(ids):
+        raise selection.SelectionError("SAMPLE_PARTICIPANT_CENSUS")
+    meta = json.loads((Path(directory) / "events.meta.json").read_bytes())
+    if type(meta["counts"].get("participants")) is not int or meta["counts"]["participants"] != len(ids):
+        raise selection.SelectionError("SAMPLE_PARTICIPANT_CENSUS")
+    return dict(P=p, V=len(votes), C=c,
+                U=len({(e["pid"], e["tid"]) for e in votes}), matrix_area=p*c,
+                registered_participants=len(ids), all_comments=len(events)-len(votes))
+
+
+def admitted_rules(manifest, config, payload_root=None):
+    """Closed census, distinct payloads and exact report-to-source size binding."""
+    declared = manifest.get("representative")
+    if fixture_config.representative_seed(config) is None:
+        if declared is not None or manifest["schema_version"] == MANIFEST_VERSION:
+            raise selection.SelectionError("UNCONFIGURED_SAMPLE_PAYLOADS")
+        return {}
+    if (manifest["schema_version"] != MANIFEST_VERSION or type(declared) is not dict
+            or set(declared) != {"schema", "report"} or declared["schema"] != BLOCK_VERSION):
+        raise selection.SelectionError("SAMPLE_MANIFEST_SCHEMA")
+    block(config, declared["report"])
+    payload_census(manifest)
+    report = declared["report"]
+    rules = {r["slug"]: r for r in (rule(i+1) for i in range(report["bucket_counts"]["selected"]))}
+    reserved = {r["slug"] for r in config["roles"] + config["public_fixtures"]}
+    reserved.update(config["coverage_role_map"])
+    if set(rules) & reserved:
+        raise selection.SelectionError("SAMPLE_ROLE_COLLISION")
+    rows = [r for r in manifest["roles"] if r.get("slug") in rules]
+    if (len(rows) != len(rules) or {r["slug"] for r in rows} != set(rules)
+            or len({r.get("dir") for r in rows}) != len(rows)):
+        raise selection.SelectionError("SAMPLE_PAYLOAD_CENSUS")
+    sizes = []
+    for row in rows:
+        source = row.get("source")
+        if source == "derived":
+            source = row.get("derived_from", {}).get("source")
+        if source != "production" or row.get("group") != "representative":
+            raise selection.SelectionError("SAMPLE_SOURCE")
+        metrics = row.get("measured_metrics", {})
+        if not all(type(metrics.get(k)) is int and metrics[k] >= 0 for k in selection.SIZE_FIELDS):
+            raise selection.SelectionError("SAMPLE_METRICS")
+        selected_sizes = {k: metrics[k] for k in selection.SIZE_FIELDS}
+        if payload_root is not None:
+            from polismath.replay.fixture_bundle import safe_join
+            if payload_sizes(safe_join(Path(payload_root), row["dir"])) != selected_sizes:
+                raise selection.SelectionError("SAMPLE_PAYLOAD_SIZE_BINDING")
+        sizes.append(tuple(selected_sizes[k] for k in selection.SIZE_FIELDS))
+    expected = [tuple(r[k] for k in selection.SIZE_FIELDS) for r in report["chosen_entry_sizes"]]
+    if Counter(sizes) != Counter(expected):
+        raise selection.SelectionError("SAMPLE_SIZE_REPORT_BINDING")
+    return rules
+
+
+def resolved_spec(alias, dataset):
+    """Ceiling-six cuts; source final moderation is applied only at the final cut.
+
+    Current comment flags cannot reconstruct a history. Applying their complete
+    final state at the final checkpoint is explicit, including missing/late
+    modification timestamps and the empty bootstrap case.
+    """
+    from polismath.replay.schedule import ScheduleSpec
+    if dataset.input_events is None:
+        raise selection.SelectionError("SAMPLE_LOSSLESS_EVENTS_REQUIRED")
+    n = dataset.n
+    at = sorted({(k*n + 5)//6 for k in range(1, 7)})
+    cuts = {"mode": "vote-count", "at": at}
+    if not n:
+        cuts["empty_checkpoint"] = True
+    return ScheduleSpec(dataset=alias, schedule_id=SCHEDULE_ID, source="events-jsonl",
+                        cuts=cuts, moderation="source-final-state", coverage="full-stream",
+                        empty_output=None if n else {"n": 0, "n-cmts": 0, "tids": [], "in-conv": []},
+                        notes="Uniform ceiling-six full stream; current source moderation at final checkpoint, not historical moderation.")
+
+
+def ordered_prepared(prepared):
+    """Measured vote count/area, preserving ordinary/restart recipe adjacency."""
+    from polismath.replay import real_data
+    groups = {}
+    for expected in prepared:
+        groups.setdefault(expected.entry.dataset, []).append(expected)
+    def size(item):
+        alias, _ = item
+        dataset = real_data.load_export_votes(alias)
+        return (dataset.n, len({v.pid for v in dataset.votes}) * len({v.tid for v in dataset.votes}), alias)
+    return [entry for _, entries in sorted(groups.items(), key=size)
+            for entry in sorted(entries, key=lambda e: (e.spec.restart_after is not None, e.entry.schedule_id))]

--- a/delphi/polismath/replay/fixture_selection.py
+++ b/delphi/polismath/replay/fixture_selection.py
@@ -1,7 +1,8 @@
 """Seeded representative selection inside the private snapshot box.
 
-No payload or battery admission: this stage returns a counts-only report and a
-separate private identity map. Raw rows and rank hashes must never be logged.
+This module returns a counts-only report and a separate private identity map.
+Whole extraction/admission is in fixture_samples. Raw rows and rank hashes must
+never be logged.
 """
 from __future__ import annotations
 
@@ -169,6 +170,8 @@ def validate_report(report: dict[str, Any]) -> None:
         # Use the same numeric consistency checks without accepting an identity.
         checked = _population([dict(row, zid=0)])[0]
         _require(checked == row, "REPORT_SIZE")
+    _require(cell_rows == sorted(cell_rows, key=_cell) and sizes == sorted(
+        sizes, key=lambda s: tuple(s[k] for k in ("p_bin", "v_bin", *SIZE_FIELDS))), "REPORT_ORDER")
     actual = Counter(_cell(row) for row in sizes)
     _require(all(actual[_cell(row)] == row["selected"] for row in cell_rows) and
              set(actual) <= seen and sum(row["population"] for row in cell_rows) == counts["population"] and

--- a/delphi/polismath/replay/schedule.py
+++ b/delphi/polismath/replay/schedule.py
@@ -275,6 +275,8 @@ def slice_schedule(dataset: ReplayDataset, spec: ScheduleSpec) -> list[ReplaySte
             for m in mod_events
             if m.t_ms <= cut_time_ms and (prev_time is None or m.t_ms > prev_time)
         )
+        if spec.moderation == "source-final-state":
+            step_mods = tuple(mod_events) if i == len(slots) - 1 else ()
         steps.append(
             ReplayStep(
                 index=i,
@@ -295,6 +297,15 @@ def _resolve_mod_events(dataset: ReplayDataset, spec: ScheduleSpec) -> list[ModE
         return []
     if mode == "interleave-by-timestamp":
         return sorted(dataset.mod_events, key=lambda m: m.t_ms)
+    if mode == "source-final-state":
+        if dataset.input_events is None:
+            raise ValueError("source-final-state requires lossless events")
+        # Source state is applied at the final checkpoint, never inferred as
+        # a history. Unknown modification timestamps use the empty watermark
+        # sentinel; the original NULL remains in the bound event payload.
+        return [ModEvent(e["modified"] if e["modified"] is not None else 0,
+                         e["tid"], e["mod"], e["is_meta"])
+                for e in dataset.input_events if e["kind"] == "comment"]
     if isinstance(mode, (list, tuple)):
         parsed = [
             m if isinstance(m, ModEvent) else ModEvent(

--- a/delphi/polismath/replay/types.py
+++ b/delphi/polismath/replay/types.py
@@ -92,8 +92,9 @@ class ReplayDataset:
     # no moderation-history columns at all (nothing was skipped — there was
     # nothing to parse).
     mod_events_skipped: int = 0
-    # Original authoritative rows, including comments and source provenance.
-    input_events: tuple[dict, ...] = ()
+    # None means compatibility input; an empty tuple is an authoritative
+    # empty stream. Keep those distinct for source-state replay admission.
+    input_events: tuple[dict, ...] | None = None
 
     @property
     def n(self) -> int:

--- a/delphi/scripts/certify_data.py
+++ b/delphi/scripts/certify_data.py
@@ -229,6 +229,7 @@ def push(bundle_id: str, payload: Path, extract_json: Path, provenance_json: Pat
             "sha256": archive_sha256, "object_version": archive_object_version},
         coverage_report=extract.get("coverage_report"),
         accepted_null_vote_drops=accept_null_vote_drops,
+        representative_report=extract.get("representative_selection"),
     )
     fb.verify(payload, manifest)
     try:

--- a/delphi/tests/replay_harness/representative_schedule_test.clj
+++ b/delphi/tests/replay_harness/representative_schedule_test.clj
@@ -1,0 +1,46 @@
+;; Synthetic final-source-state replay controls; no production data.
+(load-file "dev/replay.clj")
+(require '[clojure.test :refer :all] '[cheshire.core :as json] '[clojure.java.io :as io])
+
+(defn with-source [n f]
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory "sample-replay-test-" (make-array java.nio.file.attribute.FileAttribute 0)))
+        path (io/file dir "events.jsonl")
+        meta (io/file dir "events.meta.json")
+        votes (mapv (fn [i] {"ord" i "kind" "vote" "created" 1001 "pid" 1 "tid" 0 "vote" -1
+                             "weight_x_32767" nil "src" {"table" "votes" "row" i}}) (range n))
+        comments (mapv (fn [i] {"ord" (+ n i) "kind" "comment" "created" 900 "pid" 1 "tid" i
+                                "modified" (when (zero? i) 9000) "mod" (if (zero? i) 0 -1) "is_meta" (= i 1)
+                                "src" {"table" "comments" "row" i}}) (range 2))
+        events (into votes comments)]
+    (try
+      (spit path (apply str (map #(str (json/generate-string %) "\n") events)))
+      (spit meta (json/generate-string
+                   {"schema_version" "certify-events/2" "polarity" {"storage_agree_value" -1}
+                    "counts" {"events" (count events) "vote_events" n "comment_events" 2}
+                    "logical_digest_sha256" (#'replay/sha256-hex
+                       (apply str (map #(str (json/generate-string (into (sorted-map) (dissoc % "src"))) "\n") events)))}))
+      (f (replay/read-event-stream path))
+      (finally (.delete path) (.delete meta) (.delete dir)))))
+
+(deftest captured-state-retains-late-and-unknown-timestamps
+  (with-source 7
+    (fn [input]
+      (is (= [{:tid 0 :mod 0 :is_meta false :modified 9000}
+              {:tid 1 :mod -1 :is_meta true :modified 0}] (:final-mods input)))
+      ;; The established historical weaving mode remains unchanged.
+      (is (= 1 (get-in input [:mods :n-skipped])))
+      (is (= 1 (count (get-in input [:mods :events])))))))
+
+(deftest final-checkpoint-only-across-tiny-empty-and-tied-streams
+  (doseq [n [0 1 2 3 5 6 7 19]]
+    (with-source n
+      (fn [input]
+        (let [votes (replay/build-dataset (:votes input))
+              slots (vec (sort (set (map #(quot (+ (* % n) 5) 6) (range 1 7)))))
+              steps (replay/final-state-steps votes slots (:final-mods input))]
+          (is (= n (:cut-slot (peek steps))))
+          (is (= n (reduce + (map (comp count :votes) steps))))
+          (is (every? (comp empty? :mods) (butlast steps)))
+          (is (= (:final-mods input) (:mods (peek steps)))))))))
+
+(let [r (run-tests)] (System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))

--- a/delphi/tests/test_certify_bundle_integration.py
+++ b/delphi/tests/test_certify_bundle_integration.py
@@ -101,6 +101,45 @@ def test_scaled_config_is_still_valid():
     scaled_config()
 
 
+def test_representative_payloads_share_real_snapshot_and_admit_all_selected_rows(seeded_db, tmp_path, monkeypatch):
+    """Real SQL census/extraction with scaled synthetic shapes; no engine claim."""
+    import psycopg2
+    from polismath.replay import fixture_samples, fixture_selection
+
+    cfg=scaled_config()
+    cfg['representative_selection']=dict(algorithm=fixture_selection.VERSION,target=20,seed='01'*32)
+    fc.validate_config(cfg)
+    original=fx.fetch_conversation;fetched=[]
+    def fetch(conn,zid,tie_key):
+        fetched.append(zid)
+        return original(conn,zid,tie_key)
+    monkeypatch.setattr(fx,'fetch_conversation',fetch)
+    payload=tmp_path/'.local/payload';payload.mkdir(parents=True)
+    conn=psycopg2.connect(seeded_db)
+    try:
+        result=fx.extract_from_config(conn,config=cfg,payload_root=payload,guard_root=tmp_path)
+    finally:
+        conn.close()
+    chosen=result['representative_provenance']
+    assert len(chosen)==len({r['zid'] for r in chosen})==20
+    assert len(fetched)==len(set(fetched))
+    assert set(fetched)=={r['zid'] for r in result['provenance_rows']}
+    assert len(result['roles'])==len(cfg['roles'])+20
+    assert result['transaction_guarantee']['single_transaction'] is True
+    encoded=json.dumps(cfg).encode()
+    manifest=fb.build_manifest(bundle_id='synthetic-sampled-snapshot',payload_root=payload,
+        config=cfg,config_bytes=encoded,selections=result['roles'],generated_summaries=result['generated'],
+        snapshot=dict(identifier='synthetic-snapshot',created_at='2026-09-10T00:00:00Z',schema_migration_version='000006'),
+        transaction_guarantee=result['transaction_guarantee'],tie_key=result['tie_key'],
+        schedules=fb.collect_schedule_hashes(fc.SCRIPTS_DIR/'schedules'),owner='synthetic-test',
+        extraction_commit='0'*40,source_commit='0'*40,coverage_report=result['coverage_report'],
+        representative_report=result['representative_selection'])
+    fb.verify(payload,manifest)
+    fb.admit_manifest(manifest,config=cfg,config_bytes=encoded,payload_root=payload)
+    assert len(fixture_samples.admitted_rules(manifest,cfg,payload))==20
+    assert fb.scan_public_output(json.dumps(result['representative_selection']),PLANTED)==[]
+
+
 # ---------------------------------------------------------------------------
 # Seeding.
 # ---------------------------------------------------------------------------

--- a/delphi/tests/test_representative_payloads.py
+++ b/delphi/tests/test_representative_payloads.py
@@ -1,0 +1,234 @@
+"""Synthetic source rows through extraction, manifest, plan and independent gate."""
+import copy
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from polismath.replay import fixture_bundle as fb, fixture_extract as fx, fixture_samples as samples
+from polismath.replay import fixture_selection as selection, fixture_survey as survey
+from polismath.replay import event_ingress, schedule
+from tests.test_representative_selection import configured, mock_snapshot, SEED
+from tests.test_certify_bundle import _generate, _manifest, _selections
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / 'ci/private_cert/images'))
+import gate
+import probe
+
+TIE = dict(available=False, columns=[], method='physical-ctid', order_by='created ASC, ctid ASC',
+           guarantee='frozen-extract-order', note='synthetic')
+
+
+def raw_rows(n, *, tied=False, late=False):
+    return dict(votes=[dict(created=1000 if tied else 1000+i, pid=i%3, tid=i%2,
+                           vote=(-1,0,1)[i%3], weight_x_32767=None) for i in range(n)],
+                comments=[dict(created=900, modified=(None if i else 5000) if late else 900,
+                               pid=0, tid=i, mod=-1 if i else 0, is_meta=bool(i)) for i in range(2)],
+                participants=[dict(pid=i, mod=0, created=900) for i in range(4)])
+
+
+def metrics(raw):
+    v=raw['votes'];p=len({r['pid'] for r in v});c=len({r['tid'] for r in v})
+    return dict(P=p,V=len(v),C=c,U=len({(r['pid'],r['tid']) for r in v}),matrix_area=p*c,
+                registered_participants=len(raw['participants']),all_comments=len(raw['comments']))
+
+
+def extract_one(payload, root, raw, name, monkeypatch):
+    monkeypatch.setattr(fx,'fetch_conversation',lambda *a:raw)
+    return fx.extract_conversation(object(),zid=900000001,slug=name,role=name,
+        payload_root=payload,guard_root=root,dir_name='opaque-'+name,tie_key=TIE,measured=metrics(raw))
+
+
+def bundle(root, monkeypatch, n=20):
+    """Old role metadata is the existing synthetic admission factory's stub.
+
+    Both old and sampled payloads are real extractor output, never production
+    data. Tiny old-role bytes do not claim production predicate evidence.
+    """
+    config=configured();payload,generated=_generate(config,root)
+    old=_selections(config,payload)
+    for row in old:
+        size=0 if row['role']==config['coverage_role_map']['pc-zerovote-01'] else 24
+        new=extract_one(payload,root,raw_rows(size),row['slug'],monkeypatch)
+        row['dir']=new['dir']
+        # Remove the old factory's one-line stub, leaving no unused alias copy.
+        stub=payload/('aaaaaaaaaaaaaaaa-'+row['slug']);(stub/'events.jsonl').unlink();stub.rmdir()
+    sources={900000000+i:raw_rows(i,late=True,tied=True) for i in range(n)}
+    selected=selection.select_representative([dict(zid=z,**metrics(raw)) for z,raw in sources.items()],SEED)
+    rows=[]
+    for chosen in selected.provenance:
+        name=samples.slug(chosen['ordinal'])
+        row=extract_one(payload,root,sources[chosen['zid']],name,monkeypatch)
+        row.update(group='representative',rank=None,source='production');rows.append(row)
+    cfg=json.dumps(config).encode()
+    manifest=_manifest(config,payload,generated_summaries=generated,selections=old+rows,
+                       config_bytes=cfg,representative_report=selected.report)
+    fixture=payload.parent
+    (fixture/'config.json').write_bytes(cfg);gate.dump(fixture/'manifest.json',manifest)
+    return fixture,config,manifest
+
+
+@pytest.mark.parametrize('n',[1,19,20,24])
+def test_complete_sample_payload_census_and_manifest_version(tmp_path,monkeypatch,n):
+    fixture,config,manifest=bundle(tmp_path,monkeypatch,n)
+    assert manifest['schema_version']==samples.MANIFEST_VERSION
+    fb.verify(fixture/'payload',manifest)
+    fb.admit_manifest(manifest,config=config,config_bytes=(fixture/'config.json').read_bytes(),payload_root=fixture/'payload')
+    assert len(samples.admitted_rules(manifest,config,fixture/'payload'))==min(20,n)
+    with pytest.raises(fb.AdmissionError,match='requires payload_root'):
+        fb.admit_manifest(manifest,config=config,config_bytes=(fixture/'config.json').read_bytes())
+
+
+@pytest.mark.parametrize('mutation',['missing','duplicate','shared-dir','wrong-size','bad-seed','extra-report',
+                                   'old-version','synthetic','extra-role','missing-old-role','payload-count'])
+def test_sample_manifest_refuses_omitted_or_substituted_obligations(tmp_path,monkeypatch,mutation):
+    fixture,config,m=bundle(tmp_path,monkeypatch)
+    row=next(r for r in m['roles'] if r['slug']=='sample-001')
+    if mutation=='missing':m['roles'].remove(row)
+    elif mutation=='duplicate':m['roles'].append(copy.deepcopy(row))
+    elif mutation=='shared-dir':next(r for r in m['roles'] if r['slug']=='sample-002')['dir']=row['dir']
+    elif mutation=='wrong-size':row['measured_metrics']['V']+=1
+    elif mutation=='bad-seed':m['representative']['report']['seed']='02'*32
+    elif mutation=='extra-report':m['representative']['report']['zid']='SYNTHETIC_PRIVATE'
+    elif mutation=='old-version':m['schema_version']='certify-fixture-manifest/3'
+    elif mutation=='synthetic':row['source']='synthetic-replacement'
+    elif mutation=='extra-role':m['roles'].append(dict(row,slug='sample-021'))
+    elif mutation=='missing-old-role':m['roles'].pop(0)
+    elif mutation=='payload-count':
+        path=fixture/'payload'/row['dir']/'participants.csv'
+        path.write_text(path.read_text()+'8,0,900\n')
+    with pytest.raises(fb.AdmissionError):
+        fb.admit_manifest(m,config=config,config_bytes=(fixture/'config.json').read_bytes(),payload_root=fixture/'payload')
+
+
+@pytest.mark.parametrize('n',[0,1,2,3,5,6,7,19])
+def test_ceiling_six_exact_full_stream_and_final_state_even_at_tied_times(tmp_path,monkeypatch,n):
+    payload=tmp_path/'.local/payload';payload.mkdir(parents=True)
+    row=extract_one(payload,tmp_path,raw_rows(n,tied=True,late=True),'sample-001',monkeypatch)
+    ds=event_ingress.load_events(payload/row['dir']/'events.jsonl')
+    spec=samples.resolved_spec('sample-001',ds);steps=schedule.slice_schedule(ds,spec)
+    expected=sorted({(k*n+5)//6 for k in range(1,7)})
+    assert [s.cut_slot for s in steps]==expected and steps[-1].cut_slot==n
+    assert sum(len(s.vote_events) for s in steps)==n
+    assert all(not s.mod_events for s in steps[:-1])
+    assert [(m.t_ms,m.tid,m.mod,m.is_meta) for m in steps[-1].mod_events]==[(5000,0,0,False),(0,1,-1,True)]
+    if not n:assert spec.empty_output=={'n':0,'n-cmts':0,'tids':[],'in-conv':[]}
+
+
+def plan_bundle(tmp_path,monkeypatch):
+    # Register restoration even when the variable started absent; the box
+    # planner writes it directly as part of its process-local input binding.
+    monkeypatch.setenv('POLIS_REPLAY_INPUT_MAP','')
+    fixture,config,manifest=bundle(tmp_path,monkeypatch)
+    inputs=dict(candidateSha='c'*40,oracleSha='d'*40,policySha256=gate.sha(gate.POLICY))
+    prepared,inventory=probe.prepare_fixture_plan(fixture,config,manifest,tmp_path/'private',inputs)
+    return fixture,inputs,prepared,inventory
+
+
+def test_box_freezes_all_34_entries_and_verifier_rederives_full_inventory(tmp_path,monkeypatch):
+    fixture,inputs,prepared,inventory=plan_bundle(tmp_path,monkeypatch)
+    assert len(prepared)==34
+    assert sum(p.entry.dataset.startswith('sample-') for p in prepared)==20
+    assert inputs['expectedChecks']==sum(len(p.checkpoints) for p in prepared)
+    assert [p.stream_end for p in prepared]==sorted(p.stream_end for p in prepared)
+    mid=[i for i,p in enumerate(prepared) if p.entry.dataset=='pc-midmix-01']
+    assert len(mid)==2 and mid[1]==mid[0]+1 and prepared[mid[0]].spec.restart_after is None
+    scratch=tmp_path/'verify';scratch.mkdir()
+    checked,inv=gate.prepare(fixture,inputs,scratch)
+    assert inv==inventory and len(checked)==34
+    assert not any('provenance' in p.name or 'census' in p.name for p in fixture.rglob('*'))
+
+
+@pytest.mark.parametrize('mutation',['missing-sample','duplicate-sample','missing-old','missing-checkpoint',
+                                   'truncated','moderation','old-schema','public-only','remapped'])
+def test_independent_gate_refuses_incomplete_sample_plan(tmp_path,monkeypatch,mutation):
+    fixture,inputs,_,_=plan_bundle(tmp_path,monkeypatch)
+    plan=gate.read(fixture/'plan.json');row=next(r for r in plan['entries'] if r['dataset'].startswith('sample-') and r['schedule']['cuts']['at'][-1]>6)
+    if mutation=='missing-sample':plan['entries'].remove(row)
+    elif mutation=='duplicate-sample':plan['entries'].append(copy.deepcopy(row))
+    elif mutation=='missing-old':plan['entries'].pop(0)
+    elif mutation=='missing-checkpoint':row['schedule']['cuts']['at'].pop(0)
+    elif mutation=='truncated':row['schedule']['cuts']['at'][-1]-=1
+    elif mutation=='moderation':row['schedule']['moderation']='none'
+    elif mutation=='old-schema':plan['schema']='polis-private-paired-plan/1'
+    elif mutation=='public-only':plan['scope']='public'
+    elif mutation=='remapped':row['directory']=plan['entries'][0]['directory']
+    (fixture/'plan.json').write_bytes(gate.encoded(plan))
+    scratch=tmp_path/'verify';scratch.mkdir()
+    with pytest.raises(ValueError):gate.prepare(fixture,inputs,scratch,bind=False)
+
+
+def test_whole_snapshot_extracts_overlap_once_but_keeps_each_role(tmp_path,monkeypatch):
+    raws={900000000+i:raw_rows(i) for i in range(21)}
+    rows=[dict(zid=z,**metrics(raw)) for z,raw in raws.items()]
+    mock_snapshot(monkeypatch,rows)
+    config=configured();selected=selection.select_representative(rows,SEED)
+    zid=selected.provenance[0]['zid'];chosen=next(r for r in rows if r['zid']==zid)
+    old=[SimpleNamespace(zid=zid,slug='old-a',role='old-a',group='edge',rank=None,metrics=chosen,n_candidates=21,overlaps_with=[]),
+         SimpleNamespace(zid=zid,slug='old-b',role='old-b',group='edge',rank=None,metrics=chosen,n_candidates=21,overlaps_with=[])]
+    monkeypatch.setattr(survey,'resolve_roles',lambda *a,**k:old)
+    monkeypatch.setattr(survey,'coverage_report',lambda *a:{})
+    monkeypatch.setattr(fx,'detect_tie_key',lambda *a:TIE)
+    monkeypatch.setattr('polismath.replay.fixture_generate.write_all',lambda *a,**k:[])
+    seen=[]
+    def fetch(conn,z,tie):seen.append(z);return raws[z]
+    monkeypatch.setattr(fx,'fetch_conversation',fetch)
+    result=fx.extract_from_config(object(),config=config,payload_root=tmp_path/'.local/payload',guard_root=tmp_path)
+    assert len(seen)==len(set(seen))==20
+    assert len(result['roles'])==len(result['provenance_rows'])==22
+    aliases=[r for r in result['roles'] if r['slug'] in ('old-a','old-b','sample-001')]
+    assert len({r['dir'] for r in aliases})==1
+    assert all('zid' not in row['measured_metrics'] for row in result['roles'])
+
+
+def test_sample_bundle_cannot_use_legacy_public_pin_or_object_export(tmp_path,monkeypatch):
+    fixture,config,manifest=bundle(tmp_path,monkeypatch)
+    with pytest.raises(fb.BundleError,match='BOX_ONLY'):fb.public_pin(manifest)
+    class NoStore:
+        def __getattr__(self,name):pytest.fail('sample payload reached object store')
+    with pytest.raises(fb.BundleError,match='BOX_ONLY'):
+        fb.push(NoStore(),bundle_id=manifest['bundle_id'],payload_root=fixture/'payload',manifest=manifest,
+                provenance={},admit=False)
+
+
+@pytest.mark.parametrize('field',['zid','path','rank','topic','alias','blob'])
+@pytest.mark.parametrize('level',['report','counts','cell','size'])
+def test_receipt_selection_cannot_export_private_fields(field,level):
+    from receipt import validate_selection
+    report=selection.select_representative([dict(zid=900000001,**metrics(raw_rows(7)))],SEED).report
+    validate_selection(report)
+    target={'report':report,'counts':report['bucket_counts'],'cell':report['bucket_counts']['cells'][0],
+            'size':report['chosen_entry_sizes'][0]}[level]
+    target[field]='SYNTHETIC_PRIVATE_VALUE'
+    with pytest.raises(ValueError) as exc:validate_selection(report)
+    assert 'SYNTHETIC_PRIVATE_VALUE' not in str(exc.value)
+
+
+@pytest.mark.parametrize('n',[1,19,20,25])
+def test_box_receipt_preserves_exact_seed_and_closed_numeric_census(n):
+    from receipt import validate_selection
+    report=selection.select_representative([dict(zid=900000000+i,**metrics(raw_rows(i))) for i in range(n)],SEED).report
+    assert validate_selection(report)==report
+
+
+def test_private_payload_capacity_counts_unique_files_and_never_selects_a_subset():
+    assert samples.payload_census({'files':[{'size':2},{'size':3}]})==dict(unique_payload_bytes=5,payload_files=2)
+    with pytest.raises(selection.SelectionError,match='CAPACITY'):
+        samples.payload_census({'files':[{'size':samples.MAX_PAYLOAD_BYTES+1}]})
+    with pytest.raises(selection.SelectionError,match='CAPACITY'):
+        samples.payload_census({'files':[{'size':0}]*(samples.MAX_PAYLOAD_FILES+1)})
+
+
+@pytest.mark.parametrize('votes',[[],[(1000,1,1,1)]])
+def test_sample_recipe_rejects_compatibility_input_including_empty(votes):
+    from polismath.replay.types import ReplayDataset
+    dataset=ReplayDataset.build(votes)
+    with pytest.raises(selection.SelectionError,match='LOSSLESS'):
+        samples.resolved_spec('sample-001',dataset)
+    spec=schedule.ScheduleSpec('sample-001',samples.SCHEDULE_ID,
+        {'mode':'vote-count','at':[len(votes)],'empty_checkpoint':True},moderation='source-final-state')
+    with pytest.raises(ValueError,match='lossless'):
+        schedule.slice_schedule(dataset,spec)

--- a/delphi/tests/test_representative_payloads.py
+++ b/delphi/tests/test_representative_payloads.py
@@ -1,6 +1,7 @@
 """Synthetic source rows through extraction, manifest, plan and independent gate."""
 import copy
 import json
+import os
 from pathlib import Path
 import sys
 from types import SimpleNamespace
@@ -13,7 +14,7 @@ from polismath.replay import event_ingress, schedule
 from tests.test_representative_selection import configured, mock_snapshot, SEED
 from tests.test_certify_bundle import _generate, _manifest, _selections
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(os.environ.get('POLIS_CHECKOUT_DIR', Path(__file__).resolve().parents[2]))
 sys.path.insert(0, str(ROOT / 'ci/private_cert/images'))
 import gate
 import probe

--- a/delphi/tests/test_representative_selection.py
+++ b/delphi/tests/test_representative_selection.py
@@ -1,6 +1,6 @@
 """Synthetic-only snapshot selection, disclosure boundary and extraction wiring.
 
-Selection is not admission of extra payloads or battery recipes.
+Selection-only and whole-config extraction have separate completion contracts.
 """
 from __future__ import annotations
 
@@ -219,7 +219,7 @@ def test_missing_opt_in_refuses_before_database_access(monkeypatch):
 
 
 @pytest.mark.parametrize('enabled',[False,True])
-def test_whole_extraction_shares_census_and_keeps_recipe_payloads_unchanged(tmp_path,monkeypatch,enabled):
+def test_whole_extraction_shares_census_and_preserves_existing_recipe_resolution(tmp_path,monkeypatch,enabled):
     rows=[metric(i) for i in range(25)]
     calls=mock_snapshot(monkeypatch,rows)
     config=configured() if enabled else fc.load_config()
@@ -228,9 +228,15 @@ def test_whole_extraction_shares_census_and_keeps_recipe_payloads_unchanged(tmp_
     monkeypatch.setattr(fs,'resolve_roles',lambda cfg,r,**kw:seen.append(('roles',cfg,r)) or [])
     monkeypatch.setattr(fx,'detect_tie_key',lambda conn:{'guarantee':'synthetic'})
     monkeypatch.setattr(fg,'write_all',lambda *a,**kw:[])
+    captured=[]
+    def capture(conn,**kw):
+        captured.append(kw)
+        return dict(slug=kw['slug'],role=kw['role'],dir=kw['dir_name'],measured_metrics=kw['measured'])
+    monkeypatch.setattr(fx,'extract_conversation',capture)
     result=fx.extract_from_config(object(),config=config,payload_root=tmp_path,guard_root=tmp_path,snapshot_id='synthetic')
     assert len(calls)==2 and all(cfg is config and r is rows for _,cfg,r in seen)
-    assert result['roles']==result['generated']==result['provenance_rows']==[]
+    assert result['generated']==[]
+    assert len(result['roles'])==len(result['provenance_rows'])==len(captured)==(20 if enabled else 0)
     assert not list(tmp_path.iterdir())
     assert ('representative_selection' in result)==enabled
     assert ('representative_provenance' in result)==enabled

--- a/docs/probe-box.md
+++ b/docs/probe-box.md
@@ -112,6 +112,15 @@ engine options and checkpoint count remain bound by the verifier. Incompatible
 role selection or collapsed cuts fail admission; the pipeline never shortens the
 battery or accepts a partial result to obtain PASS.
 
+A reviewed `representative_selection` config also extracts the selected sample
+in that same replica transaction. Manifest/4 and paired-plan/2 require every
+sample alongside the 14 existing private entries. The gate orders actual sizes,
+preserves restart pairs, and reconstructs the sample's ceiling-six full-stream
+cuts and final-source-state moderation in both engines. Empty or unsupported
+inputs remain required and can fail the gate. Payloads, maps and byte census
+remain box-only; receipt/2 exports only the closed numeric selection report.
+See [representative payload admission](../delphi/docs/representative-selection.md).
+
 Bake the supervisor with `ci/probe_box/bake.sh` on the reviewed offline ARM64 builder.
 The launch template carries JSON boot configuration only, never executable commands.
 Set `enableProbeBox=true` and `PROBE_BOX_CONFIG` only when reviewing the separate

--- a/math/dev/replay.clj
+++ b/math/dev/replay.clj
@@ -51,8 +51,8 @@
     the public vw export has no such column, so the set is empty (documented in
     provenance meta_tids_source).
 
-  Moderation: vw has none. `moderation` other than \"none\" raises a clear
-  not-implemented error (Mode A mod-update interleaving is deferred, design §5).
+  Moderation supports none, timestamp interleaving, and an explicit final
+  snapshot state from authoritative events. The latter never invents history.
 
   Run:  cd math && clojure -M:replay --schedule <s.json> --votes <v.csv> \\
                         --out <dir> [--repeats N] [--edn] [--zid Z] [--comments c.csv]"
@@ -152,6 +152,8 @@
     {:votes (mapv (fn [e] {:t-ms (get e "created") :pid (get e "pid") :tid (get e "tid")
                            :sign (when-some [v (get e "vote")] (* v s))
                            :weight_x_32767 (get e "weight_x_32767") :source-ord (get e "ord")}) votes)
+     :final-mods (mapv (fn [e] {:tid (get e "tid") :mod (get e "mod")
+                               :is_meta (get e "is_meta") :modified (or (get e "modified") 0)}) comments)
      :mods {:events (mapv (fn [e] {:tid (get e "tid") :mod (get e "mod")
                                   :is_meta (get e "is_meta") :modified (get e "modified")})
                          (filter #(some? (get % "modified")) comments))
@@ -264,6 +266,15 @@
                            :votes (subvec votes prev cut)     ; (prev, cut] 0-based
                            :mods mods
                            :cut-time-ms cut-time})))))))
+
+(defn final-state-steps
+  "Apply captured current moderation only at the final checkpoint, even with
+  tied vote times. This is an explicit snapshot-state recipe, not a timeline."
+  [votes slots mod-events]
+  (let [plain (slice-schedule votes slots [])]
+    (if (seq plain)
+      (assoc-in plain [(dec (count plain)) :mods] mod-events)
+      plain)))
 
 ;; ---------------------------------------------------------------------------
 ;; Feeding conv-update: FLIP the export sign to raw-DB (design §5).
@@ -912,12 +923,14 @@
 
         (when (and (= source "events-jsonl") (nil? (:events options)))
           (throw (ex-info "events-jsonl schedule requires --events" {})))
-        (when-not (contains? #{"none" "interleave-by-timestamp" nil} moderation)
+        (when-not (contains? #{"none" "interleave-by-timestamp" "source-final-state" nil} moderation)
           (throw (ex-info
                    (str "Unknown moderation mode " (pr-str moderation)
-                        ". Use \"none\" or \"interleave-by-timestamp\" "
+                        ". Use \"none\", \"interleave-by-timestamp\" or \"source-final-state\" "
                         "(mod rows from --comments, woven by modified timestamp).")
                    {:moderation moderation})))
+        (when (and (= moderation "source-final-state") (nil? (:events options)))
+          (throw (ex-info "source-final-state requires lossless events" {})))
         (when (and (= moderation "interleave-by-timestamp")
                    (nil? (:comments options)) (nil? (:events options)))
           (throw (ex-info "moderation=interleave-by-timestamp requires --comments"
@@ -946,10 +959,16 @@
               slots (resolve-cut-slots votes cuts)
               restart-after (get schedule "restart_after")
               {mod-events :events n-mod-skipped :n-skipped}
-              (if (= moderation "interleave-by-timestamp")
+              (cond
+                (= moderation "source-final-state") {:events (:final-mods event-input) :n-skipped 0}
+                (= moderation "interleave-by-timestamp")
                 (if event-input (:mods event-input) (read-mod-events (:comments options)))
-                {:events [] :n-skipped 0})
-              steps (slice-schedule votes slots mod-events)
+                :else {:events [] :n-skipped 0})
+              steps (if (= moderation "source-final-state")
+                      ;; Current source state, not a reconstructed timeline.
+                      ;; Apply only on the final step even when vote times tie.
+                      (final-state-steps votes slots mod-events)
+                      (slice-schedule votes slots mod-events))
               ;; Under interleave moderation, meta-tids enter EXCLUSIVELY via
               ;; the woven mod-update rows (the production-reachable route) —
               ;; seeding them at conv creation as well would front-load every
@@ -959,7 +978,7 @@
               ;; creation-time seed remains for moderation="none" runs with
               ;; --comments (the original vw-compat path).
               [meta-tids meta-src]
-              (if (= moderation "interleave-by-timestamp")
+              (if (contains? #{"interleave-by-timestamp" "source-final-state"} moderation)
                 [#{} "empty (interleave moderation: meta-tids via mod-update only)"]
                 (read-meta-tids (:comments options)))]
 


### PR DESCRIPTION
Step-2 item 2d.2, on top of the probe box (#2777, merged).

Same-snapshot sampled extraction with overlap reuse; a closed manifest (schema 4) and paired plan (schema 2); all 20 sampled entries alongside the 14 existing private recipes; exact ceiling-six and empty cuts; measured ordering and restart adjacency; explicit final-source-state in both replay drivers; independent receipt and numeric-disclosure checks; box-only transport refusal and a payload byte/member census. Shipped config, battery, schema, and the empty image registry are unchanged.

**Tests.** 744 regressions pass with 4 named optional skips; 31 real-Postgres integration tests; 37 probe and 29 image tests; 13 Clojure tests (62 assertions). Offline 34-entry campaign: 68 real engine processes exit 0, 175 paired checkpoints, zero fixture copies; the verifier correctly refuses a known Clojure empty-output mismatch and issues no PASS receipt. Independent current-source audit: 66/68 engine inventories pass with the two required empty cases rejected; all 100 sampled paired moderation checkpoints correct. No production, parity, capacity, or release-image claim.

Written by the second reviewer; reviewed by the orchestrator. Schema impact: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s