### PR TITLE
probe box: admit the live primary as the read target

### DIFF
--- a/cdk/probeBox.ts
+++ b/cdk/probeBox.ts
@@ -19,6 +19,7 @@ import * as cr from 'aws-cdk-lib/custom-resources';
 export interface ProbeConfig {
   schema: 'polis-probe-box/1'; id: string; account: string; region: string; ami: string;
   vpcId: string; subnetCidr: string; availabilityZone: string; resolverAddress: string;
+  // Read target: primary under the live ruling, or a distinct replica.
   replicaHost: string; replicaSecurityGroupId: string; database: string;
   // A separate reviewed schema operation creates this secret's login on primary.
   primaryHost: string; primarySecurityGroupId: string; adminSecretArn: string; postgresLayerArn: string;
@@ -43,7 +44,7 @@ export function validateProbeConfig(a: ProbeConfig): ProbeConfig {
       !role.test(a.assetPublisherRoleArn) ||
       !a.adminSecretArn.startsWith(`arn:aws:secretsmanager:${a.region}:${a.account}:secret:`) ||
       !/^sg-[a-f0-9]+$/.test(a.primarySecurityGroupId) ||
-      !/^[a-z0-9.-]+\.rds\.amazonaws\.com$/.test(a.primaryHost) || a.primaryHost === a.replicaHost ||
+      !/^[a-z0-9.-]+\.rds\.amazonaws\.com$/.test(a.primaryHost) ||
       !new RegExp(`^arn:aws:lambda:${a.region}:${a.account}:layer:[A-Za-z0-9_-]+:[1-9][0-9]*$`).test(a.postgresLayerArn) ||
       !a.notificationTopicArn.startsWith(`arn:aws:sns:${a.region}:${a.account}:`))
     throw new Error('Invalid probe principals');
@@ -92,6 +93,7 @@ export class ProbeBox extends Construct {
     const provisionSg = new ec2.CfnSecurityGroup(this,'ProvisionSg',{vpcId:a.vpcId,groupDescription:'Reader-login provisioning only',
       securityGroupEgress:[{ipProtocol:'tcp',fromPort:5432,toPort:5432,destinationSecurityGroupId:a.primarySecurityGroupId},
         {ipProtocol:'tcp',fromPort:443,toPort:443,destinationSecurityGroupId:endpointSg.attrGroupId}]});
+    // Same destination is valid in live mode: provisioner and worker have distinct source SGs.
     new ec2.CfnSecurityGroupIngress(this,'PrimaryProvisionIngress',{groupId:a.primarySecurityGroupId,sourceSecurityGroupId:provisionSg.attrGroupId,ipProtocol:'tcp',fromPort:5432,toPort:5432});
     new ec2.CfnSecurityGroupIngress(this,'SecretProvisionIngress',{groupId:endpointSg.attrGroupId,sourceSecurityGroupId:provisionSg.attrGroupId,ipProtocol:'tcp',fromPort:443,toPort:443});
     const vpc=ec2.Vpc.fromVpcAttributes(this,'ExistingVpc',{vpcId:a.vpcId,availabilityZones:[a.availabilityZone]});

--- a/cdk/test/probeBox.test.ts
+++ b/cdk/test/probeBox.test.ts
@@ -10,7 +10,7 @@ const config: ProbeConfig = {
  postgresLayerArn:'arn:aws:lambda:us-east-1:111111111111:layer:public-fixture-postgres:1',s3PrefixListId:'pl-12345678',
  reviewerRoleArns:['arn:aws:iam::111111111111:role/public-fixture-reader'],assetPublisherRoleArn:'arn:aws:iam::111111111111:role/public-fixture-publisher',
  githubRepo:'example/example',githubEnvironment:'probe-box',githubRef:'refs/heads/edge',notificationTopicArn:'arn:aws:sns:us-east-1:111111111111:public-fixture'};
-function build(){const app=new cdk.App();const stack=new cdk.Stack(app,'Probe',{env:{account:config.account,region:config.region}});new ProbeBox(stack,'Box',config);return Template.fromStack(stack);}
+function build(input: ProbeConfig = config){const app=new cdk.App();const stack=new cdk.Stack(app,'Probe',{env:{account:config.account,region:config.region}});new ProbeBox(stack,'Box',input);return Template.fromStack(stack);}
 const resources=(j:any,t:string):any[]=>Object.values(j.Resources).filter((r:any)=>r.Type===t);
 function named(j:any,prefix:string,type?:string):any{return (Object.entries(j.Resources).find(([id,r]:any)=>id.startsWith(prefix)&&(!type||r.Type===type))![1] as any).Properties;}
 test('existing VPC isolated routes and no public ingress',()=>{const t=build(),j=t.toJSON();
@@ -36,3 +36,22 @@ test('private receipt buckets and independent sweep alarms',()=>{const t=build()
  for(const b of resources(j,'AWS::S3::Bucket')){expect(Object.values(b.Properties.PublicAccessBlockConfiguration)).toEqual([true,true,true,true]);expect(b.DeletionPolicy).toBe('Retain');}
  const p=JSON.stringify(resources(j,'AWS::S3::BucketPolicy'));for(const sid of ['PrivateReaders','WorkerWrites','CreateOnly','PrivateEndpoint'])expect(p).toContain(sid);});
 test.each(['ami','replicaHost','primaryHost','account','database'] as const)('invalid %s fails before synth',field=>{expect(()=>validateProbeConfig({...config,[field]:'!invalid'})).toThrow();});
+
+test.each([false,true])('read target and provisioner rules remain distinct (live=%s)',live=>{
+ const input={...config,...(live?{replicaHost:config.primaryHost,replicaSecurityGroupId:config.primarySecurityGroupId}:{})};
+ expect(validateProbeConfig(input)).toBe(input);
+ const j=build(input).toJSON();
+ const ingress=resources(j,'AWS::EC2::SecurityGroupIngress').map(r=>r.Properties);
+ const db=ingress.filter(r=>r.FromPort===5432);
+ expect(db).toHaveLength(2);
+ expect(db.map(r=>r.GroupId)).toEqual([input.replicaSecurityGroupId,input.primarySecurityGroupId]);
+ expect(db[0].SourceSecurityGroupId).not.toEqual(db[1].SourceSecurityGroupId);
+ const key=(r:any)=>JSON.stringify([r.GroupId,r.SourceSecurityGroupId,r.IpProtocol,r.FromPort,r.ToPort]);
+ expect(new Set(ingress.map(key)).size).toBe(ingress.length);
+ expect(named(j,'BoxWorkerSg').SecurityGroupEgress[0].DestinationSecurityGroupId).toBe(input.replicaSecurityGroupId);
+ expect(named(j,'BoxProvisionSg').SecurityGroupEgress[0].DestinationSecurityGroupId).toBe(input.primarySecurityGroupId);
+ expect(named(j,'BoxControlFunction','AWS::Lambda::Function').Environment.Variables.REPLICA_HOST).toBe(input.replicaHost);
+ expect(resources(j,'AWS::CloudFormation::CustomResource')[0].Properties.PrimaryHost).toBe(input.primaryHost);
+ const policy=JSON.stringify(named(j,'BoxWorkerDefaultPolicy').PolicyDocument);
+ expect(policy).not.toContain(input.adminSecretArn);
+});

--- a/ci/private_cert/images/probe.py
+++ b/ci/private_cert/images/probe.py
@@ -32,8 +32,17 @@ def resolve_private_spec(entry, dataset):
     return gate.schedule.ScheduleSpec.from_dict(value)
 
 
+def validate_reader_session(conn) -> None:
+    """The live primary and replicas must both use the read-only reader login."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT pg_is_in_recovery(), current_setting('transaction_read_only')")
+        row = cur.fetchone()
+        if not row or len(row) != 2 or type(row[0]) is not bool or row[1] != 'on':
+            raise ValueError('READ_ONLY_SOURCE_REQUIRED')
+
+
 def extract() -> None:
-    """Use the same owned extractor against one read-only replica snapshot."""
+    """Use the same owned extractor against one read-only snapshot of the configured read target."""
     import psycopg2
     from polismath.replay import fixture_config as fc, fixture_extract as fx, fixture_bundle as fb
     recipe = json.loads(Path('/opt/polis-private-image/recipe.json').read_bytes())
@@ -49,17 +58,14 @@ def extract() -> None:
     conn = psycopg2.connect(service='probe')
     try:
         conn.autocommit = True
-        with conn.cursor() as cur:
-            cur.execute('SELECT pg_is_in_recovery(), current_setting(\'transaction_read_only\')')
-            if cur.fetchone() != (True, 'on'):
-                raise ValueError('READ_REPLICA_REQUIRED')
+        validate_reader_session(conn)
         result = fx.extract_from_config(conn, config=config, payload_root=payload, guard_root=out)
     finally:
         conn.close()
     manifest = fb.build_manifest(bundle_id='probe-capture', payload_root=payload,
         config=config, config_bytes=config_bytes, selections=result['roles'],
         generated_summaries=result['generated'],
-        snapshot={'identifier': 'live-replica-repeatable-read',
+        snapshot={'identifier': 'live-readonly-repeatable-read',
                   'created_at': datetime.datetime.now(datetime.timezone.utc).isoformat(),
                   'schema_migration_version': None},
         transaction_guarantee=result['transaction_guarantee'], tie_key=result['tie_key'],

--- a/ci/private_cert/test_probe.py
+++ b/ci/private_cert/test_probe.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 sys.path.insert(0,str(Path(__file__).parent/'images'))
 import probe
 from polismath.replay.schedule import ScheduleSpec
@@ -23,3 +23,19 @@ class ProbeTests(unittest.TestCase):
             with patch.object(probe.gate.certify,'build_effective_spec',return_value=ScheduleSpec.from_dict(raw)):
                 self.assertEqual(probe.resolve_private_spec(SimpleNamespace(schedule_path=path),SimpleNamespace(votes=[])).to_dict(),raw)
 
+
+    def test_primary_and_replica_require_readonly_session(self):
+        for recovery in (False, True):
+            conn = MagicMock()
+            conn.cursor.return_value.__enter__.return_value.fetchone.return_value = (recovery, 'on')
+            probe.validate_reader_session(conn)
+            conn.cursor.return_value.__enter__.return_value.execute.assert_called_once_with(
+                "SELECT pg_is_in_recovery(), current_setting('transaction_read_only')")
+
+    def test_writable_or_unknown_source_refused(self):
+        for row in [(False, 'off'), (True, 'off'), (None, 'on'), (1, 'on'), None, (), (False,)]:
+            with self.subTest(row=row):
+                conn = MagicMock()
+                conn.cursor.return_value.__enter__.return_value.fetchone.return_value = row
+                with self.assertRaisesRegex(ValueError, 'READ_ONLY_SOURCE_REQUIRED'):
+                    probe.validate_reader_session(conn)

--- a/ci/probe_box/ami/prepare.sh
+++ b/ci/probe_box/ami/prepare.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Operator-only AL2023 ARM64 builder preparation. No database or account APIs.
+set -euo pipefail
+[ "$(id -u)" = 0 ]
+[ "$(uname -m)" = aarch64 ]
+: "${PROBE_RELEASE:?exact AL2023 repository release required}"
+[[ "$PROBE_RELEASE" =~ ^2023\.[0-9]+\.[0-9]{8}$ ]]
+[ "$(rpm -q --qf '%{VERSION}' system-release)" = "$PROBE_RELEASE" ]
+recipe="$(cd -- "$(dirname -- "$0")" && pwd)"
+: "${PROBE_BUILD_DIR:?absolute build evidence directory required}"
+[[ "$PROBE_BUILD_DIR" = /* ]]
+[ ! -e "$PROBE_BUILD_DIR" ]
+mkdir -m 0700 "$PROBE_BUILD_DIR"
+# This immutable AL2023 release pins the complete RPM dependency resolution.
+# Retain exact NEVRAs and checksums as well, before the offline install.
+printf '%s\n' "$PROBE_RELEASE" > "$PROBE_BUILD_DIR/release.txt"
+rpm -qa --qf '%{NAME}-%{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}\n' | sort > "$PROBE_BUILD_DIR/base-rpms.txt"
+packages=(podman nftables python3.12 python3.12-pip e2fsprogs ec2-utils util-linux shadow-utils)
+mkdir "$PROBE_BUILD_DIR/rpms"
+dnf -y --releasever="$PROBE_RELEASE" --disablerepo='*' --enablerepo=amazonlinux \
+  install --downloadonly --downloaddir="$PROBE_BUILD_DIR/rpms" "${packages[@]}"
+shopt -s nullglob
+rpms=("$PROBE_BUILD_DIR"/rpms/*.rpm)
+[ "${#rpms[@]}" -gt 0 ]
+rpmkeys --checksig "${rpms[@]}" > "$PROBE_BUILD_DIR/rpm-signatures.txt"
+(cd "$PROBE_BUILD_DIR/rpms" && sha256sum ./*.rpm) > "$PROBE_BUILD_DIR/rpm-sha256.txt"
+rpm -qp --qf '%{NAME}-%{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}\n' "${rpms[@]}" | sort > "$PROBE_BUILD_DIR/downloaded-rpms.txt"
+# Network repositories disabled; install only the frozen local closure.
+dnf -y --disablerepo='*' --setopt=localpkg_gpgcheck=1 install "${rpms[@]}"
+rpm -qa --qf '%{NAME}-%{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}\n' | sort > "$PROBE_BUILD_DIR/installed-rpms.txt"
+python3.12 -m venv /opt/polis-probe/venv
+py=/opt/polis-probe/venv/bin/python
+"$py" -m pip download --only-binary=:all: --require-hashes \
+  --dest "$PROBE_BUILD_DIR/wheels" -r "$recipe/requirements.lock"
+"$py" -m pip install --no-index --find-links "$PROBE_BUILD_DIR/wheels" \
+  --only-binary=:all: --require-hashes -r "$recipe/requirements.lock"
+"$py" -m pip check
+"$py" -m pip freeze --all > "$PROBE_BUILD_DIR/python-packages.txt"
+"$py" - "$recipe/../layer/lock.json" "$PROBE_BUILD_DIR/rds-ca.pem" <<'PY'
+import hashlib, json, pathlib, ssl, sys, urllib.request
+ca = json.loads(pathlib.Path(sys.argv[1]).read_bytes())['ca']
+with urllib.request.urlopen(ca['url'], timeout=60) as response:
+    data = response.read(ca['bytes'] + 1)
+if len(data) != ca['bytes'] or hashlib.sha256(data).hexdigest() != ca['sha256']:
+    raise SystemExit('RDS_CA_PIN_MISMATCH: review new bytes; never update the pin in the builder')
+path = pathlib.Path(sys.argv[2]); path.write_bytes(data)
+context = ssl.create_default_context(cafile=str(path))
+if len(context.get_ca_certs()) != ca['certificates']:
+    raise SystemExit('RDS_CA_CERTIFICATE_COUNT')
+PY
+"$py" - <<'PY' > "$PROBE_BUILD_DIR/native-imports.txt"
+import platform, sys, boto3, psycopg2
+assert sys.version_info[:2] == (3, 12)
+assert platform.machine() == 'aarch64'
+print(sys.version)
+print('boto3', boto3.__version__)
+print('psycopg2', psycopg2.__version__, 'libpq', psycopg2.__libpq_version__)
+PY
+for tool in podman nft mkfs.ext4 mount systemctl unshare lsblk swapoff shutdown; do command -v "$tool"; done > "$PROBE_BUILD_DIR/tools.txt"
+[ -x /sbin/ebsnvme-id ]
+podman info --format json > "$PROBE_BUILD_DIR/podman-info.json"
+# No image pulls, probe start, credentials, or database connection in this phase.

--- a/ci/probe_box/ami/prepare.sh
+++ b/ci/probe_box/ami/prepare.sh
@@ -15,7 +15,12 @@ mkdir -m 0700 "$PROBE_BUILD_DIR"
 # Retain exact NEVRAs and checksums as well, before the offline install.
 printf '%s\n' "$PROBE_RELEASE" > "$PROBE_BUILD_DIR/release.txt"
 rpm -qa --qf '%{NAME}-%{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}\n' | sort > "$PROBE_BUILD_DIR/base-rpms.txt"
-packages=(podman nftables python3.12 python3.12-pip e2fsprogs ec2-utils util-linux shadow-utils)
+# These four NEVRAs were observed in the pinned Amazon repository (BOARD [867]).
+# No third-party runtime repository or unversioned runtime fallback.
+packages=(docker-25.0.16-1.amzn2023.0.4.aarch64
+          containerd-2.2.5-1.amzn2023.0.2.aarch64
+          runc-1.3.5-1.amzn2023.0.2.aarch64
+          skopeo-2:1.22.2-1.amzn2023.0.1.aarch64 nftables python3.12 python3.12-pip e2fsprogs ec2-utils util-linux shadow-utils)
 mkdir "$PROBE_BUILD_DIR/rpms"
 dnf -y --releasever="$PROBE_RELEASE" --disablerepo='*' --enablerepo=amazonlinux \
   install --downloadonly --downloaddir="$PROBE_BUILD_DIR/rpms" "${packages[@]}"
@@ -26,6 +31,8 @@ rpmkeys --checksig "${rpms[@]}" > "$PROBE_BUILD_DIR/rpm-signatures.txt"
 (cd "$PROBE_BUILD_DIR/rpms" && sha256sum ./*.rpm) > "$PROBE_BUILD_DIR/rpm-sha256.txt"
 rpm -qp --qf '%{NAME}-%{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}\n' "${rpms[@]}" | sort > "$PROBE_BUILD_DIR/downloaded-rpms.txt"
 # Network repositories disabled; install only the frozen local closure.
+# Prevent package scripts or a later boot from starting the default daemons.
+systemctl mask docker.service docker.socket containerd.service
 dnf -y --disablerepo='*' --setopt=localpkg_gpgcheck=1 install "${rpms[@]}"
 rpm -qa --qf '%{NAME}-%{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}\n' | sort > "$PROBE_BUILD_DIR/installed-rpms.txt"
 python3.12 -m venv /opt/polis-probe/venv
@@ -56,7 +63,18 @@ print(sys.version)
 print('boto3', boto3.__version__)
 print('psycopg2', psycopg2.__version__, 'libpq', psycopg2.__libpq_version__)
 PY
-for tool in podman nft mkfs.ext4 mount systemctl unshare lsblk swapoff shutdown; do command -v "$tool"; done > "$PROBE_BUILD_DIR/tools.txt"
+for tool in docker dockerd containerd runc skopeo mountpoint nft mkfs.ext4 mount systemctl unshare lsblk swapoff shutdown; do command -v "$tool"; done > "$PROBE_BUILD_DIR/tools.txt"
 [ -x /sbin/ebsnvme-id ]
-podman info --format json > "$PROBE_BUILD_DIR/podman-info.json"
+# Version queries only: no daemon/image/network execution on the builder.
+{
+  docker --version
+  dockerd --version
+  containerd --version
+  runc --version
+  skopeo --version
+} > "$PROBE_BUILD_DIR/runtime-versions.txt"
+for unit in docker.service docker.socket containerd.service; do
+  [ "$(systemctl is-enabled "$unit" || true)" = masked ]
+  [ "$(systemctl is-active "$unit" || true)" = inactive ]
+done
 # No image pulls, probe start, credentials, or database connection in this phase.

--- a/ci/probe_box/ami/requirements.lock
+++ b/ci/probe_box/ami/requirements.lock
@@ -1,0 +1,9 @@
+# CPython 3.12 Linux aarch64 wheels; pins from the existing probe runtime/layer.
+boto3==1.43.89 --hash=sha256:fe4190afe63eb562b6ba6a3911cf4427473b35fa047adde093bf696d3ae09fc0
+botocore==1.43.89 --hash=sha256:d7211220c815427fe71225acc6909e4ab5dfab3b03770e72fd16cf9eb86b3d1a
+jmespath==1.1.0 --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64
+s3transfer==0.19.2 --hash=sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25
+python-dateutil==2.9.0.post0 --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
+six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
+urllib3==2.7.0 --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+psycopg2-binary==2.9.13 --hash=sha256:3dc3372b3731b3ef23407fe06b94f640ef87a2bda242fa386033d5589c87514a

--- a/ci/probe_box/bake.sh
+++ b/ci/probe_box/bake.sh
@@ -4,9 +4,21 @@
 set -euo pipefail
 [ "$(id -u)" = 0 ]
 [ "$(uname -m)" = aarch64 ]
-for tool in podman nft python3 mkfs.ext4 mount systemctl; do command -v "$tool" >/dev/null; done
-python3 -c 'import boto3, psycopg2'
+for tool in podman nft mkfs.ext4 mount systemctl unshare lsblk swapoff shutdown; do command -v "$tool" >/dev/null; done
+[ -x /sbin/ebsnvme-id ]
+[ -x /opt/polis-probe/venv/bin/python ]
+/opt/polis-probe/venv/bin/python -c 'import sys, boto3, psycopg2; assert sys.version_info[:2] == (3, 12)'
 : "${PROBE_RDS_CA:?path to the reviewed RDS CA bundle required}"
+# Validate the reviewed CA before writing any boot configuration.
+/opt/polis-probe/venv/bin/python - "$(dirname "$0")/layer/lock.json" <<'PYCA'
+import hashlib, json, os
+from pathlib import Path
+import sys
+ca = json.loads(Path(sys.argv[1]).read_bytes())['ca']
+raw = Path(os.environ['PROBE_RDS_CA']).read_bytes()
+if len(raw) != ca['bytes'] or hashlib.sha256(raw).hexdigest() != ca['sha256']:
+    raise SystemExit('RDS_CA_PIN_MISMATCH')
+PYCA
 install -d -m 0755 /opt/polis-probe
 install -m 0444 "$PROBE_RDS_CA" /opt/polis-probe/rds-ca.pem
 for file in worker.py contracts.py receipt.py replica.py dns.py; do install -m 0444 "$(dirname "$0")/$file" "/opt/polis-probe/$file"; done
@@ -42,7 +54,7 @@ NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
-ExecStart=/usr/bin/python3 /opt/polis-probe/dns.py
+ExecStart=/opt/polis-probe/venv/bin/python /opt/polis-probe/dns.py
 Restart=on-failure
 StandardOutput=null
 StandardError=null
@@ -60,7 +72,7 @@ swapoff -a
 ulimit -c 0
 # User-data is JSON only; cloud-init execution is disabled. This step runs
 # before any probe or private database access and reads no credential.
-python3 - <<'BOOT'
+/opt/polis-probe/venv/bin/python - <<'BOOT'
 import json,sys
 from pathlib import Path
 sys.path.insert(0,'/opt/polis-probe')
@@ -84,7 +96,7 @@ mkfs.ext4 -F "$private_disk" >/dev/null
 mkdir -p /probe-work
 mount -o nodev,nosuid,noexec "$private_disk" /probe-work
 chmod 0700 /probe-work
-python3 /opt/polis-probe/worker.py
+/opt/polis-probe/venv/bin/python /opt/polis-probe/worker.py
 START
 chmod 0500 /opt/polis-probe/start.sh
 cat > /etc/systemd/system/polis-probe-worker.service <<'UNIT'
@@ -103,6 +115,9 @@ StandardError=null
 [Install]
 WantedBy=multi-user.target
 UNIT
+systemctl daemon-reload
+systemd-analyze verify /etc/systemd/system/polis-probe-{dns,worker}.service
+# Do not start either service on the builder.
 systemctl enable polis-probe-worker.service
 # Only digest-pinned OCI archives are loaded at runtime from the private assets
 # bucket. The AMI supervisor and CA bundle are reviewed in the image build.

--- a/ci/probe_box/bake.sh
+++ b/ci/probe_box/bake.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 [ "$(id -u)" = 0 ]
 [ "$(uname -m)" = aarch64 ]
-for tool in podman nft mkfs.ext4 mount systemctl unshare lsblk swapoff shutdown; do command -v "$tool" >/dev/null; done
+for tool in docker dockerd containerd runc skopeo mountpoint nft mkfs.ext4 mount systemctl unshare lsblk swapoff shutdown; do command -v "$tool" >/dev/null; done
 [ -x /sbin/ebsnvme-id ]
 [ -x /opt/polis-probe/venv/bin/python ]
 /opt/polis-probe/venv/bin/python -c 'import sys, boto3, psycopg2; assert sys.version_info[:2] == (3, 12)'
@@ -24,7 +24,7 @@ install -m 0444 "$PROBE_RDS_CA" /opt/polis-probe/rds-ca.pem
 for file in worker.py contracts.py receipt.py replica.py dns.py; do install -m 0444 "$(dirname "$0")/$file" "/opt/polis-probe/$file"; done
 # No remote commands, cloud-init, SSM, SSH or serial interactive console.
 for unit in cloud-init-local cloud-init cloud-config cloud-final sshd amazon-ssm-agent serial-getty@ttyS0; do systemctl mask "$unit.service"; done
-systemctl mask swap.target
+systemctl mask swap.target docker.service docker.socket containerd.service
 printf '* hard core 0\n* soft core 0\n' > /etc/security/limits.d/90-probe-box.conf
 printf 'kernel.core_pattern=|/bin/false\nvm.swappiness=0\n' > /etc/sysctl.d/90-probe-box.conf
 id private-dns >/dev/null 2>&1 || useradd --system --no-create-home --shell /sbin/nologin private-dns
@@ -61,6 +61,35 @@ StandardError=null
 [Install]
 WantedBy=multi-user.target
 UNIT
+# Skopeo may read only a local OCI archive; identity is checked independently by
+# worker.py. Every other transport is refused by this baked policy.
+cat > /opt/polis-probe/image-policy.json <<'POLICY'
+{"default":[{"type":"reject"}],"transports":{"oci-archive":{"":[{"type":"insecureAcceptAnything"}]}}}
+POLICY
+# Docker 25 uses overlay2 and its own managed containerd. Do not connect to the
+# distro containerd socket (which would put image/state data on the root disk).
+cat > /opt/polis-probe/docker.json <<'DOCKER'
+{"data-root":"/probe-work/container-store","exec-root":"/probe-work/container-run","pidfile":"/probe-work/docker.pid","hosts":["unix:///probe-work/docker.sock"],"group":"root","storage-driver":"overlay2","bridge":"none","iptables":false,"ip6tables":false,"ip-forward":false,"ip-masq":false,"userland-proxy":false,"log-driver":"none"}
+DOCKER
+dockerd --validate --config-file=/opt/polis-probe/docker.json
+cat > /etc/systemd/system/polis-probe-container.service <<'UNIT'
+[Unit]
+Description=Probe-only Docker on disposable storage
+ConditionPathIsMountPoint=/probe-work
+PartOf=polis-probe-worker.service
+[Service]
+Type=notify
+ExecStartPre=/usr/bin/mountpoint -q /probe-work
+ExecStart=/usr/bin/dockerd --config-file=/opt/polis-probe/docker.json
+Environment=DOCKER_TMPDIR=/probe-work/tmp TMPDIR=/probe-work/tmp
+Delegate=yes
+KillMode=process
+TimeoutStartSec=120
+LimitCORE=0
+UMask=0077
+StandardOutput=null
+StandardError=null
+UNIT
 cat > /opt/polis-probe/start.sh <<'START'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -96,6 +125,9 @@ mkfs.ext4 -F "$private_disk" >/dev/null
 mkdir -p /probe-work
 mount -o nodev,nosuid,noexec "$private_disk" /probe-work
 chmod 0700 /probe-work
+mkdir -m 0700 /probe-work/tmp /probe-work/docker-client
+export TMPDIR=/probe-work/tmp DOCKER_CONFIG=/probe-work/docker-client
+systemctl start polis-probe-container.service
 /opt/polis-probe/venv/bin/python /opt/polis-probe/worker.py
 START
 chmod 0500 /opt/polis-probe/start.sh
@@ -116,8 +148,8 @@ StandardError=null
 WantedBy=multi-user.target
 UNIT
 systemctl daemon-reload
-systemd-analyze verify /etc/systemd/system/polis-probe-{dns,worker}.service
-# Do not start either service on the builder.
+systemd-analyze verify /etc/systemd/system/polis-probe-{dns,container,worker}.service
+# Do not start any of these services on the builder.
 systemctl enable polis-probe-worker.service
 # Only digest-pinned OCI archives are loaded at runtime from the private assets
 # bucket. The AMI supervisor and CA bundle are reviewed in the image build.

--- a/ci/probe_box/test_boundaries.py
+++ b/ci/probe_box/test_boundaries.py
@@ -102,8 +102,8 @@ class BoundaryTests(unittest.TestCase):
                 self.assertEqual(len(raw.splitlines()),2)
 
     def test_container_runtime_state_is_on_disposable_disk(self):
-        p=worker.podman()
-        self.assertEqual(p,['podman','--root','/probe-work/container-store','--runroot','/probe-work/container-run'])
+        p=worker.docker()
+        self.assertEqual(p,['docker','--host','unix:///probe-work/docker.sock'])
 
     def test_dns_refuses_unknown_shapes_and_encoded_payload(self):
         header=b'\x00\x01\x01\x00\x00\x01'+b'\x00'*6

--- a/ci/probe_box/test_runtime.py
+++ b/ci/probe_box/test_runtime.py
@@ -1,0 +1,129 @@
+"""Digest-bound OCI conversion, private daemon and sandbox failure controls."""
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import worker
+
+
+class RuntimeTests(unittest.TestCase):
+    config = 'sha256:'+'c'*64
+
+    def manifest(self, **changes):
+        return dict(schemaVersion=2, mediaType='application/vnd.oci.image.manifest.v1+json',
+                    config={'digest': self.config}, layers=[], **changes)
+
+    def load(self, manifest=None, info=None, digest=None):
+        raw = json.dumps(manifest or self.manifest()).encode()
+        image = 'localhost/probe@sha256:'+(digest or hashlib.sha256(raw).hexdigest())
+        info = info or {'Id': self.config, 'Architecture': 'arm64', 'Os': 'linux'}
+        with patch.object(worker.subprocess, 'check_output', side_effect=[raw, json.dumps([info]).encode()]) as inspect, \
+                patch.object(worker.subprocess, 'run') as copy:
+            result = worker.load_image(Path('/probe-work/image.oci.tar'), image)
+            return result, inspect.call_args_list, copy.call_args
+
+    def test_oci_manifest_bound_to_loaded_config_without_registry_pull(self):
+        result, inspect, copy = self.load()
+        self.assertEqual(result, self.config)
+        self.assertEqual(inspect[0].args[0], ['skopeo', 'inspect', '--raw', 'oci-archive:/probe-work/image.oci.tar'])
+        self.assertEqual(inspect[1].args[0], worker.docker()+['image', 'inspect', self.config])
+        argv = copy.args[0]
+        self.assertEqual(argv[:6], ['skopeo', '--policy', '/opt/polis-probe/image-policy.json', 'copy',
+                                    '--dest-daemon-host', 'unix:///probe-work/docker.sock'])
+        self.assertTrue(argv[-1].startswith('docker-daemon:polis-probe-import:'))
+        self.assertEqual(copy.kwargs['env']['TMPDIR'], '/probe-work/tmp')
+        self.assertTrue(copy.kwargs['check'])
+
+    def test_wrong_manifest_refuses_before_copy(self):
+        with patch.object(worker.subprocess, 'check_output', return_value=b'wrong manifest'), \
+                patch.object(worker.subprocess, 'run') as copy:
+            with self.assertRaisesRegex(ValueError, 'IMAGE_DIGEST'):
+                worker.load_image(Path('/probe-work/image.oci.tar'), 'localhost/probe@sha256:'+'0'*64)
+            copy.assert_not_called()
+
+    def test_index_and_invalid_config_refuse(self):
+        for field, value in [('mediaType', 'application/vnd.oci.image.index.v1+json'),
+                             ('schemaVersion', 1), ('config', {'digest': 'sha256:short'})]:
+            with self.subTest(field=field):
+                m = self.manifest(); m[field] = value
+                with self.assertRaisesRegex(ValueError, 'IMAGE_MANIFEST|IMAGE_CONFIG'):
+                    self.load(manifest=m)
+
+    def test_loaded_config_id_and_platform_must_match(self):
+        for field, value in [('Id', 'sha256:'+'d'*64), ('Architecture', 'amd64'), ('Os', 'windows')]:
+            with self.subTest(field=field):
+                info = {'Id': self.config, 'Architecture': 'arm64', 'Os': 'linux'}; info[field] = value
+                with self.assertRaisesRegex(ValueError, 'IMAGE_CONFIG'):
+                    self.load(info=info)
+
+    def test_copy_failure_propagates_without_inspection(self):
+        raw = json.dumps(self.manifest()).encode()
+        with patch.object(worker.subprocess, 'check_output', return_value=raw) as inspect, \
+                patch.object(worker.subprocess, 'run', side_effect=subprocess.CalledProcessError(1, 'copy')):
+            with self.assertRaises(subprocess.CalledProcessError):
+                worker.load_image(Path('/probe-work/image.oci.tar'), 'localhost/probe@sha256:'+hashlib.sha256(raw).hexdigest())
+            self.assertEqual(inspect.call_count, 1)
+
+    def sandbox(self, state=None, failure=None):
+        with tempfile.TemporaryDirectory() as tmp, patch.object(worker, 'SCRATCH', Path(tmp)), \
+                patch.object(worker.subprocess, 'run', side_effect=[failure or SimpleNamespace(returncode=0), SimpleNamespace(returncode=0)]) as run, \
+                patch.object(worker.subprocess, 'check_output', return_value=json.dumps([{'State': state or {'ExitCode': 0, 'OOMKilled': False}}]).encode()):
+            try:
+                worker.sandbox({'image': 'unused:mutable', 'args': ['probe']}, 'test',
+                               [(Path(tmp)/'input', '/input', 'ro'), (Path(tmp)/'output', '/output', 'rw')],
+                               time.time()+30, self.config)
+            finally:
+                self.assertEqual(run.call_args.args[0][-3:], ['rm', '--force', 'polis-probe-test'])
+            return run.call_args_list[0].args[0]
+
+    def test_sandbox_uses_id_and_preserves_limits_and_bind_modes(self):
+        argv = self.sandbox()
+        for flag in ['--pull=never', '--network=none', '--read-only', '--cap-drop=ALL',
+                     '--security-opt=no-new-privileges', '--user=65534:65534', '--pids-limit=4096',
+                     '--memory=112g', '--memory-swap=112g', '--cpus=14', '--ulimit=core=0:0',
+                     '--tmpfs=/tmp:rw,nosuid,nodev,noexec,size=4g']:
+            self.assertIn(flag, argv)
+        self.assertEqual(argv[-2:], [self.config, 'probe'])
+        self.assertNotIn('unused:mutable', argv)
+        binds = [argv[i+1] for i, arg in enumerate(argv) if arg == '--mount']
+        self.assertTrue(binds[0].endswith(',readonly'))
+        self.assertFalse(binds[1].endswith(',readonly'))
+        self.assertTrue(all('bind-propagation=rprivate' in bind for bind in binds))
+
+    def test_failed_oom_and_nonzero_containers_are_removed(self):
+        for state in [{'ExitCode': 1}, {'ExitCode': 0, 'OOMKilled': True}]:
+            with self.subTest(state=state), self.assertRaisesRegex(ValueError, 'PROBE_EXECUTION_FAILED'):
+                self.sandbox(state=state)
+        with self.assertRaises(subprocess.TimeoutExpired):
+            self.sandbox(failure=subprocess.TimeoutExpired('run', 1))
+
+    def test_sandbox_refuses_mutable_image_before_execution(self):
+        with patch.object(worker.subprocess, 'run') as run:
+            with self.assertRaisesRegex(ValueError, 'IMAGE_CONFIG'):
+                worker.sandbox({'args': []}, 'test', [], time.time()+1, 'image:latest')
+            run.assert_not_called()
+
+    def test_daemon_never_uses_root_disk_system_containerd_or_network(self):
+        bake = Path(__file__).with_name('bake.sh').read_text()
+        config = json.loads(bake.split("<<'DOCKER'\n")[1].split('\nDOCKER')[0])
+        for key in ['data-root', 'exec-root', 'pidfile']:
+            self.assertTrue(config[key].startswith('/probe-work/'))
+        self.assertEqual(config['hosts'], ['unix:///probe-work/docker.sock'])
+        self.assertNotIn('containerd', config)
+        self.assertEqual(config['storage-driver'], 'overlay2')
+        self.assertEqual(config['bridge'], 'none')
+        for key in ['iptables', 'ip6tables', 'ip-forward', 'ip-masq', 'userland-proxy']:
+            self.assertIs(config[key], False)
+        self.assertEqual(config['log-driver'], 'none')
+        self.assertIn('ConditionPathIsMountPoint=/probe-work', bake)
+        self.assertLess(bake.index('mount -o nodev,nosuid,noexec'), bake.index('systemctl start polis-probe-container.service'))
+        self.assertIn('mask swap.target docker.service docker.socket containerd.service', bake)
+        policy = json.loads(bake.split("<<'POLICY'\n")[1].split('\nPOLICY')[0])
+        self.assertEqual(policy['default'], [{'type': 'reject'}])
+        self.assertEqual(set(policy['transports']), {'oci-archive'})

--- a/ci/probe_box/worker.py
+++ b/ci/probe_box/worker.py
@@ -1,7 +1,9 @@
 """Baked supervisor. Only a validated verifier receipt may leave this machine."""
 from __future__ import annotations
+import hashlib
 import json
 import os
+import re
 from pathlib import Path
 import shutil
 import subprocess
@@ -17,10 +19,47 @@ ROOT = Path('/opt/polis-probe')
 SCRATCH = Path('/probe-work')
 
 
-def podman() -> list[str]:
-    # Images, writable layers and runtime state all use the disposable disk.
-    return ['podman','--root',str(SCRATCH/'container-store'),
-            '--runroot',str(SCRATCH/'container-run')]
+def docker() -> list[str]:
+    # Never use the system daemon or an environment-selected remote endpoint.
+    return ['docker', '--host', 'unix://'+str(SCRATCH/'docker.sock')]
+
+
+def load_image(archive: Path, image: str) -> str:
+    """Bind the admitted OCI manifest to the immutable Docker config/image ID.
+
+    Docker's archive transport does not retain registry manifest digests. Verify
+    the source bytes before conversion, then require its config digest as the
+    loaded image ID. Skopeo verifies layer digests during copy; Docker verifies
+    uncompressed layers against config.rootfs.diff_ids during import.
+    """
+    digest = image.split('@sha256:')[1]
+    source = 'oci-archive:'+str(archive)
+    env = {**os.environ, 'TMPDIR': str(SCRATCH/'tmp')}
+    raw = subprocess.check_output(['skopeo','inspect','--raw',source],
+                                  stderr=subprocess.DEVNULL, env=env)
+    if hashlib.sha256(raw).hexdigest() != digest:
+        raise ValueError('IMAGE_DIGEST')
+    manifest = json.loads(raw)
+    if (manifest.get('schemaVersion') != 2 or manifest.get('mediaType') not in (
+            'application/vnd.oci.image.manifest.v1+json',
+            'application/vnd.docker.distribution.manifest.v2+json')):
+        raise ValueError('IMAGE_MANIFEST')
+    config = manifest.get('config', {}).get('digest', '')
+    if not re.fullmatch(r'sha256:[0-9a-f]{64}', config):
+        raise ValueError('IMAGE_CONFIG')
+    # The temporary destination tag is never executable authority. The admitted
+    # job remains unchanged; only this supervisor holds the digest -> ID mapping.
+    subprocess.run(['skopeo','--policy',str(ROOT/'image-policy.json'),'copy',
+                    '--dest-daemon-host',docker()[2],source,
+                    'docker-daemon:polis-probe-import:'+digest],
+                   stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,
+                   env=env,check=True)
+    info = json.loads(subprocess.check_output(
+        docker()+['image','inspect',config],stderr=subprocess.DEVNULL))[0]
+    if (info.get('Id') != config or info.get('Architecture') != 'arm64'
+            or info.get('Os') != 'linux'):
+        raise ValueError('IMAGE_CONFIG')
+    return config
 
 
 def metadata(path: str) -> bytes:
@@ -37,26 +76,31 @@ def metadata(path: str) -> bytes:
     return raw
 
 
-def sandbox(command: dict, label: str, mounts: list[tuple[Path,str,str]], deadline: float) -> None:
-    argv = podman()+['run','--name','polis-probe-'+label,'--pull=never','--network=none',
+def sandbox(command: dict, label: str, mounts: list[tuple[Path,str,str]], deadline: float, image_id: str) -> None:
+    if not re.fullmatch(r'sha256:[0-9a-f]{64}', image_id):
+        raise ValueError('IMAGE_CONFIG')
+    argv = docker()+['run','--name','polis-probe-'+label,'--pull=never','--network=none',
             '--read-only','--cap-drop=ALL','--security-opt=no-new-privileges','--user=65534:65534',
             '--pids-limit=4096','--memory=112g','--memory-swap=112g','--cpus=14','--ulimit=core=0:0',
             '--tmpfs=/tmp:rw,nosuid,nodev,noexec,size=4g',
             '--env=OPENBLAS_NUM_THREADS=1','--env=OMP_NUM_THREADS=1','--env=MKL_NUM_THREADS=1',
             '--env=PGSERVICEFILE=/replica/service.conf']
     for source,target,mode in mounts:
-        argv += ['--volume', f'{source}:{target}:{mode},nosuid,nodev']
-    argv += [command['image'], *command['args']]
+        # The source filesystem is mounted nodev,nosuid,noexec by start.sh.
+        # Docker bind options do not accept Podman's nosuid/nodev suffixes.
+        argv += ['--mount', f'type=bind,src={source},dst={target},bind-propagation=rprivate'+
+                 (',readonly' if mode == 'ro' else '')]
+    argv += [image_id, *command['args']]
     try:
         with (SCRATCH/(label+'.log')).open('wb') as log:
             result = subprocess.run(argv, stdout=log, stderr=subprocess.STDOUT,
                                     timeout=max(1,deadline-time.time()), check=False)
-        inspected = subprocess.check_output(podman()+['inspect','polis-probe-'+label],stderr=subprocess.DEVNULL)
+        inspected = subprocess.check_output(docker()+['inspect','polis-probe-'+label],stderr=subprocess.DEVNULL)
         state = json.loads(inspected)[0]['State']
         if result.returncode or state.get('OOMKilled') or state.get('ExitCode') != 0:
             raise ValueError('PROBE_EXECUTION_FAILED')
     finally:
-        subprocess.run(podman()+['rm','--force','polis-probe-'+label],stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,check=True)
+        subprocess.run(docker()+['rm','--force','polis-probe-'+label],stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,check=True)
 
 
 def owned_dir(path: Path) -> Path:
@@ -98,6 +142,7 @@ def run() -> None:
     threading.Thread(target=heartbeat,daemon=True).start()
     try:
         commands=[job[k] for k in ('reader','producer','verifier') if k in job]
+        loaded_images = {}
         for image in sorted({c['image'] for c in commands}):
             digest=image.split('@sha256:')[1]
             archive=SCRATCH/(digest+'.oci.tar')
@@ -111,11 +156,8 @@ def run() -> None:
                     if not block: raise ValueError('IMAGE_TRUNCATED')
                     out.write(block); remaining-=len(block)
                 if response['Body'].read(1): raise ValueError('IMAGE_SIZE')
-            subprocess.run(podman()+['load','--input',str(archive)],stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,check=True)
+            loaded_images[image] = load_image(archive, image)
             archive.unlink()
-            image_info=json.loads(subprocess.check_output(podman()+['image','inspect',image],stderr=subprocess.DEVNULL))[0]
-            if image_info.get('Digest')!='sha256:'+digest or image_info.get('Architecture')!='arm64' or image_info.get('Os')!='linux':
-                raise ValueError('IMAGE_DIGEST')
         data=owned_dir(SCRATCH/'reader'); output=owned_dir(SCRATCH/'output'); verdict=owned_dir(SCRATCH/'verdict')
         specification=SCRATCH/'job'; specification.mkdir(mode=0o755)
         specification.chmod(0o755)
@@ -133,7 +175,7 @@ def run() -> None:
             (sock/'pgpass').write_text(':'.join(escape(v) for v in ['/replica','5432',boot['database'],secret['username'],secret['password']])+'\n')
             (sock/'pgpass').chmod(0o600);os.chown(sock/'pgpass',65534,65534)
             with ReplicaSocket(sock,boot['replicaHost'],ROOT/'rds-ca.pem'):
-                sandbox(job['reader'],'reader',[(sock,'/replica','ro'),(data,'/output','rw')],deadline-180)
+                sandbox(job['reader'],'reader',[(sock,'/replica','ro'),(data,'/output','rw')],deadline-180,loaded_images[job['reader']['image']])
             (sock/'service.conf').unlink();(sock/'pgpass').unlink()
             del secret,service
         fixture=data/'.local/fixture'
@@ -145,8 +187,8 @@ def run() -> None:
         verifier_mounts=[(data,'/input','ro'),(output,'/evidence','ro'),(run_spec,'/run-spec','ro'),(specification,'/job','ro'),(verdict,'/verdict','rw')]
         if fixture.is_dir():
             producer_mounts.append((fixture,'/fixture','ro'));verifier_mounts.append((fixture,'/fixture','ro'))
-        sandbox(job['producer'],'producer',producer_mounts,deadline-120)
-        sandbox(job['verifier'],'verifier',verifier_mounts,deadline-30)
+        sandbox(job['producer'],'producer',producer_mounts,deadline-120,loaded_images[job['producer']['image']])
+        sandbox(job['verifier'],'verifier',verifier_mounts,deadline-30,loaded_images[job['verifier']['image']])
         result=verdict/'receipt.json'
         if result.is_symlink() or not result.is_file() or result.stat().st_size>131072: raise ValueError('RECEIPT_FILE')
         receipt=validate_receipt(json.loads(result.read_bytes()),job)

--- a/docs/probe-box.md
+++ b/docs/probe-box.md
@@ -14,9 +14,14 @@ validated before real digests can be entered. There are no placeholder releases.
 
 ## Data flow
 
-The reader container connects through a Unix socket relay to the fixed replica
+The reader container connects through a Unix socket relay to the configured read target
 on port 5432 using TLS with hostname verification and the reviewed RDS CA.
-It checks `pg_is_in_recovery()` and read-only transaction state before extraction.
+It admits primary and replica recovery states, but requires read-only transaction
+state before extraction. Under Colin's live-primary ruling, set `replicaHost` to
+`primaryHost` and `replicaSecurityGroupId` to `primarySecurityGroupId`. These legacy
+configuration names identify the read target; a distinct replica remains supported.
+Both database ingress rules then target the same group but have different source
+groups (worker versus login provisioner), so their rule tuples do not collide.
 The owned extractor surveys and selects roles inside one read-only repeatable-read
 snapshot. Raw fixtures and provenance remain on the disposable encrypted disk.
 The producer runs fresh paired Clojure/Python recordings. The verifier independently
@@ -26,12 +31,12 @@ The producer never copies fixtures into its output tree.
 Producer, reader and verifier have disconnected network namespaces, no host
 credentials or metadata access, unprivileged users, read-only roots, no capabilities,
 resource limits and separate writable mounts. Only the reader receives the
-socket and replica credential. Producer output is read-only to the verifier;
+socket and reader credential. Producer output is read-only to the verifier;
 the verifier alone writes the receipt directory. Container storage also resides
 on the disposable disk. The root supervisor, baked into the AMI, is trusted.
 
 The host subnet has no default internet route or NAT. Security-group egress is
-limited to the replica, a private Secrets Manager endpoint and S3 via a gateway
+limited to the read target, a private Secrets Manager endpoint and S3 via a gateway
 endpoint whose policy admits only the box's assets/control/receipt paths. Because
 security groups do not filter the VPC resolver, the baked firewall restricts DNS
 to an exact-name local forwarder. Probe containers have no network route to it.
@@ -67,7 +72,7 @@ is distinct from application output. No private application runs on the runner.
 `ci/probe_box/provision_login.py` is the primary-side schema operation. The stack
 creates a generated Secrets Manager credential and invokes this code via a
 separate custom-resource Lambda with a separate security group and admin-secret
-permission. The probe worker never receives the primary connection or admin secret.
+permission. The probe worker connects only as the reader and never receives the admin secret.
 The reviewed ARM64 Lambda layer must contain psycopg2 and `/opt/rds-ca.pem`.
 The [pinned Python 3.12 ARM64 recipe](../ci/probe_box/layer/README.md) builds and
 checks that ZIP locally and prints the operator-only SSO publication command.
@@ -78,7 +83,8 @@ limits; schema usage, database connect, and SELECT on exactly conversations,
 votes, comments, participants, math_main and math_ticks. Provisioning locks and
 marks its role ownership, refuses a foreign role or unexpected membership/write
 authority, and rolls back partial failure. Role creation on primary replicates to
-the physical replica. The runtime additionally refuses a primary target.
+the physical replica. Live-primary extraction uses that same restricted login; the owned extractor
+opens and verifies its own read-only repeatable-read transaction.
 
 Deleting the stack retains the role and secret. Disabling/removing that role is
 an explicit separately reviewed schema action after all readers stop; stack
@@ -115,7 +121,7 @@ role selection or collapsed cuts fail admission; the pipeline never shortens the
 battery or accepts a partial result to obtain PASS.
 
 A reviewed `representative_selection` config also extracts the selected sample
-in that same replica transaction. Manifest/4 and paired-plan/2 require every
+in that same read-only transaction. Manifest/4 and paired-plan/2 require every
 sample alongside the 14 existing private entries. The gate orders actual sizes,
 preserves restart pairs, and reconstructs the sample's ceiling-six full-stream
 cuts and final-source-state moderation in both engines. Empty or unsupported
@@ -131,7 +137,7 @@ existing VPC/replica/primary endpoints, security groups, CA-bearing Lambda layer
 admin secret ARN, asset publisher, reviewer roles and notification topic.
 
 Before private use, retain actual target receipts for the AMI/OCI source admission,
-read-only replica login, DNS/metadata/egress isolation, cancellation/lost launch,
+read-only reader login, DNS/metadata/egress isolation, cancellation/lost launch,
 boot failure, killed supervisor and observed disk disposal. Local mocks and
 public-fixture data establish code behavior; they do not establish those AWS facts.
 The old signed-admission, fixture-upload and download-to-verify runbook is superseded.

--- a/docs/probe-box.md
+++ b/docs/probe-box.md
@@ -112,7 +112,14 @@ entrypoint. A certification registry entry uses the producer digest for reader
 `["verify"]`. The job schema is `polis-probe-job/1`; `run_id` is supplied by the
 dispatcher, and `max_seconds` is bounded by 18000. Store actual digest references
 in `ci/probe_box/jobs.json`. OCI archives are loaded from the private assets bucket
-by manifest digest; mutable tags and remote image pulls are refused.
+by manifest digest; mutable tags and remote image pulls are refused. The AL2023
+supervisor uses Docker 25 with Skopeo from the pinned Amazon repository. The worker
+checks the original OCI manifest bytes returned by Skopeo against the admitted
+digest before local conversion; the worker verifies the resulting Docker image ID against that
+manifest's config digest and checks Linux/ARM64. It executes only that immutable
+image ID. Docker's imported image metadata is not used as a registry-digest proof.
+The admitted job and exported receipt continue to identify the original manifest.
+Single-image OCI manifests are required; multi-platform indexes fail admission.
 
 Historical explicit full-stream vote-count schedules retain their relative cut
 positions against the new snapshot. Empty schedules, moderation, restart indices,
@@ -130,6 +137,18 @@ remain box-only; receipt/2 exports only the closed numeric selection report.
 See [representative payload admission](../delphi/docs/representative-selection.md).
 
 Bake the supervisor with `ci/probe_box/bake.sh` on the reviewed offline ARM64 builder.
+First run `ci/probe_box/ami/prepare.sh` on AL2023 2023.12.20260831 ARM64. It installs
+Amazon-signed Docker 25.0.16, containerd 2.2.5, runc 1.3.5 and Skopeo 1.22.2 at the
+exact RPM releases in that script, alongside the pinned Python dependencies.
+Podman is unavailable in this repository release. The standard docker/containerd
+units stay masked. Bake validates the custom daemon configuration without starting
+it; only the worker starts `polis-probe-container.service`, after mounting the
+disposable disk. Docker data, managed containerd state, socket, import temporary
+files and client configuration all stay under `/probe-work`. The custom daemon
+uses overlay2, no bridge, no firewall changes, no forwarding and no container log
+driver. It has a root-only Unix socket; no socket is mounted into a job. Containers
+retain network=none, nonroot execution, capability/resource limits and read-only
+roots. Input/output bind mounts inherit nodev/nosuid/noexec from the scratch disk.
 The launch template carries JSON boot configuration only, never executable commands.
 Set `enableProbeBox=true` and `PROBE_BOX_CONFIG` only when reviewing the separate
 `ProbeStack`; absent/false leaves the existing stack unchanged. Configuration names
@@ -156,6 +175,9 @@ PYTHONPATH=delphi python -B -m unittest discover -s ci/private_cert -p 'test_*.p
 The explicit local Postgres rehearsal is `login_rehearsal.py`; start only
 `test.compose.yml` with unique COMPOSE_PROJECT_NAME and both recovery ports,
 then provide PROBE_TEST_DATABASE_URL for that local instance and tear it down.
+
+Runtime references: [Docker daemon configuration](https://docs.docker.com/reference/cli/dockerd/),
+[Skopeo copy transports](https://github.com/containers/skopeo/blob/v1.22.0/docs/skopeo-copy.1.md).
 
 References: [AWS OIDC claim conditions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html),
 [launch-template IAM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ExamplePolicies_EC2.html),


### PR DESCRIPTION
The probe box reads production through the restricted reader login on the primary (no replica). The config validator rejected equal primary/read hosts and the extractor refused a target that is not in recovery, so that configuration could neither synthesize nor extract.

- Validator admits equal hosts; a distinct replica remains supported. The two database ingress rules then share a destination group with distinct source groups (worker vs login provisioner); the synth test proves the rule tuples do not collide.
- Extractor admits either recovery state but requires a read-only transaction and opens its own read-only repeatable-read transaction. The worker never receives the admin secret.
- Docs updated. No schema change. The reader OCI must be rebuilt from this source before use.

Verified locally: cdk jest 13/13, tsc clean, private_cert probe unit tests 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s