### PR TITLE
characterization: resolve a rebase-merged archive pin in re-record accounting

### DIFF
--- a/.github/workflows/characterization-rerecord.yml
+++ b/.github/workflows/characterization-rerecord.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: Target commit or ref (empty uses the immutable dispatch SHA)
+        description: Full 40-character target SHA (empty uses the immutable dispatch SHA)
         type: string
         required: false
         default: ''
@@ -44,6 +44,12 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
+      - name: Fetch the authenticated archive source object
+        working-directory: target
+        run: |
+          pin=$(node ../control/server/characterization/rerecord-accounting.cjs --archive-pin "$PWD")
+          git fetch --no-tags origin "$pin"
+          test "$(git rev-parse --verify "$pin^{commit}")" = "$pin"
       - name: Install accounting dependencies and linters
         working-directory: target
         run: |

--- a/ci/p027_rerecord.sh
+++ b/ci/p027_rerecord.sh
@@ -93,7 +93,7 @@ const evidencePass = record.cases > 0 && record.failures === 0 &&
   replay.cases === record.cases && replay.failures === 0 && replay.differences === 0 &&
   replay.coverage.missing === 0 && controls.length === expectedControls.length &&
   controls.every((c,i) => c.control === expectedControls[i] && c.exit === (i < 6 ? 1 : 0));
-const result = {target: a.target, base: a.base, record: {cases: record.cases, failures: record.failures},
+const result = {target: a.target, base: a.base, baseResolution: a.baseResolution, record: {cases: record.cases, failures: record.failures},
   replay: {cases: replay.cases, failures: replay.failures, differences: replay.differences},
   negativeControls: controls.length, evidencePass, archiveSha256: fs.readFileSync(path.join(out,'baseline.sha256'),'utf8').trim(),
   counts: a.counts, checks, reviewEligible: a.reviewEligible && failed === '0' && evidencePass, autoMerge: false};

--- a/server/characterization/README.md
+++ b/server/characterization/README.md
@@ -326,9 +326,9 @@ server Node dependencies (or run their equivalents inside the sealed driver).
 ## Dispatchable corpus re-record
 
 The **Characterization corpus re-record** Actions workflow accepts `target`, a
-commit or ref in this repository. Empty means the immutable SHA of the dispatching
-ref. The workflow must first be present on the default branch for dispatch to be
-available. It keeps its dispatch tools separate from the resolved target checkout,
+full 40-character commit SHA in this repository (short hashes are not supported).
+Empty means the immutable SHA of the dispatching ref. The workflow must first be
+present on the default branch for dispatch to be available. It keeps its dispatch tools separate from the resolved target checkout,
 uses read-only repository permissions, and persists no checkout credentials.
 It does not create or merge a PR.
 
@@ -365,7 +365,20 @@ its own required inventory). Cases are keyed by identity, with independent
 unchanged/changed/added/removed counts, serial-order and exact request-artifact
 checks. The served comparator is `compare.cjs::firstDifference`; checker changes
 are reported and prevent automatic eligibility. Shared-file hashes remain visible.
-The archive's source commit must be an ancestor of the target HEAD.
+Before self-tests, the workflow verifies the archive digest and agreement of its
+source/run pins, then fetches that exact object from origin. Fetch failure is
+fatal; no historical reader is substituted. The archive's source commit must be
+an ancestor of target HEAD, or a nonempty single-parent commit with exactly one
+`git patch-id --stable` equivalent on the target's complete first-parent history
+(merge commits are not candidates). Missing, empty, ambiguous or shallow history
+refuses resolution. `baseResolution` in accounting and summary records the original
+pin, resolved commit, method and patch ID; ancestral pins retain their identity.
+
+Patch identity proves a changeset, not the whole recorded source tree. Historical
+admission, old callback fingerprints and checker-file diffs still use the original
+pin. Only ancestry and attribution traversal use the resolved commit. A callback
+whose recorded hash differs at that history anchor remains unattributed; rebase
+context or whitespace differences cannot silently disappear through the mapping.
 
 The census preserves registration/verb identities, ordered callbacks and global
 middleware. A changed callback is attributed only when both runtime hashes match

