### PR TITLE
chore: public-fixture terminology in files merged after the sweep base

### DIFF
--- a/ci/probe_box/test_boundaries.py
+++ b/ci/probe_box/test_boundaries.py
@@ -49,7 +49,7 @@ class BoundaryTests(unittest.TestCase):
             with self.subTest(mutation=mutation):
                 r=sampled_receipt();s=r['selection']
                 if mutation=='missing':r['selection']=None
-                elif mutation=='extra':s['chosen_entry_sizes'][0]['path']='synthetic private value'
+                elif mutation=='extra':s['chosen_entry_sizes'][0]['path']='public-fixture private value'
                 elif mutation=='seed':s['seed']=42
                 elif mutation=='count':s['bucket_counts']['population']=True
                 elif mutation=='cell':s['bucket_counts']['cells'].pop()

--- a/delphi/docs/representative-selection.md
+++ b/delphi/docs/representative-selection.md
@@ -109,7 +109,7 @@ ordinal must have a distinct materialized directory; an old role may share that
 directory. Admission recounts P, V, C, U, registered participants and comments
 from lossless events and participant rows and compares the complete size census
 with the report. Missing, substituted, duplicated, unknown or unconfigured sample
-roles fail. Existing role predicates, synthetic approval, generated cases and
+roles fail. Existing role predicates, public-fixture approval, generated cases and
 NULL-drop policy still apply. Configs without sampling retain manifest/3 and
 the original battery; historical manifest/2 remains supported.
 

--- a/delphi/tests/replay_harness/representative_schedule_test.clj
+++ b/delphi/tests/replay_harness/representative_schedule_test.clj
@@ -1,4 +1,4 @@
-;; Synthetic final-source-state replay controls; no production data.
+;; Public-fixture final-source-state replay controls; no production data.
 (load-file "dev/replay.clj")
 (require '[clojure.test :refer :all] '[cheshire.core :as json] '[clojure.java.io :as io])
 

--- a/delphi/tests/test_certify_bundle_integration.py
+++ b/delphi/tests/test_certify_bundle_integration.py
@@ -102,7 +102,7 @@ def test_scaled_config_is_still_valid():
 
 
 def test_representative_payloads_share_real_snapshot_and_admit_all_selected_rows(seeded_db, tmp_path, monkeypatch):
-    """Real SQL census/extraction with scaled synthetic shapes; no engine claim."""
+    """Real SQL census/extraction with scaled public-fixture shapes; no engine claim."""
     import psycopg2
     from polismath.replay import fixture_samples, fixture_selection
 
@@ -127,11 +127,11 @@ def test_representative_payloads_share_real_snapshot_and_admit_all_selected_rows
     assert len(result['roles'])==len(cfg['roles'])+20
     assert result['transaction_guarantee']['single_transaction'] is True
     encoded=json.dumps(cfg).encode()
-    manifest=fb.build_manifest(bundle_id='synthetic-sampled-snapshot',payload_root=payload,
+    manifest=fb.build_manifest(bundle_id='public-fixture-sampled-snapshot',payload_root=payload,
         config=cfg,config_bytes=encoded,selections=result['roles'],generated_summaries=result['generated'],
-        snapshot=dict(identifier='synthetic-snapshot',created_at='2026-09-10T00:00:00Z',schema_migration_version='000006'),
+        snapshot=dict(identifier='public-fixture-snapshot',created_at='2026-09-10T00:00:00Z',schema_migration_version='000006'),
         transaction_guarantee=result['transaction_guarantee'],tie_key=result['tie_key'],
-        schedules=fb.collect_schedule_hashes(fc.SCRIPTS_DIR/'schedules'),owner='synthetic-test',
+        schedules=fb.collect_schedule_hashes(fc.SCRIPTS_DIR/'schedules'),owner='public-fixture-test',
         extraction_commit='0'*40,source_commit='0'*40,coverage_report=result['coverage_report'],
         representative_report=result['representative_selection'])
     fb.verify(payload,manifest)

--- a/delphi/tests/test_representative_payloads.py
+++ b/delphi/tests/test_representative_payloads.py
@@ -1,4 +1,4 @@
-"""Synthetic source rows through extraction, manifest, plan and independent gate."""
+"""Public-fixture source rows through extraction, manifest, plan and independent gate."""
 import copy
 import json
 import os
@@ -20,7 +20,7 @@ import gate
 import probe
 
 TIE = dict(available=False, columns=[], method='physical-ctid', order_by='created ASC, ctid ASC',
-           guarantee='frozen-extract-order', note='synthetic')
+           guarantee='frozen-extract-order', note='public-fixture')
 
 
 def raw_rows(n, *, tied=False, late=False):
@@ -44,7 +44,7 @@ def extract_one(payload, root, raw, name, monkeypatch):
 
 
 def bundle(root, monkeypatch, n=20):
-    """Old role metadata is the existing synthetic admission factory's stub.
+    """Old role metadata is the existing public-fixture admission factory's stub.
 
     Both old and sampled payloads are real extractor output, never production
     data. Tiny old-role bytes do not claim production predicate evidence.
@@ -84,7 +84,7 @@ def test_complete_sample_payload_census_and_manifest_version(tmp_path,monkeypatc
 
 
 @pytest.mark.parametrize('mutation',['missing','duplicate','shared-dir','wrong-size','bad-seed','extra-report',
-                                   'old-version','synthetic','extra-role','missing-old-role','payload-count'])
+                                   'old-version','public-fixture','extra-role','missing-old-role','payload-count'])
 def test_sample_manifest_refuses_omitted_or_substituted_obligations(tmp_path,monkeypatch,mutation):
     fixture,config,m=bundle(tmp_path,monkeypatch)
     row=next(r for r in m['roles'] if r['slug']=='sample-001')
