### PR TITLE
server: public-fixture terminology in queue and migration seals

### DIFF
--- a/delphi/polismath/queue/executor.py
+++ b/delphi/polismath/queue/executor.py
@@ -1,4 +1,4 @@
-"""Standalone transitional executor for polis-queue/1 synthetic ``noop`` jobs.
+"""Standalone transitional executor for polis-queue/1 public-fixture ``noop`` jobs.
 
 P-024 first slice. Claims a job with ``pq_claim``, renews its lease with
 ``pq_heartbeat``, and finalizes with ``pq_finalize``; reserves one bounded
@@ -10,10 +10,10 @@ Boundaries this module keeps, all of them deliberate:
 * It touches neither existing poller. ``polismath.poller`` and
   ``scripts/job_poller.py`` neither import this nor are imported by it, so
   rollback is stopping a process.
-* The stage is ``noop`` and its output is exactly its fixed synthetic input
+* The stage is ``noop`` and its output is exactly its fixed public-fixture input
   descriptor. It never follows the input URI, reads a file named by a job,
   starts a child process, loads science code or calls a provider. A job whose
-  descriptor is not the expected synthetic one is failed permanently rather
+  descriptor is not the expected public-fixture one is failed permanently rather
   than executed.
 * It refuses to run on a broad database login. Every connection asserts
   membership in ``polis_queue_executor``, the absence of ANY table-level or
@@ -56,13 +56,13 @@ SCHEMA_VERSION = "polis-queue/1"
 #: the SQL so that neither is silently upgraded by a schema change; the Node
 #: adapter pins the same value in ``server/src/queue/protocol.ts``. This pins
 #: the repository file, and is not runtime attestation about the live catalog.
-QUEUE_SQL_SHA256 = "2d8e205f1d36e0e2e6a4fc63d1d03cbf8837ca57ccaac503c88238fa2a14a055"
+QUEUE_SQL_SHA256 = "240d445ecc88c0ddb3b24ba2d62a8ad00316fe4381dadb566d2c5d1f48c2c1bc"
 
-#: The fixed synthetic input descriptor of the /1 noop stage. The enqueuer pins
+#: The fixed public-fixture input descriptor of the /1 noop stage. The enqueuer pins
 #: it and this executor refuses anything else.
-NOOP_URI = "synthetic:polis-queue-noop/1"
+NOOP_URI = "public-fixture:polis-queue-noop/1"
 NOOP_SHA256 = hashlib.sha256(b"polis-queue-noop/1\n").hexdigest()
-NOOP_IMAGE = "synthetic-noop/1"
+NOOP_IMAGE = "public-fixture-noop/1"
 
 #: Repeating weighted lane slots. 0 is most urgent; the cycle guarantees lane 2
 #: is visited at least once every six claim opportunities.
@@ -453,11 +453,11 @@ class Executor:
             or job["input"] != expected
         ):
             # Refuse rather than execute: this executor admits exactly one
-            # synthetic descriptor and never dereferences a job-supplied URI.
+            # public-fixture descriptor and never dereferences a job-supplied URI.
             return str(
                 self.call(
                     "pq_fail",
-                    self.token(job) + [True, "invalid_synthetic_descriptor"],
+                    self.token(job) + [True, "invalid_public_fixture_descriptor"],
                 )["outcome"]
             )
         renewed = self.call("pq_heartbeat", self.token(job) + [self.lease_seconds])

--- a/delphi/tests/test_queue_noop_executor.py
+++ b/delphi/tests/test_queue_noop_executor.py
@@ -111,7 +111,7 @@ def require_migration():
 
 ENV = "test-p024-py"
 PRODUCT = "product-noop"
-ACTOR = "synthetic-actor"
+ACTOR = "public-fixture-actor"
 LOCAL_ROLE_PASSWORD = "pq-local-test"
 
 
@@ -435,7 +435,7 @@ def test_claims_heartbeats_and_finalizes_one_noop_job(queue_db):
     assert job["owner_id"] is None
 
 