--- a/server/characterization/rerecord-accounting.cjs
+++ b/server/characterization/rerecord-accounting.cjs
@@ -10,7 +10,7 @@ const equal = (a, b) => JSON.stringify(a) === JSON.stringify(b);
 const read = (dir, name) => fs.readFileSync(path.join(dir, name));
 const json = (dir, name) => JSON.parse(read(dir, name));
 function git(repo, ...args) {
-  return cp.execFileSync("git", args, {
+  return cp.execFileSync("git", ["--no-replace-objects", ...args], {
     cwd: repo,
     encoding: "utf8",
     maxBuffer: 32 * 1024 * 1024,
@@ -21,6 +21,101 @@ function commit(repo, value) {
   if (git(repo, "rev-parse", "--verify", `${value}^{commit}`).trim() !== value)
     throw Error("commit unavailable");
   return value;
+}
+// Read only authenticated archive bytes before asking Git for the historical object.
+function archivePin(repo) {
+  const dir = path.join(repo, "server/characterization/artifacts");
+  const bytes = read(dir, "baseline.json.gz");
+  if (sha(bytes) !== read(dir, "baseline.sha256").toString().trim())
+    throw Error("trusted baseline archive digest mismatch");
+  const files = JSON.parse(require("node:zlib").gunzipSync(bytes));
+  const index = JSON.parse(files["index.json"]);
+  const pin = index.meta.appCommit;
+  if (!/^[a-f0-9]{40}$/.test(pin)) throw Error("expected full commit SHA");
+  if (
+    index.cases.some(
+      (c) => JSON.parse(files[c.manifest.path]).source_commit !== pin
+    ) ||
+    index.meta.stack.commit !== pin ||
+    JSON.parse(files["run.json"]).commit !== pin
+  )
+    throw Error("archive run/source pin mismatch");
+  return pin;
+}
+function isAncestor(repo, base, target) {
+  try {
+    git(repo, "merge-base", "--is-ancestor", base, target);
+    return true;
+  } catch (error) {
+    if (error.status === 1) return false;
+    throw error;
+  }
+}
+const patchOptions = [
+  "--no-ext-diff",
+  "--no-textconv",
+  "--no-renames",
+  "--full-index",
+  "--binary",
+  "--diff-algorithm=myers",
+  "--unified=3",
+  "--no-color",
+];
+function resolveBase(repo, pin, target) {
+  commit(repo, pin);
+  commit(repo, target);
+  if (git(repo, "rev-parse", "--is-shallow-repository").trim() !== "false")
+    throw Error("complete history required for archive pin resolution");
+  if (isAncestor(repo, pin, target))
+    return { pin, resolvedCommit: pin, method: "ancestor", patchId: null };
+  const parents = git(repo, "rev-list", "--parents", "-n", "1", pin)
+    .trim()
+    .split(" ")
+    .slice(1);
+  if (parents.length !== 1)
+    throw Error("rebased archive pin must have exactly one parent");
+  const patch = git(repo, "show", "--format=%H", ...patchOptions, pin);
+  const patchId = cp
+    .execFileSync("git", ["patch-id", "--stable"], {
+      cwd: repo,
+      input: patch,
+      encoding: "utf8",
+    })
+    .trim()
+    .split(/\s+/)[0];
+  if (!/^[a-f0-9]{40}$/.test(patchId))
+    throw Error("rebased archive pin has no patch identity");
+  // Stream the complete history: do not buffer repository-wide diffs or truncate
+  // the search at the first match. Only the already validated SHA is an argument.
+  const rows = cp
+    .execFileSync(
+      "bash",
+      [
+        "-o",
+        "pipefail",
+        "-c",
+        "git --no-replace-objects log --first-parent --no-merges --root --format=%H -p " +
+          patchOptions.join(" ") +
+          ' "$1" | git patch-id --stable',
+        "p027-patch-history",
+        target,
+      ],
+      { cwd: repo, encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }
+    )
+    .trim();
+  const matches = rows
+    .split("\n")
+    .filter(Boolean)
+    .map((row) => row.trim().split(/\s+/))
+    .filter(([id]) => id === patchId)
+    .map(([, id]) => id);
+  if (matches.length !== 1)
+    throw Error(
+      `archive pin patch equivalence requires exactly one first-parent candidate; found ${matches.length}`
+    );
+  const resolvedCommit = commit(repo, matches[0]);
+  git(repo, "merge-base", "--is-ancestor", resolvedCommit, target);
+  return { pin, resolvedCommit, method: "stable-patch-id", patchId };
 }
 function indexed(items, key) {
   const result = new Map();
@@ -141,7 +236,7 @@ function functions(source, file, ts, options) {
   visit(ast);
   return out;
 }
-function attributor(repo, base, target) {
+function attributor(repo, base, target, historyBase = base) {
   const ts = require(path.join(repo, "server/node_modules/typescript"));
   const config = ts.readConfigFile(
     path.join(repo, "server/tsconfig.json"),
@@ -207,12 +302,20 @@ function attributor(repo, base, target) {
     };
     if (matches.length === 1) {
       const [a] = matches[0];
+      const resolved = snapshot(historyBase, a.file).filter(
+        (f) => f.name === a.name
+      );
+      if (resolved.length !== 1 || resolved[0].sha256 !== before) {
+        result.reason = "recorded callback differs at resolved history base";
+        memo.set(pair, result);
+        return result;
+      }
       const range = git(
         repo,
         "rev-list",
         "--reverse",
         "--ancestry-path",
-        `${base}..${target}`
+        `${historyBase}..${target}`
       )
         .trim()
         .split("\n")
@@ -329,7 +432,7 @@ function account(repo, beforeDir, afterDir) {
   const target = commit(repo, b.manifest.appCommit);
   if (target !== git(repo, "rev-parse", "HEAD").trim())
     throw Error("recording does not pin target HEAD");
-  git(repo, "merge-base", "--is-ancestor", base, target);
+  const baseResolution = resolveBase(repo, base, target);
   if (
     json(beforeDir, "run.json").commit !== base ||
     json(afterDir, "run.json").commit !== target
@@ -346,12 +449,13 @@ function account(repo, beforeDir, afterDir) {
     version: "p027-rerecord-accounting/1",
     base,
     target,
+    baseResolution,
     cases: caseDelta(a.cases, b.cases, firstDifference),
     requestArtifactChanges: [],
     census: censusDelta(
       json(beforeDir, "routes.json"),
       json(afterDir, "routes.json"),
-      attributor(repo, base, target)
+      attributor(repo, base, target, baseResolution.resolvedCommit)
     ),
     sharedFiles: [],
     checkerChanges: [],
@@ -373,6 +477,8 @@ function account(repo, beforeDir, afterDir) {
     if (before !== after)
       report.sharedFiles.push({ path: name, before, after });
   }
+  // Compare the ORIGINAL recording source, not its patch-equivalent history
+  // anchor: equal patch IDs do not prove equal trees (or even whitespace).
   // A changed comparator/seed/profile needs explicit review, even if its own comparison says equal.
   const checkers = git(
     repo,
@@ -399,7 +505,9 @@ function account(repo, beforeDir, afterDir) {
   );
   return report;
 }
-if (require.main === module) {
+if (require.main === module && process.argv[2] === "--archive-pin") {
+  console.log(archivePin(path.resolve(process.argv[3])));
+} else if (require.main === module) {
   const [repo, before, after, output] = process.argv.slice(2);
   if (!output)
     throw Error("usage: rerecord-accounting.cjs REPO BEFORE AFTER OUTPUT");
@@ -420,4 +528,6 @@ module.exports = {
   eligible,
   account,
   attributor,
+  archivePin,
+  resolveBase,
 };

--- a/server/characterization/rerecord-accounting.test.cjs
+++ b/server/characterization/rerecord-accounting.test.cjs
@@ -8,6 +8,8 @@ const {
   functions,
   eligible,
   attributor,
+  archivePin,
+  resolveBase,
 } = require("./rerecord-accounting.cjs");
 const repo =
   process.env.P027_ACCOUNTING_REPO || path.resolve(__dirname, "../..");
@@ -319,4 +321,338 @@ test("changed shared schema or fixture requires review even with unchanged outco
     r.sharedFiles.push({ path: file, before: "old", after: "new" });
     assert.equal(eligible(r), false);
   }
+});
+
+// Real Git reads over a self-contained loose-object fixture. No network, checkout,
+// commit command or dependency on locally cached PR-branch objects.
+function historyFixture(t) {
+  const fs = require("node:fs"),
+    os = require("node:os"),
+    crypto = require("node:crypto"),
+    zlib = require("node:zlib");
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "p027-pin-history-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.mkdirSync(path.join(root, ".git/objects"), { recursive: true });
+  fs.mkdirSync(path.join(root, ".git/refs/heads"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, ".git/config"),
+    "[core]\nrepositoryformatversion = 0\nbare = false\n"
+  );
+  fs.writeFileSync(path.join(root, ".git/HEAD"), "ref: refs/heads/test\n");
+  function object(type, body) {
+    const bytes = Buffer.concat([
+      Buffer.from(`${type} ${Buffer.byteLength(body)}\0`),
+      Buffer.from(body),
+    ]);
+    const id = crypto.createHash("sha1").update(bytes).digest("hex");
+    const dir = path.join(root, ".git/objects", id.slice(0, 2));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, id.slice(2)), zlib.deflateSync(bytes));
+    return id;
+  }
+  function tree(files) {
+    return object(
+      "tree",
+      Buffer.concat(
+        Object.entries(files)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([name, value]) => {
+            const nested = typeof value === "object";
+            return Buffer.concat([
+              Buffer.from(`${nested ? "40000" : "100644"} ${name}\0`),
+              Buffer.from(nested ? tree(value) : object("blob", value), "hex"),
+            ]);
+          })
+      )
+    );
+  }
+  function revision(files, parents, label) {
+    const id = object(
+      "commit",
+      `tree ${tree(files)}\n${parents
+        .map((p) => `parent ${p}\n`)
+        .join(
+          ""
+        )}author Test <test@example.invalid> 1700000000 +0000\ncommitter Test <test@example.invalid> 1700000000 +0000\n\n${label}\n`
+    );
+    fs.writeFileSync(path.join(root, ".git/refs/heads/test"), id + "\n");
+    return id;
+  }
+  const first = revision({ "value.txt": "old\n" }, [], "root");
+  const pin = revision({ "value.txt": "new\n" }, [first], "recorded");
+  const context = revision(
+    { "value.txt": "old\n", "context.txt": "context\n" },
+    [first],
+    "intervening"
+  );
+  const resolved = revision(
+    { "value.txt": "new\n", "context.txt": "context\n" },
+    [context],
+    "rebased"
+  );
+  return { root, first, pin, context, resolved, revision, fs, zlib, crypto };
+}
+test("ancestral archive pin retains its identity", (t) => {
+  const f = historyFixture(t);
+  assert.deepEqual(resolveBase(f.root, f.first, f.resolved), {
+    pin: f.first,
+    resolvedCommit: f.first,
+    method: "ancestor",
+    patchId: null,
+  });
+});
+test("rebased pin resolves to its sole first-parent patch equivalent", (t) => {
+  const f = historyFixture(t);
+  const r = resolveBase(f.root, f.pin, f.resolved);
+  assert.equal(r.pin, f.pin);
+  assert.equal(r.resolvedCommit, f.resolved);
+  assert.equal(r.method, "stable-patch-id");
+  assert.match(r.patchId, /^[a-f0-9]{40}$/);
+});
+test("non-equivalent pin refuses with zero candidates", (t) => {
+  const f = historyFixture(t);
+  assert.throws(() => resolveBase(f.root, f.pin, f.context), /found 0/);
+});
+test("revert and reapply create two candidates and refuse", (t) => {
+  const f = historyFixture(t);
+  const revert = f.revision(
+    { "value.txt": "old\n", "context.txt": "context\n" },
+    [f.resolved],
+    "revert"
+  );
+  const again = f.revision(
+    { "value.txt": "new\n", "context.txt": "context\n" },
+    [revert],
+    "reapply"
+  );
+  assert.throws(() => resolveBase(f.root, f.pin, again), /found 2/);
+});
+test("equivalent commit on a second-parent branch is not a candidate", (t) => {
+  const f = historyFixture(t);
+  const merge = f.revision(
+    { "value.txt": "new\n", "context.txt": "context\n" },
+    [f.context, f.resolved],
+    "merge"
+  );
+  assert.throws(() => resolveBase(f.root, f.pin, merge), /found 0/);
+});
+test("unavailable source object refuses instead of substituting a reader", (t) => {
+  const f = historyFixture(t);
+  f.fs.unlinkSync(
+    path.join(f.root, ".git/objects", f.pin.slice(0, 2), f.pin.slice(2))
+  );
+  assert.throws(() => resolveBase(f.root, f.pin, f.resolved), /rev-parse/);
+});
+test("empty or merge source pins cannot use patch equivalence", (t) => {
+  const f = historyFixture(t);
+  const empty = f.revision({ "value.txt": "old\n" }, [f.first], "empty");
+  assert.throws(
+    () => resolveBase(f.root, empty, f.resolved),
+    /no patch identity/
+  );
+  const merge = f.revision(
+    { "value.txt": "new\n" },
+    [f.first, f.pin],
+    "merge pin"
+  );
+  assert.throws(
+    () => resolveBase(f.root, merge, f.resolved),
+    /exactly one parent/
+  );
+});
+test("shallow history cannot assert unique patch equivalence", (t) => {
+  const f = historyFixture(t);
+  f.fs.writeFileSync(path.join(f.root, ".git/shallow"), f.first + "\n");
+  assert.throws(
+    () => resolveBase(f.root, f.pin, f.resolved),
+    /complete history/
+  );
+});
+test("invalid and abbreviated source pins refuse before Git interpretation", (t) => {
+  const f = historyFixture(t);
+  for (const pin of [f.pin.slice(0, 9), "--all", "HEAD"])
+    assert.throws(
+      () => resolveBase(f.root, pin, f.resolved),
+      /full commit SHA/
+    );
+});
+test("archive fetch pin authenticates bytes and all declared source identities", (t) => {
+  const f = historyFixture(t),
+    dir = path.join(f.root, "server/characterization/artifacts");
+  f.fs.mkdirSync(dir, { recursive: true });
+  const files = {
+    "index.json": JSON.stringify({
+      meta: { appCommit: f.pin, stack: { commit: f.pin } },
+      cases: [{ manifest: { path: "case/manifest.json" } }],
+    }),
+    "run.json": JSON.stringify({ commit: f.pin }),
+    "case/manifest.json": JSON.stringify({ source_commit: f.pin }),
+  };
+  function save() {
+    const bytes = f.zlib.gzipSync(JSON.stringify(files));
+    f.fs.writeFileSync(path.join(dir, "baseline.json.gz"), bytes);
+    f.fs.writeFileSync(
+      path.join(dir, "baseline.sha256"),
+      f.crypto.createHash("sha256").update(bytes).digest("hex") + "\n"
+    );
+  }
+  save();
+  assert.equal(archivePin(f.root), f.pin);
+  f.fs.appendFileSync(path.join(dir, "baseline.json.gz"), "bad");
+  assert.throws(() => archivePin(f.root), /digest mismatch/);
+  save();
+  for (const name of ["run.json", "case/manifest.json"]) {
+    const old = files[name];
+    files[name] = old.replace(f.pin, f.context);
+    save();
+    assert.throws(() => archivePin(f.root), /pin mismatch/);
+    files[name] = old;
+  }
+});
+test("real archive fetch pin agrees with the recording source", () => {
+  const { testBaseline } = require(path.join(
+    repo,
+    "server/characterization/baseline.cjs"
+  ));
+  const index = JSON.parse(
+    require("node:fs").readFileSync(path.join(testBaseline(), "index.json"))
+  );
+  assert.equal(archivePin(repo), index.meta.appCommit);
+});
+test("resolved context cannot hide a changed recorded callback", (t) => {
+  const f = historyFixture(t);
+  const files = (body) => ({
+    server: {
+      src: { "handler.ts": `export function handler() { return ${body}; }` },
+    },
+  });
+  const before = f.revision(files("1"), [], "recorded context");
+  const resolved = f.revision(files("2"), [], "different context");
+  const target = f.revision(files("3"), [resolved], "later change");
+  f.fs.mkdirSync(path.join(f.root, "server"), { recursive: true });
+  f.fs.symlinkSync(
+    path.join(repo, "server/node_modules"),
+    path.join(f.root, "server/node_modules"),
+    "dir"
+  );
+  f.fs.writeFileSync(
+    path.join(f.root, "server/tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: { target: "esnext", module: "commonjs" },
+      files: ["src/handler.ts"],
+    })
+  );
+  const hash = (body) =>
+    functions(
+      files(body).server.src["handler.ts"],
+      "server/src/handler.ts",
+      ts,
+      { target: ts.ScriptTarget.ESNext, module: ts.ModuleKind.CommonJS }
+    )[0].sha256;
+  const attribute = attributor(f.root, before, target, resolved);
+  assert.deepEqual(attribute(hash("1"), hash("3")), {
+    status: "unattributed",
+    reason: "recorded callback differs at resolved history base",
+  });
+  const positive = attributor(
+    f.root,
+    resolved,
+    target,
+    resolved
+  )(hash("2"), hash("3"));
+  assert.equal(positive.status, "attributed");
+  assert.equal(positive.transitions[0].commit, target);
+  const equivalent = f.revision(files("1"), [], "equivalent recorded context");
+  const later = f.revision(files("3"), [equivalent], "change after rebase");
+  const mapped = attributor(
+    f.root,
+    before,
+    later,
+    equivalent
+  )(hash("1"), hash("3"));
+  assert.equal(mapped.status, "attributed");
+  assert.deepEqual(
+    mapped.transitions.map((x) => [x.parent, x.commit]),
+    [[equivalent, later]]
+  );
+});
+
+test("accounting reports the rebase mapping without hiding original checker drift", (t) => {
+  const f = historyFixture(t);
+  const reader = `const fs = require("node:fs"), path = require("node:path");
+exports.readRecording = dir => {
+  const index = JSON.parse(fs.readFileSync(path.join(dir, "index.json")));
+  return { index, manifest: index.meta, cases: JSON.parse(fs.readFileSync(path.join(dir, "cases.json"))) };
+};`;
+  const comparator = `exports.firstDifference = (a,b) => JSON.stringify(a) === JSON.stringify(b) ? null : "changed";`;
+  const source = (marker, context = "old") => ({
+    server: {
+      characterization: {
+        "recording.cjs": reader,
+        "compare.cjs": comparator,
+        "context.json": JSON.stringify({ context }),
+      },
+      src: { "marker.ts": `export const marker = ${marker};` },
+    },
+  });
+  const first = f.revision(source(0), [], "initial harness");
+  const pin = f.revision(source(1), [first], "recorded patch");
+  const intervening = f.revision(source(0, "new"), [first], "checker changed");
+  const resolved = f.revision(source(1, "new"), [intervening], "rebased patch");
+  const harness = path.join(f.root, "server/characterization");
+  f.fs.mkdirSync(harness, { recursive: true });
+  for (const [name, text] of Object.entries(
+    source(1, "new").server.characterization
+  ))
+    f.fs.writeFileSync(path.join(harness, name), text);
+  f.fs.symlinkSync(
+    path.join(repo, "server/node_modules"),
+    path.join(f.root, "server/node_modules"),
+    "dir"
+  );
+  f.fs.writeFileSync(
+    path.join(f.root, "server/tsconfig.json"),
+    JSON.stringify({ files: ["src/marker.ts"] })
+  );
+  function recording(label, commit) {
+    const dir = path.join(f.root, label);
+    f.fs.mkdirSync(dir);
+    for (const [name, value] of Object.entries({
+      "index.json": { meta: { appCommit: commit }, cases: [], files: [] },
+      "run.json": { commit },
+      "routes.json": census([]),
+      "cases.json": [{ ...c("one"), wire: { response: { status: 200 } } }],
+    }))
+      f.fs.writeFileSync(path.join(dir, name), JSON.stringify(value));
+    return dir;
+  }
+  const { account } = require("./rerecord-accounting.cjs");
+  const before = recording("before", pin),
+    after = recording("after", resolved);
+  const report = account(f.root, before, after);
+  assert.equal(report.base, pin);
+  assert.equal(report.target, resolved);
+  assert.equal(report.baseResolution.pin, pin);
+  assert.equal(report.baseResolution.resolvedCommit, resolved);
+  assert.equal(report.baseResolution.method, "stable-patch-id");
+  assert.match(report.baseResolution.patchId, /^[a-f0-9]{40}$/);
+  assert.deepEqual(report.counts, {
+    unchanged: 1,
+    changed: 0,
+    added: 0,
+    removed: 0,
+    oracleFailures: 0,
+  });
+  assert.deepEqual(report.checkerChanges, [
+    "server/characterization/context.json",
+  ]);
+  assert.equal(report.reviewEligible, false);
+  f.fs.writeFileSync(
+    path.join(before, "run.json"),
+    JSON.stringify({ commit: resolved })
+  );
+  assert.throws(
+    () => account(f.root, before, after),
+    /archive run\/source pin mismatch/
+  );
 });


### PR DESCRIPTION
The dispatchable corpus re-record job (#2769) has never been able to pass on GitHub: the round-7 archive pins the commit of #2753 as it stood on its PR branch, edge is rebase-merged, so that commit is on no branch and is not an ancestor of edge. A fresh clone cannot resolve it and the job's self-test fails at "Validate the dispatch tools" (runs 34539899676, 34540254858).

This change:
- verifies the archive digest and pin agreement, then fetches the exact pinned object from origin before the self-tests (fetch failure is fatal);
- lets accounting accept a pin that is an ancestor as before, or a single-parent commit with exactly one `git patch-id --stable` equivalent on the target's complete first-parent history; missing, empty, ambiguous or shallow history refuses;
- keeps the original pin authoritative for historical admission, callback fingerprints and checker diffs; only ancestry and attribution use the resolved commit, and a callback whose recorded hash differs at that anchor stays unattributed;
- records the mapping as `baseResolution` in the report and the job summary; documents the `target` input as a full 40-character SHA.

Archive and digest unchanged. Self-test 40/40; complete-history probe resolves the round-7 pin to its edge equivalent. Touches a workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s