@@ -93,9 +93,9 @@ def test_sample_manifest_refuses_omitted_or_substituted_obligations(tmp_path,mon
     elif mutation=='shared-dir':next(r for r in m['roles'] if r['slug']=='sample-002')['dir']=row['dir']
     elif mutation=='wrong-size':row['measured_metrics']['V']+=1
     elif mutation=='bad-seed':m['representative']['report']['seed']='02'*32
-    elif mutation=='extra-report':m['representative']['report']['zid']='SYNTHETIC_PRIVATE'
+    elif mutation=='extra-report':m['representative']['report']['zid']='PUBLIC_FIXTURE_PRIVATE'
     elif mutation=='old-version':m['schema_version']='certify-fixture-manifest/3'
-    elif mutation=='synthetic':row['source']='synthetic-replacement'
+    elif mutation=='public-fixture':row['source']='public-fixture-replacement'
     elif mutation=='extra-role':m['roles'].append(dict(row,slug='sample-021'))
     elif mutation=='missing-old-role':m['roles'].pop(0)
     elif mutation=='payload-count':
@@ -203,9 +203,9 @@ def test_receipt_selection_cannot_export_private_fields(field,level):
     validate_selection(report)
     target={'report':report,'counts':report['bucket_counts'],'cell':report['bucket_counts']['cells'][0],
             'size':report['chosen_entry_sizes'][0]}[level]
-    target[field]='SYNTHETIC_PRIVATE_VALUE'
+    target[field]='PUBLIC_FIXTURE_PRIVATE_VALUE'
     with pytest.raises(ValueError) as exc:validate_selection(report)
-    assert 'SYNTHETIC_PRIVATE_VALUE' not in str(exc.value)
+    assert 'PUBLIC_FIXTURE_PRIVATE_VALUE' not in str(exc.value)
 
 
 @pytest.mark.parametrize('n',[1,19,20,25])


### PR DESCRIPTION
Follow-up to the terminology sweep (#2782, #2783, #2785): five files that landed with the representative-selection change after the sweep's base still carried the old wording. Exact case-specific substitutions only; paired refusal markers stay aligned; science, schema and assertion structure unchanged; no persisted pin moves.

Verified locally: payload/selection/bundle/config selection 349 passed (1 optional skip); real-PostgreSQL bundle integration file 31 passed; probe unit tests 53 passed; Clojure schedule test 2 tests / 35 assertions.

Note: #2787 also touches `ci/probe_box/test_boundaries.py`; this change is one marker hunk there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NVGBuYCk4EZmiz4csUv9s