### PR TITLE
chore: public-fixture terminology in CI, probe, server and client markers

### DIFF
--- a/cdk/ciEc2.ts
+++ b/cdk/ciEc2.ts
@@ -211,6 +211,7 @@ export class CertificationCiEc2 extends Construct {
     // ------------------------------------------------------------------- net
     const securityGroup = new ec2.SecurityGroup(this, 'WorkerSg', {
       vpc: props.vpc,
+      // Frozen deployed description: changing it replaces the security group.
       description: 'P-022 E synthetic CI worker: no inbound, egress only',
       allowAllOutbound: true,
     });

--- a/cdk/test/probeBox.test.ts
+++ b/cdk/test/probeBox.test.ts
@@ -2,14 +2,14 @@ import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { ProbeBox, ProbeConfig, validateProbeConfig } from '../probeBox';
 const config: ProbeConfig = {
- schema:'polis-probe-box/1',id:'synthetic',account:'111111111111',region:'us-east-1',ami:'ami-'+'1'.repeat(17),
+ schema:'polis-probe-box/1',id:'public-fixture',account:'111111111111',region:'us-east-1',ami:'ami-'+'1'.repeat(17),
  vpcId:'vpc-12345678',subnetCidr:'10.0.240.0/24',availabilityZone:'us-east-1a',resolverAddress:'10.0.0.2',
- replicaHost:'synthetic-replica.abc.us-east-1.rds.amazonaws.com',replicaSecurityGroupId:'sg-12345678',database:'polis',
- primaryHost:'synthetic-primary.abc.us-east-1.rds.amazonaws.com',primarySecurityGroupId:'sg-87654321',
- adminSecretArn:'arn:aws:secretsmanager:us-east-1:111111111111:secret:synthetic-admin',
- postgresLayerArn:'arn:aws:lambda:us-east-1:111111111111:layer:synthetic-postgres:1',s3PrefixListId:'pl-12345678',
- reviewerRoleArns:['arn:aws:iam::111111111111:role/synthetic-reader'],assetPublisherRoleArn:'arn:aws:iam::111111111111:role/synthetic-publisher',
- githubRepo:'example/example',githubEnvironment:'probe-box',githubRef:'refs/heads/edge',notificationTopicArn:'arn:aws:sns:us-east-1:111111111111:synthetic'};
+ replicaHost:'public-fixture-replica.abc.us-east-1.rds.amazonaws.com',replicaSecurityGroupId:'sg-12345678',database:'polis',
+ primaryHost:'public-fixture-primary.abc.us-east-1.rds.amazonaws.com',primarySecurityGroupId:'sg-87654321',
+ adminSecretArn:'arn:aws:secretsmanager:us-east-1:111111111111:secret:public-fixture-admin',
+ postgresLayerArn:'arn:aws:lambda:us-east-1:111111111111:layer:public-fixture-postgres:1',s3PrefixListId:'pl-12345678',
+ reviewerRoleArns:['arn:aws:iam::111111111111:role/public-fixture-reader'],assetPublisherRoleArn:'arn:aws:iam::111111111111:role/public-fixture-publisher',
+ githubRepo:'example/example',githubEnvironment:'probe-box',githubRef:'refs/heads/edge',notificationTopicArn:'arn:aws:sns:us-east-1:111111111111:public-fixture'};
 function build(){const app=new cdk.App();const stack=new cdk.Stack(app,'Probe',{env:{account:config.account,region:config.region}});new ProbeBox(stack,'Box',config);return Template.fromStack(stack);}
 const resources=(j:any,t:string):any[]=>Object.values(j.Resources).filter((r:any)=>r.Type===t);
 function named(j:any,prefix:string,type?:string):any{return (Object.entries(j.Resources).find(([id,r]:any)=>id.startsWith(prefix)&&(!type||r.Type===type))![1] as any).Properties;}