-def test_permanently_fails_a_job_whose_descriptor_is_not_the_synthetic_one(queue_db):
+def test_permanently_fails_a_job_whose_descriptor_is_not_the_public_fixture_one(queue_db):
     """It never dereferences a job-supplied URI; it refuses the job instead."""
     reply = _enqueue(
         queue_db,
@@ -449,7 +449,7 @@ def test_permanently_fails_a_job_whose_descriptor_is_not_the_synthetic_one(queue
     assert executor.run_once() == "dead"
     job = executor.call("pq_job_status", [queue_db["env"], reply["job_id"]])
     assert job["state"] == "dead"
-    assert job["last_error_code"] == "invalid_synthetic_descriptor"
+    assert job["last_error_code"] == "invalid_public_fixture_descriptor"
 
 
 def test_reaper_recovers_an_expired_lease_without_a_new_enqueue(queue_db):
@@ -674,7 +674,7 @@ def test_reaper_pages_101_parked_jobs_and_resets_its_cursor(queue_db):
         )
         assert job["outcome"] == "owned"
         assert (
-            executor.call("pq_park", executor.token(job) + ["synthetic"])["outcome"]
+            executor.call("pq_park", executor.token(job) + ["public-fixture"])["outcome"]
             == "parked"
         )
     _admin(
@@ -802,10 +802,10 @@ def test_a_mid_setup_failure_releases_only_what_it_created(queue_db, monkeypatch
             sys.modules[__name__],
             "_executor_dsn",
             lambda *args, **kwargs: (_ for _ in ()).throw(
-                RuntimeError("synthetic setup failure")
+                RuntimeError("public-fixture setup failure")
             ),
         )
-        with pytest.raises(RuntimeError, match="synthetic setup failure"):
+        with pytest.raises(RuntimeError, match="public-fixture setup failure"):
             next(_provision_queue_db())
         assert counts() == before
     finally:

--- a/docs/queue-substrate.md
+++ b/docs/queue-substrate.md
@@ -218,7 +218,7 @@ does not add a route and does not change any served bytes; it only lets
 dev/test code call `enqueueNoopJob`.
 
 The env namespace is restricted to `dev` or `test`, optionally suffixed
-(`test-p024-3f2a`), so a synthetic job cannot be addressed at another
+(`test-p024-3f2a`), so a public-fixture job cannot be addressed at another
 environment's product heads.
 
 The Node enqueuer runs on the server's existing broad read-write login. The
@@ -248,10 +248,10 @@ POLIS_QUEUE_SUBSTRATE_ENABLED=true python -m polismath.queue.executor \
   --env dev --once
 ```
 
-It executes nothing. The noop stage's output is exactly its fixed synthetic
+It executes nothing. The noop stage's output is exactly its fixed public-fixture
 input descriptor; the executor never follows the input URI, reads a job-named
 file, starts a child process, loads science code or calls a provider. A job
-whose descriptor is not the expected synthetic one is failed permanently.
+whose descriptor is not the expected public-fixture one is failed permanently.
 
 Two behaviours are worth knowing because they are not obvious:
 

--- a/server/__tests__/integration/queue-substrate.test.ts
+++ b/server/__tests__/integration/queue-substrate.test.ts
@@ -15,7 +15,7 @@
  *     wire, lock and privilege check runs against the REAL public.conversations
  *     shape. Rows are namespaced by a per-run env prefix and removed afterwards.
  *
- *   * A scratch database created for this run, holding the harness's synthetic
+ *   * A scratch database created for this run, holding the harness's public-fixture
  *     parent fixture. The fresh non-superuser apply and the two plan checks at
  *     20,000 rows live there: they insert 20,000 conversations and 20,000 jobs
  *     and delete parent rows, which must not happen in a shared test database.
@@ -83,7 +83,7 @@ const ROLE_STRANGER = `pq_t_str_${RUN_ID}`;
 const ROLE_PASSWORD = `pq-local-test-${RUN_ID}`;
 
 const H = "1".repeat(64);
-const URI = "synthetic-input";
+const URI = "public-fixture-input";
 const OWNER = randomUUID();
 
 const describeProvisioned = SKIP_PROVISIONING ? describe.skip : describe;
@@ -121,7 +121,7 @@ const created = {
 };
 /** Real conversations.zid used by every protocol check. */
 let zid = 0;
-/** Synthetic parent zid inside the scratch database. */
+/** Public-fixture parent zid inside the scratch database. */
 const SCRATCH_ZID = 1;
 
 // ---------------------------------------------------------------- primitives
@@ -307,7 +307,7 @@ function enqueue(
       env,
       options.zid ?? (pool === scratchPool ? SCRATCH_ZID : zid),
       options.product ?? "product",
-      "synthetic-actor",
+      "public-fixture-actor",
       options.key ?? "request",
       options.requestSha ?? H,
       randomUUID(),
@@ -315,7 +315,7 @@ function enqueue(
       URI,
       H,
       H,
-      "synthetic-image",
+      "public-fixture-image",
       1,
       options.maxAttempts ?? 3,
     ]
@@ -712,7 +712,7 @@ async function provision(): Promise<void> {
       "description VARCHAR(50000), UNIQUE(zid))"
   );
   await scratchPool.query(
-    "INSERT INTO public.conversations VALUES (1,'synthetic',NULL),(2,'synthetic',NULL)"
+    "INSERT INTO public.conversations VALUES (1,'public-fixture',NULL),(2,'public-fixture',NULL)"
   );
 }
 
@@ -1016,7 +1016,7 @@ describe("P-024 queue substrate protocol", () => {
           mainPool,
           "pq_fail",
           [...TOKEN_CASTS, "boolean", "text"],
-          [...token(old), false, "synthetic"]
+          [...token(old), false, "public-fixture"]
         )
       ).outcome
     ).toBe("fenced");
@@ -1062,7 +1062,7 @@ describe("P-024 queue substrate protocol", () => {
           mainPool,
           "pq_fail",
           [...TOKEN_CASTS, "boolean", "text"],
-          [...token(j), false, "synthetic"]
+          [...token(j), false, "public-fixture"]
         )
       ).outcome
     ).toBe("dead");
@@ -1079,7 +1079,7 @@ describe("P-024 queue substrate protocol", () => {
           mainPool,
           "pq_park",
           [...TOKEN_CASTS, "text"],
-          [...token(j), "synthetic"]
+          [...token(j), "public-fixture"]
         )
       ).outcome
     ).toBe("parked");
@@ -1273,16 +1273,16 @@ describe("P-024 queue substrate protocol", () => {
     // Owner-only control standing in for a Q21 enqueuer change, not an
     // executor mutation: the executor has no table write at all.
     await mainPool.query(
-      "UPDATE public.polis_queue_runs SET expected_output_uri = 'synthetic-output', " +
+      "UPDATE public.polis_queue_runs SET expected_output_uri = 'public-fixture-output', " +
         "expected_output_sha256 = $2 WHERE env = $1",
       [env, "3".repeat(64)]
     );
     expect((await finalize(mainPool, j)).outcome).toBe("invalid_output");
     expect(
-      (await finalize(mainPool, j, "synthetic-output", "3".repeat(64))).outcome
+      (await finalize(mainPool, j, "public-fixture-output", "3".repeat(64))).outcome
     ).toBe("succeeded");
     expect(
-      (await finalize(mainPool, j, "synthetic-output", "3".repeat(64))).outcome
+      (await finalize(mainPool, j, "public-fixture-output", "3".repeat(64))).outcome
     ).toBe("already_succeeded");
   }, 60000);
 
@@ -1299,7 +1299,7 @@ describe("P-024 queue substrate protocol", () => {
           mainPool,
           "pq_fail",
           [...TOKEN_CASTS, "boolean", "text"],
-          [...token(fresh), true, "synthetic_failure"]
+          [...token(fresh), true, "public_fixture_failure"]
         )
       ).outcome
     ).toBe("dead");
@@ -1348,7 +1348,7 @@ describe("P-024 queue substrate protocol", () => {
 
   it.each([
     ["pq_release", [] as unknown[], ["retry_wait"]],
-    ["pq_fail", [false, "synthetic"], ["retry_wait"]],
+    ["pq_fail", [false, "public-fixture"], ["retry_wait"]],
     ["pq_park", ["dependency"], ["parked"]],
   ])(
     "31-33. %s succeeds under a held head while the full-prefix finalize control blocks",
@@ -1456,7 +1456,7 @@ describe("P-024 queue substrate protocol", () => {
       mainPool,
       "pq_fail",
       [...TOKEN_CASTS, "boolean", "text"],
-      [...token(j), false, "synthetic"]
+      [...token(j), false, "public-fixture"]
     );
     expect(failed.outcome).toBe("retry_wait");
     expect(
@@ -1628,7 +1628,7 @@ describe("P-024 queue substrate protocol", () => {
       env,
       zid,
       productKey: "product",
-      actorScope: "synthetic-actor",
+      actorScope: "public-fixture-actor",
       requestKey: "adapter",
       priority: 1,
       maxAttempts: 3,
@@ -1708,7 +1708,7 @@ describe("P-024 queue substrate protocol", () => {
         env: "prod",
         zid,
         productKey: "product",
-        actorScope: "synthetic-actor",
+        actorScope: "public-fixture-actor",
         requestKey: "rejected",
       })
     ).rejects.toThrow(/env must be/);
@@ -1752,7 +1752,7 @@ describeProvisioned(
     it("38. uses a zid index for both parent lookups at 20,000 rows and restricts parent deletion", async () => {
       requireProvisioning();
       await scratchPool.query(
-        "INSERT INTO public.conversations(zid,topic) SELECT g,'synthetic' FROM generate_series(3,20002) g"
+        "INSERT INTO public.conversations(zid,topic) SELECT g,'public-fixture' FROM generate_series(3,20002) g"
       );
       await scratchPool.query(
         "INSERT INTO public.polis_queue_heads(env,product_key,zid) " +
@@ -1762,8 +1762,8 @@ describeProvisioned(
         "INSERT INTO public.polis_queue_runs(env,run_id,zid,product_key,requested_generation," +
           "input_uri,input_sha256,expected_output_uri,expected_output_sha256,config_sha256," +
           "code_image_digest,contract_version) " +
-          "SELECT 'r4-fk',gen_random_uuid(),g,g::text,1,'synthetic',$1,'synthetic',$1,$1," +
-          "'synthetic','polis-queue/1' FROM generate_series(3,20002) g",
+          "SELECT 'r4-fk',gen_random_uuid(),g,g::text,1,'public-fixture',$1,'public-fixture',$1,$1," +
+          "'public-fixture','polis-queue/1' FROM generate_series(3,20002) g",
         [H]
       );
       for (const table of ["heads", "runs"]) {
@@ -1786,7 +1786,7 @@ describeProvisioned(
         "23503"
       );
       await scratchPool.query(
-        "INSERT INTO public.conversations(zid,topic) VALUES (20003,'synthetic')"
+        "INSERT INTO public.conversations(zid,topic) VALUES (20003,'public-fixture')"
       );
       const deleted = await scratchPool.query(
         "DELETE FROM public.conversations WHERE zid=20003"

--- a/server/__tests__/unit/queue-transaction.test.ts
+++ b/server/__tests__/unit/queue-transaction.test.ts
@@ -104,7 +104,7 @@ describe("withTransaction", () => {
   it.each(["BEGIN", "SET LOCAL"])(
     "rolls back and never runs the callback when %s fails",
     async (seam) => {
-      const boom = new Error("synthetic");
+      const boom = new Error("public-fixture");
       const client = scripted((text) => {
         if (text.startsWith(seam)) throw boom;
         return undefined;

--- a/server/postgres/migrations/000019_create_polis_queue.sql
+++ b/server/postgres/migrations/000019_create_polis_queue.sql
@@ -488,7 +488,7 @@ BEGIN
   RETURN public.pq_result('already_succeeded',j,COALESCE(h.published_run_id=r.run_id,false));
  END IF;
  IF NOT public.pq_owns(j,p_owner,p_attempt,p_epoch) THEN RETURN public.pq_result('fenced',j); END IF;
- -- Admission target is data. /1 enqueue fixes it to synthetic input; Q21 may change only that assignment.
+ -- Admission target is data. /1 enqueue fixes it to public-fixture input; Q21 may change only that assignment.
  IF p_output_sha IS DISTINCT FROM r.expected_output_sha256 OR p_output_uri IS DISTINCT FROM r.expected_output_uri THEN
   RETURN public.pq_result('invalid_output',j);
  END IF;

--- a/server/postgres/migrations/down/000019_drop_polis_queue.sql
+++ b/server/postgres/migrations/down/000019_drop_polis_queue.sql
@@ -201,7 +201,7 @@ DECLARE
   -- This digest adds prosrc, so a drifted body is caught. It is 000019's fresh
   -- catalog value on PostgreSQL 17 with the body field present, recomputed in
   -- the same reviewed change if any function body changes.
-  expected_function_md5 constant text := '246ed8c30b7ca049563046085a9f221c';
+  expected_function_md5 constant text := '421b97d455585679175b06360b9903ed';
   -- The 12 functions 000019 grants EXECUTE to the executor (000019:574).
   granted_execute constant text[] := ARRAY[
     'pq_cancel','pq_claim','pq_due','pq_enqueue','pq_fail','pq_finalize','pq_head_status',

--- a/server/postgres/migrations/down/test_000019_down.sh
+++ b/server/postgres/migrations/down/test_000019_down.sh
@@ -508,7 +508,7 @@ createdb sc_f
 apply_upto sc_f "$MAX_FULL"
 docker exec -i "$CONTAINER" psql -v ON_ERROR_STOP=1 -U postgres -d sc_f >/dev/null <<'SQL'
 CREATE TABLE public.unrelated_f(value text);
-INSERT INTO public.unrelated_f VALUES ('synthetic unrelated data');
+INSERT INTO public.unrelated_f VALUES ('public-fixture unrelated data');
 ALTER TABLE public.unrelated_f OWNER TO polis_queue_owner;
 SQL
 set +e

--- a/server/postgres/migrations/down/test_000021_down.sh
+++ b/server/postgres/migrations/down/test_000021_down.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Own disposable synthetic cluster only. No target connection string accepted.
+# Own disposable public-fixture cluster only. No target connection string accepted.
 set -euo pipefail
 : "${COMPOSE_PROJECT_NAME:?set a unique project name}"
 : "${POLIS_RECOVERY_PG_PORT:?set a unique port}"

--- a/server/src/queue/enqueue.ts
+++ b/server/src/queue/enqueue.ts
@@ -11,7 +11,7 @@
  * Three guards, all required:
  *   1. Config.queueSubstrateEnabled (POLIS_QUEUE_SUBSTRATE_ENABLED), default
  *      off and forced off when NODE_ENV is production.
- *   2. The env namespace must be dev or test, so a synthetic job cannot be
+ *   2. The env namespace must be dev or test, so a public-fixture job cannot be
  *      addressed at some other environment's product heads.
  *   3. The migration must have been applied. It is not applied automatically to
  *      an existing database; see docs/queue-substrate.md.
@@ -23,7 +23,7 @@
  *     caller. A dedicated service login with executor membership is separate,
  *     separately reviewed provisioning work. The Python executor does require
  *     the restricted login.
- *   - The input descriptor is fixed and synthetic, and is built here rather
+ *   - The input descriptor is fixed and public-fixture, and is built here rather
  *     than accepted from the caller. /1 enqueue pins expected_output_uri and
  *     expected_output_sha256 to that descriptor, and the noop stage returns it
  *     unchanged. Admitting a real captured artifact is Q21 plus a reviewed
@@ -45,15 +45,15 @@ import {
 export const QUEUE_SUBSTRATE_FLAG = "POLIS_QUEUE_SUBSTRATE_ENABLED";
 
 /**
- * The fixed synthetic input descriptor of the /1 noop stage. Not caller
+ * The fixed public-fixture input descriptor of the /1 noop stage. Not caller
  * supplied: the enqueuer pins it, and the executor refuses any job whose
  * descriptor differs.
  */
-export const NOOP_INPUT_URI = "synthetic:polis-queue-noop/1";
+export const NOOP_INPUT_URI = "public-fixture:polis-queue-noop/1";
 export const NOOP_INPUT_SHA256 = createHash("sha256")
   .update("polis-queue-noop/1\n")
   .digest("hex");
-export const NOOP_IMAGE_DIGEST = "synthetic-noop/1";
+export const NOOP_IMAGE_DIGEST = "public-fixture-noop/1";
 
 /** dev or test, optionally suffixed for per-run isolation in tests. */
 const ENV_NAMESPACE = /^(dev|test)(-[a-z0-9][a-z0-9-]{0,48})?$/;

--- a/server/src/queue/protocol.ts
+++ b/server/src/queue/protocol.ts
@@ -27,7 +27,7 @@ export const QUEUE_STAGE = "noop";
  * migration's own catalog fingerprints cover that.
  */
 export const QUEUE_SQL_SHA256 =
-  "2d8e205f1d36e0e2e6a4fc63d1d03cbf8837ca57ccaac503c88238fa2a14a055";
+  "240d445ecc88c0ddb3b24ba2d62a8ad00316fe4381dadb566d2c5d1f48c2c1bc";
 
 export const QUEUE_MIGRATION_PATH = path.join(
   __dirname,


### PR DESCRIPTION
Terminology sweep, group 2 of 4: comment-only edits in the 000019 SQL and its down script, with the down-script fingerprint re-measured on PostgreSQL 17 and adapter byte pins re-pinned. Migration 000021 is not touched: its rev6 revision on edge already carries no old wording and its file pins match edge. No migration is applied anywhere.

Verified locally: full queue down script 19/19 groups; sealed coordinator down 96 passed; Node queue integration 48/48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s