--- a/ci/probe_box/login_rehearsal.py
+++ b/ci/probe_box/login_rehearsal.py
@@ -25,7 +25,7 @@ class LoginTests(unittest.TestCase):
         with self.conn.cursor() as c:
             c.execute('SELECT 1 FROM pg_roles WHERE rolname=%s',(ROLE,));return bool(c.fetchone())
 
-    def install(self,owner='synthetic-owned-stack'):
+    def install(self,owner='public-fixture-owned-stack'):
         provision(self.conn,self.password,self.database,owner)
 
     def test_create_select_and_no_dml(self):

--- a/ci/probe_box/test_boundaries.py
+++ b/ci/probe_box/test_boundaries.py
@@ -39,7 +39,7 @@ class BoundaryTests(unittest.TestCase):
             for location in ['root','entry','selection','digests']:
                 with self.subTest(key=key,location=location):
                     r=receipt();node={'root':r,'entry':r['entries'][0],'digests':r['digests'],'selection':r}[location]
-                    node[key]='synthetic private value'
+                    node[key]='public-fixture private value'
                     with self.assertRaises(ValueError):validate_receipt(r,job())
 
     def test_false_pass_nonfinite_boolean_or_negative_rejected(self):
@@ -62,7 +62,7 @@ class BoundaryTests(unittest.TestCase):
         for stream in [None,1,2]:
             with self.subTest(stream=stream):
                 code="import os;os.write(1,b'PASS\\n')"
-                if stream:code+=f";os.write({stream},b'synthetic-private-value\\n')"
+                if stream:code+=f";os.write({stream},b'public-fixture-private-value\\n')"
                 def run(*args,**kw):return actual_run([sys.executable,'-c',code],**kw)
                 out=SimpleNamespace(buffer=io.BytesIO())
                 with patch.object(dispatch.subprocess,'run',run),patch.object(dispatch.sys,'stdout',out):

--- a/ci/probe_box/test_controller.py
+++ b/ci/probe_box/test_controller.py
@@ -205,5 +205,5 @@ class HandlerTests(unittest.TestCase):
             key='results/arn:aws:ec2:us-east-1:111111111111:instance/i-test/receipt.json'
             s.objects['evidence',key]=encoded(receipt())
             self.assertEqual(controller.handler({'action':'status','run_id':'a'*32},None),{'run_id':'a'*32,'complete':True,'passed':True})
-            bad=receipt();bad['rows']=[{'synthetic':1}];s.objects['evidence',key]=encoded(bad)
+            bad=receipt();bad['rows']=[{'public-fixture':1}];s.objects['evidence',key]=encoded(bad)
             self.assertFalse(controller.handler({'action':'status','run_id':'a'*32},None)['passed'])

--- a/client-participation-alpha/jest.config.mjs
+++ b/client-participation-alpha/jest.config.mjs
@@ -27,7 +27,6 @@ const config = {
           module: 'commonjs',
           target: 'es2022',
           esModuleInterop: true,
-          allowSyntheticDefaultImports: true,
           strict: true,
           skipLibCheck: true,
           resolveJsonModule: true,

--- a/client-report/src/components/commentsReport/CommentsReport.test.jsx
+++ b/client-report/src/components/commentsReport/CommentsReport.test.jsx
@@ -131,7 +131,7 @@ describe('CommentsReport Delphi job status', () => {
       deduplicated: false,
     });
 
-    render(<CommentsReport {...props} showControls authToken="synthetic-token" />);
+    render(<CommentsReport {...props} showControls authToken="public-fixture-token" />);
     await waitFor(() => expect(net.polisGet).toHaveBeenCalled());
 
     fireEvent.click(screen.getAllByRole('button', { name: /Generate Batch Topics/ })[0]);

--- a/docs/probe-box.md
+++ b/docs/probe-box.md
@@ -122,7 +122,7 @@ admin secret ARN, asset publisher, reviewer roles and notification topic.
 Before private use, retain actual target receipts for the AMI/OCI source admission,
 read-only replica login, DNS/metadata/egress isolation, cancellation/lost launch,
 boot failure, killed supervisor and observed disk disposal. Local mocks and
-synthetic data establish code behavior; they do not establish those AWS facts.
+public-fixture data establish code behavior; they do not establish those AWS facts.
 The old signed-admission, fixture-upload and download-to-verify runbook is superseded.
 No migration, image release, deployment or private run is authorized by local tests.
 

--- a/server/__tests__/integration/comment-translation.test.ts
+++ b/server/__tests__/integration/comment-translation.test.ts
@@ -50,7 +50,7 @@ describe("POST comments with unavailable language detection", () => {
     async (scenario) => {
       if (scenario === "rejection")
         mockDetect.mockRejectedValue(
-          new Error("synthetic provider unavailable")
+          new Error("public-fixture provider unavailable")
         );
       else if (scenario === "malformed") mockDetect.mockResolvedValue([]);
       else if (scenario === "timeout")
@@ -64,7 +64,7 @@ describe("POST comments with unavailable language detection", () => {
       const conversationId = await createConversation(agent, {
         is_active: true,
       });
-      const txt = `Synthetic translation ${scenario}`;
+      const txt = `Public-fixture translation ${scenario}`;
       const response = await agent
         .post("/api/v3/comments")
         .send({ conversation_id: conversationId, txt, is_seed: true });

--- a/server/__tests__/integration/oidc-transaction.test.ts
+++ b/server/__tests__/integration/oidc-transaction.test.ts
@@ -10,7 +10,7 @@ import { pool, closePool } from "../setup/db-test-helpers";
 describe("OIDC transaction ownership", () => {
   const suffix = randomUUID();
   const email = `oidc-tx-${suffix}@example.invalid`;
-  const sub = `synthetic-oidc-tx-${suffix}`;
+  const sub = `public-fixture-oidc-tx-${suffix}`;
   let uid: number;
   let zid: number;
   let pid: number;
@@ -18,7 +18,7 @@ describe("OIDC transaction ownership", () => {
   beforeAll(async () => {
     uid = (await pool.query("INSERT INTO users (email) VALUES ($1) RETURNING uid", [email])).rows[0].uid;
     await pool.query("INSERT INTO oidc_user_mappings (oidc_sub,uid) VALUES ($1,$2)", [sub, uid]);
-    zid = (await pool.query("INSERT INTO conversations (owner,topic) VALUES ($1,$2) RETURNING zid", [uid, "Synthetic OIDC transaction witness"])).rows[0].zid;
+    zid = (await pool.query("INSERT INTO conversations (owner,topic) VALUES ($1,$2) RETURNING zid", [uid, "Public-fixture OIDC transaction witness"])).rows[0].zid;
     pid = (await pool.query("INSERT INTO participants (uid,zid) VALUES ($1,$2) RETURNING pid", [uid,zid])).rows[0].pid;
   });
   afterAll(async () => {
@@ -53,13 +53,13 @@ describe("OIDC transaction ownership", () => {
       "INSERT INTO comments (pid,zid,uid,txt,is_seed) VALUES ($1,$2,$3,$4,true) RETURNING tid",
       [pid,zid,uid,txt]
     ) as Promise<{tid: number}[]>;
-    const [seed] = await insert("Synthetic acknowledged seed");
+    const [seed] = await insert("Public-fixture acknowledged seed");
     // Observe through a different pool, then deterministically evict the last
     // application session (the same rollback as idle eviction, without a timer).
     const visibleBefore = await pool.query("SELECT tid FROM comments WHERE zid=$1 AND tid=$2", [zid,seed.tid]);
     const lastClient = await pg.connect();
     lastClient.release(true);
-    const [next] = await insert("Synthetic subsequent seed");
+    const [next] = await insert("Public-fixture subsequent seed");
     const visibleAfter = await pool.query("SELECT tid FROM comments WHERE zid=$1 ORDER BY tid", [zid]);
     expect(visibleBefore.rows).toEqual([{tid: seed.tid}]);
     expect(next.tid).toBeGreaterThan(seed.tid);

--- a/server/__tests__/integration/topic-agenda-job-attribution.test.ts
+++ b/server/__tests__/integration/topic-agenda-job-attribution.test.ts
@@ -30,7 +30,7 @@ describe.each(["post", "put"] as const)(
     let conversationId: string;
     let zid: string;
     let jobIds: string[];
-    const selections = [{ topic_id: "synthetic-topic", priority: 1 }];
+    const selections = [{ topic_id: "public-fixture-topic", priority: 1 }];
 
     beforeAll(async () => {
       await ensureJobQueueTableExists();
@@ -220,7 +220,7 @@ describe.each(["post", "put"] as const)(
           command: any
         ): any {
           if (command instanceof QueryCommand && ++queryCount === 2) {
-            return Promise.reject(new Error("Synthetic DynamoDB page failure"));
+            return Promise.reject(new Error("Public-fixture DynamoDB page failure"));
           }
           return originalSend.call(this, command);
         });

--- a/server/__tests__/unit/commentTranslation.test.ts
+++ b/server/__tests__/unit/commentTranslation.test.ts
@@ -70,7 +70,7 @@ function post(seed = true) {
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
   const done = handle_POST_comments(
     {
-      p: { zid: 7, uid: 11, pid: 0, txt: "A synthetic comment", is_seed: seed },
+      p: { zid: 7, uid: 11, pid: 0, txt: "A public-fixture comment", is_seed: seed },
       headers: {},
     },
     res
@@ -115,7 +115,7 @@ describe("comment creation during translation failures", () => {
   test.each([true, false])(
     "provider rejection preserves comment creation (seed=%s)",
     async (seed) => {
-      const err = new Error("synthetic provider authentication failure");
+      const err = new Error("public-fixture provider authentication failure");
       mockDetect.mockRejectedValue(err);
       const { res, done } = post(seed);
       await done;
@@ -169,7 +169,7 @@ describe("comment creation during translation failures", () => {
           },
         ],
         response: {
-          headers: { "x-synthetic-private-header": "must not be logged" },
+          headers: { "x-public-fixture-private-header": "must not be logged" },
         },
       });
       mockDetect.mockRejectedValue(err);
@@ -217,7 +217,7 @@ describe("comment creation during translation failures", () => {
       { provider: "response" },
     ];
     mockDetect.mockResolvedValue(result);
-    expect(await detectLanguage("synthetic")).toBe(result);
+    expect(await detectLanguage("public-fixture")).toBe(result);
     expect(jest.getTimerCount()).toBe(0);
     const { res, done } = post();
     await done;
@@ -230,7 +230,7 @@ describe("comment creation during translation failures", () => {
     mockDetect.mockImplementation(() => {
       throw new Error("sync provider failure");
     });
-    expect(await detectLanguage("synthetic")).toEqual(nullDetection);
+    expect(await detectLanguage("public-fixture")).toEqual(nullDetection);
     expect(jest.getTimerCount()).toBe(0);
     expect(mockWarn).toHaveBeenCalledTimes(1);
   });
@@ -256,7 +256,7 @@ describe("comment creation during translation failures", () => {
       {
         p: { zid: 7, uid: 11, pid: 0, is_seed: true },
         body: {
-          csv: "comment_text,original_id\nA synthetic seed,00000000-0000-4000-8000-000000000001",
+          csv: "comment_text,original_id\nA public-fixture seed,00000000-0000-4000-8000-000000000001",
         },
       },
       res
@@ -272,7 +272,7 @@ describe("comment creation during translation failures", () => {
       currentPid: 0,
       results: [
         {
-          txt: "A synthetic seed",
+          txt: "A public-fixture seed",
           status: "success",
           tid: 3,
           original_id: "00000000-0000-4000-8000-000000000001",
@@ -285,9 +285,9 @@ describe("comment creation during translation failures", () => {
 
 describe("optional stored translations", () => {
   test("provider rejection logs once and does not write a translation", async () => {
-    const err = new Error("synthetic translation failure");
+    const err = new Error("public-fixture translation failure");
     mockTranslate.mockRejectedValue(err);
-    expect(await translateAndStoreComment(7, 3, "synthetic", "fr")).toBeNull();
+    expect(await translateAndStoreComment(7, 3, "public-fixture", "fr")).toBeNull();
     expect(mockQuery).not.toHaveBeenCalled();
     expect(mockWarn).toHaveBeenCalledTimes(1);
     expect(mockWarn).toHaveBeenCalledWith(
@@ -299,7 +299,7 @@ describe("optional stored translations", () => {
     [null, [], [null], [{}], [""], [["nested"]]].map((value) => [value])
   )("invalid translation %p is not stored", async (value) => {
     mockTranslate.mockResolvedValue(value);
-    expect(await translateAndStoreComment(7, 3, "synthetic", "fr")).toBeNull();
+    expect(await translateAndStoreComment(7, 3, "public-fixture", "fr")).toBeNull();
     expect(mockQuery).not.toHaveBeenCalled();
     expect(mockWarn).toHaveBeenCalledTimes(1);
   });
@@ -310,7 +310,7 @@ describe("optional stored translations", () => {
         resolveProvider = resolve;
       })
     );
-    const done = translateAndStoreComment(7, 3, "synthetic", "fr");
+    const done = translateAndStoreComment(7, 3, "public-fixture", "fr");
     await jest.advanceTimersByTimeAsync(5000);
     expect(await done).toBeNull();
     resolveProvider!(["late translation"]);
@@ -322,7 +322,7 @@ describe("optional stored translations", () => {
   test("success stores the original translation and returns the database row", async () => {
     const row = { zid: 7, tid: 3, txt: "A translation", lang: "fr", src: -1 };
     mockQuery.mockResolvedValue([row]);
-    expect(await translateAndStoreComment(7, 3, "synthetic", "fr")).toBe(row);
+    expect(await translateAndStoreComment(7, 3, "public-fixture", "fr")).toBe(row);
     expect(mockQuery).toHaveBeenCalledWith(
       expect.stringContaining("insert into comment_translations"),
       [7, 3, "A translation", "fr", -1]
@@ -334,7 +334,7 @@ describe("optional stored translations", () => {
     const err = new Error("database write failure");
     mockQuery.mockRejectedValue(err);
     await expect(
-      translateAndStoreComment(7, 3, "synthetic", "fr")
+      translateAndStoreComment(7, 3, "public-fixture", "fr")
     ).rejects.toBe(err);
     expect(mockWarn).not.toHaveBeenCalled();
   });
@@ -346,11 +346,11 @@ describe("optional stored translations", () => {
     try {
       jest.isolateModules(() => {
         const helpers = require("../../src/comment");
-        detectionResult = helpers.detectLanguage("synthetic");
+        detectionResult = helpers.detectLanguage("public-fixture");
         translationResult = helpers.translateAndStoreComment(
           7,
           3,
-          "synthetic",
+          "public-fixture",
           "fr"
         );
       });

--- a/server/__tests__/unit/delphi-job-guard.test.ts
+++ b/server/__tests__/unit/delphi-job-guard.test.ts
@@ -26,7 +26,7 @@ import {
 
 const scope = {
   conversationId: "4242",
-  reportId: "r-synthetic",
+  reportId: "r-public-fixture",
   jobType: "FULL_PIPELINE",
   jobConfig: JSON.stringify({ include_moderation: false }),
 };
@@ -113,7 +113,7 @@ describe("admitDelphiJob: substrate failures fail closed", () => {
     const store = makeStore({
       sweepUnguardedActiveRoot: jest.fn(async () => ({
         kind: "unknown" as const,
-        reason: "synthetic",
+        reason: "public-fixture",
       })),
     });
 
@@ -147,7 +147,7 @@ describe("admitDelphiJob: release needs authoritative proof", () => {
       })),
       sweepLiveDescendants: jest.fn(async () => ({
         kind: "unknown" as const,
-        reason: "synthetic read failure",
+        reason: "public-fixture read failure",
       })),
     });
 
@@ -849,7 +849,7 @@ describe("assessConversationLiveness", () => {
     const store = makeStore({
       sweepConversation: jest.fn(async () => ({
         kind: "unknown" as const,
-        reason: "synthetic",
+        reason: "public-fixture",
       })),
     });
 
@@ -998,7 +998,7 @@ describe("assessConversationLiveness: stable reads", () => {
   it("reports live when the second sweep cannot be completed", async () => {
     const results: any[] = [
       { kind: "found", value: [{ job_id: "root", status: "COMPLETED" }] },
-      { kind: "unknown", reason: "synthetic" },
+      { kind: "unknown", reason: "public-fixture" },
     ];
     const store = makeStore({
       sweepConversation: jest.fn(async () => results.shift()),

--- a/server/__tests__/unit/dynamoClient.test.ts
+++ b/server/__tests__/unit/dynamoClient.test.ts
@@ -41,7 +41,7 @@ const PLACEHOLDER_ENV = {
 
 describe("buildDynamoClientConfig credential precedence", () => {
   describe("branch 1: explicit endpoint (DynamoDB Local)", () => {
-    it("uses the endpoint with synthetic credentials", () => {
+    it("uses the endpoint with public-fixture credentials", () => {
       const config = buildDynamoClientConfig(
         {
           endpoint: "http://host.docker.internal:8000",

--- a/server/__tests__/unit/pcaMathTickZero.test.ts
+++ b/server/__tests__/unit/pcaMathTickZero.test.ts
@@ -361,7 +361,7 @@ describe("latest-existing cache provenance (review R2-F1)", () => {
   });
 
   test("it re-reads the store, so a first publication after the warm-up is visible", async () => {
-    // The second reviewer's step 3: the synthetic entry must not hide a generation that was
+    // The second reviewer's step 3: the fallback entry must not hide a generation that was
     // committed after it was cached.
     const zid = freshZid();
     serveNoRows();
@@ -422,14 +422,14 @@ describe("latest-existing cache provenance (review R2-F1)", () => {
   test("the synthesized entry is bypassed, not evicted: ordinary reads keep it", async () => {
     const zid = freshZid();
     serveNoRows();
-    const synthetic = await getPca(zid);
-    expect(synthetic).toBeDefined();
+    const fallback = await getPca(zid);
+    expect(fallback).toBeDefined();
     expect(await getLatestExistingPca(zid)).toBeUndefined();
 
     // Still cached for the ordinary caller, still zero queries.
     queryP_readOnly.mockClear();
     const again = await getPca(zid);
-    expect(again).toBe(synthetic);
+    expect(again).toBe(fallback);
     expect(queryP_readOnly).not.toHaveBeenCalled();
   });
 

--- a/server/src/utils/dynamoClient.ts
+++ b/server/src/utils/dynamoClient.ts
@@ -7,7 +7,7 @@ import logger from "./logger";
  *
  * Every DynamoDB client in the server must resolve credentials the same way:
  *
- *   1. `DYNAMODB_ENDPOINT` set  -> DynamoDB Local. Send synthetic credentials;
+ *   1. `DYNAMODB_ENDPOINT` set  -> DynamoDB Local. Send public-fixture credentials;
  *      DynamoDB Local accepts any syntactically valid pair and never validates
  *      them, so no real credential is ever needed (or leaked) locally.
  *   2. Real `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` -> use them explicitly.

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -59,8 +59,7 @@
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
     // "types": [],                                 /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. */,
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
 


### PR DESCRIPTION
Terminology sweep, group 4 of 4: test markers and config labels across CI, the probe box, server and client fixtures. The deployed CI worker security-group description is deliberately preserved (a description change replaces the group) and annotated. One redundant TypeScript compiler option removed; effective value and emitted CommonJS unchanged.

Verified locally: probe 35/35, CDK 67/67 (four suites), selected server unit 138/138 (five suites), server ESLint and CDK typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s